### PR TITLE
Rename notebook editor (fixes #3521)

### DIFF
--- a/src/sql/parts/common/customInputConverter.ts
+++ b/src/sql/parts/common/customInputConverter.ts
@@ -29,7 +29,7 @@ export const untitledFilePrefix = 'SQLQuery';
 
 // mode identifier for SQL mode
 export const sqlModeId = 'sql';
-export const notebookModeId = 'ipynb';
+export const notebookModeId = 'notebook';
 
 /**
  * Checks if the specified input is supported by one our custom input types, and if so convert it
@@ -242,3 +242,17 @@ function hasFileExtension(extensions: string[], input: EditorInput, checkUntitle
 	return false;
 }
 
+// Returns file mode - notebookModeId or sqlModeId
+export function getFileMode(instantiationService: IInstantiationService, resource: URI): string {
+	if (!resource) {
+		return sqlModeId;
+	}
+	return withService<INotebookService, string>(instantiationService, INotebookService, notebookService => {
+		for (const editor of notebookService.listNotebookEditors()) {
+			if (editor.notebookParams.notebookUri === resource) {
+				return notebookModeId;
+			}
+		}
+		return sqlModeId;
+	});
+}

--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -408,7 +408,6 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 					this.saveNotebook().then(result => {
 						if(result)
 						{
-							this.notebookService.renameNotebookEditor(resource, target, this);
 							return this.replaceUntitledNotebookEditor(resource, target);
 						}
 						return result;
@@ -438,6 +437,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 				editor: { resource },
 				replacement
 			}], g))).then(() => {
+				this.notebookService.renameNotebookEditor(resource, target, this);
 				return true;
 			});
 	}

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -29,7 +29,8 @@ import { coalesce } from 'vs/base/common/arrays';
 import { isCodeEditor, isDiffEditor, ICodeEditor, IDiffEditor } from 'vs/editor/browser/editorBrowser';
 import { IEditorGroupView, IEditorOpeningEvent, EditorGroupsServiceImpl, EditorServiceImpl } from 'vs/workbench/browser/parts/editor/editor';
 import { IUriDisplayService } from 'vs/platform/uriDisplay/common/uriDisplay';
-import { convertEditorInput, notebookModeId } from 'sql/parts/common/customInputConverter';
+//{{ SQL CARBON EDIT }}
+import { convertEditorInput, getFileMode } from 'sql/parts/common/customInputConverter';
 
 type ICachedEditorInput = ResourceEditorInput | IFileEditorInput | DataUriEditorInput;
 
@@ -67,7 +68,7 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		@IInstantiationService private instantiationService: IInstantiationService,
 		@IUriDisplayService private uriDisplayService: IUriDisplayService,
 		@IFileService private fileService: IFileService,
-		@IConfigurationService private configurationService: IConfigurationService
+		@IConfigurationService private configurationService: IConfigurationService,
 	) {
 		super();
 
@@ -495,10 +496,11 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		const untitledInput = <IUntitledResourceInput>input;
 		if (!untitledInput.resource || typeof untitledInput.filePath === 'string' || (untitledInput.resource instanceof URI && untitledInput.resource.scheme === Schemas.untitled)) {
 			// {{SQL CARBON EDIT}}
+
+			let mode: string = getFileMode( this.instantiationService, untitledInput.resource);
 			return convertEditorInput(this.untitledEditorService.createOrGet(
 				untitledInput.filePath ? URI.file(untitledInput.filePath) : untitledInput.resource,
-				(untitledInput.resource &&
-				(untitledInput.resource.path.includes('Notebook') || untitledInput.resource.path.includes('Untitled'))) ? notebookModeId: 'sql',
+				mode,
 				untitledInput.contents,
 				untitledInput.encoding
 			), undefined, this.instantiationService);


### PR DESCRIPTION
Sooner the new notebook is saved to local, we have to replace the current editor with the saved one and need to make some changes in editor code base to support notebook file type
1. Replace notebook editor by creating a custom object and pass in both resource and target URI's
2. Replace editor using editor service methods
3. Add code to support ipynb file type
4. Add conditions to support notebook's untitled mode
