### PR TITLE
Fix query plan scrollbars

### DIFF
--- a/src/sql/parts/queryPlan/queryPlan.ts
+++ b/src/sql/parts/queryPlan/queryPlan.ts
@@ -45,8 +45,8 @@ export class QueryPlanView implements IPanelView {
 	}
 
 	public layout(dimension: Dimension): void {
-		this.container.style.width = dimension.width.toString() + 'px';
-		this.container.style.height = dimension.height.toString() + 'px';
+		this.container.style.width = dimension.width + 'px';
+		this.container.style.height = dimension.height + 'px';
 	}
 
 	public showPlan(xml: string) {

--- a/src/sql/parts/queryPlan/queryPlan.ts
+++ b/src/sql/parts/queryPlan/queryPlan.ts
@@ -45,6 +45,8 @@ export class QueryPlanView implements IPanelView {
 	}
 
 	public layout(dimension: Dimension): void {
+		this.container.style.width = dimension.width.toString() + 'px';
+		this.container.style.height = dimension.height.toString() + 'px';
 	}
 
 	public showPlan(xml: string) {


### PR DESCRIPTION
Currently the query plan control can have a height larger than the tab panel so the horizontal scrollbar won't be visible.  This sets the height\width on `layout`.