### PR TITLE
Alanren/profiler search

### DIFF
--- a/src/sql/base/browser/ui/table/tableDataView.ts
+++ b/src/sql/base/browser/ui/table/tableDataView.ts
@@ -78,7 +78,7 @@ export class TableDataView<T extends Slick.SlickData> implements IDisposableData
 		this._onRowCountChange.fire();
 	}
 
-	find(exp: string, maxMatches: number = -1): Thenable<IFindPosition> {
+	find(exp: string, maxMatches: number = 0): Thenable<IFindPosition> {
 		if (!this._findFn) {
 			return TPromise.wrapError(new Error('no find function provided'));
 		}

--- a/src/sql/base/browser/ui/table/tableDataView.ts
+++ b/src/sql/base/browser/ui/table/tableDataView.ts
@@ -78,7 +78,7 @@ export class TableDataView<T extends Slick.SlickData> implements IDisposableData
 		this._onRowCountChange.fire();
 	}
 
-	find(exp: string): Thenable<IFindPosition> {
+	find(exp: string, maxMatches: number = -1): Thenable<IFindPosition> {
 		if (!this._findFn) {
 			return TPromise.wrapError(new Error('no find function provided'));
 		}
@@ -87,7 +87,8 @@ export class TableDataView<T extends Slick.SlickData> implements IDisposableData
 		this._onFindCountChange.fire(this._findArray.length);
 		if (exp) {
 			this._findObs = Observable.create((observer: Observer<IFindPosition>) => {
-				this._data.forEach((item, i) => {
+				for (let i = 0; i < this._data.length; i++) {
+					let item = this._data[i];
 					let result = this._findFn(item, exp);
 					if (result) {
 						result.forEach(pos => {
@@ -96,8 +97,11 @@ export class TableDataView<T extends Slick.SlickData> implements IDisposableData
 							observer.next(index);
 							this._onFindCountChange.fire(this._findArray.length);
 						});
+						if (maxMatches > 0 && this._findArray.length > maxMatches) {
+							break;
+						}
 					}
-				});
+				}
 			});
 			return this._findObs.take(1).toPromise().then(() => {
 				return this._findArray[this._findIndex];

--- a/src/sql/parts/profiler/editor/controller/profilerTableEditor.ts
+++ b/src/sql/parts/profiler/editor/controller/profilerTableEditor.ts
@@ -27,6 +27,7 @@ import { Event, Emitter } from 'vs/base/common/event';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { Dimension } from 'vs/base/browser/dom';
 import { textFormatter } from 'sql/parts/grid/services/sharedServices';
+import { PROFILER_MAX_MATCHES } from 'sql/parts/profiler/editor/controller/profilerFindWidget';
 
 export interface ProfilerTableViewState {
 	scrollTop: number;
@@ -214,7 +215,7 @@ export class ProfilerTableEditor extends BaseEditor implements IProfilerControll
 		if (e.searchString) {
 			if (this._input && this._input.data) {
 				if (this._findState.searchString) {
-					this._input.data.find(this._findState.searchString).then(p => {
+					this._input.data.find(this._findState.searchString, PROFILER_MAX_MATCHES).then(p => {
 						if (p) {
 							this._profilerTable.setActiveCell(p.row, p.col);
 							this._updateFinderMatchState();


### PR DESCRIPTION
further improve the search experience for profiler, this is related to #3379 
1. add a delay to prevent each keystroke from triggering a search operation.
2. add the max match count logic. without this, the search could potentially make the UI unresponsive.

![image](https://user-images.githubusercontent.com/13777222/49679624-938b5380-fa41-11e8-9862-564a7dd971fb.png)
