### PR TITLE
Add "Update to ADS" prompt to SQL Ops Studio

### DIFF
--- a/src/vs/workbench/parts/welcome/gettingStarted/electron-browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/parts/welcome/gettingStarted/electron-browser/gettingStarted.contribution.ts
@@ -7,6 +7,7 @@
 import { Registry } from 'vs/platform/registry/common/platform';
 import { GettingStarted } from './gettingStarted';
 import { TelemetryOptOut } from './telemetryOptOut';
+import { UpgradeToAzureDataStudio } from './updateToAzureDataStudio';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 // {{SQL CARBON EDIT}} - Add preview feature switch
@@ -29,3 +30,7 @@ Registry
 Registry
 	.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
 	.registerWorkbenchContribution(EnablePreviewFeatures, LifecyclePhase.Eventually);
+
+Registry
+	.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
+	.registerWorkbenchContribution(UpgradeToAzureDataStudio, LifecyclePhase.Eventually);

--- a/src/vs/workbench/parts/welcome/gettingStarted/electron-browser/updateToAzureDataStudio.ts
+++ b/src/vs/workbench/parts/welcome/gettingStarted/electron-browser/updateToAzureDataStudio.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import URI from 'vs/base/common/uri';
+import { IWindowService, IWindowsService } from 'vs/platform/windows/common/windows';
+
+export class UpgradeToAzureDataStudio implements IWorkbenchContribution {
+	private static AzureDataStudioDownloadLink = 'https://go.microsoft.com/fwlink/?linkid=2049035';
+	private static AzureDataStudioMoreInfoLink = 'https://go.microsoft.com/fwlink/?linkid=2048944';
+
+	constructor(
+		@IOpenerService openerService: IOpenerService,
+		@INotificationService notificationService: INotificationService,
+		@IWindowService windowService: IWindowService,
+		@IWindowsService windowsService: IWindowsService,
+	) {
+		Promise.all([
+			windowService.isFocused(),
+			windowsService.getWindowCount()
+		]).then(([focused, count]) => {
+			if (!focused && count > 1) {
+				return null;
+			}
+
+			notificationService.prompt(
+				Severity.Info,
+				'SQL Operations Studio Preview will no longer receive future updates.  Please download Azure Data Studio for the latest enhancements and bug fixes.  ' +
+				'Upgrading to Azure Data Studio is a 1-time manual process.',
+				[{
+					label: 'Download Now',
+					run: () => openerService.open(URI.parse(UpgradeToAzureDataStudio.AzureDataStudioDownloadLink))
+				},
+				{
+					label: 'More Info',
+					run: () => openerService.open(URI.parse(UpgradeToAzureDataStudio.AzureDataStudioMoreInfoLink))
+				}]
+			);
+		});
+	}
+}


### PR DESCRIPTION
Add an "Update to ADS" prompt to a final SQL Operations Studio release to notify users still on 0.32.9 that a manual upgrade is required to move to current Azure Data Studio builds.  I'll follow-up over email to nail down the exact notification text and URL targets.

![image](https://user-images.githubusercontent.com/599935/49612746-85aed300-f95a-11e8-8225-15da466d0df0.png)
