### PR TITLE
Dispose of query grid memory on tab switch

### DIFF
--- a/src/sql/parts/query/editor/queryResultsView.ts
+++ b/src/sql/parts/query/editor/queryResultsView.ts
@@ -282,6 +282,7 @@ export class QueryResultsView extends Disposable {
 	}
 
 	public dispose() {
+		dispose(this.runnerDisposables);
 		super.dispose();
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Microsoft/azuredatastudio/issues/2899.  I'm not sure if this is only issue impacting #2899, but this fixes the leak in the tab-switching scenario.