### PR TITLE
Stop Showing Overview Rulers in Notebooks

### DIFF
--- a/src/sql/parts/modelComponents/queryTextEditor.ts
+++ b/src/sql/parts/modelComponents/queryTextEditor.ts
@@ -70,6 +70,9 @@ export class QueryTextEditor extends BaseTextEditor {
 			options.minimap = {
 				enabled: false
 			};
+			options.overviewRulerLanes = 0;
+			options.overviewRulerBorder = false;
+			options.hideCursorInOverviewRuler = true;
 		}
 		return options;
 	}

--- a/src/sql/parts/notebook/cellViews/code.css
+++ b/src/sql/parts/notebook/cellViews/code.css
@@ -25,6 +25,12 @@ code-component .toolbarIconRun {
 	background-image: url('../media/dark/execute_cell_inverse.svg');
 }
 
+/* overview ruler */
+code-component .monaco-editor.vs .decorationsOverviewRuler,
+code-component .monaco-editor.vs-dark .decorationsOverviewRuler {
+	visibility: hidden;
+}
+
 code-component .carbon-taskbar .icon {
 	background-size: 20px;
 	width: 40px;


### PR DESCRIPTION
Stop showing overview rulers in notebooks, which clutters up the notebook cells.

There are some options available while creating the editor that hide the majority of the ruler on the right side, but there is one case when a scrollbar-like object will show up on the right hand side of the editor. I tinkered with the various options for quite a while (and managed to break the editor a few times), and didn't have any luck fully hiding the ruler fully, so I decided to hide the decorationsOverviewRuler in CSS for notebook cells only as an extra precaution and step.

Old:
![image](https://user-images.githubusercontent.com/40371649/48528329-3ede2980-e843-11e8-98bb-fda823a33dd2.png)

New:
![image](https://user-images.githubusercontent.com/40371649/48528316-3259d100-e843-11e8-9e37-528863e83db1.png)
