### PR TITLE
Stop line highlighting in notebooks

### DIFF
--- a/src/sql/parts/modelComponents/queryTextEditor.ts
+++ b/src/sql/parts/modelComponents/queryTextEditor.ts
@@ -73,6 +73,7 @@ export class QueryTextEditor extends BaseTextEditor {
 			options.overviewRulerLanes = 0;
 			options.overviewRulerBorder = false;
 			options.hideCursorInOverviewRuler = true;
+			options.renderLineHighlight = 'none';
 		}
 		return options;
 	}


### PR DESCRIPTION
Chatted with Rony, and this was a one-line change. Looking for feedback about what people think with line highlighting on/off.

Before:
![image](https://user-images.githubusercontent.com/40371649/48657049-72ef5100-e9e1-11e8-859b-989534b6be13.png)

After:
![image](https://user-images.githubusercontent.com/40371649/48657023-37548700-e9e1-11e8-8b20-0d08b5c06277.png)

