### PR TITLE
Fix for broken checkbox status in checkbox tree node

### DIFF
--- a/src/sql/parts/modelComponents/tree/tree.component.ts
+++ b/src/sql/parts/modelComponents/tree/tree.component.ts
@@ -82,9 +82,10 @@ export default class TreeComponent extends ComponentBase implements IComponent, 
 	}
 
 	public refreshDataProvider(itemsToRefreshByHandle: { [treeItemHandle: string]: ITreeComponentItem }): void {
-		// if (this._dataProvider) {
-		// 	const itemsToRefresh = this._dataProvider.getItemsToRefresh(itemsToRefreshByHandle);
-		// }
+		if (this._dataProvider) {
+			this._dataProvider.getItemsToRefresh(itemsToRefreshByHandle);
+		}
+
 		if (this._tree) {
 			for (const item of Object.values(itemsToRefreshByHandle)) {
 				this._tree.refresh(<ITreeComponentItem>item);

--- a/src/sql/parts/modelComponents/tree/treeComponentRenderer.ts
+++ b/src/sql/parts/modelComponents/tree/treeComponentRenderer.ts
@@ -142,7 +142,7 @@ export class TreeComponentRenderer extends Disposable implements IRenderer {
 		if (element) {
 			element.onCheckedChanged = (checked: boolean) => {
 				this._dataProvider.onNodeCheckedChanged(element.handle, checked);
-			}
+			};
 			templateData.model = element;
 		}
 		if (templateId === TreeComponentRenderer.DEFAULT_TEMPLATE) {


### PR DESCRIPTION
This fix is for the checkbox bug.
The checkbox tree was working previously, but now it has some issues after big code update happened in SqlOpsStudio. There 2 issues are discovered (see attached files for details):
1) The check in checkbox does not stay if we signal tree data is changed.
2) The neutral state of the check box is no longer working.

![check does not stay](https://user-images.githubusercontent.com/19577035/46118279-99032c80-c1ba-11e8-9f33-4d7921271071.gif)
![neutral checkbox state no more working](https://user-images.githubusercontent.com/19577035/46118280-99032c80-c1ba-11e8-84cf-0fdbfd5fa4be.gif)
