### PR TITLE
Fix some TSLint issues

### DIFF
--- a/src/sql/base/browser/ui/table/asyncDataView.ts
+++ b/src/sql/base/browser/ui/table/asyncDataView.ts
@@ -11,7 +11,7 @@ export interface IObservableCollection<T> {
 	at(index: number): T;
 	getRange(start: number, end: number): T[];
 	setCollectionChangedCallback(callback: (startIndex: number, count: number) => void): void;
-	setLength(number): void;
+	setLength(length: number): void;
 	dispose(): void;
 }
 
@@ -115,8 +115,8 @@ export class VirtualizedCollection<T extends Slick.SlickData> implements IObserv
 		return this.length;
 	}
 
-	setLength(number: any): void {
-		this.length = number;
+	setLength(length: number): void {
+		this.length = length;
 	}
 
 	public at(index: number): T {

--- a/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
@@ -316,8 +316,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 		let trusted = uri.scheme === Schemas.untitled;
 		let model = new NotebookInputModel(uri, undefined, trusted, undefined);
 		let providerId = options.providerId;
-		if(!providerId)
-		{
+		if (!providerId) {
 			// Ensure there is always a sensible provider ID for this file type
 			providerId = getProviderForFileName(uri.fsPath, this._notebookService);
 		}

--- a/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
@@ -99,7 +99,7 @@ class MainThreadNotebookEditor extends Disposable {
 }
 
 function wait(timeMs: number): Promise<void> {
-	return new Promise(resolve => setTimeout(resolve, timeMs));
+	return new Promise((resolve: Function) => setTimeout(resolve, timeMs));
 }
 
 


### PR DESCRIPTION
We have a few TSLint issues that recently got introduced:
```
ERROR: /Users/mairvine/code/sqlopsstudio/src/sql/base/browser/ui/table/asyncDataView.ts[14, 12]: variable name clashes with keyword/type
ERROR: /Users/mairvine/code/sqlopsstudio/src/sql/base/browser/ui/table/asyncDataView.ts[118, 12]: variable name clashes with keyword/type
ERROR: /Users/mairvine/code/sqlopsstudio/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts[102, 32]: Forbidden setTimeout string parameter: resolve
```

The last one is actually a false positive in Microsoft's TSLint rules (see https://github.com/Microsoft/tslint-microsoft-contrib/issues/355) but this will work around it

I'll also plan to look into running TSLint as part of the build process so that changes that would introduce TSLint bugs get fixed earlier