### PR TITLE
Restore grids when maximized

### DIFF
--- a/src/sql/parts/query/editor/gridPanel.ts
+++ b/src/sql/parts/query/editor/gridPanel.ts
@@ -242,6 +242,7 @@ export class GridPanel extends ViewletPanel {
 		}
 		dispose(this.tables);
 		this.tables = [];
+		this.maximizedGrid = undefined;
 
 		this.maximumBodySize = this.tables.reduce((p, c) => {
 			return p + c.maximumSize;


### PR DESCRIPTION
fixes #2743 
This properly handles reset to make grids show up after rerunning after maximizing.

This doesn't maintain the maximized grid, it basically resets the table states. Not sure if we want to restore the maximized state or not.