### PR TITLE
Fix database not getting set correctly in DacFx wizard deploy scenario

### DIFF
--- a/extensions/import/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/import/src/wizard/pages/deployConfigPage.ts
@@ -32,7 +32,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 	}
 
 	async start(): Promise<boolean> {
-				let serverComponent = await this.createServerDropdown(true);
+		let serverComponent = await this.createServerDropdown(true);
 		let fileBrowserComponent = await this.createFileBrowser();
 		this.databaseComponent = await this.createDatabaseTextBox();
 		this.databaseComponent.title = localize('dacFx.databaseNameTextBox', 'Database Name');
@@ -149,7 +149,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 	}
 
 	protected async createDeployDatabaseDropdown(): Promise<sqlops.FormComponent> {
-			this.databaseDropdown = this.view.modelBuilder.dropDown().withProperties({
+		this.databaseDropdown = this.view.modelBuilder.dropDown().withProperties({
 			required: true
 		}).component();
 		// Handle database changes
@@ -172,7 +172,8 @@ export class DeployConfigPage extends DacFxConfigPage {
 		}
 		let values = await this.getDatabaseValues();
 
-		if (this.model.database === undefined) {
+		// set the database to the first dropdown value if upgrading, otherwise it should get set to the textbox value
+		if (this.model.upgradeExisting) {
 			this.model.database = values[0].name;
 		}
 

--- a/extensions/import/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/import/src/wizard/pages/deployConfigPage.ts
@@ -131,7 +131,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 			this.model.database = this.databaseTextBox.value;
 		});
 
-		// Initialize with upgrade existing true
+		//Initialize with upgrade existing true
 		upgradeRadioButton.checked = true;
 		this.model.upgradeExisting = true;
 
@@ -152,7 +152,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 		this.databaseDropdown = this.view.modelBuilder.dropDown().withProperties({
 			required: true
 		}).component();
-		// Handle database changes
+		//Handle database changes
 		this.databaseDropdown.onValueChanged(async () => {
 			this.model.database = (<sqlops.CategoryValue>this.databaseDropdown.value).name;
 		});
@@ -172,7 +172,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 		}
 		let values = await this.getDatabaseValues();
 
-		// set the database to the first dropdown value if upgrading, otherwise it should get set to the textbox value
+		//set the database to the first dropdown value if upgrading, otherwise it should get set to the textbox value
 		if (this.model.upgradeExisting) {
 			this.model.database = values[0].name;
 		}


### PR DESCRIPTION
This fixes the database not getting set correctly for deploy scenario if coming from the import page. Previously, the database value was only getting set when the value was undefined, but it is already set to a value when coming a different page before going through the deploy scenario steps.