### PR TITLE
Fix Active Cell Null Ref Issue in Specific Deselection Case

### DIFF
--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -171,7 +171,6 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		if (this.model.activeCell) {
 			this.model.activeCell.active = false;
 		}
-		this.model.activeCell = null;
 		this._changeRef.detectChanges();
 	}
 


### PR DESCRIPTION
Setting activeCell on the model to null during cell deselection isn't necessary; on a subsequent cell selection, we were trying to set activeCell.active when activeCell was null, leading to an exception being thrown when trying to add a new cell when a cell wasn't currently selected; this caused new cells not to be drawn until a cell was selected.