### PR TITLE
🔧 (Launch.json) Fix Invalid Configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -148,7 +148,7 @@
 		{
 			"name": "Renderer and Extension Host processes",
 			"configurations": [
-				"Launch SQL Ops",
+				"Launch azuredatastudio",
 				"Attach to Extension Host"
 			]
 		}


### PR DESCRIPTION
🔧 Fix Invalid Configuration in Launch.json [732038c]
- There was an invalid configuration in the launch.json that was based on original SQL Ops brand. All other configurations were referencing `Launch azuredatastudio`. 