### PR TITLE
Turn off "something went wrong" message

### DIFF
--- a/src/sql/parts/query/execution/queryRunner.ts
+++ b/src/sql/parts/query/execution/queryRunner.ts
@@ -434,10 +434,10 @@ export default class QueryRunner extends Disposable {
 		};
 
 		return this._queryManagementService.getQueryRows(rowData).then(r => r, error => {
-			this._notificationService.notify({
-				severity: Severity.Error,
-				message: nls.localize('query.gettingRowsFailedError', 'Something went wrong getting more rows: {0}', error)
-			});
+			// this._notificationService.notify({
+			// 	severity: Severity.Error,
+			// 	message: nls.localize('query.gettingRowsFailedError', 'Something went wrong getting more rows: {0}', error)
+			// });
 			return error;
 		});
 	}
@@ -492,11 +492,11 @@ export default class QueryRunner extends Disposable {
 				}
 				resolve(result);
 			}, error => {
-				let errorMessage = nls.localize('query.moreRowsFailedError', 'Something went wrong getting more rows:');
-				self._notificationService.notify({
-					severity: Severity.Error,
-					message: `${errorMessage} ${error}`
-				});
+				// let errorMessage = nls.localize('query.moreRowsFailedError', 'Something went wrong getting more rows:');
+				// self._notificationService.notify({
+				// 	severity: Severity.Error,
+				// 	message: `${errorMessage} ${error}`
+				// });
 				reject(error);
 			});
 		});


### PR DESCRIPTION
I'm seeing the "Something went wrong" error message document in https://github.com/Microsoft/azuredatastudio/issues/3369 much more frequently with the result streaming feature.  

As far as I can tell there is no user impacting issue beyond the annoying notifications.  This PR turns off the notification in the `release/1.3` branch.  The prompt is still enabled in `master` so we can root cause https://github.com/Microsoft/azuredatastudio/issues/3369.