### PR TITLE
Add notebook feature flag that is enabled by default

### DIFF
--- a/src/sql/parts/common/customInputConverter.ts
+++ b/src/sql/parts/common/customInputConverter.ts
@@ -16,7 +16,7 @@ import { QueryResultsInput } from 'sql/parts/query/common/queryResultsInput';
 import { QueryInput } from 'sql/parts/query/common/queryInput';
 import { IQueryEditorOptions } from 'sql/parts/query/common/queryEditorService';
 import { QueryPlanInput } from 'sql/parts/queryPlan/queryPlanInput';
-import { NotebookInput, NotebookInputModel } from 'sql/parts/notebook/notebookInput';
+import { NotebookInput, NotebookInputModel, NotebookInputValidator } from 'sql/parts/notebook/notebookInput';
 import { Extensions, INotebookProviderRegistry } from 'sql/services/notebook/notebookRegistry';
 import { DEFAULT_NOTEBOOK_PROVIDER } from 'sql/services/notebook/notebookService';
 
@@ -57,8 +57,9 @@ export function convertEditorInput(input: EditorInput, options: IQueryEditorOpti
 		}
 
 		//Notebook
+		let notebookValidator = instantiationService.createInstance(NotebookInputValidator);
 		uri = getNotebookEditorUri(input);
-		if(uri){
+		if(uri && notebookValidator.isNotebookEnabled()){
 			//TODO: We need to pass in notebook data either through notebook input or notebook service
 			let fileName: string = 'untitled';
 			let providerId: string = DEFAULT_NOTEBOOK_PROVIDER;
@@ -161,6 +162,8 @@ function getNotebookEditorUri(input: EditorInput): URI {
 	if (!input || !input.getName()) {
 		return undefined;
 	}
+
+
 
 	// If this editor is not already of type notebook input
 	if (!(input instanceof NotebookInput)) {

--- a/src/sql/parts/notebook/notebook.contribution.ts
+++ b/src/sql/parts/notebook/notebook.contribution.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import { Registry } from 'vs/platform/registry/common/platform';
 import { EditorDescriptor, IEditorRegistry, Extensions as EditorExtensions } from 'vs/workbench/browser/editor';
+import { IConfigurationRegistry, Extensions as ConfigExtensions } from 'vs/platform/configuration/common/configurationRegistry';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
-import { IWorkbenchActionRegistry, Extensions } from 'vs/workbench/common/actions';
-import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
+import { MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
 import { Action } from 'vs/base/common/actions';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { TPromise } from 'vs/base/common/winjs.base';
@@ -15,8 +15,9 @@ import URI from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
-import { NotebookInput, NotebookInputModel } from 'sql/parts/notebook/notebookInput';
+import { NotebookInput, NotebookInputModel, notebooksEnabledCondition } from 'sql/parts/notebook/notebookInput';
 import { NotebookEditor } from 'sql/parts/notebook/notebookEditor';
+import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 
 
 let counter = 0;
@@ -25,10 +26,10 @@ let counter = 0;
  * todo: Will remove this code.
  * This is the entry point to open the new Notebook
  */
-export class OpenNotebookAction extends Action {
+export class NewNotebookAction extends Action {
 
-	public static ID = 'OpenNotebookAction';
-	public static LABEL = localize('OpenNotebookAction', 'Open Notebook editor');
+	public static ID = 'workbench.action.newnotebook';
+	public static LABEL = localize('workbench.action.newnotebook.description', 'New Notebook');
 
 	constructor(
 		id: string,
@@ -40,12 +41,11 @@ export class OpenNotebookAction extends Action {
 	}
 
 	public run(): TPromise<void> {
-		return new TPromise<void>((resolve, reject) => {
-			let untitledUri = URI.from({ scheme: Schemas.untitled, path: `Untitled-${counter++}`});
-			let model = new NotebookInputModel(untitledUri, undefined, false, undefined);
-			let input = this._instantiationService.createInstance(NotebookInput, 'modelViewId', model);
-			this._editorService.openEditor(input, { pinned: true });
-		});
+		let title = `Untitled-${counter++}`;
+		let untitledUri = URI.from({ scheme: Schemas.untitled, path: title });
+		let model = new NotebookInputModel(untitledUri, undefined, false, undefined);
+		let input = this._instantiationService.createInstance(NotebookInput, title, model);
+		return this._editorService.openEditor(input, { pinned: true }).then(() => undefined);
 	}
 }
 
@@ -59,15 +59,30 @@ const viewModelEditorDescriptor = new EditorDescriptor(
 Registry.as<IEditorRegistry>(EditorExtensions.Editors)
 	.registerEditor(viewModelEditorDescriptor, [new SyncDescriptor(NotebookInput)]);
 
-// todo: Will remove this code.
-// this is the entry point to open the new Notebook
-let actionRegistry = <IWorkbenchActionRegistry>Registry.as(Extensions.WorkbenchActions);
-actionRegistry.registerWorkbenchAction(
-	new SyncActionDescriptor(
-		OpenNotebookAction,
-		OpenNotebookAction.ID,
-		OpenNotebookAction.LABEL
-	),
-	OpenNotebookAction.LABEL
-);
+// Feature flag for built-in Notebooks. Will be removed in the future.
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigExtensions.Configuration);
+configurationRegistry.registerConfiguration({
+	'id': 'notebook',
+	'title': 'Notebook',
+	'type': 'object',
+	'properties': {
+		'notebook.enabled': {
+			'type': 'boolean',
+			'default': false,
+			'description': localize('notebook.enabledDescription', 'Enable.')
+		}
+	}
+});
 
+// this is the entry point to open the new Notebook
+CommandsRegistry.registerCommand(NewNotebookAction.ID, serviceAccessor => {
+	serviceAccessor.get(IInstantiationService).createInstance(NewNotebookAction, NewNotebookAction.ID, NewNotebookAction.LABEL).run();
+});
+
+MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
+	command: {
+		id: NewNotebookAction.ID,
+		title:NewNotebookAction.LABEL,
+	},
+	when: notebooksEnabledCondition
+});

--- a/src/sql/parts/notebook/notebook.contribution.ts
+++ b/src/sql/parts/notebook/notebook.contribution.ts
@@ -69,7 +69,7 @@ configurationRegistry.registerConfiguration({
 		'notebook.enabled': {
 			'type': 'boolean',
 			'default': false,
-			'description': localize('notebook.enabledDescription', 'Enable.')
+			'description': localize('notebook.enabledDescription', 'Enable viewing notebook files using built-in notebook editor.')
 		}
 	}
 });

--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -10,9 +10,14 @@ import { IEditorModel } from 'vs/platform/editor/common/editor';
 import { EditorInput, EditorModel, ConfirmResult } from 'vs/workbench/common/editor';
 import { Emitter, Event } from 'vs/base/common/event';
 import URI from 'vs/base/common/uri';
+import { IContextKeyService, ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
+
 import { INotebookService } from 'sql/services/notebook/notebookService';
 
 export type ModeViewSaveHandler = (handle: number) => Thenable<boolean>;
+
+export let notebooksEnabledCondition = ContextKeyExpr.equals('config.notebook.enabled', true);
+
 
 export class NotebookInputModel extends EditorModel {
 	private dirty: boolean;
@@ -59,6 +64,16 @@ export class NotebookInputModel extends EditorModel {
 		return TPromise.wrap(true);
 	}
 }
+
+export class NotebookInputValidator {
+
+	constructor(@IContextKeyService private readonly _contextKeyService: IContextKeyService) {}
+
+	public isNotebookEnabled(): boolean {
+		return this._contextKeyService.contextMatchesRules(notebooksEnabledCondition);
+	}
+}
+
 export class NotebookInput extends EditorInput {
 
 	public static ID: string = 'workbench.editorinputs.notebookInput';


### PR DESCRIPTION
- After this, the `notebook.enabled` flag must be set to true when testing notebook integration