### PR TITLE
Fixed add multiple connection from "Add new connection" #3387 

### DIFF
--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -314,6 +314,7 @@ export class AttachToDropdown extends SelectBox {
 				attachToConnections = attachToConnections.filter(val => val !== msgSelectConnection);
 
 				let index = attachToConnections.findIndex((connection => connection === connectedServer));
+				this.setOptions([]);
 				this.setOptions(attachToConnections);
 				if (!index || index < 0 || index >= attachToConnections.length) {
 					index = 0;


### PR DESCRIPTION
AttachTo SelectBox options values are update before this.setOptions in openConnectionDialog by somehow. But from code, didn't find any set. So clear the options value before setOptions