### PR TITLE
#3753: User settings configuration - python installation path

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -13,7 +13,7 @@
 		"*"
 	],
 	"contributes": {
-		"configuration": {
+		"configuration": [{
 			"type": "object",
 			"title": "%notebook.configuration.title%",
 			"properties": {
@@ -24,6 +24,18 @@
 				}
 			}
 		},
+		{
+			"type": "object",
+			"title": "%notebook.configuration.title%",
+			"properties": {
+				"notebook.pythonPath": {
+					"type": "string",
+					"default": "",
+					"description": "%notebook.pythonPath.description%"
+				}
+			}
+		}
+	],
 		"commands": [
 			{
 				"command": "notebook.command.new",

--- a/extensions/notebook/package.nls.json
+++ b/extensions/notebook/package.nls.json
@@ -3,6 +3,7 @@
 	"description": "Defines the Data-procotol based Notebook contribution and many Notebook commands and contributions.",
 	"notebook.configuration.title": "Notebook configuration",
 	"notebook.enabled.description": "Enable viewing notebook files using built-in notebook editor.",
+	"notebook.pythonPath.description": "Contains python installation path on user's machine",
 	"notebook.command.new": "New Notebook",
 	"notebook.command.open": "Open Notebook"
 }


### PR DESCRIPTION
Added configuration to read python path in extension code base. This is empty by default. When user changes directory in local, it will be updated.