### PR TITLE
Use correct foreground color for copy details button

### DIFF
--- a/src/sql/workbench/errorMessageDialog/errorMessageDialog.ts
+++ b/src/sql/workbench/errorMessageDialog/errorMessageDialog.ts
@@ -14,7 +14,7 @@ import { attachButtonStyler, attachModalDialogStyler } from 'sql/common/theme/st
 import { Builder } from 'vs/base/browser/builder';
 import Severity from 'vs/base/common/severity';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
-import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
+import { SIDE_BAR_BACKGROUND, SIDE_BAR_FOREGROUND } from 'vs/workbench/common/theme';
 import { IPartService } from 'vs/workbench/services/part/common/partService';
 import { Event, Emitter } from 'vs/base/common/event';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
@@ -76,7 +76,7 @@ export class ErrorMessageDialog extends Modal {
 		this._copyButton = this.addFooterButton(copyButtonLabel, () => this._clipboardService.writeText(this._messageDetails), 'left');
 		this._copyButton.icon = 'icon scriptToClipboard';
 		this._copyButton.element.title = copyButtonLabel;
-		this._register(attachButtonStyler(this._copyButton, this._themeService, { buttonBackground: SIDE_BAR_BACKGROUND, buttonHoverBackground: SIDE_BAR_BACKGROUND }));
+		this._register(attachButtonStyler(this._copyButton, this._themeService, { buttonBackground: SIDE_BAR_BACKGROUND, buttonHoverBackground: SIDE_BAR_BACKGROUND, buttonForeground: SIDE_BAR_FOREGROUND }));
 	}
 
 	private createStandardButton(label: string, onSelect: () => void): Button {


### PR DESCRIPTION
Fixes a bug where the "Copy details" button on the connection error message pop-up always had white text regardless of its background, making it hard to read on light themes

![Screen shot showing the "Copy details" button with white text on a light grey background in the connection error pop-up on light theme](https://user-images.githubusercontent.com/3758704/48035027-b65edb00-e116-11e8-860d-9c1eafc732b0.png)
