### PR TITLE
Display multi-line messages correctly in query results

### DIFF
--- a/src/sql/parts/query/editor/messagePanel.ts
+++ b/src/sql/parts/query/editor/messagePanel.ts
@@ -154,6 +154,7 @@ export class MessagePanel extends ViewletPanel {
 			this.countMessageLines(message);
 			this.model.messages.push(message);
 		}
+		this.maximumBodySize = this.totalLines * 22;
 		if (hasError) {
 			this.setExpanded(true);
 		}
@@ -177,7 +178,6 @@ export class MessagePanel extends ViewletPanel {
 		let lines = resultMessage.message.split('\n').length;
 		this.messageLineCountMap.set(resultMessage, lines);
 		this.totalLines += lines;
-		this.maximumBodySize = this.totalLines * 22;
 	}
 
 	private reset() {


### PR DESCRIPTION
This modifies how we render query messages to support multi-line messages. Previously new lines were stripped from messages, meaning that things like stack traces did not display correctly, and each message was hardcoded to 22px height since it was only ever a single line. Now the height of each message is calculated dynamically based on the number of lines in the message.

This also fixes a couple other bugs with how we displayed messages:
- Maintains the message scroll position when switching between query tabs, which used to work but broke recently
- If a query returned so many messages that it scrolled the message window the message window would start scrolled all the way down instead of starting at the top

Before:
![Messages window showing multiple errors including stack traces. Each message is displayed on a single line and the user would have to scroll very far to the right to see the stack traces](https://user-images.githubusercontent.com/3758704/47115881-d2a4e180-d214-11e8-879f-bbabc02861b9.png)

After:
![Messages window showing multiple errors including stack traces with proper line breaks in the stack traces and other messages](https://user-images.githubusercontent.com/3758704/47115908-e9e3cf00-d214-11e8-817f-bd7aa7ccfdb6.png)
