### PR TITLE
Remove a style that is breaking the "Clear MRU" list

### DIFF
--- a/src/sql/parts/connection/connectionDialog/media/connectionDialog.css
+++ b/src/sql/parts/connection/connectionDialog/media/connectionDialog.css
@@ -105,10 +105,12 @@
 	background: url('clear-search-results.svg');
 }
 
+/*
 .vs-dark .search-action.clear-search-results,
 .hc-black .search-action.clear-search-results {
 	background: url('clear-search-results-dark.svg');
 }
+*/
 
 .connection-details-title {
 	font-size: 14px;


### PR DESCRIPTION
This is a hacky fix for https://github.com/Microsoft/azuredatastudio/issues/3514 which appears to be related to https://github.com/Microsoft/azuredatastudio/commit/f36f3ffd211b2a6aead709652dd175620a620223#diff-8d7ef5bb586fea22d1506d362b8a2d22.  I'm going to take this fix directly in `release\1.3` branch and a proper fix can be done in master.

![image](https://user-images.githubusercontent.com/599935/49772398-009d2400-fca2-11e8-9cb1-baca769ac1c1.png)
