### PR TITLE
Make resource parameter optional for getSecurityToken API

### DIFF
--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -1912,10 +1912,11 @@ declare module 'sqlops' {
 
 		/**
 		 * Generates a security token by asking the account's provider
-		 * @param {Account} account Account to generate security token for
+		 * @param {Account} account Account to generate security token for (defaults to
+		 * AzureResource.ResourceManagement if not given)
 		 * @return {Thenable<{}>} Promise to return the security token
 		 */
-		export function getSecurityToken(account: Account, resource: AzureResource): Thenable<{}>;
+		export function getSecurityToken(account: Account, resource?: AzureResource): Thenable<{}>;
 
 		/**
 		 * An [event](#Event) which fires when the accounts have changed.

--- a/src/sql/workbench/api/node/extHostAccountManagement.ts
+++ b/src/sql/workbench/api/node/extHostAccountManagement.ts
@@ -13,6 +13,7 @@ import {
 	MainThreadAccountManagementShape,
 	SqlMainContext,
 } from 'sql/workbench/api/node/sqlExtHost.protocol';
+import { AzureResource } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { IMainContext } from 'vs/workbench/api/node/extHost.protocol';
 import { Event, Emitter } from 'vs/base/common/event';
 
@@ -89,7 +90,10 @@ export class ExtHostAccountManagement extends ExtHostAccountManagementShape {
 		return Promise.all(promises).then(() => resultAccounts);
 	}
 
-	public $getSecurityToken(account: sqlops.Account, resource: sqlops.AzureResource): Thenable<{}> {
+	public $getSecurityToken(account: sqlops.Account, resource?: sqlops.AzureResource): Thenable<{}> {
+		if (resource === undefined) {
+			resource = AzureResource.ResourceManagement;
+		}
 		return this.$getAllAccounts().then(() => {
 			for (const handle in this._accounts) {
 				const providerHandle = parseInt(handle);

--- a/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
@@ -97,7 +97,7 @@ export function createApiFactory(
 				getAllAccounts(): Thenable<sqlops.Account[]> {
 					return extHostAccountManagement.$getAllAccounts();
 				},
-				getSecurityToken(account: sqlops.Account, resource: sqlops.AzureResource): Thenable<{}> {
+				getSecurityToken(account: sqlops.Account, resource?: sqlops.AzureResource): Thenable<{}> {
 					return extHostAccountManagement.$getSecurityToken(account, resource);
 				},
 				onDidChangeAccounts(listener: (e: sqlops.DidChangeAccountsParams) => void, thisArgs?: any, disposables?: extHostTypes.Disposable[]) {


### PR DESCRIPTION
I added the `resource` parameter to this API in my AAD changes but it needs to be optional so that it doesn't break any extensions that are already using the API