### PR TITLE
Fixed when right clicking and selecting Manage-correct name displays

### DIFF
--- a/src/sql/parts/dashboard/dashboardInput.ts
+++ b/src/sql/parts/dashboard/dashboardInput.ts
@@ -90,6 +90,9 @@ export class DashboardInput extends EditorInput {
 			// Only add DB name if this is a non-default, non-master connection
 			name = name + ':' + this.connectionProfile.databaseName;
 		}
+		if (this.connectionProfile.connectionName !== null &&  this.connectionProfile.connectionName !== undefined){
+			return this.connectionProfile.connectionName;
+		}
 		return name;
 	}
 

--- a/src/sql/parts/dashboard/dashboardInput.ts
+++ b/src/sql/parts/dashboard/dashboardInput.ts
@@ -84,13 +84,13 @@ export class DashboardInput extends EditorInput {
 			return '';
 		}
 
-		let name = this.connectionProfile.serverName;
+		let name = this.connectionProfile.connectionName ? this.connectionProfile.connectionName : this.connectionProfile.serverName;
 		if (this.connectionProfile.databaseName
 			&& !this.isMasterMssql()) {
 			// Only add DB name if this is a non-default, non-master connection
 			name = name + ':' + this.connectionProfile.databaseName;
 		}
-		return this.connectionProfile.connectionName ? this.connectionProfile.connectionName : name;
+		return name;
 	}
 
 	private isMasterMssql(): boolean {

--- a/src/sql/parts/dashboard/dashboardInput.ts
+++ b/src/sql/parts/dashboard/dashboardInput.ts
@@ -90,10 +90,7 @@ export class DashboardInput extends EditorInput {
 			// Only add DB name if this is a non-default, non-master connection
 			name = name + ':' + this.connectionProfile.databaseName;
 		}
-		if (this.connectionProfile.connectionName !== null &&  this.connectionProfile.connectionName !== undefined){
-			return this.connectionProfile.connectionName;
-		}
-		return name;
+		return this.connectionProfile.connectionName ? this.connectionProfile.connectionName : name;
 	}
 
 	private isMasterMssql(): boolean {

--- a/src/sql/parts/dashboard/services/breadcrumb.service.ts
+++ b/src/sql/parts/dashboard/services/breadcrumb.service.ts
@@ -60,6 +60,9 @@ export class BreadcrumbService implements IBreadcrumbService {
 	}
 
 	private getServerBreadcrumb(profile: ConnectionProfile): MenuItem {
+		if (profile.connectionName !== null && profile.connectionName !== undefined){
+			return { label: profile.connectionName, routerLink: ['server-dashboard'] };
+		}
 		return { label: profile.serverName, routerLink: ['server-dashboard'] };
 	}
 

--- a/src/sql/parts/dashboard/services/breadcrumb.service.ts
+++ b/src/sql/parts/dashboard/services/breadcrumb.service.ts
@@ -60,10 +60,7 @@ export class BreadcrumbService implements IBreadcrumbService {
 	}
 
 	private getServerBreadcrumb(profile: ConnectionProfile): MenuItem {
-		if (profile.connectionName !== null && profile.connectionName !== undefined){
-			return { label: profile.connectionName, routerLink: ['server-dashboard'] };
-		}
-		return { label: profile.serverName, routerLink: ['server-dashboard'] };
+		return profile.connectionName ? { label: profile.connectionName, routerLink: ['server-dashboard'] } : { label: profile.serverName, routerLink: ['server-dashboard'] };
 	}
 
 	private getDbBreadcrumb(profile: ConnectionProfile): MenuItem {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43353067/46637211-f464e100-cb0f-11e8-9958-e872ea2bd939.png)

Ensuring connection name is used in 'Manage' tab name per this issue:
https://github.com/Microsoft/azuredatastudio/issues/2763