### PR TITLE
Set element text instead of HTML where possible

### DIFF
--- a/src/sql/base/browser/ui/modal/dialogHelper.ts
+++ b/src/sql/base/browser/ui/modal/dialogHelper.ts
@@ -33,7 +33,7 @@ export function appendRowLink(container: Builder, label: string, labelClass: str
 	container.element('tr', {}, (rowContainer) => {
 		rowContainer.element('td', { class: labelClass }, (labelCellContainer) => {
 			labelCellContainer.div({}, (labelContainer) => {
-				labelContainer.innerHtml(label);
+				labelContainer.text(label);
 			});
 		});
 		rowContainer.element('td', { class: cellContainerClass }, (inputCellContainer) => {

--- a/src/sql/base/browser/ui/modal/optionsDialog.ts
+++ b/src/sql/base/browser/ui/modal/optionsDialog.ts
@@ -150,8 +150,8 @@ export class OptionsDialog extends Modal {
 
 	private onOptionLinkClicked(optionName: string): void {
 		var option = this._optionElements[optionName].option;
-		this._optionTitle.innerHtml(option.displayName);
-		this._optionDescription.innerHtml(option.description);
+		this._optionTitle.text(option.displayName);
+		this._optionDescription.text(option.description);
 	}
 
 	private fillInOptions(container: Builder, options: sqlops.ServiceOption[]): void {

--- a/src/sql/base/browser/ui/panel/tabHeader.component.ts
+++ b/src/sql/base/browser/ui/panel/tabHeader.component.ts
@@ -62,7 +62,7 @@ export class TabHeaderComponent extends Disposable implements AfterContentInit, 
 			tabLabelcontainer.classList.add(this.tab.iconClass);
 		} else {
 			tabLabelcontainer.className = 'tabLabel';
-			tabLabelcontainer.innerHTML = this.tab.title;
+			tabLabelcontainer.textContent = this.tab.title;
 		}
 		tabLabelcontainer.title = this.tab.title;
 	}

--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -6,6 +6,7 @@ import { mixin } from 'vs/base/common/objects';
 import { SlickGrid } from 'angular2-slickgrid';
 import { Button } from '../../button/button';
 import { attachButtonStyler } from 'sql/common/theme/styler';
+import { escape } from 'sql/base/common/strings';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 
 export class HeaderFilter {
@@ -174,7 +175,7 @@ export class HeaderFilter {
 			if (filterItems[i] && filterItems[i].indexOf('Error:') < 0) {
 				filterOptions += '<label><input type="checkbox" value="' + i + '"'
 				+ (filtered ? ' checked="checked"' : '')
-				+ '/>' + filterItems[i] + '</label>';
+				+ '/>' + escape(filterItems[i]) + '</label>';
 			}
 		}
 		let $filter = $('<div class="filter">')

--- a/src/sql/base/browser/ui/table/plugins/rowDetailView.ts
+++ b/src/sql/base/browser/ui/table/plugins/rowDetailView.ts
@@ -1,5 +1,6 @@
 // Adopted and converted to typescript from https://github.com/6pac/SlickGrid/blob/master/plugins/slick.rowdetailview.js
 // heavily modified
+import { escape } from 'sql/base/common/strings';
 import { mixin } from 'vs/base/common/objects';
 import * as nls from 'vs/nls';
 
@@ -354,7 +355,7 @@ export class RowDetailView {
 			html.push("style='height:", dataContext._height, "px;"); //set total height of padding
 			html.push("top:", rowHeight, "px'>");             //shift detail below 1st row
 			html.push("<div id='detailViewContainer_", dataContext.id, "'  class='detail-container' style='max-height:" + (dataContext._height - rowHeight + bottomMargin) + "px'>"); //sub ctr for custom styling
-			html.push("<div id='innerDetailView_", dataContext.id, "'>", dataContext._detailContent, "</div></div>");
+			html.push("<div id='innerDetailView_", dataContext.id, "'>", escape(dataContext._detailContent), "</div></div>");
 			//&omit a final closing detail container </div> that would come next
 
 			return html.join('');

--- a/src/sql/base/browser/ui/taskbar/taskbar.ts
+++ b/src/sql/base/browser/ui/taskbar/taskbar.ts
@@ -82,7 +82,7 @@ export class Taskbar {
 	public static createTaskbarText(inputText: string): HTMLElement {
 		let element = document.createElement('div');
 		element.className = 'taskbarTextSeparator';
-		element.innerHTML = inputText;
+		element.textContent = inputText;
 		return element;
 	}
 

--- a/src/sql/parts/accountManagement/autoOAuthDialog/autoOAuthDialog.ts
+++ b/src/sql/parts/accountManagement/autoOAuthDialog/autoOAuthDialog.ts
@@ -100,7 +100,7 @@ export class AutoOAuthDialog extends Modal {
 		let inputBox: InputBox;
 		container.div({ class: 'dialog-input-section' }, (inputContainer) => {
 			inputContainer.div({ class: 'dialog-label' }, (labelContainer) => {
-				labelContainer.innerHtml(label);
+				labelContainer.text(label);
 			});
 
 			inputContainer.div({ class: 'dialog-input' }, (inputCellContainer) => {

--- a/src/sql/parts/accountManagement/firewallRuleDialog/firewallRuleDialog.ts
+++ b/src/sql/parts/accountManagement/firewallRuleDialog/firewallRuleDialog.ts
@@ -145,7 +145,7 @@ export class FirewallRuleDialog extends Modal {
 			subnetIPRangeSection = subnetIPRangeContainer.getHTMLElement();
 			subnetIPRangeContainer.div({ 'class': 'dialog-input-section' }, (inputContainer) => {
 				inputContainer.div({ 'class': 'dialog-label' }, (labelContainer) => {
-					labelContainer.innerHtml(LocalizedStrings.FROM);
+					labelContainer.text(LocalizedStrings.FROM);
 				});
 
 				inputContainer.div({ 'class': 'dialog-input' }, (inputCellContainer) => {
@@ -155,7 +155,7 @@ export class FirewallRuleDialog extends Modal {
 				});
 
 				inputContainer.div({ 'class': 'dialog-label' }, (labelContainer) => {
-					labelContainer.innerHtml(LocalizedStrings.TO);
+					labelContainer.text(LocalizedStrings.TO);
 				});
 
 				inputContainer.div({ 'class': 'dialog-input' }, (inputCellContainer) => {
@@ -234,7 +234,7 @@ export class FirewallRuleDialog extends Modal {
 			className += ' header';
 		}
 		container.div({ 'class': className }, (labelContainer) => {
-			labelContainer.innerHtml(content);
+			labelContainer.text(content);
 		});
 	}
 

--- a/src/sql/parts/connection/connectionDialog/connectionDialogWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogWidget.ts
@@ -262,7 +262,7 @@ export class ConnectionDialogWidget extends Modal {
 			let recentHistoryLabel = localize('recentHistory', 'Recent history');
 			recentConnectionContainer.div({ class: 'recent-titles-container' }, (container) => {
 				container.div({ class: 'connection-history-label' }, (recentTitle) => {
-					recentTitle.innerHtml(recentHistoryLabel);
+					recentTitle.text(recentHistoryLabel);
 				});
 				container.div({ class: 'connection-history-actions' }, (actionsContainer) => {
 					this._actionbar = this._register(new ActionBar(actionsContainer.getHTMLElement(), { animated: false }));
@@ -303,7 +303,7 @@ export class ConnectionDialogWidget extends Modal {
 		this._noRecentConnectionBuilder.div({ class: 'connection-recent-content' }, (noRecentConnectionContainer) => {
 			let noRecentHistoryLabel = localize('noRecentConnections', 'No recent connection');
 			noRecentConnectionContainer.div({ class: 'no-recent-connections' }, (noRecentTitle) => {
-				noRecentTitle.innerHtml(noRecentHistoryLabel);
+				noRecentTitle.text(noRecentHistoryLabel);
 			});
 		});
 	}
@@ -335,7 +335,7 @@ export class ConnectionDialogWidget extends Modal {
 		this._noSavedConnectionBuilder.div({ class: 'connection-saved-content' }, (noSavedConnectionContainer) => {
 			let noSavedConnectionLabel = localize('noSavedConnections', 'No saved connection');
 			noSavedConnectionContainer.div({ class: 'no-saved-connections' }, (titleContainer) => {
-				titleContainer.innerHtml(noSavedConnectionLabel);
+				titleContainer.text(noSavedConnectionLabel);
 			});
 		});
 	}

--- a/src/sql/parts/dashboard/newDashboardTabDialog/newDashboardTabDialog.ts
+++ b/src/sql/parts/dashboard/newDashboardTabDialog/newDashboardTabDialog.ts
@@ -163,7 +163,7 @@ export class NewDashboardTabDialog extends Modal {
 		this._noExtensionViewContainer = DOM.$('.no-extension-view');
 		let noExtensionTitle = DOM.append(this._noExtensionViewContainer, DOM.$('.no-extensionTab-label'));
 		let noExtensionLabel = localize('newdashboardTabDialog.noExtensionLabel', 'No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.');
-		noExtensionTitle.innerHTML = noExtensionLabel;
+		noExtensionTitle.textContent = noExtensionLabel;
 
 		DOM.append(container, this._noExtensionViewContainer);
 	}

--- a/src/sql/parts/disasterRecovery/restore/restoreDialog.ts
+++ b/src/sql/parts/disasterRecovery/restore/restoreDialog.ts
@@ -226,7 +226,7 @@ export class RestoreDialog extends Modal {
 
 			destinationContainer.div({ class: 'dialog-input-section' }, (inputContainer) => {
 				inputContainer.div({ class: 'dialog-label' }, (labelContainer) => {
-					labelContainer.innerHtml(LocalizedStrings.TARGETDATABASE);
+					labelContainer.text(LocalizedStrings.TARGETDATABASE);
 				});
 
 				inputContainer.div({ class: 'dialog-input' }, (inputCellContainer) => {
@@ -471,7 +471,7 @@ export class RestoreDialog extends Modal {
 			className += ' header';
 		}
 		container.div({ class: className }, (labelContainer) => {
-			labelContainer.innerHtml(content);
+			labelContainer.text(content);
 		});
 	}
 
@@ -535,7 +535,7 @@ export class RestoreDialog extends Modal {
 		let selectBox: SelectBox;
 		container.div({ class: 'dialog-input-section' }, (inputContainer) => {
 			inputContainer.div({ class: 'dialog-label' }, (labelContainer) => {
-				labelContainer.innerHtml(label);
+				labelContainer.text(label);
 			});
 
 			inputContainer.div({ class: 'dialog-input' }, (inputCellContainer) => {

--- a/src/sql/parts/jobManagement/views/jobsView.component.ts
+++ b/src/sql/parts/jobManagement/views/jobsView.component.ts
@@ -35,6 +35,7 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { IAction } from 'vs/base/common/actions';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IDashboardService } from 'sql/services/dashboard/common/dashboardService';
+import { escape } from 'sql/base/common/strings';
 
 export const JOBSVIEW_SELECTOR: string = 'jobsview-component';
 export const ROW_HEIGHT: number = 45;
@@ -485,7 +486,7 @@ export class JobsViewComponent extends JobManagementView implements OnInit  {
 
 		return '<table class="jobview-jobnametable"><tr class="jobview-jobnamerow">' +
 			'<td nowrap class=' + resultIndicatorClass + '></td>' +
-			'<td nowrap class="jobview-jobnametext">' + dataContext.name + '</td>' +
+			'<td nowrap class="jobview-jobnametext">' + escape(dataContext.name) + '</td>' +
 			'</tr></table>';
 	}
 

--- a/src/sql/parts/objectExplorer/serverGroupDialog/serverGroupDialog.ts
+++ b/src/sql/parts/objectExplorer/serverGroupDialog/serverGroupDialog.ts
@@ -79,7 +79,7 @@ export class ServerGroupDialog extends Modal {
 		// Connection Group Name
 		let serverGroupNameLabel = localize('connectionGroupName', 'Server group name');
 		this._bodyBuilder.div({ class: 'dialog-label' }, (labelContainer) => {
-			labelContainer.innerHtml(serverGroupNameLabel);
+			labelContainer.text(serverGroupNameLabel);
 		});
 		this._bodyBuilder.div({ class: 'input-divider' }, (inputCellContainer) => {
 			let errorMessage = localize('MissingGroupNameError', 'Group name is required.');
@@ -94,7 +94,7 @@ export class ServerGroupDialog extends Modal {
 		// Connection Group Description
 		let groupDescriptionLabel = localize('groupDescription', 'Group description');
 		this._bodyBuilder.div({ class: 'dialog-label' }, (labelContainer) => {
-			labelContainer.innerHtml(groupDescriptionLabel);
+			labelContainer.text(groupDescriptionLabel);
 		});
 		this._bodyBuilder.div({ class: 'input-divider' }, (inputCellContainer) => {
 			this._groupDescriptionInputBox = new InputBox(inputCellContainer.getHTMLElement(), this._contextViewService, {
@@ -105,7 +105,7 @@ export class ServerGroupDialog extends Modal {
 		// Connection Group Color
 		this._bodyBuilder.div({ class: 'dialog-label' }, (labelContainer) => {
 			let groupColorLabel = localize('groupColor', 'Group color');
-			labelContainer.innerHtml(groupColorLabel);
+			labelContainer.text(groupColorLabel);
 		});
 
 		this._bodyBuilder.div({ class: 'group-color-options' }, (groupColorContainer) => {


### PR DESCRIPTION
This fixes a handful more places in the code where we were setting elements' HTML properties directly instead of just setting their text.

@abist could you take a look at the agent changes and confirm whether they're guaranteed to just be text?