### PR TITLE
Fix #3470 Notebook: Switching between Servers and File Explorer opens a duplicate notebook

### DIFF
--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -177,4 +177,20 @@ export class NotebookInput extends EditorInput {
 	setDirty(isDirty: boolean): void {
 		this._model.setDirty(isDirty);
 	}
+
+
+	public matches(otherInput: any): boolean {
+		if (super.matches(otherInput) === true) {
+			return true;
+		}
+
+		if (otherInput instanceof NotebookInput) {
+			const otherNotebookEditorInput = <NotebookInput>otherInput;
+
+			// Compare by resource
+			return otherNotebookEditorInput.notebookUri.toString() === this.notebookUri.toString();
+		}
+
+		return false;
+	}
 }


### PR DESCRIPTION
- We missed implementing matches functionality. This is required in order to skip reopening of the notebook