### PR TITLE
Update the SSMSKeymap extension to 1.0.0

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -185,14 +185,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.2.0",
-							"lastUpdated": "4/16/2018",
+							"version": "1.0.0",
+							"lastUpdated": "10/03/2018",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/kevcunnane/ssmskeymap/releases/tag/0.2.0"
+									"source": "https://github.com/kevcunnane/ssmskeymap/releases/tag/1.0.0"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -185,14 +185,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.2.0",
-							"lastUpdated": "4/16/2018",
+							"version": "1.0.0",
+							"lastUpdated": "10/03/2018",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/kevcunnane/ssmskeymap/releases/tag/0.2.0"
+									"source": "https://github.com/kevcunnane/ssmskeymap/releases/tag/1.0.0"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This updates the SSMSKeymap extension to 1.0.0. This has updated README contents to reference Azure Data Studio and adds 1 additional keybinding for *Refresh Intellisense Cache*