### PR TITLE
fix for issue 2719

### DIFF
--- a/src/sql/base/browser/ui/splitview/splitview.css
+++ b/src/sql/base/browser/ui/splitview/splitview.css
@@ -89,10 +89,6 @@
 	-moz-transition-property: width;
 }
 
-.hc-black .split-view-view .action-label {
-	background: none;
-}
-
 .hc-black .split-view-view > .header .action-label:before {
 	top: 4px !important;
 }


### PR DESCRIPTION
the removed css class was designed to hide icon in toolbar when HC theme is selected. but I don't see such rule in other parts of the product or VS Code.