### PR TITLE
Remove os.tmpDir deprecation warning

### DIFF
--- a/extensions/import/package.json
+++ b/extensions/import/package.json
@@ -83,9 +83,8 @@
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#0.2.7",
     "opener": "^1.4.3",
     "service-downloader": "github:anthonydresser/service-downloader#0.1.5",
-    "vscode-extension-telemetry": "^0.0.5",
+    "vscode-extension-telemetry": "0.0.18",
     "vscode-nls": "^3.2.1"
   },
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }

--- a/extensions/import/yarn.lock
+++ b/extensions/import/yarn.lock
@@ -8,9 +8,13 @@ agent-base@4, agent-base@^4.1.0:
   dependencies:
     es6-promisify "^5.0.0"
 
-applicationinsights@0.15.6:
-  version "0.15.6"
-  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-0.15.6.tgz#201a0682c0704fe4bdd9a92d0b2cbe34d2ae5972"
+applicationinsights@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.1.tgz#53446b830fe8d5d619eee2a278b31d3d25030927"
+  dependencies:
+    diagnostic-channel "0.2.0"
+    diagnostic-channel-publishers "0.2.1"
+    zone.js "0.7.6"
 
 base64-js@0.0.8:
   version "0.0.8"
@@ -119,6 +123,16 @@ decompress@^4.2.0:
     make-dir "^1.0.0"
     pify "^2.3.0"
     strip-dirs "^2.0.0"
+
+diagnostic-channel-publishers@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz#8e2d607a8b6d79fe880b548bc58cc6beb288c4f3"
+
+diagnostic-channel@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz#cc99af9612c23fb1fff13612c72f2cbfaa8d5a17"
+  dependencies:
+    semver "^5.3.0"
 
 end-of-stream@^1.0.0:
   version "1.4.1"
@@ -297,6 +311,10 @@ seek-bzip@^1.0.5:
   dependencies:
     commander "~2.8.1"
 
+semver@^5.3.0:
+  version "5.6.0"
+  resolved "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+
 "service-downloader@github:anthonydresser/service-downloader#0.1.5":
   version "0.1.5"
   resolved "https://codeload.github.com/anthonydresser/service-downloader/tar.gz/6ebb0465573cc140e461a22f334260f55ef45546"
@@ -357,12 +375,11 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-vscode-extension-telemetry@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.5.tgz#21e2abb4cbce3326e469ddbb322123b3702f3f85"
+vscode-extension-telemetry@0.0.18:
+  version "0.0.18"
+  resolved "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.18.tgz#602ba20d8c71453aa34533a291e7638f6e5c0327"
   dependencies:
-    applicationinsights "0.15.6"
-    winreg "0.0.13"
+    applicationinsights "1.0.1"
 
 vscode-jsonrpc@3.5.0:
   version "3.5.0"
@@ -389,10 +406,6 @@ vscode-nls@^3.2.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-3.2.4.tgz#2166b4183c8aea884d20727f5449e62be69fd398"
 
-winreg@0.0.13:
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/winreg/-/winreg-0.0.13.tgz#76bfe02e1dd0c9c8275fb9fdf17a9f36846e3483"
-
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -407,3 +420,7 @@ yauzl@^2.4.2:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+zone.js@0.7.6:
+  version "0.7.6"
+  resolved "https://registry.npmjs.org/zone.js/-/zone.js-0.7.6.tgz#fbbc39d3e0261d0986f1ba06306eb3aeb0d22009"


### PR DESCRIPTION
- Import extension used very old version of telemetry. Updating avoids sending deprecation warning to console which CSS requested we fix.