### PR TITLE
Fix #3676 DacFx wizard import page next button doesn't update

### DIFF
--- a/src/sql/platform/dialog/wizardModal.ts
+++ b/src/sql/platform/dialog/wizardModal.ts
@@ -97,15 +97,6 @@ export class WizardModal extends Modal {
 
 		messageChangeHandler(this._wizard.message);
 		this._wizard.onMessageChange(message => messageChangeHandler(message));
-
-		this._wizard.pages.forEach((page, index) => {
-			page.onValidityChanged(valid => {
-				if (index === this._wizard.currentPage) {
-					this._nextButton.enabled = this._wizard.nextButton.enabled && page.valid;
-					this._doneButton.enabled = this._wizard.doneButton.enabled && page.valid;
-				}
-			});
-		});
 	}
 
 	private addDialogButton(button: DialogButton, onSelect: () => void = () => undefined, registerClickEvent: boolean = true, requirePageValid: boolean = false): Button {
@@ -198,6 +189,13 @@ export class WizardModal extends Modal {
 		let currentPageValid = this._wizard.pages[this._wizard.currentPage].valid;
 		this._nextButton.enabled = this._wizard.nextButton.enabled && currentPageValid;
 		this._doneButton.enabled = this._wizard.doneButton.enabled && currentPageValid;
+
+		pageToShow.onValidityChanged(valid => {
+			if (index === this._wizard.currentPage) {
+				this._nextButton.enabled = this._wizard.nextButton.enabled && pageToShow.valid;
+				this._doneButton.enabled = this._wizard.doneButton.enabled && pageToShow.valid;
+			}
+		});
 	}
 
 	private setButtonsForPage(index: number) {


### PR DESCRIPTION
The DacFx wizard adds and removes pages based on the selected operation. The onValidityChanged listener wasn't getting added to newly added pages, causing the next button to not get enabled even when the page became valid.

This change moves adding the onValidityChanged listener from render() to showPage() so that it gets added to pages that are added to the wizard after the initial start up.