### PR TITLE
Feature: Open path of saved files

### DIFF
--- a/src/sql/parts/query/common/localizedConstants.ts
+++ b/src/sql/parts/query/common/localizedConstants.ts
@@ -15,6 +15,7 @@ export const msgCancelQueryFailed = localize('msgCancelQueryFailed', 'Canceling 
 export const msgSaveStarted = localize('msgSaveStarted', 'Started saving results to ');
 export const msgSaveFailed = localize('msgSaveFailed', 'Failed to save results. ');
 export const msgSaveSucceeded = localize('msgSaveSucceeded', 'Successfully saved results to ');
+export const msgSaveFileSucceeded = localize('msgSaveFileSucceeded', 'Successfully saved file to ');
 
 export const msgStatusRunQueryInProgress = localize('msgStatusRunQueryInProgress', 'Executing query...');
 

--- a/src/sql/parts/query/services/queryEditorService.ts
+++ b/src/sql/parts/query/services/queryEditorService.ts
@@ -182,7 +182,6 @@ export class QueryEditorService implements IQueryEditorService {
 		);
 	}
 
-
 	onSaveAsCompleted(oldResource: URI, newResource: URI): void {
 		this.promptFileSavedNotification(newResource.fsPath);
 

--- a/src/sql/parts/query/services/queryEditorService.ts
+++ b/src/sql/parts/query/services/queryEditorService.ts
@@ -30,6 +30,10 @@ import { isLinux } from 'vs/base/common/platform';
 import { Schemas } from 'vs/base/common/network';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { EditDataResultsInput } from 'sql/parts/editData/common/editDataResultsInput';
+import * as LocalizedConstants from 'sql/parts/query/common/localizedConstants';
+import { IWindowsService } from 'vs/platform/windows/common/windows';
+import { getBaseLabel } from 'vs/base/common/labels';
+import { ShowFileInFolderAction } from 'sql/workbench/common/workspaceActions';
 
 const fs = require('fs');
 
@@ -63,6 +67,7 @@ export class QueryEditorService implements IQueryEditorService {
 		@IEditorGroupService private _editorGroupService: IEditorGroupService,
 		@INotificationService private _notificationService: INotificationService,
 		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
+		@IWindowsService private windowsService: IWindowsService
 	) {
 		QueryEditorService.editorService = _editorService;
 		QueryEditorService.instantiationService = _instantiationService;
@@ -161,7 +166,26 @@ export class QueryEditorService implements IQueryEditorService {
 	public onQueryInputClosed(uri: string): void {
 	}
 
+	private promptFileSavedNotification(savedFilePath: string) {
+	let label = getBaseLabel(paths.dirname(savedFilePath));
+ 		this._notificationService.prompt(
+			Severity.Info,
+			LocalizedConstants.msgSaveFileSucceeded + savedFilePath,
+			[{
+				label: nls.localize('openLocation', "Open file location"),
+				run: () => {
+					let action = new ShowFileInFolderAction(savedFilePath, label || paths.sep, this.windowsService);
+					action.run();
+					action.dispose();
+				}
+			}]
+		);
+	}
+
+
 	onSaveAsCompleted(oldResource: URI, newResource: URI): void {
+		this.promptFileSavedNotification(newResource.fsPath);
+
 		let oldResourceString: string = oldResource.toString();
 		const stacks = this._editorGroupService.getStacksModel();
 		stacks.groups.forEach(group => {

--- a/src/sql/workbench/common/workspaceActions.ts
+++ b/src/sql/workbench/common/workspaceActions.ts
@@ -1,0 +1,13 @@
+import { TPromise } from 'vs/base/common/winjs.base';
+import { Action } from 'vs/base/common/actions';
+import { IWindowsService } from 'vs/platform/windows/common/windows';
+
+export class ShowFileInFolderAction extends Action {
+
+	constructor(private path: string, label: string, private windowsService: IWindowsService) {
+		super('showItemInFolder.action.id', label);
+	}
+ 	run(): TPromise<void> {
+		return this.windowsService.showItemInFolder(this.path);
+	}
+}


### PR DESCRIPTION
Added feature for showing folder for saved files when saving a new file from the menu "File->Save As...".
This PR was added after discussion in #2216. 

Questions I'd like to discuss:
1. Will this be a nice feature without annoyance of too many popup notifications?
2. We could also show an option for opening the saved file in the default Windows app. However, the file is already opened inside of sqlops after saving, maybe this is enough?

Preview:
![image](https://user-images.githubusercontent.com/11557675/44286950-3b023180-a26b-11e8-9e5f-b6d8967c67b5.png)
