### PR TITLE
hide the profiler commands meant for internal use

### DIFF
--- a/extensions/profiler/package.json
+++ b/extensions/profiler/package.json
@@ -26,8 +26,7 @@
     "Microsoft.mssql"
   ],
   "contributes": {
-    "commands": [
-      {
+    "commands": [{
         "command": "profiler.newProfiler",
         "title": "Launch Profiler",
         "category": "Profiler"
@@ -49,13 +48,23 @@
       }
     ],
     "menus": {
-      "objectExplorer/item/context": [
+      "commandPalette": [{
+          "command": "profiler.start",
+          "when": "False"
+        },
         {
-          "command": "profiler.newProfiler",
-          "when": "connectionProvider == MSSQL && nodeType && nodeType == Server",
-          "group": "profiler"
+          "command": "profiler.stop",
+          "when": "False"
+        }, {
+          "command": "profiler.openCreateSessionDialog",
+          "when": "False"
         }
-      ]
+      ],
+      "objectExplorer/item/context": [{
+        "command": "profiler.newProfiler",
+        "when": "connectionProvider == MSSQL && nodeType && nodeType == Server",
+        "group": "profiler"
+      }]
     },
     "outputChannels": [
       "sqlprofiler"


### PR DESCRIPTION
#3325 

These 3 commands are for internal use only (by the profiler task bar buttons) and require additional parameters to be passed in. I am hiding them in the command palette to avoid confusion.