### PR TITLE
Fix bug where failed OE expands could not be retried

### DIFF
--- a/src/sql/parts/objectExplorer/common/objectExplorerService.ts
+++ b/src/sql/parts/objectExplorer/common/objectExplorerService.ts
@@ -350,7 +350,9 @@ export class ObjectExplorerService implements IObjectExplorerService {
 	}
 
 	public resolveTreeNodeChildren(session: sqlops.ObjectExplorerSession, parentTree: TreeNode): Thenable<TreeNode[]> {
-		return this.expandOrRefreshTreeNode(session, parentTree);
+		// Always refresh the node if it has an error, otherwise expand it normally
+		let needsRefresh = !!parentTree.errorStateMessage;
+		return this.expandOrRefreshTreeNode(session, parentTree, needsRefresh);
 	}
 
 	public refreshTreeNode(session: sqlops.ObjectExplorerSession, parentTree: TreeNode): Thenable<TreeNode[]> {

--- a/src/sqltest/parts/connection/objectExplorerService.test.ts
+++ b/src/sqltest/parts/connection/objectExplorerService.test.ts
@@ -758,10 +758,12 @@ suite('SQL Object Explorer Service tests', () => {
 		await objectExplorerService.createNewSession('MSSQL', connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 
-		// If I call resolveTreeNodeChildren on a node with an error
+		// If I call resolveTreeNodeChildren once, set an error on the node, and then call it again
 		let tablesNodePath = 'testServerName/tables';
 		let tablesNode = new TreeNode(NodeType.Folder, 'Tables', false, tablesNodePath, '', '', null, null, undefined, undefined);
 		tablesNode.connection = connection;
+		await objectExplorerService.resolveTreeNodeChildren(objectExplorerSession, tablesNode);
+		sqlOEProvider.verify(x => x.refreshNode(TypeMoq.It.is(x => x.nodePath === tablesNodePath)), TypeMoq.Times.never());
 		tablesNode.errorStateMessage = 'test error message';
 		await objectExplorerService.resolveTreeNodeChildren(objectExplorerSession, tablesNode);
 

--- a/src/sqltest/parts/connection/objectExplorerService.test.ts
+++ b/src/sqltest/parts/connection/objectExplorerService.test.ts
@@ -753,4 +753,19 @@ suite('SQL Object Explorer Service tests', () => {
 			assert.equal(childNode.nodePath, objectExplorerExpandInfoRefresh.nodes[index].nodePath);
 		});
 	});
+
+	test('resolveTreeNodeChildren refreshes a node if it currently has an error', async () => {
+		await objectExplorerService.createNewSession('MSSQL', connection);
+		objectExplorerService.onSessionCreated(1, objectExplorerSession);
+
+		// If I call resolveTreeNodeChildren on a node with an error
+		let tablesNodePath = 'testServerName/tables';
+		let tablesNode = new TreeNode(NodeType.Folder, 'Tables', false, tablesNodePath, '', '', null, null, undefined, undefined);
+		tablesNode.connection = connection;
+		tablesNode.errorStateMessage = 'test error message';
+		await objectExplorerService.resolveTreeNodeChildren(objectExplorerSession, tablesNode);
+
+		// Then refresh gets called on the node
+		sqlOEProvider.verify(x => x.refreshNode(TypeMoq.It.is(x => x.nodePath === tablesNodePath)), TypeMoq.Times.once());
+	});
 });

--- a/src/vs/base/parts/tree/browser/treeModel.ts
+++ b/src/vs/base/parts/tree/browser/treeModel.ts
@@ -361,12 +361,6 @@ export class Item {
 			return WinJS.TPromise.as(false);
 		}
 
-		// {{SQL CARBON EDIT}} - Original code does not handle the need to refresh children in case previous refreshchildren errored out.
-		//						 resetting the errorStateMessage before we refresh children so we can track if there has been error in processing.
-		if (this.element instanceof TreeNode) {
-			this.element.errorStateMessage = null;
-		}
-
 		var result = this.lock.run(this, () => {
 			var eventData: IItemExpandEvent = { item: this };
 			var result: WinJS.Promise;


### PR DESCRIPTION
If an OE expand operation failed with a timeout or other error then whenever the user tried to reexpand the node it would just pop up the same error message again instead of retrying. This change makes the code call refresh if the node has an error