### PR TITLE
fix for issue 3065

### DIFF
--- a/src/sql/parts/commandLine/common/commandLineService.ts
+++ b/src/sql/parts/commandLine/common/commandLineService.ts
@@ -17,18 +17,17 @@ import { IObjectExplorerService } from 'sql/parts/objectExplorer/common/objectEx
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 export class CommandLineService implements ICommandLineProcessing {
-	private _connectionProfile : ConnectionProfile;
+	private _connectionProfile: ConnectionProfile;
 	private _showConnectionDialog: boolean;
 
 	constructor(
-		@IConnectionManagementService private _connectionManagementService : IConnectionManagementService,
-		@ICapabilitiesService private _capabilitiesService : ICapabilitiesService,
-		@IEnvironmentService private _environmentService : IEnvironmentService,
-		@IQueryEditorService private _queryEditorService : IQueryEditorService,
-		@IObjectExplorerService private _objectExplorerService : IObjectExplorerService,
-		@IEditorService private _editorService : IEditorService,
-	)
-	{
+		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
+		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService,
+		@IEnvironmentService private _environmentService: IEnvironmentService,
+		@IQueryEditorService private _queryEditorService: IQueryEditorService,
+		@IObjectExplorerService private _objectExplorerService: IObjectExplorerService,
+		@IEditorService private _editorService: IEditorService,
+	) {
 		let profile = null;
 		if (this._environmentService && this._environmentService.args.server) {
 			profile = new ConnectionProfile(_capabilitiesService, null);
@@ -38,7 +37,7 @@ export class CommandLineService implements ICommandLineProcessing {
 			profile.serverName = _environmentService.args.server;
 			profile.databaseName = _environmentService.args.database ? _environmentService.args.database : '';
 			profile.userName = _environmentService.args.user ? _environmentService.args.user : '';
-			profile.authenticationType = _environmentService.args.integrated ? 'Integrated'  :  'SqlLogin';
+			profile.authenticationType = _environmentService.args.integrated ? 'Integrated' : 'SqlLogin';
 			profile.connectionName = '';
 			profile.setOptionValue('applicationName', Constants.applicationName);
 			profile.setOptionValue('databaseDisplayName', profile.databaseName);
@@ -46,14 +45,13 @@ export class CommandLineService implements ICommandLineProcessing {
 		}
 		this._connectionProfile = profile;
 		const registry = platform.Registry.as<IConnectionProviderRegistry>(ConnectionProviderExtensions.ConnectionProviderContributions);
-		let sqlProvider = registry.getProperties( Constants.mssqlProviderName);
+		let sqlProvider = registry.getProperties(Constants.mssqlProviderName);
 		// We can't connect to object explorer until the MSSQL connection provider is registered
 		if (sqlProvider) {
 			this.processCommandLine();
 		} else {
 			registry.onNewProvider(e => {
-				if (e.id === Constants.mssqlProviderName)
-				{
+				if (e.id === Constants.mssqlProviderName) {
 					this.processCommandLine();
 				}
 			});
@@ -64,14 +62,15 @@ export class CommandLineService implements ICommandLineProcessing {
 		if (!this._connectionProfile && !this._connectionManagementService.hasRegisteredServers()) {
 			// prompt the user for a new connection on startup if no profiles are registered
 			this._connectionManagementService.showConnectionDialog();
-		} else if (this._connectionProfile)	{
-			this._connectionManagementService.connectIfNotConnected(this._connectionProfile, 'connection')
+		} else if (this._connectionProfile) {
+			// Should saving the connection be a command line switch?
+			this._connectionManagementService.connectIfNotConnected(this._connectionProfile, 'connection', true)
 				.then(result => TaskUtilities.newQuery(this._connectionProfile,
-											this._connectionManagementService,
-											this._queryEditorService,
-											this._objectExplorerService,
-											this._editorService))
-				.catch(() => {});
+					this._connectionManagementService,
+					this._queryEditorService,
+					this._objectExplorerService,
+					this._editorService))
+				.catch(() => { });
 		}
 	}
 }

--- a/src/sql/parts/commandLine/common/commandLineService.ts
+++ b/src/sql/parts/commandLine/common/commandLineService.ts
@@ -63,8 +63,7 @@ export class CommandLineService implements ICommandLineProcessing {
 			// prompt the user for a new connection on startup if no profiles are registered
 			this._connectionManagementService.showConnectionDialog();
 		} else if (this._connectionProfile) {
-			// Should saving the connection be a command line switch?
-			this._connectionManagementService.connectIfNotConnected(this._connectionProfile, 'connection', true)
+			this._connectionManagementService.connectIfNotConnected(this._connectionProfile, 'connection')
 				.then(result => TaskUtilities.newQuery(this._connectionProfile,
 					this._connectionManagementService,
 					this._queryEditorService,

--- a/src/sql/parts/connection/common/connectionManagement.ts
+++ b/src/sql/parts/connection/common/connectionManagement.ts
@@ -121,7 +121,7 @@ export interface IConnectionManagementService {
 	 * otherwise tries to make a connection and returns the owner uri when connection is complete
 	 * The purpose is connection by default
 	 */
-	connectIfNotConnected(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection'): Promise<string>;
+	connectIfNotConnected(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection', saveConnection?: boolean): Promise<string>;
 
 	/**
 	 * Adds the successful connection to MRU and send the connection error back to the connection handler for failed connections

--- a/src/sql/parts/connection/common/connectionManagement.ts
+++ b/src/sql/parts/connection/common/connectionManagement.ts
@@ -121,7 +121,7 @@ export interface IConnectionManagementService {
 	 * otherwise tries to make a connection and returns the owner uri when connection is complete
 	 * The purpose is connection by default
 	 */
-	connectIfNotConnected(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection', saveConnection?: boolean): Promise<string>;
+	connectIfNotConnected(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection'): Promise<string>;
 
 	/**
 	 * Adds the successful connection to MRU and send the connection error back to the connection handler for failed connections

--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -374,14 +374,14 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	 * otherwise tries to make a connection and returns the owner uri when connection is complete
 	 * The purpose is connection by default
 	 */
-	public connectIfNotConnected(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection', saveConnecion?: boolean): Promise<string> {
+	public connectIfNotConnected(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection'): Promise<string> {
 		return new Promise<string>((resolve, reject) => {
 			let ownerUri: string = Utils.generateUri(connection, purpose);
 			if (this._connectionStatusManager.isConnected(ownerUri)) {
 				resolve(this._connectionStatusManager.getOriginalOwnerUri(ownerUri));
 			} else {
 				const options: IConnectionCompletionOptions = {
-					saveTheConnection: saveConnecion,
+					saveTheConnection: false,
 					showConnectionDialogOnError: true,
 					showDashboard: purpose === 'dashboard',
 					params: undefined,

--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -374,19 +374,18 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	 * otherwise tries to make a connection and returns the owner uri when connection is complete
 	 * The purpose is connection by default
 	 */
-	public connectIfNotConnected(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection'): Promise<string> {
+	public connectIfNotConnected(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection', saveConnecion?: boolean): Promise<string> {
 		return new Promise<string>((resolve, reject) => {
 			let ownerUri: string = Utils.generateUri(connection, purpose);
 			if (this._connectionStatusManager.isConnected(ownerUri)) {
 				resolve(this._connectionStatusManager.getOriginalOwnerUri(ownerUri));
 			} else {
 				const options: IConnectionCompletionOptions = {
-					// Should saving the connection be a command line switch?
-					saveTheConnection : true,
-					showConnectionDialogOnError : true,
-					showDashboard : purpose === 'dashboard',
-					params : undefined,
-					showFirewallRuleOnError : true,
+					saveTheConnection: saveConnecion,
+					showConnectionDialogOnError: true,
+					showDashboard: purpose === 'dashboard',
+					params: undefined,
+					showFirewallRuleOnError: true,
 				};
 				this.connect(connection, ownerUri, options).then(connectionResult => {
 					if (connectionResult && connectionResult.connected) {


### PR DESCRIPTION
#3065 
aside from the issue tracked in #3065, opening the database dashboard will also cause a connection to be saved in OE.

introduced a parameter so that the commandline can choose whether to save the connection without impacting other features using the connection management service.