### PR TITLE
profiler extension bug fixes

### DIFF
--- a/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
+++ b/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
@@ -9,7 +9,7 @@ import { ServicesAccessor, IInstantiationService } from 'vs/platform/instantiati
 import * as nls from 'vs/nls';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { IEditorService, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
-import { IConnectionManagementService, IConnectionDialogService} from 'sql/parts/connection/common/connectionManagement';
+import { IConnectionManagementService, IConnectionDialogService } from 'sql/parts/connection/common/connectionManagement';
 import { IObjectExplorerService } from '../../objectExplorer/common/objectExplorerService';
 import { ProfilerInput } from 'sql/parts/profiler/editor/profilerInput';
 import { TPromise } from 'vs/base/common/winjs.base';
@@ -55,10 +55,10 @@ CommandsRegistry.registerCommand({
 
 		let promise;
 		if (connectionProfile) {
-			promise = connectionService.connectIfNotConnected(connectionProfile);
+			promise = connectionService.connectIfNotConnected(connectionProfile, 'connection', true);
 		} else {
 			// if still no luck, we will open the Connection dialog and let user connect to a server
-			promise = connectionDialogService.openDialogAndWait(connectionService, { connectionType: 1, providers: [mssqlProviderName] }).then((profile) => {
+			promise = connectionDialogService.openDialogAndWait(connectionService, { connectionType: 0, showDashboard: false, providers: [mssqlProviderName] }).then((profile) => {
 				connectionProfile = profile as ConnectionProfile;
 			});
 		}

--- a/src/sql/parts/profiler/editor/controller/profilerFindWidget.ts
+++ b/src/sql/parts/profiler/editor/controller/profilerFindWidget.ts
@@ -308,8 +308,6 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 	// ----- Public
 
 	public focusFindInput(): void {
-		this._findInput.select();
-		// Edge browser requires focus() in addition to select()
 		this._findInput.focus();
 	}
 

--- a/src/sql/parts/profiler/editor/controller/profilerTableEditor.ts
+++ b/src/sql/parts/profiler/editor/controller/profilerTableEditor.ts
@@ -218,6 +218,7 @@ export class ProfilerTableEditor extends BaseEditor implements IProfilerControll
 						if (p) {
 							this._profilerTable.setActiveCell(p.row, p.col);
 							this._updateFinderMatchState();
+							this._finder.focusFindInput();
 						}
 					});
 				} else {

--- a/src/sql/parts/profiler/editor/profilerEditor.ts
+++ b/src/sql/parts/profiler/editor/profilerEditor.ts
@@ -557,6 +557,7 @@ export class ProfilerEditor extends BaseEditor {
 	}
 
 	public focus() {
+		this._profilerEditorContextKey.set(true);
 		super.focus();
 		let savedViewState = this._savedTableViewStates.get(this.input);
 		if (savedViewState) {

--- a/src/sql/parts/profiler/editor/profilerInput.ts
+++ b/src/sql/parts/profiler/editor/profilerInput.ts
@@ -66,7 +66,8 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 		let searchFn = (val: { [x: string]: string }, exp: string): Array<number> => {
 			let ret = new Array<number>();
 			for (let i = 0; i < this._columns.length; i++) {
-				if (val[this._columns[i]].includes(exp)) {
+				let colVal = val[this._columns[i]];
+				if (colVal && colVal.toLocaleLowerCase().includes(exp.toLocaleLowerCase())) {
 					ret.push(i);
 				}
 			}


### PR DESCRIPTION
Fix the following issues
1. #3379 the focus got moved away from the search box on every keystroke, fix it by moving the focus back to the find input box after locating the 1 occurrence in the grid.
2. show the connection in Object Explorer when starting profiling for a connection
3. The find feature is case sensitive, making it hard to search for strings. 
4. sometimes the search is not working as a result of a missing null check, adding the null check to make search more robust
5. CTRL+F will not able to bring up the search box for profiler table after tab switching, this is caused by the context key not being set properly after the view is re-focused.
