### PR TITLE
Stop OE connection spinner when user closes connection dialog

### DIFF
--- a/src/sql/parts/connection/common/connectionManagement.ts
+++ b/src/sql/parts/connection/common/connectionManagement.ts
@@ -67,6 +67,7 @@ export interface IConnectionCallbacks {
 	onConnectReject(error?: string): void;
 	onConnectSuccess(params?: INewConnectionParams): void;
 	onDisconnect(): void;
+	onConnectCanceled(): void;
 }
 
 export const SERVICE_ID = 'connectionManagementService';
@@ -336,6 +337,7 @@ export interface IConnectableInput {
 	onConnectReject(error?: string): void;
 	onConnectSuccess(params?: INewConnectionParams): void;
 	onDisconnect(): void;
+	onConnectCanceled(): void;
 }
 
 export enum ConnectionType {

--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -366,6 +366,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 				onConnectStart: callbacks ? callbacks.onConnectStart : undefined,
 				onConnectSuccess: callbacks ? callbacks.onConnectSuccess : undefined,
 				onDisconnect: callbacks ? callbacks.onDisconnect : undefined,
+				onConnectCanceled: callbacks ? callbacks.onConnectCanceled : undefined,
 				uri: uri
 			};
 		}
@@ -438,7 +439,8 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 				onConnectReject: () => { },
 				onConnectStart: () => { },
 				onConnectSuccess: () => { },
-				onDisconnect: () => { }
+				onDisconnect: () => { },
+				onConnectCanceled: () => { }
 			};
 		}
 		if (!options) {

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -148,10 +148,13 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		if (this.uiController.databaseDropdownExpanded) {
 			this.uiController.closeDatabaseDropdown();
 		} else {
-			if (params && params.input && params.connectionType === ConnectionType.editor) {
+			if (params && params.input && params.connectionType === ConnectionType.editor) {''
 				this._connectionManagementService.cancelEditorConnection(params.input);
 			} else {
 				this._connectionManagementService.cancelConnection(this._model);
+			}
+			if (params && params.input && params.input.onConnectCanceled) {
+				params.input.onConnectCanceled();
 			}
 			this._connectionDialog.resetConnection();
 			this._connecting = false;

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -148,7 +148,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		if (this.uiController.databaseDropdownExpanded) {
 			this.uiController.closeDatabaseDropdown();
 		} else {
-			if (params && params.input && params.connectionType === ConnectionType.editor) {''
+			if (params && params.input && params.connectionType === ConnectionType.editor) {
 				this._connectionManagementService.cancelEditorConnection(params.input);
 			} else {
 				this._connectionManagementService.cancelConnection(this._model);

--- a/src/sql/parts/editData/common/editDataInput.ts
+++ b/src/sql/parts/editData/common/editDataInput.ts
@@ -175,6 +175,9 @@ export class EditDataInput extends EditorInput implements IConnectableInput {
 		}
 	}
 
+	public onConnectCanceled(): void {
+	}
+
 	public onConnectSuccess(params?: INewConnectionParams): void {
 		let rowLimit: number = undefined;
 		let queryString: string = undefined;

--- a/src/sql/parts/objectExplorer/viewlet/treeUpdateUtils.ts
+++ b/src/sql/parts/objectExplorer/viewlet/treeUpdateUtils.ts
@@ -130,14 +130,16 @@ export class TreeUpdateUtils {
 					if (tree) {
 						// Show the spinner in OE by adding the 'loading' trait to the connection, and set up callbacks to hide the spinner
 						tree.addTraits('loading', [connection]);
+						let rejectOrCancelCallback = () => {
+							tree.collapse(connection);
+							tree.removeTraits('loading', [connection]);
+						};
 						callbacks = {
 							onConnectStart: undefined,
-							onConnectReject: () => {
-								tree.collapse(connection);
-								tree.removeTraits('loading', [connection]);
-							},
+							onConnectReject: rejectOrCancelCallback,
 							onConnectSuccess: () => tree.removeTraits('loading', [connection]),
-							onDisconnect: undefined
+							onDisconnect: undefined,
+							onConnectCanceled: rejectOrCancelCallback,
 						};
 					}
 					connectionManagementService.connect(connection, undefined, options, callbacks).then(result => {

--- a/src/sql/parts/query/common/queryInput.ts
+++ b/src/sql/parts/query/common/queryInput.ts
@@ -225,6 +225,9 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 		this._updateTaskbar.fire();
 	}
 
+	public onConnectCanceled(): void {
+	}
+
 	public onConnectSuccess(params?: INewConnectionParams): void {
 		this._runQueryEnabled = true;
 		this._connectEnabled = false;

--- a/src/sqltest/parts/connection/connectionDialogService.test.ts
+++ b/src/sqltest/parts/connection/connectionDialogService.test.ts
@@ -56,7 +56,8 @@ suite('ConnectionDialogService tests', () => {
 				onConnectStart: undefined,
 				onConnectSuccess: undefined,
 				onConnectReject: undefined,
-				onDisconnect: undefined
+				onDisconnect: undefined,
+				onConnectCanceled: undefined
 			},
 			runQueryOnCompletion: undefined,
 			querySelection: undefined

--- a/src/sqltest/parts/connection/connectionManagementService.test.ts
+++ b/src/sqltest/parts/connection/connectionManagementService.test.ts
@@ -259,6 +259,7 @@ suite('SQL ConnectionManagementService tests', () => {
 				onConnectStart: undefined,
 				onDisconnect: undefined,
 				onConnectSuccess: undefined,
+				onConnectCanceled: undefined,
 				uri: 'Editor Uri'
 			},
 			runQueryOnCompletion: RunQueryOnConnectionMode.executeQuery
@@ -279,6 +280,7 @@ suite('SQL ConnectionManagementService tests', () => {
 				onConnectStart: undefined,
 				onDisconnect: undefined,
 				onConnectSuccess: undefined,
+				onConnectCanceled: undefined,
 				uri: 'Editor Uri'
 			},
 			runQueryOnCompletion: RunQueryOnConnectionMode.executeQuery
@@ -348,6 +350,7 @@ suite('SQL ConnectionManagementService tests', () => {
 					onConnectReject: undefined,
 					onConnectStart: undefined,
 					onDisconnect: undefined,
+					onConnectCanceled: undefined,
 					uri: uri
 				},
 				querySelection: undefined,
@@ -661,6 +664,7 @@ suite('SQL ConnectionManagementService tests', () => {
 					onConnectReject: undefined,
 					onConnectStart: undefined,
 					onDisconnect: undefined,
+					onConnectCanceled: undefined,
 					uri: uri
 				},
 				querySelection: undefined,


### PR DESCRIPTION
Fixes a bug where the OE spinner keeps spinning forever if you click on a disconnected connection without a saved password and then cancel out of the connection dialog 