### PR TITLE
Fix bug where connections edited in connection dialog moved to bottom of group

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.39",
+	"version": "1.5.0-alpha.41",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.1.zip",
 		"Windows_64": "win-x64-netcoreapp2.1.zip",

--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.34",
+	"version": "1.5.0-alpha.39",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.1.zip",
 		"Windows_64": "win-x64-netcoreapp2.1.zip",

--- a/src/sql/parts/connection/common/connectionConfig.ts
+++ b/src/sql/parts/connection/common/connectionConfig.ts
@@ -84,12 +84,13 @@ export class ConnectionConfig implements IConnectionConfig {
 						return providerConnectionProfile.matches(connectionProfile);
 					});
 					if (sameProfileInList) {
-						profiles = profiles.filter(value => value !== sameProfileInList);
+						let profileIndex = profiles.findIndex(value => value === sameProfileInList);
 						newProfile.id = sameProfileInList.id;
 						connectionProfile.id = sameProfileInList.id;
+						profiles[profileIndex] = newProfile;
+					} else {
+						profiles.push(newProfile);
 					}
-
-					profiles.push(newProfile);
 
 					this.writeConfiguration(Constants.connectionsArrayName, profiles).then(() => {
 						resolve(connectionProfile);


### PR DESCRIPTION
Right now if you open the connection dialog and choose an existing connection and then connect, or if you try to connect to a server with an unsaved password and then fill in the password in the dialog once it pops up, the saved connection jumps to the bottom of its group in OE. This code changes the connection saving logic so that the ordering won't change when a connection is edited.

I also increased the Tools Service version to bring in my other OE fixes