### PR TITLE
Kenvh/editdatatabname

### DIFF
--- a/src/sql/parts/query/services/queryEditorService.ts
+++ b/src/sql/parts/query/services/queryEditorService.ts
@@ -124,7 +124,7 @@ export class QueryEditorService implements IQueryEditorService {
 			try {
 				// Create file path and file URI
 				let objectName = schemaName ? schemaName + '.' + tableName : tableName;
-				let filePath = this.createEditDataFileName(objectName);
+				let filePath = this.createPrefixedSqlFilePlath(objectName);
 				let docUri: URI = URI.from({ scheme: Schemas.untitled, path: filePath });
 
 				// Create a sql document pane with accoutrements
@@ -265,45 +265,26 @@ export class QueryEditorService implements IQueryEditorService {
 	////// Private functions
 
 	private createUntitledSqlFilePath(): string {
-		let sqlFileName = (counter: number): string => {
-			return `${untitledFilePrefix}${counter}`;
-		};
-
-		let counter = 1;
-		// Get document name and check if it exists
-		let filePath = sqlFileName(counter);
-		while (fs.existsSync(filePath)) {
-			counter++;
-			filePath = sqlFileName(counter);
-		}
-
-		// check if this document name already exists in any open documents
-		let untitledEditors = this._untitledEditorService.getAll();
-		while (untitledEditors.find(x => x.getName().toUpperCase() === filePath.toUpperCase())) {
-			counter++;
-			filePath = sqlFileName(counter);
-		}
-
-		return filePath;
+		return this.createPrefixedSqlFilePlath(untitledFilePrefix);
 	}
 
-	private createEditDataFileName(tableName: string): string {
-		let editDataFileName = (counter: number): string => {
-			return `${tableName}_${counter}`;
+	private createPrefixedSqlFilePlath(prefix: string): string {
+		let prefixFileName = (counter: number): string => {
+			return `${prefix}_${counter}`;
 		};
 
 		let counter = 1;
 		// Get document name and check if it exists
-		let filePath = editDataFileName(counter);
+		let filePath = prefixFileName(counter);
 		while (fs.existsSync(filePath)) {
 			counter++;
-			filePath = editDataFileName(counter);
+			filePath = prefixFileName(counter);
 		}
 
 		let untitledEditors = this._untitledEditorService.getAll();
 		while (untitledEditors.find(x => x.getName().toUpperCase() === filePath.toUpperCase())) {
 			counter++;
-			filePath = editDataFileName(counter);
+			filePath = prefixFileName(counter);
 		}
 
 		return filePath;

--- a/src/sql/parts/query/services/queryEditorService.ts
+++ b/src/sql/parts/query/services/queryEditorService.ts
@@ -289,7 +289,7 @@ export class QueryEditorService implements IQueryEditorService {
 
 	private createEditDataFileName(tableName: string): string {
 		let editDataFileName = (counter: number): string => {
-			return encodeURIComponent(`${tableName}_${counter}`);
+			return `${tableName}_${counter}`;
 		};
 
 		let counter = 1;

--- a/src/sql/parts/query/services/queryEditorService.ts
+++ b/src/sql/parts/query/services/queryEditorService.ts
@@ -124,7 +124,7 @@ export class QueryEditorService implements IQueryEditorService {
 			try {
 				// Create file path and file URI
 				let objectName = schemaName ? schemaName + '.' + tableName : tableName;
-				let filePath = this.createPrefixedSqlFilePlath(objectName);
+				let filePath = this.createPrefixedSqlFilePath(objectName);
 				let docUri: URI = URI.from({ scheme: Schemas.untitled, path: filePath });
 
 				// Create a sql document pane with accoutrements
@@ -265,10 +265,10 @@ export class QueryEditorService implements IQueryEditorService {
 	////// Private functions
 
 	private createUntitledSqlFilePath(): string {
-		return this.createPrefixedSqlFilePlath(untitledFilePrefix);
+		return this.createPrefixedSqlFilePath(untitledFilePrefix);
 	}
 
-	private createPrefixedSqlFilePlath(prefix: string): string {
+	private createPrefixedSqlFilePath(prefix: string): string {
 		let prefixFileName = (counter: number): string => {
 			return `${prefix}_${counter}`;
 		};


### PR DESCRIPTION
edit data was escaping the doc URI - this isn't necessary.  The SMO code is doing necessary escaping for scripting functions.  

This change removes the escaping so that the tab has a clean name and refactored slightly the code used to create the editor names.