### PR TITLE
Alanren/custom message box location

### DIFF
--- a/src/sql/base/browser/ui/modal/modal.ts
+++ b/src/sql/base/browser/ui/modal/modal.ts
@@ -253,7 +253,7 @@ export abstract class Modal extends Disposable implements IThemable {
 			this._messageElement = this._modalMessageSection.getHTMLElement();
 			this.updateElementVisibility(this._messageElement, false);
 
-			if (!this._useDefaultMessageBoxLocation) {
+			if (this._useDefaultMessageBoxLocation) {
 				parts.push(this._messageElement);
 			}
 		}

--- a/src/sql/base/browser/ui/modal/modal.ts
+++ b/src/sql/base/browser/ui/modal/modal.ts
@@ -72,8 +72,8 @@ const defaultOptions: IModalOptions = {
 };
 
 export abstract class Modal extends Disposable implements IThemable {
-
-	private _messageElement: HTMLElement;
+	protected _useDefaultMessageBoxLocation: boolean = true;
+	protected _messageElement: HTMLElement;
 	private _messageIcon: HTMLElement;
 	private _messageSeverity: Builder;
 	private _messageSummary: Builder;
@@ -253,7 +253,9 @@ export abstract class Modal extends Disposable implements IThemable {
 			this._messageElement = this._modalMessageSection.getHTMLElement();
 			this.updateElementVisibility(this._messageElement, false);
 
-			parts.push(this._messageElement);
+			if (!this._useDefaultMessageBoxLocation) {
+				parts.push(this._messageElement);
+			}
 		}
 
 		// This modal body section refers to the body of of the dialog

--- a/src/sql/platform/dialog/media/dialogModal.css
+++ b/src/sql/platform/dialog/media/dialogModal.css
@@ -16,6 +16,18 @@
 	min-width: 800px;
 }
 
+.dialog-message-and-page-container {
+	display: flex;
+	flex-direction: column;
+	flex: 1 1;
+	overflow: hidden;
+}
+
+.dialogModal-page-container {
+	flex: 1 1;
+	overflow: hidden;
+}
+
 .dialogModal-pane {
 	display: flex;
 	flex-direction: column;

--- a/src/sql/platform/dialog/wizardModal.ts
+++ b/src/sql/platform/dialog/wizardModal.ts
@@ -140,7 +140,7 @@ export class WizardModal extends Modal {
 
 		bodyBuilderObj.div({ class: 'dialog-message-and-page-container' }, (mpContainer) => {
 			this._messageAndPageContainer = mpContainer.getHTMLElement();
-			this._messageAndPageContainer.append(this._messageElement);
+			mpContainer.append(this._messageElement);
 			this._pageContainer = mpContainer.div({ class: 'dialogModal-page-container' }).getHTMLElement();
 		});
 

--- a/src/sql/platform/dialog/wizardModal.ts
+++ b/src/sql/platform/dialog/wizardModal.ts
@@ -34,6 +34,9 @@ export class WizardModal extends Modal {
 	// Wizard HTML elements
 	private _body: HTMLElement;
 
+	private _messageAndPageContainer: HTMLElement;
+	private _pageContainer: HTMLElement;
+
 	// Buttons
 	private _previousButton: Button;
 	private _nextButton: Button;
@@ -53,6 +56,7 @@ export class WizardModal extends Modal {
 		@IClipboardService clipboardService: IClipboardService
 	) {
 		super(_wizard.title, name, partService, telemetryService, clipboardService, themeService, contextKeyService, options);
+		this._useDefaultMessageBoxLocation = false;
 	}
 
 	public layout(): void {
@@ -126,11 +130,20 @@ export class WizardModal extends Modal {
 	}
 
 	protected renderBody(container: HTMLElement): void {
+		let bodyBuilderObj;
 		new Builder(container).div({ class: 'dialogModal-body' }, (bodyBuilder) => {
+			bodyBuilderObj = bodyBuilder;
 			this._body = bodyBuilder.getHTMLElement();
 		});
 
 		this.initializeNavigation(this._body);
+
+		bodyBuilderObj.div({ class: 'dialog-message-and-page-container' }, (mpContainer) => {
+			this._messageAndPageContainer = mpContainer.getHTMLElement();
+			this._messageAndPageContainer.append(this._messageElement);
+			this._pageContainer = mpContainer.div({ class: 'dialogModal-page-container' }).getHTMLElement();
+		});
+
 
 		this._wizard.pages.forEach(page => {
 			this.registerPage(page);
@@ -159,7 +172,7 @@ export class WizardModal extends Modal {
 
 	private registerPage(page: WizardPage): void {
 		let dialogPane = new DialogPane(page.title, page.content, valid => page.notifyValidityChanged(valid), this._instantiationService, this._wizard.displayPageTitles, page.description);
-		dialogPane.createBody(this._body);
+		dialogPane.createBody(this._pageContainer);
 		this._dialogPanes.set(page, dialogPane);
 		page.onUpdate(() => this.setButtonsForPage(this._wizard.currentPage));
 	}


### PR DESCRIPTION
Fix for #3090 

by default the message box will appear under the dialog header, but for wizard, we would like to make it visually associated with the content page, see pic below.

![image](https://user-images.githubusercontent.com/13777222/48084790-80b90100-e1ad-11e8-8440-524c34b4dd90.png)
