### PR TITLE
Remove unhandled exception telemetry

### DIFF
--- a/src/vs/platform/telemetry/browser/errorTelemetry.ts
+++ b/src/vs/platform/telemetry/browser/errorTelemetry.ts
@@ -166,7 +166,8 @@ export default class ErrorTelemetry {
 					"${include}": [ "${ErrorEvent}" ]
 				}
 			*/
-			this._telemetryService.publicLog('UnhandledError', error, true);
+			// {{SQL CARBON EDIT}}
+			//this._telemetryService.publicLog('UnhandledError', error, true);
 		}
 		this._buffer.length = 0;
 	}

--- a/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
@@ -206,35 +206,36 @@ suite('TelemetryService', () => {
 		});
 	}));
 
-	test('Error events', sinon.test(function (this: any) {
+	// {{SQL CARBON EDIT}}
+	// test('Error events', sinon.test(function (this: any) {
 
-		let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
-		Errors.setUnexpectedErrorHandler(() => { });
+	// 	let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+	// 	Errors.setUnexpectedErrorHandler(() => { });
 
-		try {
-			let testAppender = new TestTelemetryAppender();
-			let service = new TelemetryService({ appender: testAppender }, undefined);
-			const errorTelemetry = new ErrorTelemetry(service);
+	// 	try {
+	// 		let testAppender = new TestTelemetryAppender();
+	// 		let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 		const errorTelemetry = new ErrorTelemetry(service);
 
 
-			let e: any = new Error('This is a test.');
-			// for Phantom
-			if (!e.stack) {
-				e.stack = 'blah';
-			}
+	// 		let e: any = new Error('This is a test.');
+	// 		// for Phantom
+	// 		if (!e.stack) {
+	// 			e.stack = 'blah';
+	// 		}
 
-			Errors.onUnexpectedError(e);
-			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-			assert.equal(testAppender.getEventsCount(), 1);
-			assert.equal(testAppender.events[0].eventName, 'UnhandledError');
-			assert.equal(testAppender.events[0].data.msg, 'This is a test.');
+	// 		Errors.onUnexpectedError(e);
+	// 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+	// 		assert.equal(testAppender.getEventsCount(), 1);
+	// 		assert.equal(testAppender.events[0].eventName, 'UnhandledError');
+	// 		assert.equal(testAppender.events[0].data.msg, 'This is a test.');
 
-			errorTelemetry.dispose();
-			service.dispose();
-		} finally {
-			Errors.setUnexpectedErrorHandler(origErrorHandler);
-		}
-	}));
+	// 		errorTelemetry.dispose();
+	// 		service.dispose();
+	// 	} finally {
+	// 		Errors.setUnexpectedErrorHandler(origErrorHandler);
+	// 	}
+	// }));
 
 	// 	test('Unhandled Promise Error events', sinon.test(function() {
 	//
@@ -265,32 +266,32 @@ suite('TelemetryService', () => {
 	// 		}
 	// 	}));
 
-	test('Handle global errors', sinon.test(function (this: any) {
-		let errorStub = sinon.stub();
-		window.onerror = errorStub;
+	// test('Handle global errors', sinon.test(function (this: any) {
+	// 	let errorStub = sinon.stub();
+	// 	window.onerror = errorStub;
 
-		let testAppender = new TestTelemetryAppender();
-		let service = new TelemetryService({ appender: testAppender }, undefined);
-		const errorTelemetry = new ErrorTelemetry(service);
+	// 	let testAppender = new TestTelemetryAppender();
+	// 	let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 	const errorTelemetry = new ErrorTelemetry(service);
 
-		let testError = new Error('test');
-		(<any>window.onerror)('Error Message', 'file.js', 2, 42, testError);
-		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+	// 	let testError = new Error('test');
+	// 	(<any>window.onerror)('Error Message', 'file.js', 2, 42, testError);
+	// 	this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 
-		assert.equal(errorStub.alwaysCalledWithExactly('Error Message', 'file.js', 2, 42, testError), true);
-		assert.equal(errorStub.callCount, 1);
+	// 	assert.equal(errorStub.alwaysCalledWithExactly('Error Message', 'file.js', 2, 42, testError), true);
+	// 	assert.equal(errorStub.callCount, 1);
 
-		assert.equal(testAppender.getEventsCount(), 1);
-		assert.equal(testAppender.events[0].eventName, 'UnhandledError');
-		assert.equal(testAppender.events[0].data.msg, 'Error Message');
-		assert.equal(testAppender.events[0].data.file, 'file.js');
-		assert.equal(testAppender.events[0].data.line, 2);
-		assert.equal(testAppender.events[0].data.column, 42);
-		assert.equal(testAppender.events[0].data.uncaught_error_msg, 'test');
+	// 	assert.equal(testAppender.getEventsCount(), 1);
+	// 	assert.equal(testAppender.events[0].eventName, 'UnhandledError');
+	// 	assert.equal(testAppender.events[0].data.msg, 'Error Message');
+	// 	assert.equal(testAppender.events[0].data.file, 'file.js');
+	// 	assert.equal(testAppender.events[0].data.line, 2);
+	// 	assert.equal(testAppender.events[0].data.column, 42);
+	// 	assert.equal(testAppender.events[0].data.uncaught_error_msg, 'test');
 
-		errorTelemetry.dispose();
-		service.dispose();
-	}));
+	// 	errorTelemetry.dispose();
+	// 	service.dispose();
+	// }));
 
 	test('Error Telemetry removes PII from filename with spaces', sinon.test(function (this: any) {
 		let errorStub = sinon.stub();

--- a/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
@@ -293,29 +293,29 @@ suite('TelemetryService', () => {
 	// 	service.dispose();
 	// }));
 
-	test('Error Telemetry removes PII from filename with spaces', sinon.test(function (this: any) {
-		let errorStub = sinon.stub();
-		window.onerror = errorStub;
-		let settings = new ErrorTestingSettings();
-		let testAppender = new TestTelemetryAppender();
-		let service = new TelemetryService({ appender: testAppender }, undefined);
-		const errorTelemetry = new ErrorTelemetry(service);
+	// test('Error Telemetry removes PII from filename with spaces', sinon.test(function (this: any) {
+	// 	let errorStub = sinon.stub();
+	// 	window.onerror = errorStub;
+	// 	let settings = new ErrorTestingSettings();
+	// 	let testAppender = new TestTelemetryAppender();
+	// 	let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 	const errorTelemetry = new ErrorTelemetry(service);
 
-		let personInfoWithSpaces = settings.personalInfo.slice(0, 2) + ' ' + settings.personalInfo.slice(2);
-		let dangerousFilenameError: any = new Error('dangerousFilename');
-		dangerousFilenameError.stack = settings.stack;
-		(<any>window.onerror)('dangerousFilename', settings.dangerousPathWithImportantInfo.replace(settings.personalInfo, personInfoWithSpaces) + '/test.js', 2, 42, dangerousFilenameError);
-		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+	// 	let personInfoWithSpaces = settings.personalInfo.slice(0, 2) + ' ' + settings.personalInfo.slice(2);
+	// 	let dangerousFilenameError: any = new Error('dangerousFilename');
+	// 	dangerousFilenameError.stack = settings.stack;
+	// 	(<any>window.onerror)('dangerousFilename', settings.dangerousPathWithImportantInfo.replace(settings.personalInfo, personInfoWithSpaces) + '/test.js', 2, 42, dangerousFilenameError);
+	// 	this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
 
-		assert.equal(errorStub.callCount, 1);
-		assert.equal(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo.replace(settings.personalInfo, personInfoWithSpaces)), -1);
-		assert.equal(testAppender.events[0].data.file, settings.importantInfo + '/test.js');
+	// 	assert.equal(errorStub.callCount, 1);
+	// 	assert.equal(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo.replace(settings.personalInfo, personInfoWithSpaces)), -1);
+	// 	assert.equal(testAppender.events[0].data.file, settings.importantInfo + '/test.js');
 
-		errorTelemetry.dispose();
-		service.dispose();
-	}));
+	// 	errorTelemetry.dispose();
+	// 	service.dispose();
+	// }));
 
-	// {{SQL CARBON EDIT}}
+
 	// test('Uncaught Error Telemetry removes PII from filename', sinon.test(function (this: any) {
 	// 	let errorStub = sinon.stub();
 	// 	window.onerror = errorStub;

--- a/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
@@ -315,408 +315,409 @@ suite('TelemetryService', () => {
 		service.dispose();
 	}));
 
-	test('Uncaught Error Telemetry removes PII from filename', sinon.test(function (this: any) {
-		let errorStub = sinon.stub();
-		window.onerror = errorStub;
-		let settings = new ErrorTestingSettings();
-		let testAppender = new TestTelemetryAppender();
-		let service = new TelemetryService({ appender: testAppender }, undefined);
-		const errorTelemetry = new ErrorTelemetry(service);
-
-		let dangerousFilenameError: any = new Error('dangerousFilename');
-		dangerousFilenameError.stack = settings.stack;
-		(<any>window.onerror)('dangerousFilename', settings.dangerousPathWithImportantInfo + '/test.js', 2, 42, dangerousFilenameError);
-		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-		assert.equal(errorStub.callCount, 1);
-		assert.equal(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo), -1);
-
-		dangerousFilenameError = new Error('dangerousFilename');
-		dangerousFilenameError.stack = settings.stack;
-		(<any>window.onerror)('dangerousFilename', settings.dangerousPathWithImportantInfo + '/test.js', 2, 42, dangerousFilenameError);
-		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-		assert.equal(errorStub.callCount, 2);
-		assert.equal(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo), -1);
-		assert.equal(testAppender.events[0].data.file, settings.importantInfo + '/test.js');
-
-		errorTelemetry.dispose();
-		service.dispose();
-	}));
-
-	test('Unexpected Error Telemetry removes PII', sinon.test(function (this: any) {
-		let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
-		Errors.setUnexpectedErrorHandler(() => { });
-		try {
-			let settings = new ErrorTestingSettings();
-			let testAppender = new TestTelemetryAppender();
-			let service = new TelemetryService({ appender: testAppender }, undefined);
-			const errorTelemetry = new ErrorTelemetry(service);
-
-			let dangerousPathWithoutImportantInfoError: any = new Error(settings.dangerousPathWithoutImportantInfo);
-			dangerousPathWithoutImportantInfoError.stack = settings.stack;
-			Errors.onUnexpectedError(dangerousPathWithoutImportantInfoError);
-			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
-
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
-
-			errorTelemetry.dispose();
-			service.dispose();
-		}
-		finally {
-			Errors.setUnexpectedErrorHandler(origErrorHandler);
-		}
-	}));
-
-	test('Uncaught Error Telemetry removes PII', sinon.test(function (this: any) {
-		let errorStub = sinon.stub();
-		window.onerror = errorStub;
-		let settings = new ErrorTestingSettings();
-		let testAppender = new TestTelemetryAppender();
-		let service = new TelemetryService({ appender: testAppender }, undefined);
-		const errorTelemetry = new ErrorTelemetry(service);
-
-		let dangerousPathWithoutImportantInfoError: any = new Error('dangerousPathWithoutImportantInfo');
-		dangerousPathWithoutImportantInfoError.stack = settings.stack;
-		(<any>window.onerror)(settings.dangerousPathWithoutImportantInfo, 'test.js', 2, 42, dangerousPathWithoutImportantInfoError);
-		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-		assert.equal(errorStub.callCount, 1);
-		// Test that no file information remains, esp. personal info
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
-		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
-
-		errorTelemetry.dispose();
-		service.dispose();
-	}));
-
-	test('Unexpected Error Telemetry removes PII but preserves Code file path', sinon.test(function (this: any) {
-
-		let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
-		Errors.setUnexpectedErrorHandler(() => { });
-
-		try {
-			let settings = new ErrorTestingSettings();
-			let testAppender = new TestTelemetryAppender();
-			let service = new TelemetryService({ appender: testAppender }, undefined);
-			const errorTelemetry = new ErrorTelemetry(service);
-
-			let dangerousPathWithImportantInfoError: any = new Error(settings.dangerousPathWithImportantInfo);
-			dangerousPathWithImportantInfoError.stack = settings.stack;
-
-			// Test that important information remains but personal info does not
-			Errors.onUnexpectedError(dangerousPathWithImportantInfoError);
-			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-			assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
-
-			errorTelemetry.dispose();
-			service.dispose();
-		}
-		finally {
-			Errors.setUnexpectedErrorHandler(origErrorHandler);
-		}
-	}));
-
-	test('Uncaught Error Telemetry removes PII but preserves Code file path', sinon.test(function (this: any) {
-		let errorStub = sinon.stub();
-		window.onerror = errorStub;
-		let settings = new ErrorTestingSettings();
-		let testAppender = new TestTelemetryAppender();
-		let service = new TelemetryService({ appender: testAppender }, undefined);
-		const errorTelemetry = new ErrorTelemetry(service);
-
-		let dangerousPathWithImportantInfoError: any = new Error('dangerousPathWithImportantInfo');
-		dangerousPathWithImportantInfoError.stack = settings.stack;
-		(<any>window.onerror)(settings.dangerousPathWithImportantInfo, 'test.js', 2, 42, dangerousPathWithImportantInfoError);
-		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-		assert.equal(errorStub.callCount, 1);
-		// Test that important information remains but personal info does not
-		assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
-		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
-		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
-
-		errorTelemetry.dispose();
-		service.dispose();
-	}));
-
-	test('Unexpected Error Telemetry removes PII but preserves Code file path with node modules', sinon.test(function (this: any) {
-
-		let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
-		Errors.setUnexpectedErrorHandler(() => { });
-
-		try {
-			let settings = new ErrorTestingSettings();
-			let testAppender = new TestTelemetryAppender();
-			let service = new TelemetryService({ appender: testAppender }, undefined);
-			const errorTelemetry = new ErrorTelemetry(service);
-
-			let dangerousPathWithImportantInfoError: any = new Error(settings.dangerousPathWithImportantInfo);
-			dangerousPathWithImportantInfoError.stack = settings.stack;
-
-
-			Errors.onUnexpectedError(dangerousPathWithImportantInfoError);
-			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf('(' + settings.nodeModuleAsarPathToRetain), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf('(' + settings.nodeModulePathToRetain), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf('(/' + settings.nodeModuleAsarPathToRetain), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf('(/' + settings.nodeModulePathToRetain), -1);
-
-			errorTelemetry.dispose();
-			service.dispose();
-		}
-		finally {
-			Errors.setUnexpectedErrorHandler(origErrorHandler);
-		}
-	}));
-
-	test('Uncaught Error Telemetry removes PII but preserves Code file path', sinon.test(function (this: any) {
-		let errorStub = sinon.stub();
-		window.onerror = errorStub;
-		let settings = new ErrorTestingSettings();
-		let testAppender = new TestTelemetryAppender();
-		let service = new TelemetryService({ appender: testAppender }, undefined);
-		const errorTelemetry = new ErrorTelemetry(service);
-
-		let dangerousPathWithImportantInfoError: any = new Error('dangerousPathWithImportantInfo');
-		dangerousPathWithImportantInfoError.stack = settings.stack;
-		(<any>window.onerror)(settings.dangerousPathWithImportantInfo, 'test.js', 2, 42, dangerousPathWithImportantInfoError);
-		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-		assert.equal(errorStub.callCount, 1);
-
-		assert.notEqual(testAppender.events[0].data.callstack.indexOf('(' + settings.nodeModuleAsarPathToRetain), -1);
-		assert.notEqual(testAppender.events[0].data.callstack.indexOf('(' + settings.nodeModulePathToRetain), -1);
-		assert.notEqual(testAppender.events[0].data.callstack.indexOf('(/' + settings.nodeModuleAsarPathToRetain), -1);
-		assert.notEqual(testAppender.events[0].data.callstack.indexOf('(/' + settings.nodeModulePathToRetain), -1);
-
-		errorTelemetry.dispose();
-		service.dispose();
-	}));
-
-
-	test('Unexpected Error Telemetry removes PII but preserves Code file path when PIIPath is configured', sinon.test(function (this: any) {
-
-		let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
-		Errors.setUnexpectedErrorHandler(() => { });
-
-		try {
-			let settings = new ErrorTestingSettings();
-			let testAppender = new TestTelemetryAppender();
-			let service = new TelemetryService({ appender: testAppender, piiPaths: [settings.personalInfo + '/resources/app/'] }, undefined);
-			const errorTelemetry = new ErrorTelemetry(service);
-
-			let dangerousPathWithImportantInfoError: any = new Error(settings.dangerousPathWithImportantInfo);
-			dangerousPathWithImportantInfoError.stack = settings.stack;
-
-			// Test that important information remains but personal info does not
-			Errors.onUnexpectedError(dangerousPathWithImportantInfoError);
-			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-			assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
-
-			errorTelemetry.dispose();
-			service.dispose();
-		}
-		finally {
-			Errors.setUnexpectedErrorHandler(origErrorHandler);
-		}
-	}));
-
-	test('Uncaught Error Telemetry removes PII but preserves Code file path when PIIPath is configured', sinon.test(function (this: any) {
-		let errorStub = sinon.stub();
-		window.onerror = errorStub;
-		let settings = new ErrorTestingSettings();
-		let testAppender = new TestTelemetryAppender();
-		let service = new TelemetryService({ appender: testAppender, piiPaths: [settings.personalInfo + '/resources/app/'] }, undefined);
-		const errorTelemetry = new ErrorTelemetry(service);
-
-		let dangerousPathWithImportantInfoError: any = new Error('dangerousPathWithImportantInfo');
-		dangerousPathWithImportantInfoError.stack = settings.stack;
-		(<any>window.onerror)(settings.dangerousPathWithImportantInfo, 'test.js', 2, 42, dangerousPathWithImportantInfoError);
-		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-		assert.equal(errorStub.callCount, 1);
-		// Test that important information remains but personal info does not
-		assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
-		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
-		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
-
-		errorTelemetry.dispose();
-		service.dispose();
-	}));
-
-	test('Unexpected Error Telemetry removes PII but preserves Missing Model error message', sinon.test(function (this: any) {
-
-		let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
-		Errors.setUnexpectedErrorHandler(() => { });
-
-		try {
-			let settings = new ErrorTestingSettings();
-			let testAppender = new TestTelemetryAppender();
-			let service = new TelemetryService({ appender: testAppender }, undefined);
-			const errorTelemetry = new ErrorTelemetry(service);
-
-			let missingModelError: any = new Error(settings.missingModelMessage);
-			missingModelError.stack = settings.stack;
-
-			// Test that no file information remains, but this particular
-			// error message does (Received model events for missing model)
-			Errors.onUnexpectedError(missingModelError);
-			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-			assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.missingModelPrefix), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.missingModelPrefix), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
-
-			errorTelemetry.dispose();
-			service.dispose();
-		} finally {
-			Errors.setUnexpectedErrorHandler(origErrorHandler);
-		}
-	}));
-
-	test('Uncaught Error Telemetry removes PII but preserves Missing Model error message', sinon.test(function (this: any) {
-		let errorStub = sinon.stub();
-		window.onerror = errorStub;
-		let settings = new ErrorTestingSettings();
-		let testAppender = new TestTelemetryAppender();
-		let service = new TelemetryService({ appender: testAppender }, undefined);
-		const errorTelemetry = new ErrorTelemetry(service);
-
-		let missingModelError: any = new Error('missingModelMessage');
-		missingModelError.stack = settings.stack;
-		(<any>window.onerror)(settings.missingModelMessage, 'test.js', 2, 42, missingModelError);
-		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-		assert.equal(errorStub.callCount, 1);
-		// Test that no file information remains, but this particular
-		// error message does (Received model events for missing model)
-		assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.missingModelPrefix), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
-		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.missingModelPrefix), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
-		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
-
-		errorTelemetry.dispose();
-		service.dispose();
-	}));
-
-	test('Unexpected Error Telemetry removes PII but preserves No Such File error message', sinon.test(function (this: any) {
-
-		let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
-		Errors.setUnexpectedErrorHandler(() => { });
-
-		try {
-			let settings = new ErrorTestingSettings();
-			let testAppender = new TestTelemetryAppender();
-			let service = new TelemetryService({ appender: testAppender }, undefined);
-			const errorTelemetry = new ErrorTelemetry(service);
-
-			let noSuchFileError: any = new Error(settings.noSuchFileMessage);
-			noSuchFileError.stack = settings.stack;
-
-			// Test that no file information remains, but this particular
-			// error message does (ENOENT: no such file or directory)
-			Errors.onUnexpectedError(noSuchFileError);
-			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-			assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.noSuchFilePrefix), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.noSuchFilePrefix), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
-
-			errorTelemetry.dispose();
-			service.dispose();
-		} finally {
-			Errors.setUnexpectedErrorHandler(origErrorHandler);
-		}
-	}));
-
-	test('Uncaught Error Telemetry removes PII but preserves No Such File error message', sinon.test(function (this: any) {
-		let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
-		Errors.setUnexpectedErrorHandler(() => { });
-
-		try {
-			let errorStub = sinon.stub();
-			window.onerror = errorStub;
-			let settings = new ErrorTestingSettings();
-			let testAppender = new TestTelemetryAppender();
-			let service = new TelemetryService({ appender: testAppender }, undefined);
-			const errorTelemetry = new ErrorTelemetry(service);
-
-			let noSuchFileError: any = new Error('noSuchFileMessage');
-			noSuchFileError.stack = settings.stack;
-			(<any>window.onerror)(settings.noSuchFileMessage, 'test.js', 2, 42, noSuchFileError);
-			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
-
-			assert.equal(errorStub.callCount, 1);
-			// Test that no file information remains, but this particular
-			// error message does (ENOENT: no such file or directory)
-			Errors.onUnexpectedError(noSuchFileError);
-			assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.noSuchFilePrefix), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.noSuchFilePrefix), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
-			assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
-			assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
-			assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
-
-			errorTelemetry.dispose();
-			service.dispose();
-		} finally {
-			Errors.setUnexpectedErrorHandler(origErrorHandler);
-		}
-	}));
+	// {{SQL CARBON EDIT}}
+	// test('Uncaught Error Telemetry removes PII from filename', sinon.test(function (this: any) {
+	// 	let errorStub = sinon.stub();
+	// 	window.onerror = errorStub;
+	// 	let settings = new ErrorTestingSettings();
+	// 	let testAppender = new TestTelemetryAppender();
+	// 	let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 	const errorTelemetry = new ErrorTelemetry(service);
+
+	// 	let dangerousFilenameError: any = new Error('dangerousFilename');
+	// 	dangerousFilenameError.stack = settings.stack;
+	// 	(<any>window.onerror)('dangerousFilename', settings.dangerousPathWithImportantInfo + '/test.js', 2, 42, dangerousFilenameError);
+	// 	this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 	assert.equal(errorStub.callCount, 1);
+	// 	assert.equal(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo), -1);
+
+	// 	dangerousFilenameError = new Error('dangerousFilename');
+	// 	dangerousFilenameError.stack = settings.stack;
+	// 	(<any>window.onerror)('dangerousFilename', settings.dangerousPathWithImportantInfo + '/test.js', 2, 42, dangerousFilenameError);
+	// 	this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 	assert.equal(errorStub.callCount, 2);
+	// 	assert.equal(testAppender.events[0].data.file.indexOf(settings.dangerousPathWithImportantInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.file, settings.importantInfo + '/test.js');
+
+	// 	errorTelemetry.dispose();
+	// 	service.dispose();
+	// }));
+
+	// test('Unexpected Error Telemetry removes PII', sinon.test(function (this: any) {
+	// 	let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+	// 	Errors.setUnexpectedErrorHandler(() => { });
+	// 	try {
+	// 		let settings = new ErrorTestingSettings();
+	// 		let testAppender = new TestTelemetryAppender();
+	// 		let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 		const errorTelemetry = new ErrorTelemetry(service);
+
+	// 		let dangerousPathWithoutImportantInfoError: any = new Error(settings.dangerousPathWithoutImportantInfo);
+	// 		dangerousPathWithoutImportantInfoError.stack = settings.stack;
+	// 		Errors.onUnexpectedError(dangerousPathWithoutImportantInfoError);
+	// 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+
+	// 		errorTelemetry.dispose();
+	// 		service.dispose();
+	// 	}
+	// 	finally {
+	// 		Errors.setUnexpectedErrorHandler(origErrorHandler);
+	// 	}
+	// }));
+
+	// test('Uncaught Error Telemetry removes PII', sinon.test(function (this: any) {
+	// 	let errorStub = sinon.stub();
+	// 	window.onerror = errorStub;
+	// 	let settings = new ErrorTestingSettings();
+	// 	let testAppender = new TestTelemetryAppender();
+	// 	let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 	const errorTelemetry = new ErrorTelemetry(service);
+
+	// 	let dangerousPathWithoutImportantInfoError: any = new Error('dangerousPathWithoutImportantInfo');
+	// 	dangerousPathWithoutImportantInfoError.stack = settings.stack;
+	// 	(<any>window.onerror)(settings.dangerousPathWithoutImportantInfo, 'test.js', 2, 42, dangerousPathWithoutImportantInfoError);
+	// 	this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 	assert.equal(errorStub.callCount, 1);
+	// 	// Test that no file information remains, esp. personal info
+	// 	assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+	// 	assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+
+	// 	errorTelemetry.dispose();
+	// 	service.dispose();
+	// }));
+
+	// test('Unexpected Error Telemetry removes PII but preserves Code file path', sinon.test(function (this: any) {
+
+	// 	let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+	// 	Errors.setUnexpectedErrorHandler(() => { });
+
+	// 	try {
+	// 		let settings = new ErrorTestingSettings();
+	// 		let testAppender = new TestTelemetryAppender();
+	// 		let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 		const errorTelemetry = new ErrorTelemetry(service);
+
+	// 		let dangerousPathWithImportantInfoError: any = new Error(settings.dangerousPathWithImportantInfo);
+	// 		dangerousPathWithImportantInfoError.stack = settings.stack;
+
+	// 		// Test that important information remains but personal info does not
+	// 		Errors.onUnexpectedError(dangerousPathWithImportantInfoError);
+	// 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 		assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+
+	// 		errorTelemetry.dispose();
+	// 		service.dispose();
+	// 	}
+	// 	finally {
+	// 		Errors.setUnexpectedErrorHandler(origErrorHandler);
+	// 	}
+	// }));
+
+	// test('Uncaught Error Telemetry removes PII but preserves Code file path', sinon.test(function (this: any) {
+	// 	let errorStub = sinon.stub();
+	// 	window.onerror = errorStub;
+	// 	let settings = new ErrorTestingSettings();
+	// 	let testAppender = new TestTelemetryAppender();
+	// 	let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 	const errorTelemetry = new ErrorTelemetry(service);
+
+	// 	let dangerousPathWithImportantInfoError: any = new Error('dangerousPathWithImportantInfo');
+	// 	dangerousPathWithImportantInfoError.stack = settings.stack;
+	// 	(<any>window.onerror)(settings.dangerousPathWithImportantInfo, 'test.js', 2, 42, dangerousPathWithImportantInfoError);
+	// 	this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 	assert.equal(errorStub.callCount, 1);
+	// 	// Test that important information remains but personal info does not
+	// 	assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+	// 	assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+	// 	assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+
+	// 	errorTelemetry.dispose();
+	// 	service.dispose();
+	// }));
+
+	// test('Unexpected Error Telemetry removes PII but preserves Code file path with node modules', sinon.test(function (this: any) {
+
+	// 	let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+	// 	Errors.setUnexpectedErrorHandler(() => { });
+
+	// 	try {
+	// 		let settings = new ErrorTestingSettings();
+	// 		let testAppender = new TestTelemetryAppender();
+	// 		let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 		const errorTelemetry = new ErrorTelemetry(service);
+
+	// 		let dangerousPathWithImportantInfoError: any = new Error(settings.dangerousPathWithImportantInfo);
+	// 		dangerousPathWithImportantInfoError.stack = settings.stack;
+
+
+	// 		Errors.onUnexpectedError(dangerousPathWithImportantInfoError);
+	// 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf('(' + settings.nodeModuleAsarPathToRetain), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf('(' + settings.nodeModulePathToRetain), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf('(/' + settings.nodeModuleAsarPathToRetain), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf('(/' + settings.nodeModulePathToRetain), -1);
+
+	// 		errorTelemetry.dispose();
+	// 		service.dispose();
+	// 	}
+	// 	finally {
+	// 		Errors.setUnexpectedErrorHandler(origErrorHandler);
+	// 	}
+	// }));
+
+	// test('Uncaught Error Telemetry removes PII but preserves Code file path', sinon.test(function (this: any) {
+	// 	let errorStub = sinon.stub();
+	// 	window.onerror = errorStub;
+	// 	let settings = new ErrorTestingSettings();
+	// 	let testAppender = new TestTelemetryAppender();
+	// 	let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 	const errorTelemetry = new ErrorTelemetry(service);
+
+	// 	let dangerousPathWithImportantInfoError: any = new Error('dangerousPathWithImportantInfo');
+	// 	dangerousPathWithImportantInfoError.stack = settings.stack;
+	// 	(<any>window.onerror)(settings.dangerousPathWithImportantInfo, 'test.js', 2, 42, dangerousPathWithImportantInfoError);
+	// 	this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 	assert.equal(errorStub.callCount, 1);
+
+	// 	assert.notEqual(testAppender.events[0].data.callstack.indexOf('(' + settings.nodeModuleAsarPathToRetain), -1);
+	// 	assert.notEqual(testAppender.events[0].data.callstack.indexOf('(' + settings.nodeModulePathToRetain), -1);
+	// 	assert.notEqual(testAppender.events[0].data.callstack.indexOf('(/' + settings.nodeModuleAsarPathToRetain), -1);
+	// 	assert.notEqual(testAppender.events[0].data.callstack.indexOf('(/' + settings.nodeModulePathToRetain), -1);
+
+	// 	errorTelemetry.dispose();
+	// 	service.dispose();
+	// }));
+
+
+	// test('Unexpected Error Telemetry removes PII but preserves Code file path when PIIPath is configured', sinon.test(function (this: any) {
+
+	// 	let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+	// 	Errors.setUnexpectedErrorHandler(() => { });
+
+	// 	try {
+	// 		let settings = new ErrorTestingSettings();
+	// 		let testAppender = new TestTelemetryAppender();
+	// 		let service = new TelemetryService({ appender: testAppender, piiPaths: [settings.personalInfo + '/resources/app/'] }, undefined);
+	// 		const errorTelemetry = new ErrorTelemetry(service);
+
+	// 		let dangerousPathWithImportantInfoError: any = new Error(settings.dangerousPathWithImportantInfo);
+	// 		dangerousPathWithImportantInfoError.stack = settings.stack;
+
+	// 		// Test that important information remains but personal info does not
+	// 		Errors.onUnexpectedError(dangerousPathWithImportantInfoError);
+	// 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 		assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+
+	// 		errorTelemetry.dispose();
+	// 		service.dispose();
+	// 	}
+	// 	finally {
+	// 		Errors.setUnexpectedErrorHandler(origErrorHandler);
+	// 	}
+	// }));
+
+	// test('Uncaught Error Telemetry removes PII but preserves Code file path when PIIPath is configured', sinon.test(function (this: any) {
+	// 	let errorStub = sinon.stub();
+	// 	window.onerror = errorStub;
+	// 	let settings = new ErrorTestingSettings();
+	// 	let testAppender = new TestTelemetryAppender();
+	// 	let service = new TelemetryService({ appender: testAppender, piiPaths: [settings.personalInfo + '/resources/app/'] }, undefined);
+	// 	const errorTelemetry = new ErrorTelemetry(service);
+
+	// 	let dangerousPathWithImportantInfoError: any = new Error('dangerousPathWithImportantInfo');
+	// 	dangerousPathWithImportantInfoError.stack = settings.stack;
+	// 	(<any>window.onerror)(settings.dangerousPathWithImportantInfo, 'test.js', 2, 42, dangerousPathWithImportantInfoError);
+	// 	this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 	assert.equal(errorStub.callCount, 1);
+	// 	// Test that important information remains but personal info does not
+	// 	assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.importantInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+	// 	assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.importantInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+	// 	assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+
+	// 	errorTelemetry.dispose();
+	// 	service.dispose();
+	// }));
+
+	// test('Unexpected Error Telemetry removes PII but preserves Missing Model error message', sinon.test(function (this: any) {
+
+	// 	let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+	// 	Errors.setUnexpectedErrorHandler(() => { });
+
+	// 	try {
+	// 		let settings = new ErrorTestingSettings();
+	// 		let testAppender = new TestTelemetryAppender();
+	// 		let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 		const errorTelemetry = new ErrorTelemetry(service);
+
+	// 		let missingModelError: any = new Error(settings.missingModelMessage);
+	// 		missingModelError.stack = settings.stack;
+
+	// 		// Test that no file information remains, but this particular
+	// 		// error message does (Received model events for missing model)
+	// 		Errors.onUnexpectedError(missingModelError);
+	// 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 		assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.missingModelPrefix), -1);
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.missingModelPrefix), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+
+	// 		errorTelemetry.dispose();
+	// 		service.dispose();
+	// 	} finally {
+	// 		Errors.setUnexpectedErrorHandler(origErrorHandler);
+	// 	}
+	// }));
+
+	// test('Uncaught Error Telemetry removes PII but preserves Missing Model error message', sinon.test(function (this: any) {
+	// 	let errorStub = sinon.stub();
+	// 	window.onerror = errorStub;
+	// 	let settings = new ErrorTestingSettings();
+	// 	let testAppender = new TestTelemetryAppender();
+	// 	let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 	const errorTelemetry = new ErrorTelemetry(service);
+
+	// 	let missingModelError: any = new Error('missingModelMessage');
+	// 	missingModelError.stack = settings.stack;
+	// 	(<any>window.onerror)(settings.missingModelMessage, 'test.js', 2, 42, missingModelError);
+	// 	this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 	assert.equal(errorStub.callCount, 1);
+	// 	// Test that no file information remains, but this particular
+	// 	// error message does (Received model events for missing model)
+	// 	assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.missingModelPrefix), -1);
+	// 	assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+	// 	assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.missingModelPrefix), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+	// 	assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
+	// 	assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+
+	// 	errorTelemetry.dispose();
+	// 	service.dispose();
+	// }));
+
+	// test('Unexpected Error Telemetry removes PII but preserves No Such File error message', sinon.test(function (this: any) {
+
+	// 	let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+	// 	Errors.setUnexpectedErrorHandler(() => { });
+
+	// 	try {
+	// 		let settings = new ErrorTestingSettings();
+	// 		let testAppender = new TestTelemetryAppender();
+	// 		let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 		const errorTelemetry = new ErrorTelemetry(service);
+
+	// 		let noSuchFileError: any = new Error(settings.noSuchFileMessage);
+	// 		noSuchFileError.stack = settings.stack;
+
+	// 		// Test that no file information remains, but this particular
+	// 		// error message does (ENOENT: no such file or directory)
+	// 		Errors.onUnexpectedError(noSuchFileError);
+	// 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 		assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.noSuchFilePrefix), -1);
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.noSuchFilePrefix), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+
+	// 		errorTelemetry.dispose();
+	// 		service.dispose();
+	// 	} finally {
+	// 		Errors.setUnexpectedErrorHandler(origErrorHandler);
+	// 	}
+	// }));
+
+	// test('Uncaught Error Telemetry removes PII but preserves No Such File error message', sinon.test(function (this: any) {
+	// 	let origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+	// 	Errors.setUnexpectedErrorHandler(() => { });
+
+	// 	try {
+	// 		let errorStub = sinon.stub();
+	// 		window.onerror = errorStub;
+	// 		let settings = new ErrorTestingSettings();
+	// 		let testAppender = new TestTelemetryAppender();
+	// 		let service = new TelemetryService({ appender: testAppender }, undefined);
+	// 		const errorTelemetry = new ErrorTelemetry(service);
+
+	// 		let noSuchFileError: any = new Error('noSuchFileMessage');
+	// 		noSuchFileError.stack = settings.stack;
+	// 		(<any>window.onerror)(settings.noSuchFileMessage, 'test.js', 2, 42, noSuchFileError);
+	// 		this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+	// 		assert.equal(errorStub.callCount, 1);
+	// 		// Test that no file information remains, but this particular
+	// 		// error message does (ENOENT: no such file or directory)
+	// 		Errors.onUnexpectedError(noSuchFileError);
+	// 		assert.notEqual(testAppender.events[0].data.msg.indexOf(settings.noSuchFilePrefix), -1);
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.msg.indexOf(settings.filePrefix), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.noSuchFilePrefix), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.personalInfo), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.indexOf(settings.filePrefix), -1);
+	// 		assert.notEqual(testAppender.events[0].data.callstack.indexOf(settings.stack[4].replace(settings.randomUserFile, settings.anonymizedRandomUserFile)), -1);
+	// 		assert.equal(testAppender.events[0].data.callstack.split('\n').length, settings.stack.length);
+
+	// 		errorTelemetry.dispose();
+	// 		service.dispose();
+	// 	} finally {
+	// 		Errors.setUnexpectedErrorHandler(origErrorHandler);
+	// 	}
+	// }));
 
 	test('Telemetry Service sends events when enableTelemetry is on', sinon.test(function () {
 		let testAppender = new TestTelemetryAppender();


### PR DESCRIPTION
Since we're not using this event in our reporting, let's remove it.