### PR TITLE
make checkbox vertically aligned and remove the x scroll for modaldialog

### DIFF
--- a/src/sql/base/browser/ui/checkbox/checkbox.ts
+++ b/src/sql/base/browser/ui/checkbox/checkbox.ts
@@ -27,6 +27,7 @@ export class Checkbox extends Widget {
 
 		this._el = document.createElement('input');
 		this._el.type = 'checkbox';
+		this._el.style.verticalAlign = 'middle';
 
 		if (opts.ariaLabel) {
 			this._el.setAttribute('aria-label', opts.ariaLabel);
@@ -44,6 +45,7 @@ export class Checkbox extends Widget {
 		});
 
 		this._label = document.createElement('span');
+		this._label.style.verticalAlign = 'middle';
 
 		this.label = opts.label;
 		this.enabled = opts.enabled || true;

--- a/src/sql/platform/dialog/media/dialogModal.css
+++ b/src/sql/platform/dialog/media/dialogModal.css
@@ -21,7 +21,8 @@
 	flex-direction: column;
 	width: 100%;
 	height: 100%;
-	overflow: scroll;
+	overflow-x: hidden;
+	overflow-y: scroll;
 }
 
 .dialogModal-hidden {


### PR DESCRIPTION
1. Make the checkbox and label vertically aligned. there are multiple

Before:

![image](https://user-images.githubusercontent.com/13777222/47530529-b4b42e00-d85f-11e8-85e6-f58d0d264779.png)

![image](https://user-images.githubusercontent.com/13777222/47530697-2ee4b280-d860-11e8-9bb7-af001945141d.png)

After:

![image](https://user-images.githubusercontent.com/13777222/47530756-55a2e900-d860-11e8-9a23-f3eeade582f1.png)

![image](https://user-images.githubusercontent.com/13777222/47530731-458b0980-d860-11e8-8cb5-e55683164f05.png)

2. Also slide in a fix for an issue introduced by my dialog message improvement, Previously there is no scrollbar for the content, I introduced a vertical one, but instead of using overflow-x I used overflow. this caused the h-scrollbar to show up for agent dialogs. here i am setting it to v-scroll only.