### PR TITLE
Ensure we call Dispose() on NotebookModel when notebook component is destroyed

### DIFF
--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -126,6 +126,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	}
 
 	ngOnDestroy() {
+		this.dispose();
 		if (this.notebookService) {
 			this.notebookService.removeNotebookEditor(this);
 		}
@@ -242,9 +243,8 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		model.onError((errInfo: INotification) => this.handleModelError(errInfo));
 		await model.requestModelLoad(this._notebookParams.isTrusted);
 		model.contentChanged((change) => this.handleContentChanged(change));
-		this._model = model;
+		this._model = this._register(model);
 		this.updateToolbarComponents(this._model.trustedMode);
-		this._register(model);
 		this._modelRegisteredDeferred.resolve(this._model);
 		model.backgroundStartSession();
 		// Set first cell as default active cell


### PR DESCRIPTION
Ensure we call Dispose() on NotebookModel when notebook component is destroyed.

We need a fix on the extension side as well for #3524 but this improves the experience by not throwing errors anymore. Extension PR coming soon...