### PR TITLE
Release version 0.9.1 of the SQL Server 2019 Preview Extension

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -755,8 +755,8 @@
 					},
 					"versions": [
 						{
-							"version": "0.8.0",
-							"lastUpdated": "11/06/2018",
+							"version": "0.9.1",
+							"lastUpdated": "12/13/2018",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -770,15 +770,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://go.microsoft.com/fwlink/?linkid=2038170"
+									"source": "https://go.microsoft.com/fwlink/?linkid=2051170"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://go.microsoft.com/fwlink/?linkid=2038089"
+									"source": "https://go.microsoft.com/fwlink/?linkid=2051169"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://go.microsoft.com/fwlink/?linkid=2038308"
+									"source": "https://go.microsoft.com/fwlink/?linkid=2051168"
 								}
 							],
 							"properties": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -755,8 +755,8 @@
 					},
 					"versions": [
 						{
-							"version": "0.8.0",
-							"lastUpdated": "11/06/2018",
+							"version": "0.9.1",
+							"lastUpdated": "12/13/2018",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -770,15 +770,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://go.microsoft.com/fwlink/?linkid=2038170"
+									"source": "https://go.microsoft.com/fwlink/?linkid=2051170"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://go.microsoft.com/fwlink/?linkid=2038089"
+									"source": "https://go.microsoft.com/fwlink/?linkid=2051169"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://go.microsoft.com/fwlink/?linkid=2038308"
+									"source": "https://go.microsoft.com/fwlink/?linkid=2051168"
 								}
 							],
 							"properties": [


### PR DESCRIPTION
Please align this with the December release. I've verified locally that the links all work as expected.