### PR TITLE
Fix widget title in home tab

### DIFF
--- a/src/sql/parts/dashboard/contents/dashboardWidgetWrapper.component.ts
+++ b/src/sql/parts/dashboard/contents/dashboardWidgetWrapper.component.ts
@@ -156,6 +156,14 @@ export class DashboardWidgetWrapper extends AngularDisposable implements OnInit 
 			return;
 		}
 
+		// If _config.name is not set, set it to _config.widget.name
+		if (!this._config.name) {
+			let widget = Object.values(this._config.widget)[0];
+			if (widget.name) {
+				this._config.name = widget.name;
+			}
+		}
+
 		let componentFactory = this._componentFactoryResolver.resolveComponentFactory(selector);
 
 		let viewContainerRef = this.componentHost.viewContainerRef;

--- a/src/sql/parts/dashboard/pages/databaseDashboardPage.contribution.ts
+++ b/src/sql/parts/dashboard/pages/databaseDashboardPage.contribution.ts
@@ -99,6 +99,7 @@ export const databaseDashboardSettingSchema: IJSONSchema = {
 			}
 		},
 		{
+			name: 'Search',
 			gridItemConfig: {
 				sizex: 1,
 				sizey: 2

--- a/src/sql/parts/dashboard/pages/serverDashboardPage.contribution.ts
+++ b/src/sql/parts/dashboard/pages/serverDashboardPage.contribution.ts
@@ -85,6 +85,7 @@ let defaultVal = [
 		}
 	},
 	{
+		name: 'Search',
 		gridItemConfig: {
 			sizex: 1,
 			sizey: 2


### PR DESCRIPTION
Fix #1312: Names of backup and DB size widgets are not shown on dashboard 

![image](https://user-images.githubusercontent.com/25463959/39543713-d8f17226-4e00-11e8-842d-b6170b25cb9b.png)
