### PR TITLE
Save grid selection/vertical scroll when switching tabs

### DIFF
--- a/src/sql/parts/query/editor/gridPanel.ts
+++ b/src/sql/parts/query/editor/gridPanel.ts
@@ -548,7 +548,6 @@ class GridTable<T> extends Disposable implements IView {
 			}
 		});
 
-		// TODO: just save horizontal scroll and should be good
 		this.table.grid.onScroll.subscribe((e, data) => {
 			if (!this.visible) {
 				return;
@@ -567,8 +566,6 @@ class GridTable<T> extends Disposable implements IView {
 				this.state.activeCell = this.table.grid.getActiveCell();
 			}
 		});
-
-		// this.setupState();
 	}
 
 	private setupState() {

--- a/src/sql/parts/query/editor/gridPanel.ts
+++ b/src/sql/parts/query/editor/gridPanel.ts
@@ -455,6 +455,7 @@ class GridTable<T> extends Disposable implements IView {
 		});
 		this.dataProvider.dataRows = collection;
 		this.table.updateRowCount();
+		this.setupState();
 	}
 
 	public onRemove() {
@@ -547,7 +548,11 @@ class GridTable<T> extends Disposable implements IView {
 			}
 		});
 
+		// TODO: just save horizontal scroll and should be good
 		this.table.grid.onScroll.subscribe((e, data) => {
+			if (!this.visible) {
+				return;
+			}
 			if (!this.scrolled && this.state.scrollPosition && isInDOM(this.container)) {
 				this.scrolled = true;
 				this.table.grid.scrollTo(this.state.scrollPosition);
@@ -563,7 +568,7 @@ class GridTable<T> extends Disposable implements IView {
 			}
 		});
 
-		this.setupState();
+		// this.setupState();
 	}
 
 	private setupState() {
@@ -579,12 +584,14 @@ class GridTable<T> extends Disposable implements IView {
 			// doesn't work with it offDOM.
 		}
 
-		if (this.state.selection) {
-			this.selectionModel.setSelectedRanges(this.state.selection);
-		}
+		let savedSelection = this.state.selection;
 
 		if (this.state.activeCell) {
 			this.table.setActiveCell(this.state.activeCell.row, this.state.activeCell.cell);
+		}
+
+		if (savedSelection) {
+			this.selectionModel.setSelectedRanges(savedSelection);
 		}
 	}
 

--- a/src/sql/parts/query/editor/gridPanel.ts
+++ b/src/sql/parts/query/editor/gridPanel.ts
@@ -550,6 +550,8 @@ class GridTable<T> extends Disposable implements IView {
 
 		this.table.grid.onScroll.subscribe((e, data) => {
 			if (!this.visible) {
+				// If the grid is not set up yet it can get scroll events resetting the top to 0px,
+				// so ignore those events
 				return;
 			}
 			if (!this.scrolled && this.state.scrollPosition && isInDOM(this.container)) {
@@ -581,6 +583,7 @@ class GridTable<T> extends Disposable implements IView {
 			// doesn't work with it offDOM.
 		}
 
+		// Setting the active cell resets the selection so save it here
 		let savedSelection = this.state.selection;
 
 		if (this.state.activeCell) {

--- a/src/sql/parts/query/editor/gridPanel.ts
+++ b/src/sql/parts/query/editor/gridPanel.ts
@@ -145,7 +145,7 @@ export class GridPanel extends ViewletPanel {
 		super(options, keybindingService, contextMenuService, configurationService);
 		this.splitView = new ScrollableSplitView(this.container, { enableResizing: false, verticalScrollbarVisibility: ScrollbarVisibility.Visible });
 		this.splitView.onScroll(e => {
-			if (this.state) {
+			if (this.state && this.splitView.length !== 0) {
 				this.state.scrollPosition = e;
 			}
 		});


### PR DESCRIPTION
This is for #3673, where result grid selections and scroll positions are no longer getting saved when switching between tabs.

I'm still investigating an issue where the overall result's scroll position gets reset only when switching between a query editor tab and a non-query tab. Also the horizontal scroll position in the grid doesn't get saved but that's not a regression from November at least

Update: Solved the issue with the overall split view's scroll position getting reset