### PR TITLE
Defaulting 'attach to' to localhost when no extension is installed #3419

### DIFF
--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -18,6 +18,7 @@ import { NotebookComponent } from 'sql/parts/notebook/notebook.component';
 import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 import { IConnectionManagementService, IConnectionDialogService } from 'sql/parts/connection/common/connectionManagement';
 import { getErrorMessage } from 'sql/parts/notebook/notebookUtils';
+import { noKernel } from 'sql/services/notebook/sessionManager';
 
 const msgLoading = localize('loading', 'Loading kernels...');
 const kernelLabel: string = localize('Kernel', 'Kernel: ');
@@ -238,7 +239,7 @@ export class AttachToDropdown extends SelectBox {
 
 	// Load "Attach To" dropdown with the values corresponding to Kernel dropdown
 	public async loadAttachToDropdown(model: INotebookModel, currentKernel: string): Promise<void> {
-		if (currentKernel === notebookConstants.python3) {
+		if (currentKernel === notebookConstants.python3 || currentKernel === noKernel) {
 			this.setOptions([msgLocalHost]);
 		}
 		else {

--- a/src/sql/services/notebook/sessionManager.ts
+++ b/src/sql/services/notebook/sessionManager.ts
@@ -4,7 +4,7 @@ import { nb } from 'sqlops';
 import { localize } from 'vs/nls';
 import { FutureInternal } from 'sql/parts/notebook/models/modelInterfaces';
 
-const noKernel: string = localize('noKernel', 'No Kernel');
+export const noKernel: string = localize('noKernel', 'No Kernel');
 const runNotebookDisabled = localize('runNotebookDisabled', 'Cannot run cells as no kernel has been configured');
 
 let noKernelSpec: nb.IKernelSpec = ({
@@ -24,9 +24,9 @@ export class SessionManager implements nb.SessionManager {
 
 	public get specs(): nb.IAllKernels {
 		let allKernels: nb.IAllKernels = {
-            defaultKernel: noKernel,
+			defaultKernel: noKernel,
 			kernels: [noKernelSpec]
-        };
+		};
 		return allKernels;
 	}
 


### PR DESCRIPTION
Assign attach to value as 'localhost' when the kernel is 'No Kernel' which means there is no extension installed.