### PR TITLE
Hide connection account picker when there are no auth type options

### DIFF
--- a/src/sql/parts/connection/connectionDialog/connectionWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionWidget.ts
@@ -545,6 +545,10 @@ export class ConnectionWidget {
 
 			if (this._authTypeSelectBox) {
 				this.onAuthTypeSelected(this._authTypeSelectBox.value);
+			} else {
+				let tableContainerElement = this._tableContainer.getContainer();
+				tableContainerElement.classList.remove('hide-username-password');
+				tableContainerElement.classList.add('hide-azure-accounts');
 			}
 
 			// Disable connect button if -


### PR DESCRIPTION
The logic I added for hiding/showing the username and password boxes or the Azure account picker only ran if there was an auth type dropdown, which isn't true for all connection providers. This updates it to hide the Azure account picker by default

Fixes #3345 