### PR TITLE
fix for stop session error and session selection lost issue

### DIFF
--- a/src/sql/parts/profiler/editor/profilerEditor.ts
+++ b/src/sql/parts/profiler/editor/profilerEditor.ts
@@ -468,34 +468,16 @@ export class ProfilerEditor extends BaseEditor {
 			this._connectAction.connected = this.input.state.isConnected;
 
 			if (this.input.state.isConnected) {
-
 				this._updateToolbar();
-				this._sessionSelector.enable();
-				this._profilerService.getXEventSessions(this.input.id).then((r) => {
-					// set undefined result to empty list
-					if (!r) {
-						r = [];
-					}
 
-					this._sessionSelector.setOptions(r);
-					this._sessionsList = r;
-					if ((this.input.sessionName === undefined || this.input.sessionName === '') && this._sessionsList.length > 0) {
-						let sessionIndex: number = 0;
-						let uiState = this._profilerService.getSessionViewState(this.input.id);
-						if (uiState && uiState.previousSessionName) {
-							sessionIndex = this._sessionsList.indexOf(uiState.previousSessionName);
-						} else {
-							this._profilerService.launchCreateSessionDialog(this.input);
-						}
+				// Launch the create session dialog if openning a new window.
+				let uiState = this._profilerService.getSessionViewState(this.input.id);
+				let previousSessionName = uiState && uiState.previousSessionName;
+				if (!this.input.sessionName && !previousSessionName) {
+					this._profilerService.launchCreateSessionDialog(this.input);
+				}
 
-						if (sessionIndex < 0) {
-							sessionIndex = 0;
-						}
-
-						this.input.sessionName = this._sessionsList[sessionIndex];
-						this._sessionSelector.selectWithOptionName(this.input.sessionName);
-					}
-				});
+				this._updateSessionSelector(previousSessionName);
 			} else {
 				this._startAction.enabled = false;
 				this._stopAction.enabled = false;
@@ -521,26 +503,33 @@ export class ProfilerEditor extends BaseEditor {
 			}
 			if (this.input.state.isStopped) {
 				this._updateToolbar();
-				this._sessionSelector.enable();
-				this._profilerService.getXEventSessions(this.input.id).then((r) => {
-					// set undefined result to empty list
-					if (!r) {
-						r = [];
-					}
-
-					this._sessionsList = r;
-					this._sessionSelector.setOptions(r);
-					if ((this.input.sessionName === undefined || this.input.sessionName === '') && this._sessionsList.length > 0) {
-						this.input.sessionName = this._sessionsList[0];
-					}
-
-					if (this.input.sessionName) {
-						this._sessionSelector.selectWithOptionName(this.input.sessionName);
-					}
-
-				});
+				this._updateSessionSelector();
 			}
 		}
+	}
+
+	private _updateSessionSelector(previousSessionName: string = undefined) {
+		this._sessionSelector.enable();
+		this._profilerService.getXEventSessions(this.input.id).then((r) => {
+			if (!r) {
+				r = [];
+			}
+
+			this._sessionSelector.setOptions(r);
+			this._sessionsList = r;
+			if (this._sessionsList.length > 0) {
+				if (!this.input.sessionName) {
+					this.input.sessionName = previousSessionName;
+				}
+
+				if (this._sessionsList.indexOf(this.input.sessionName) === -1) {
+					this.input.sessionName = this._sessionsList[0];
+				}
+
+				this._sessionSelector.selectWithOptionName(this.input.sessionName);
+			};
+		});
+
 	}
 
 	private _updateToolbar(): void {

--- a/src/sql/parts/profiler/service/profilerService.ts
+++ b/src/sql/parts/profiler/service/profilerService.ts
@@ -141,7 +141,11 @@ export class ProfilerService implements IProfilerService {
 			this._sessionMap.get(this._idMap.reverseGet(id)).onSessionStateChanged({ isStopped: true, isPaused: false, isRunning: false });
 			return true;
 		}, (reason) => {
-			this._notificationService.error(reason.message);
+			// The error won't be actionable to the user, so only log it to console.
+			// In case of error, the state of the UI is not usable, makes more sense to
+			// set it to stopped so that user can restart it or pick a different session
+			console.error(reason.message);
+			this._sessionMap.get(this._idMap.reverseGet(id)).onSessionStateChanged({ isStopped: true, isPaused: false, isRunning: false });
 		});
 	}
 

--- a/src/sql/parts/profiler/service/profilerService.ts
+++ b/src/sql/parts/profiler/service/profilerService.ts
@@ -144,7 +144,6 @@ export class ProfilerService implements IProfilerService {
 			// The error won't be actionable to the user, so only log it to console.
 			// In case of error, the state of the UI is not usable, makes more sense to
 			// set it to stopped so that user can restart it or pick a different session
-			console.error(reason.message);
 			this._sessionMap.get(this._idMap.reverseGet(id)).onSessionStateChanged({ isStopped: true, isPaused: false, isRunning: false });
 		});
 	}


### PR DESCRIPTION
1. fix #3123 - this is the UI side of fix, there is another fix at the sqltoolsservice side. basically regardless the error, we will set the UI to allow user to start another session instead of the unrecoverable state. with the service side fix, this should not happen, but just in case.

2. fix the issue that the session selection in the dropdown is lost when switch 2 running profiler editors. previously the code is resetting the collection but not restoring the selection, I refactored the code a bit.