### PR TITLE
Notebooks: Add text cell should open in edit mode

### DIFF
--- a/src/sql/parts/notebook/cellViews/textCell.component.ts
+++ b/src/sql/parts/notebook/cellViews/textCell.component.ts
@@ -60,7 +60,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		@Inject(IOpenerService) private readonly openerService: IOpenerService,
 	) {
 		super();
-		this.isEditMode = false;
+		this.isEditMode = true;
 		this.isLoading = true;
 		this._cellToggleMoreActions = this._instantiationService.createInstance(CellToggleMoreActions);
 	}
@@ -87,7 +87,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	}
 
 	ngOnInit() {
-		this.updatePreview();
+		this.toggleEditMode(true);
 		this.setLoading(false);
 		this._register(this.themeService.onDidColorThemeChange(this.updateTheme, this));
 		this.updateTheme(this.themeService.getColorTheme());
@@ -101,7 +101,11 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			if (propName === 'activeCellId') {
 				let changedProp = changes[propName];
 				this._activeCellId = changedProp.currentValue;
-				this.toggleEditMode(false);
+				// If the activeCellId is undefined (i.e. in an active cell update), don't unnecessarily set editMode to false;
+				// it will be set to true in a subsequent call to toggleEditMode()
+				if (changedProp.previousValue !== undefined) {
+					this.toggleEditMode(false);
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
+Text cell should open in edit instead of preview mode. This allows users to immediately create a markdown cell and start typing without extra clicks. Fixes #2900.

Note: if you navigate away from a markdown cell after it's been added but the cell is still empty, it still shows the old "Double-click to edit" text.