### PR TITLE
Add generate script option to DacFx wizard

### DIFF
--- a/extensions/import/src/wizard/api/models.ts
+++ b/extensions/import/src/wizard/api/models.ts
@@ -45,4 +45,6 @@ export interface DacFxDataModel extends BaseDataModel {
 	filePath: string;
 	version: string;
 	upgradeExisting: boolean;
+	scriptFilePath: string;
+	generateScriptAndDeploy: boolean;
 }

--- a/extensions/import/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/import/src/wizard/dataTierApplicationWizard.ts
@@ -35,6 +35,31 @@ export enum Operation {
 	generateDeployScript
 }
 
+export enum DeployOperationPath {
+	selectOperation,
+	deployOptions,
+	deployAction,
+	summary
+}
+
+export enum ExtractOperationPath {
+	selectOperation,
+	options,
+	summary
+}
+
+export enum ImportOperationPath {
+	selectOperation,
+	options,
+	summary
+}
+
+export enum ExportOperationPath {
+	selectOperation,
+	options,
+	summary
+}
+
 export class DataTierApplicationWizard {
 	public wizard: sqlops.window.modelviewdialog.Wizard;
 	private connection: sqlops.connection.Connection;
@@ -144,11 +169,13 @@ export class DataTierApplicationWizard {
 						break;
 					}
 				}
-			//deploy path has 4 pages, not 3 pages like the other operations
-			} else if ((idx === 2 && this.wizard.pages.length !== 4) || idx === 3) {
-				page = this.pages.get('summary');
-			} else if (idx === 2 && this.wizard.pages.length === 4) {
+			} else if ((this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.deployAction) {
 				page = this.pages.get('deployAction');
+			} else if (this.selectedOperation === Operation.import && idx === ImportOperationPath.summary
+				|| this.selectedOperation === Operation.export && idx === ExportOperationPath.summary
+				|| this.selectedOperation === Operation.extract && idx === ExtractOperationPath.summary
+				|| (this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.summary) {
+				page = this.pages.get('summary');
 			}
 
 			if (page !== undefined) {

--- a/extensions/import/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/import/src/wizard/dataTierApplicationWizard.ts
@@ -148,35 +148,7 @@ export class DataTierApplicationWizard {
 
 		this.wizard.onPageChanged(async (event) => {
 			let idx = event.newPage;
-			let page: Page;
-
-			if (idx === 1) {
-				switch (this.selectedOperation) {
-					case Operation.deploy: {
-						page = this.pages.get('deployConfig');
-						break;
-					}
-					case Operation.extract: {
-						page = this.pages.get('extractConfig');
-						break;
-					}
-					case Operation.import: {
-						page = this.pages.get('importConfig');
-						break;
-					}
-					case Operation.export: {
-						page = this.pages.get('exportConfig');
-						break;
-					}
-				}
-			} else if ((this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.deployAction) {
-				page = this.pages.get('deployAction');
-			} else if (this.selectedOperation === Operation.import && idx === ImportOperationPath.summary
-				|| this.selectedOperation === Operation.export && idx === ExportOperationPath.summary
-				|| this.selectedOperation === Operation.extract && idx === ExtractOperationPath.summary
-				|| (this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.summary) {
-				page = this.pages.get('summary');
-			}
+			let page = this.getPage(idx);
 
 			if (page !== undefined) {
 				page.dacFxPage.setupNavigationValidator();
@@ -186,7 +158,7 @@ export class DataTierApplicationWizard {
 			//do onPageLeave for summary page so that GenerateScript button only shows up if upgrading database
 			let idxLast = event.lastPage;
 
-			if ((idxLast === 2 && this.wizard.pages.length !== 4) || idxLast === 3) {
+			if (this.isSummaryPage(idxLast)) {
 				let lastPage = this.pages.get('summary');
 				if (lastPage) {
 					lastPage.dacFxPage.onPageLeave();
@@ -327,6 +299,44 @@ export class DataTierApplicationWizard {
 			vscode.window.showErrorMessage(
 				localize('alertData.deployErrorMessage', "Deploy failed '{0}'", result.errorMessage ? result.errorMessage : 'Unknown'));
 		}
+	}
+
+	private getPage(idx: number): Page {
+		let page: Page;
+
+		if (idx === 1) {
+			switch (this.selectedOperation) {
+				case Operation.deploy: {
+					page = this.pages.get('deployConfig');
+					break;
+				}
+				case Operation.extract: {
+					page = this.pages.get('extractConfig');
+					break;
+				}
+				case Operation.import: {
+					page = this.pages.get('importConfig');
+					break;
+				}
+				case Operation.export: {
+					page = this.pages.get('exportConfig');
+					break;
+				}
+			}
+		} else if ((this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.deployAction) {
+			page = this.pages.get('deployAction');
+		} else if (this.isSummaryPage(idx)) {
+			page = this.pages.get('summary');
+		}
+
+		return page;
+	}
+
+	private isSummaryPage(idx: number): boolean {
+		return this.selectedOperation === Operation.import && idx === ImportOperationPath.summary
+			|| this.selectedOperation === Operation.export && idx === ExportOperationPath.summary
+			|| this.selectedOperation === Operation.extract && idx === ExtractOperationPath.summary
+			|| (this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.summary;
 	}
 
 	private static async getService(providerName: string): Promise<sqlops.DacFxServicesProvider> {

--- a/extensions/import/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/import/src/wizard/pages/dacFxSummaryPage.ts
@@ -49,6 +49,14 @@ export class DacFxSummaryPage extends BasePage {
 	async onPageEnter(): Promise<boolean> {
 		this.populateTable();
 		this.loader.loading = false;
+		if (this.model.upgradeExisting && this.model.generateScriptAndDeploy) {
+			this.instance.wizard.generateScriptButton.hidden = false;
+		}
+		return true;
+	}
+
+	async onPageLeave(): Promise<boolean> {
+		this.instance.wizard.generateScriptButton.hidden = true;
 		return true;
 	}
 
@@ -68,6 +76,7 @@ export class DacFxSummaryPage extends BasePage {
 		let sourceServer = localize('dacfx.sourceServerName', 'Source Server');
 		let sourceDatabase = localize('dacfx.sourceDatabaseName', 'Source Database');
 		let fileLocation = localize('dacfx.fileLocation', 'File Location');
+		let scriptLocation = localize('dacfx.scriptLocation', 'Deployment Script Location');
 
 		switch (this.instance.selectedOperation) {
 			case Operation.deploy: {
@@ -75,6 +84,9 @@ export class DacFxSummaryPage extends BasePage {
 					[targetServer, this.model.serverName],
 					[fileLocation, this.model.filePath],
 					[targetDatabase, this.model.database]];
+				if (this.model.generateScriptAndDeploy) {
+					data[3] = [scriptLocation, this.model.scriptFilePath];
+				}
 				break;
 			}
 			case Operation.extract: {
@@ -99,12 +111,20 @@ export class DacFxSummaryPage extends BasePage {
 					[fileLocation, this.model.filePath]];
 				break;
 			}
+			case Operation.generateDeployScript: {
+				data = [
+					[targetServer, this.model.serverName],
+					[fileLocation, this.model.filePath],
+					[targetDatabase, this.model.database],
+					[scriptLocation, this.model.scriptFilePath]];
+				break;
+			}
 		}
 
 		this.table.updateProperties({
 			data: data,
 			columns: ['Setting', 'Value'],
-			width: 600,
+			width: 700,
 			height: 200
 		});
 	}

--- a/extensions/import/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/import/src/wizard/pages/dacFxSummaryPage.ts
@@ -77,6 +77,9 @@ export class DacFxSummaryPage extends BasePage {
 		let sourceDatabase = localize('dacfx.sourceDatabaseName', 'Source Database');
 		let fileLocation = localize('dacfx.fileLocation', 'File Location');
 		let scriptLocation = localize('dacfx.scriptLocation', 'Deployment Script Location');
+		let action = localize('dacfx.action', 'Action');
+		let deploy = localize('dacfx.deploy', 'Deploy');
+		let generateScript = localize('dacfx.generateScript', 'Generate Deployment Script');
 
 		switch (this.instance.selectedOperation) {
 			case Operation.deploy: {
@@ -86,6 +89,10 @@ export class DacFxSummaryPage extends BasePage {
 					[targetDatabase, this.model.database]];
 				if (this.model.generateScriptAndDeploy) {
 					data[3] = [scriptLocation, this.model.scriptFilePath];
+					data[4] = [action, generateScript + ', ' + deploy];
+				}
+				else {
+					data[3] = [action, deploy];
 				}
 				break;
 			}
@@ -116,7 +123,8 @@ export class DacFxSummaryPage extends BasePage {
 					[targetServer, this.model.serverName],
 					[fileLocation, this.model.filePath],
 					[targetDatabase, this.model.database],
-					[scriptLocation, this.model.scriptFilePath]];
+					[scriptLocation, this.model.scriptFilePath],
+					[action, generateScript]];
 				break;
 			}
 		}

--- a/extensions/import/src/wizard/pages/deployActionPage.ts
+++ b/extensions/import/src/wizard/pages/deployActionPage.ts
@@ -1,0 +1,176 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+import * as sqlops from 'sqlops';
+import * as nls from 'vscode-nls';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as os from 'os';
+import { DacFxDataModel } from '../api/models';
+import { DataTierApplicationWizard, Operation } from '../dataTierApplicationWizard';
+import { DacFxConfigPage } from '../api/dacFxConfigPage';
+
+const localize = nls.loadMessageBundle();
+
+export class DeployActionPage extends DacFxConfigPage {
+
+	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly instance: DataTierApplicationWizard;
+	protected readonly model: DacFxDataModel;
+	protected readonly view: sqlops.ModelView;
+	private deployRadioButton: sqlops.RadioButtonComponent;
+	private deployScriptRadioButton: sqlops.RadioButtonComponent;
+	private scriptRadioButton: sqlops.RadioButtonComponent;
+	private form: sqlops.FormContainer;
+
+	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
+		super(instance, wizardPage, model, view);
+	}
+
+	async start(): Promise<boolean> {
+		let deployComponent = await this.createDeployRadioButton();
+		let deployScriptComponent = await this.createDeployScriptRadioButton();
+		let scriptComponent = await this.createScriptRadioButton();
+		let fileBrowserComponent = await this.createFileBrowser();
+
+		this.form = this.view.modelBuilder.formContainer()
+			.withFormItems(
+				[
+					deployComponent,
+					scriptComponent,
+					deployScriptComponent,
+					fileBrowserComponent
+				]).component();
+		await this.view.initializeModel(this.form);
+
+		//default have the first radio button checked
+		this.deployRadioButton.checked = true;
+		this.toggleFileBrowser(false);
+
+		return true;
+	}
+
+	async onPageEnter(): Promise<boolean> {
+		return true;
+	}
+
+	private async createDeployRadioButton(): Promise<sqlops.FormComponent> {
+		this.deployRadioButton = this.view.modelBuilder.radioButton()
+			.withProperties({
+				name: 'selectedDeployAction',
+				label: localize('dacFx.deployRadioButtonLabel', 'Deploy'),
+			}).component();
+
+		this.deployRadioButton.onDidClick(() => {
+			this.model.generateScriptAndDeploy = false;
+			this.instance.setDoneButton(Operation.deploy);
+			this.toggleFileBrowser(false);
+		});
+
+		return {
+			component: this.deployRadioButton,
+			title: ''
+		};
+	}
+
+	private async createDeployScriptRadioButton(): Promise<sqlops.FormComponent> {
+		this.deployScriptRadioButton = this.view.modelBuilder.radioButton()
+			.withProperties({
+				name: 'selectedDeployAction',
+				label: localize('dacFx.deployScriptRadioButtonLabel', 'Generate Deployment Script and Deploy'),
+			}).component();
+
+		this.deployScriptRadioButton.onDidClick(() => {
+			this.model.generateScriptAndDeploy = true;
+			this.instance.setDoneButton(Operation.deploy);
+			this.toggleFileBrowser(true);
+		});
+
+		return {
+			component: this.deployScriptRadioButton,
+			title: ''
+		};
+	}
+
+	private async createScriptRadioButton(): Promise<sqlops.FormComponent> {
+		this.scriptRadioButton = this.view.modelBuilder.radioButton()
+			.withProperties({
+				name: 'selectedDeployAction',
+				label: localize('dacFx.scriptRadioButtonLabel', 'Generate Deployment Script'),
+			}).component();
+
+		this.scriptRadioButton.onDidClick(() => {
+			this.model.generateScriptAndDeploy = false;
+			this.toggleFileBrowser(true);
+
+			//change button text and operation
+			this.instance.setDoneButton(Operation.generateDeployScript);
+		});
+
+		return {
+			component: this.scriptRadioButton,
+			title: ''
+		};
+	}
+
+	private async createFileBrowser(): Promise<sqlops.FormComponentGroup> {
+		this.createFileBrowserParts();
+
+		//default filepath
+		let now = new Date();
+		let datetime = now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + '-' + now.getHours() + '-' + now.getMinutes();
+		this.fileTextBox.value= path.join(os.homedir(), this.model.database + '_UpgradeDACScript_' + datetime + '.sql');
+		this.model.scriptFilePath = this.fileTextBox.value;
+
+		this.fileButton.onDidClick(async (click) => {
+			let fileUri = await vscode.window.showSaveDialog(
+				{
+					defaultUri: vscode.Uri.file(this.fileTextBox.value),
+					saveLabel: localize('dacfxDeployScript.saveFile', 'Save'),
+					filters: {
+						'SQL Files': ['sql'],
+					}
+				}
+			);
+
+			if (!fileUri) {
+				return;
+			}
+
+			this.fileTextBox.value = fileUri.fsPath;
+			this.model.scriptFilePath = fileUri.fsPath;
+		});
+
+		this.fileTextBox.onTextChanged(async () => {
+			this.model.scriptFilePath = this.fileTextBox.value;
+		});
+
+		return {
+			title: '',
+			components: [
+			{
+				title: localize('dacfx.generatedScriptLocation','Deployment Script Location'),
+				component: this.fileTextBox,
+				layout: {
+					horizontal: true,
+					componentWidth: 400
+				},
+				actions: [this.fileButton]
+			},],
+		};
+	}
+
+	private toggleFileBrowser(enable: boolean): void {
+		this.fileTextBox.enabled = enable;
+		this.fileButton.enabled = enable;
+	}
+
+	public setupNavigationValidator() {
+		this.instance.registerNavigationValidator(() => {
+			return true;
+		});
+	}
+}

--- a/extensions/import/src/wizard/pages/selectOperationpage.ts
+++ b/extensions/import/src/wizard/pages/selectOperationpage.ts
@@ -58,11 +58,6 @@ export class SelectOperationPage extends BasePage {
 	}
 
 	async onPageEnter(): Promise<boolean> {
-		let numPages = this.instance.wizard.pages.length;
-		for (let i = numPages - 1; i > 2; --i) {
-			await this.instance.wizard.removePage(i);
-		}
-
 		return true;
 	}
 
@@ -77,9 +72,12 @@ export class SelectOperationPage extends BasePage {
 			// remove the previous page
 			this.instance.wizard.removePage(1);
 
-			// add deploy page
-			let page = this.instance.pages.get('deployConfig');
-			this.instance.wizard.addPage(page.wizardPage, 1);
+			//add deploy pages
+			let configPage = this.instance.pages.get('deployConfig');
+			this.instance.wizard.addPage(configPage.wizardPage, 1);
+
+			let actionPage = this.instance.pages.get('deployAction');
+			this.instance.wizard.addPage(actionPage.wizardPage, 2);
 
 			// change button text and operation
 			this.instance.setDoneButton(Operation.deploy);
@@ -99,7 +97,10 @@ export class SelectOperationPage extends BasePage {
 			}).component();
 
 		this.extractRadioButton.onDidClick(() => {
-			// remove the previous pages
+			//remove the previous pages
+			if (this.instance.wizard.pages.length === 4) {
+				this.instance.wizard.removePage(2);
+			}
 			this.instance.wizard.removePage(1);
 
 			// add the extract page
@@ -124,7 +125,10 @@ export class SelectOperationPage extends BasePage {
 			}).component();
 
 		this.importRadioButton.onDidClick(() => {
-			// remove the  previous page
+			//remove the previous pages
+			if (this.instance.wizard.pages.length === 4) {
+				this.instance.wizard.removePage(2);
+			}
 			this.instance.wizard.removePage(1);
 
 			// add the import page
@@ -149,7 +153,10 @@ export class SelectOperationPage extends BasePage {
 			}).component();
 
 		this.exportRadioButton.onDidClick(() => {
-			// remove the 2 previous pages
+			//remove the previous pages
+			if (this.instance.wizard.pages.length === 4) {
+				this.instance.wizard.removePage(2);
+			}
 			this.instance.wizard.removePage(1);
 
 			// add the export pages

--- a/extensions/import/src/wizard/pages/selectOperationpage.ts
+++ b/extensions/import/src/wizard/pages/selectOperationpage.ts
@@ -69,15 +69,14 @@ export class SelectOperationPage extends BasePage {
 			}).component();
 
 		this.deployRadioButton.onDidClick(() => {
-			// remove the previous page
-			this.instance.wizard.removePage(1);
+			this.removePages();
 
 			//add deploy pages
 			let configPage = this.instance.pages.get('deployConfig');
 			this.instance.wizard.addPage(configPage.wizardPage, 1);
-
 			let actionPage = this.instance.pages.get('deployAction');
 			this.instance.wizard.addPage(actionPage.wizardPage, 2);
+			this.addSummaryPage(3);
 
 			// change button text and operation
 			this.instance.setDoneButton(Operation.deploy);
@@ -97,15 +96,12 @@ export class SelectOperationPage extends BasePage {
 			}).component();
 
 		this.extractRadioButton.onDidClick(() => {
-			//remove the previous pages
-			if (this.instance.wizard.pages.length === 4) {
-				this.instance.wizard.removePage(2);
-			}
-			this.instance.wizard.removePage(1);
+			this.removePages();
 
 			// add the extract page
 			let page = this.instance.pages.get('extractConfig');
 			this.instance.wizard.addPage(page.wizardPage, 1);
+			this.addSummaryPage(2);
 
 			// change button text and operation
 			this.instance.setDoneButton(Operation.extract);
@@ -125,15 +121,12 @@ export class SelectOperationPage extends BasePage {
 			}).component();
 
 		this.importRadioButton.onDidClick(() => {
-			//remove the previous pages
-			if (this.instance.wizard.pages.length === 4) {
-				this.instance.wizard.removePage(2);
-			}
-			this.instance.wizard.removePage(1);
+			this.removePages();
 
 			// add the import page
 			let page = this.instance.pages.get('importConfig');
 			this.instance.wizard.addPage(page.wizardPage, 1);
+			this.addSummaryPage(2);
 
 			// change button text and operation
 			this.instance.setDoneButton(Operation.import);
@@ -153,15 +146,12 @@ export class SelectOperationPage extends BasePage {
 			}).component();
 
 		this.exportRadioButton.onDidClick(() => {
-			//remove the previous pages
-			if (this.instance.wizard.pages.length === 4) {
-				this.instance.wizard.removePage(2);
-			}
-			this.instance.wizard.removePage(1);
+			this.removePages();
 
 			// add the export pages
 			let page = this.instance.pages.get('exportConfig');
 			this.instance.wizard.addPage(page.wizardPage, 1);
+			this.addSummaryPage(2);
 
 			// change button text and operation
 			this.instance.setDoneButton(Operation.export);
@@ -171,6 +161,18 @@ export class SelectOperationPage extends BasePage {
 			component: this.exportRadioButton,
 			title: ''
 		};
+	}
+
+	private removePages() {
+		let numPages = this.instance.wizard.pages.length;
+		for (let i = numPages - 1; i > 0; --i) {
+			this.instance.wizard.removePage(i);
+		}
+	}
+
+	private addSummaryPage(index: number) {
+		let summaryPage = this.instance.pages.get('summary');
+		this.instance.wizard.addPage(summaryPage.wizardPage, index);
 	}
 
 	public setupNavigationValidator() {

--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.67",
+	"version": "1.5.0-alpha.68",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -331,6 +331,14 @@ export interface DeployParams {
 	taskExecutionMode: TaskExecutionMode;
 }
 
+export interface GenerateDeployScriptParams {
+	packageFilePath: string;
+	databaseName: string;
+	scriptFilePath: string;
+	ownerUri: string;
+	taskExecutionMode: TaskExecutionMode;
+}
+
 export namespace ExportRequest {
 	export const type = new RequestType<ExportParams, sqlops.DacFxResult, void, void>('dacfx/export');
 }
@@ -345,6 +353,10 @@ export namespace ExtractRequest {
 
 export namespace DeployRequest {
 	export const type = new RequestType<DeployParams, sqlops.DacFxResult, void, void>('dacfx/deploy');
+}
+
+export namespace GenerateDeployScriptRequest {
+	export const type = new RequestType<GenerateDeployScriptParams, sqlops.DacFxResult, void, void>('dacfx/generateUgradeScript');
 }
 
 // ------------------------------- < DacFx > ------------------------------------

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -356,7 +356,7 @@ export namespace DeployRequest {
 }
 
 export namespace GenerateDeployScriptRequest {
-	export const type = new RequestType<GenerateDeployScriptParams, sqlops.DacFxResult, void, void>('dacfx/generateUgradeScript');
+	export const type = new RequestType<GenerateDeployScriptParams, sqlops.DacFxResult, void, void>('dacfx/generateDeploymentScript');
 }
 
 // ------------------------------- < DacFx > ------------------------------------

--- a/extensions/mssql/src/features.ts
+++ b/extensions/mssql/src/features.ts
@@ -106,12 +106,26 @@ export class DacFxServicesFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
+		let generateDeployScript = (packageFilePath: string, targetDatabaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> => {
+			let params: contracts.GenerateDeployScriptParams = { packageFilePath: packageFilePath, databaseName: targetDatabaseName, scriptFilePath: scriptFilePath, ownerUri: ownerUri, taskExecutionMode: taskExecutionMode };
+			return client.sendRequest(contracts.GenerateDeployScriptRequest.type, params).then(
+				r => {
+					return r;
+				},
+				e => {
+					client.logFailedRequest(contracts.DeployRequest.type, e);
+					return Promise.resolve(undefined);
+				}
+			);
+		};
+
 		return sqlops.dataprotocol.registerDacFxServicesProvider({
 			providerId: client.providerId,
 			exportBacpac,
 			importBacpac,
 			extractDacpac,
-			deployDacpac
+			deployDacpac,
+			generateDeployScript
 		});
 	}
 }

--- a/src/sql/platform/dacfx/common/dacFxService.ts
+++ b/src/sql/platform/dacfx/common/dacFxService.ts
@@ -22,6 +22,7 @@ export interface IDacFxService {
 	importBacpac(packageFilePath: string, targetDatabaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
 	extractDacpac(sourceDatabaseName: string, packageFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
 	deployDacpac(packageFilePath: string, targetDatabaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
+	generateDeployScript(packageFilePath: string, targetDatabaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
 }
 
 export class DacFxService implements IDacFxService {
@@ -58,6 +59,12 @@ export class DacFxService implements IDacFxService {
 	deployDacpac(packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> {
 		return this._runAction(ownerUri, (runner) => {
 			return runner.deployDacpac(packageFilePath, databaseName, upgradeExisting, ownerUri, taskExecutionMode);
+		});
+	}
+
+	generateDeployScript(packageFilePath: string, databaseName: string, generateDeployScript: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> {
+		return this._runAction(ownerUri, (runner) => {
+			return runner.generateDeployScript(packageFilePath, databaseName, generateDeployScript, ownerUri, taskExecutionMode);
 		});
 	}
 

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -1626,11 +1626,20 @@ declare module 'sqlops' {
 		taskExecutionMode: TaskExecutionMode;
 	}
 
+	export interface GenerateDeployScriptParams {
+		packageFilePath: string;
+		databaseName: string;
+		scriptFilePath: string;
+		ownerUri: string;
+		taskExecutionMode: TaskExecutionMode;
+	}
+
 	export interface DacFxServicesProvider extends DataProvider {
 		exportBacpac(databaseName: string, packageFilePath: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		importBacpac(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		extractDacpac(databaseName: string, packageFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		deployDacpac(packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
+		generateDeployScript(packageFilePath: string, databaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 	}
 
 	// Security service interfaces ------------------------------------------------------------------------

--- a/src/sql/workbench/api/node/mainThreadDataProtocol.ts
+++ b/src/sql/workbench/api/node/mainThreadDataProtocol.ts
@@ -415,6 +415,9 @@ export class MainThreadDataProtocol implements MainThreadDataProtocolShape {
 			},
 			deployDacpac(packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> {
 				return self._proxy.$deployDacpac(handle, packageFilePath, databaseName, upgradeExisting, ownerUri, taskExecutionMode);
+			},
+			generateDeployScript(packageFilePath: string, databaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> {
+				return self._proxy.$generateDeployScript(handle, packageFilePath, databaseName, scriptFilePath, ownerUri, taskExecutionMode);
 			}
 		});
 

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -440,6 +440,12 @@ export abstract class ExtHostDataProtocolShape {
 	 * DacFx deploy dacpac
 	 */
 	$deployDacpac(handle: number, packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> { throw ni(); }
+
+	/**
+	 * DacFx generate deploy script
+	 */
+	$generateDeployScript(handle: number, packageFilePath: string, databaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> { throw ni(); }
+
 }
 
 /**


### PR DESCRIPTION
This adds the ability to generate the script for a deployment to the DacFx wizard. An additional page was added to the deploy scenario to choose whether to Deploy, Generate Deployment Script, or do both.

Generate Script:
![generatescriptonly](https://user-images.githubusercontent.com/31145923/51698881-3ed77400-1fc0-11e9-976f-6ed1d11715ba.gif)

Generate Script and Deploy:
![generatescriptdeploy](https://user-images.githubusercontent.com/31145923/51698889-43039180-1fc0-11e9-9529-d8d697110f18.gif)

