### PR TITLE
Fix focus issue when opening notebooks

### DIFF
--- a/src/sql/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/parts/notebook/cellViews/code.component.ts
@@ -128,7 +128,6 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 		let uri = this.createUri();
 		this._editorInput = instantiationService.createInstance(UntitledEditorInput, uri, false, this.cellModel.language, '', '');
 		this._editor.setInput(this._editorInput, undefined);
-		this._editor.focus();
 		this._editorInput.resolve().then(model => {
 			this._editorModel = model.textEditorModel;
 			this._modelService.updateModel(this._editorModel, this.cellModel.source);


### PR DESCRIPTION
When creating a new notebook, adding one cell at a time and calling this.editor.focus() is totally fine.

However, when opening an existing notebook with existing editor cells, this means that every editor instance will demand focus. Which is really bad.

As a workaround for right now, getting rid of the call to focus(). @kevcunnane we need a better solution longterm, as we previously discussed.