### PR TITLE
Notebooks: Ensure we always get all providers, regardless if a provider is passed in

### DIFF
--- a/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
@@ -321,16 +321,13 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 		let model = new NotebookInputModel(uri, undefined, trusted, undefined);
 		let providerId = options.providerId;
 		let providers: string[] = undefined;
-		if (!providerId)
-		{
-			// Ensure there is always a sensible provider ID for this file type
-			providers = getProvidersForFileName(uri.fsPath, this._notebookService);
-			// Try to use a non-builtin provider first
-			if (providers) {
-				providerId = providers.find(p => p !== DEFAULT_NOTEBOOK_PROVIDER);
-				if (!providerId) {
-					providerId = model.providerId;
-				}
+		// Ensure there is always a sensible provider ID for this file type
+		providers = getProvidersForFileName(uri.fsPath, this._notebookService);
+		// Try to use a non-builtin provider first
+		if (providers) {
+			providerId = providers.find(p => p !== DEFAULT_NOTEBOOK_PROVIDER);
+			if (!providerId) {
+				providerId = model.providerId;
 			}
 		}
 		model.providers = providers;


### PR DESCRIPTION
Notebook always shows as loading kernels if we pass in a connection, which means that we set the providerId upfront.

Regardless of whether the providerId is set or not, we should still get all providers and populate the providers array.