### PR TITLE
Fix Default Height for Editor Component

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -93,30 +93,6 @@
 			"timeout": 45000
 		},
 		{
-			"type": "chrome",
-			"request": "launch",
-			"name": "Launch azuredatastudio with extension",
-			"windows": {
-				"runtimeExecutable": "${workspaceFolder}/scripts/sql.bat"
-			},
-			"osx": {
-				"runtimeExecutable": "${workspaceFolder}/scripts/sql.sh"
-			},
-			"linux": {
-				"runtimeExecutable": "${workspaceFolder}/scripts/sql.sh"
-			},
-			"urlFilter": "*index.html*",
-			"runtimeArgs": [
-				"--inspect=5875",
-				"--extensionDevelopmentPath=C:\\SqlOpsStudioExtensions\\extensions\\aris"
-			],
-			"skipFiles": [
-				"**/winjs*.js"
-			],
-			"webRoot": "${workspaceFolder}",
-			"timeout": 15000
-		},
-		{
 			"type": "node",
 			"request": "launch",
 			"name": "Unit Tests",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -93,6 +93,30 @@
 			"timeout": 45000
 		},
 		{
+			"type": "chrome",
+			"request": "launch",
+			"name": "Launch azuredatastudio with extension",
+			"windows": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/sql.bat"
+			},
+			"osx": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/sql.sh"
+			},
+			"linux": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/sql.sh"
+			},
+			"urlFilter": "*index.html*",
+			"runtimeArgs": [
+				"--inspect=5875",
+				"--extensionDevelopmentPath=C:\\SqlOpsStudioExtensions\\extensions\\aris"
+			],
+			"skipFiles": [
+				"**/winjs*.js"
+			],
+			"webRoot": "${workspaceFolder}",
+			"timeout": 15000
+		},
+		{
 			"type": "node",
 			"request": "launch",
 			"name": "Unit Tests",

--- a/src/sql/parts/modelComponents/editor.component.ts
+++ b/src/sql/parts/modelComponents/editor.component.ts
@@ -39,6 +39,7 @@ export default class EditorComponent extends ComponentBase implements IComponent
 	private _languageMode: string;
 	private _uri: string;
 	private _isAutoResizable: boolean;
+	private _minimumEditorSize: number;
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef,
@@ -79,6 +80,7 @@ export default class EditorComponent extends ComponentBase implements IComponent
 		this._register(this._editorModel.onDidChangeContent(e => {
 			this.content = this._editorModel.getValue();
 			if (this._isAutoResizable) {
+				this._editor.setMinimumHeight(this._minimumEditorSize);
 				this._editor.setHeightToScrollHeight();
 			}
 
@@ -108,8 +110,9 @@ export default class EditorComponent extends ComponentBase implements IComponent
 		let width: number = this.convertSizeToNumber(this.width);
 
 		let height: number = this.convertSizeToNumber(this.height);
-		if (this._isAutoResizable) {
-			height = this._editor.scrollHeight;
+		if (this._isAutoResizable && this._minimumEditorSize !== undefined) {
+			this._editor.setHeightToScrollHeight();
+			height = Math.max(this._editor.scrollHeight, this._minimumEditorSize);
 		}
 		this._editor.layout(new DOM.Dimension(
 			width && width > 0 ? width : DOM.getContentWidth(this._el.nativeElement),
@@ -152,6 +155,7 @@ export default class EditorComponent extends ComponentBase implements IComponent
 		// Intentionally always updating editorUri as it's wiped out by parent setProperties call.
 		this.editorUri = this._uri;
 		this._isAutoResizable = this.isAutoResizable;
+		this._minimumEditorSize = this.minimumEditorSize;
 	}
 
 	// CSS-bound properties
@@ -177,6 +181,14 @@ export default class EditorComponent extends ComponentBase implements IComponent
 
 	public set isAutoResizable(newValue: boolean) {
 		this.setPropertyFromUI<sqlops.EditorProperties, boolean>((properties, isAutoResizable) => { properties.isAutoResizable = isAutoResizable; }, newValue);
+	}
+
+	public get minimumEditorSize(): number {
+		return this.getPropertyOrDefault<sqlops.EditorProperties, number>((props) => props.minimumEditorSize, this._editor.minimumHeight);
+	}
+
+	public set minimumEditorSize(newValue: number) {
+		this.setPropertyFromUI<sqlops.EditorProperties, number>((properties, minimumEditorSize) => { properties.minimumEditorSize = minimumEditorSize; }, newValue);
 	}
 
 	public get editorUri(): string {

--- a/src/sql/parts/modelComponents/editor.component.ts
+++ b/src/sql/parts/modelComponents/editor.component.ts
@@ -39,7 +39,7 @@ export default class EditorComponent extends ComponentBase implements IComponent
 	private _languageMode: string;
 	private _uri: string;
 	private _isAutoResizable: boolean;
-	private _minimumEditorSize: number;
+	private _minimumHeight: number;
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef,
@@ -80,7 +80,9 @@ export default class EditorComponent extends ComponentBase implements IComponent
 		this._register(this._editorModel.onDidChangeContent(e => {
 			this.content = this._editorModel.getValue();
 			if (this._isAutoResizable) {
-				this._editor.setMinimumHeight(this._minimumEditorSize);
+				if (this._minimumHeight) {
+					this._editor.setMinimumHeight(this._minimumHeight);
+				}
 				this._editor.setHeightToScrollHeight();
 			}
 
@@ -110,9 +112,9 @@ export default class EditorComponent extends ComponentBase implements IComponent
 		let width: number = this.convertSizeToNumber(this.width);
 
 		let height: number = this.convertSizeToNumber(this.height);
-		if (this._isAutoResizable && this._minimumEditorSize !== undefined) {
+		if (this._isAutoResizable) {
 			this._editor.setHeightToScrollHeight();
-			height = Math.max(this._editor.scrollHeight, this._minimumEditorSize);
+			height = Math.max(this._editor.scrollHeight, this._minimumHeight ? this._minimumHeight : 0);
 		}
 		this._editor.layout(new DOM.Dimension(
 			width && width > 0 ? width : DOM.getContentWidth(this._el.nativeElement),
@@ -155,7 +157,7 @@ export default class EditorComponent extends ComponentBase implements IComponent
 		// Intentionally always updating editorUri as it's wiped out by parent setProperties call.
 		this.editorUri = this._uri;
 		this._isAutoResizable = this.isAutoResizable;
-		this._minimumEditorSize = this.minimumEditorSize;
+		this._minimumHeight = this.minimumHeight;
 	}
 
 	// CSS-bound properties
@@ -183,12 +185,12 @@ export default class EditorComponent extends ComponentBase implements IComponent
 		this.setPropertyFromUI<sqlops.EditorProperties, boolean>((properties, isAutoResizable) => { properties.isAutoResizable = isAutoResizable; }, newValue);
 	}
 
-	public get minimumEditorSize(): number {
-		return this.getPropertyOrDefault<sqlops.EditorProperties, number>((props) => props.minimumEditorSize, this._editor.minimumHeight);
+	public get minimumHeight(): number {
+		return this.getPropertyOrDefault<sqlops.EditorProperties, number>((props) => props.minimumHeight, this._editor.minimumHeight);
 	}
 
-	public set minimumEditorSize(newValue: number) {
-		this.setPropertyFromUI<sqlops.EditorProperties, number>((properties, minimumEditorSize) => { properties.minimumEditorSize = minimumEditorSize; }, newValue);
+	public set minimumHeight(newValue: number) {
+		this.setPropertyFromUI<sqlops.EditorProperties, number>((properties, minimumHeight) => { properties.minimumHeight = minimumHeight; }, newValue);
 	}
 
 	public get editorUri(): string {

--- a/src/sql/parts/modelComponents/queryTextEditor.ts
+++ b/src/sql/parts/modelComponents/queryTextEditor.ts
@@ -34,6 +34,7 @@ export class QueryTextEditor extends BaseTextEditor {
 	public static ID = 'modelview.editors.textEditor';
 	private _dimension: DOM.Dimension;
 	private _config: editorCommon.IConfiguration;
+	private _minHeight: number;
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -116,6 +117,11 @@ export class QueryTextEditor extends BaseTextEditor {
 			this._config = new Configuration(undefined, editorWidget.getDomNode());
 		}
 		let editorHeightUsingLines = this._config.editor.lineHeight * editorWidget.getModel().getLineCount();
-		this.setHeight(editorHeightUsingLines);
+		let editorHeightUsingMin = Math.max(editorHeightUsingLines, this._minHeight);
+		this.setHeight(editorHeightUsingMin);
+	}
+
+	public setMinimumHeight(height: number) : void {
+		this._minHeight = height;
 	}
 }

--- a/src/sql/parts/modelComponents/queryTextEditor.ts
+++ b/src/sql/parts/modelComponents/queryTextEditor.ts
@@ -117,8 +117,8 @@ export class QueryTextEditor extends BaseTextEditor {
 			this._config = new Configuration(undefined, editorWidget.getDomNode());
 		}
 		let editorHeightUsingLines = this._config.editor.lineHeight * editorWidget.getModel().getLineCount();
-		let editorHeightUsingMin = Math.max(editorHeightUsingLines, this._minHeight);
-		this.setHeight(editorHeightUsingMin);
+		let editorHeightUsingMinHeight = Math.max(editorHeightUsingLines, this._minHeight);
+		this.setHeight(editorHeightUsingMinHeight);
 	}
 
 	public setMinimumHeight(height: number) : void {

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -722,6 +722,11 @@ declare module 'sqlops' {
 		 */
 		isAutoResizable: boolean;
 
+		/**
+		 * Minimum height for editor component
+		 */
+		minimumEditorSize: number;
+
 	}
 
 	export interface ButtonComponent extends Component, ButtonProperties {

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -595,6 +595,10 @@ declare module 'sqlops' {
 		 * The languge mode for this text editor. The language mode is SQL by default.
 		 */
 		languageMode?: string;
+		/**
+		 * Minimum height for editor component
+		 */
+		minimumHeight?: number;
 	}
 
 	export interface ButtonProperties extends ComponentProperties, ComponentWithIcon {
@@ -725,7 +729,7 @@ declare module 'sqlops' {
 		/**
 		 * Minimum height for editor component
 		 */
-		minimumEditorSize: number;
+		minimumHeight: number;
 
 	}
 

--- a/src/sql/workbench/api/node/extHostModelView.ts
+++ b/src/sql/workbench/api/node/extHostModelView.ts
@@ -913,6 +913,14 @@ class EditorWrapper extends ComponentWrapper implements sqlops.EditorComponent {
 		this.setProperty('isAutoResizable', v);
 	}
 
+	public get minimumEditorSize(): number {
+		return this.properties['minimumEditorSize'];
+	}
+
+	public set minimumEditorSize(v: number) {
+		this.setProperty('minimumEditorSize', v);
+	}
+
 	public get onContentChanged(): vscode.Event<any> {
 		let emitter = this._emitterMap.get(ComponentEventType.onDidChange);
 		return emitter && emitter.event;

--- a/src/sql/workbench/api/node/extHostModelView.ts
+++ b/src/sql/workbench/api/node/extHostModelView.ts
@@ -913,12 +913,12 @@ class EditorWrapper extends ComponentWrapper implements sqlops.EditorComponent {
 		this.setProperty('isAutoResizable', v);
 	}
 
-	public get minimumEditorSize(): number {
-		return this.properties['minimumEditorSize'];
+	public get minimumHeight(): number {
+		return this.properties['minimumHeight'];
 	}
 
-	public set minimumEditorSize(v: number) {
-		this.setProperty('minimumEditorSize', v);
+	public set minimumHeight(v: number) {
+		this.setProperty('minimumHeight', v);
 	}
 
 	public get onContentChanged(): vscode.Event<any> {


### PR DESCRIPTION
Editor component didn't have a minimum height set, so fixing this by passing through a minimum height to EditorComponent. Now, if the scrollable height of the editor is less than the minimum height, we use the minimum height as the height of the component.

Also fixed an issue where the markdown code editor's height was far too high. Now we're calculating the height on the layout() call, which gets called every  time we display the markdown editor.