### PR TITLE
add sql class for task icon images

### DIFF
--- a/src/sql/parts/taskHistory/viewlet/taskHistoryRenderer.ts
+++ b/src/sql/parts/taskHistory/viewlet/taskHistoryRenderer.ts
@@ -19,7 +19,7 @@ import * as Utils from 'sql/parts/connection/common/utils';
 export class TaskHistoryRenderer implements IRenderer {
 
 	public static readonly TASKOBJECT_HEIGHT = 65;
-	private static readonly ICON_CLASS = 'task-icon icon';
+	private static readonly ICON_CLASS = 'task-icon sql icon';
 	private static readonly TASKOBJECT_TEMPLATE_ID = 'carbonTask';
 	private static readonly FAIL_CLASS = 'error';
 	private static readonly SUCCESS_CLASS = 'success';


### PR DESCRIPTION
Added "sql" as class for task icons.  The CSS styles for "common icons" have some with 'sql' and some with out. 

This fixes the issue with the task history showing the text "failed" rather than the icon.  