### PR TITLE
Set active editor with dirty value before and after save #3411

### DIFF
--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -321,6 +321,9 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	public async save(): Promise<boolean> {
 		try {
 			let saved = await this._model.saveModel();
+			if (saved) {
+				this.setDirty(false);
+			}
 			return saved;
 		} catch (err) {
 			this.notificationService.error(localize('saveFailed', 'Failed to save notebook: {0}', notebookUtils.getErrorMessage(err)));
@@ -329,10 +332,9 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	}
 
 	private setDirty(isDirty: boolean): void {
-		// TODO reenable handling of isDirty
-		// if (this.editor) {
-		//     this.editor.isDirty = isDirty;
-		// }
+		if(this._notebookParams.input){
+			this._notebookParams.input.setDirty(isDirty);
+		}
 	}
 
 	private actionItemProvider(action: Action): IActionItem {

--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -169,4 +169,12 @@ export class NotebookInput extends EditorInput {
 	save(): TPromise<boolean> {
 		return this._model.save();
 	}
+
+	/**
+	 * Sets active editor with dirty value.
+	 * @param isDirty boolean value to set editor dirty
+	 */
+	setDirty(isDirty: boolean): void {
+		this._model.setDirty(isDirty);
+	}
 }


### PR DESCRIPTION
Exposed setDirty method from NotebookInput class
Consumed it in NotebookComponent when there is a change in the content
Set it back after save

![image](https://user-images.githubusercontent.com/44002319/49463941-712dd780-f7ae-11e8-89d6-ac418425a073.png)
