### PR TITLE
Update edit data for result set streaming changes

### DIFF
--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -343,6 +343,9 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 	handleResultSet(self: EditDataComponent, event: any): void {
 		// Clone the data before altering it to avoid impacting other subscribers
 		let resultSet = Object.assign({}, event.data);
+		if (!resultSet.complete) {
+			return;
+		}
 
 		// Add an extra 'new row'
 		resultSet.rowCount++;

--- a/src/sql/parts/query/execution/queryModelService.ts
+++ b/src/sql/parts/query/execution/queryModelService.ts
@@ -387,8 +387,14 @@ export class QueryModelService implements IQueryModelService {
 			// We do not have a query runner for this editor, so create a new one
 			// and map it to the results uri
 			queryRunner = this._instantiationService.createInstance(QueryRunner, ownerUri);
+			const resultSetEventType = 'resultSet';
 			queryRunner.addListener(QREvents.RESULT_SET, resultSet => {
-				this._fireQueryEvent(ownerUri, 'resultSet', resultSet);
+				this._fireQueryEvent(ownerUri, resultSetEventType, resultSet);
+			});
+			queryRunner.onResultSetUpdate(resultSetSummaries => {
+				resultSetSummaries.forEach(resultSet => {
+					this._fireQueryEvent(ownerUri, resultSetEventType, resultSet);
+				})
 			});
 			queryRunner.addListener(QREvents.BATCH_START, batch => {
 				let link = undefined;


### PR DESCRIPTION
Fixes #3633 by updating Edit Data to process both 'resultSetAvailable' and 'resultSetUpdated' events, ignoring any event that isn't marked as complete.

This essentially matches the old behavior where it would just listen for a single resultSetComplete notification.