### PR TITLE
Improve Agent performance 

### DIFF
--- a/src/sql/parts/jobManagement/views/jobHistory.component.ts
+++ b/src/sql/parts/jobManagement/views/jobHistory.component.ts
@@ -177,7 +177,9 @@ export class JobHistoryComponent extends JobManagementView implements OnInit {
 			} else {
 				self._showPreviousRuns = false;
 				self._showSteps = false;
-				self._cd.detectChanges();
+				if (self._agentViewComponent.showHistory) {
+					self._cd.detectChanges();
+				}
 			}
 		});
 	}
@@ -209,7 +211,9 @@ export class JobHistoryComponent extends JobManagementView implements OnInit {
 			} else {
 				self._showSteps = false;
 			}
-			self._cd.detectChanges();
+			if (self._agentViewComponent.showHistory) {
+				self._cd.detectChanges();
+			}
 		}
 	}
 

--- a/src/sql/parts/jobManagement/views/jobHistory.css
+++ b/src/sql/parts/jobManagement/views/jobHistory.css
@@ -262,7 +262,7 @@ jobhistory-component {
 }
 
 jobhistory-component > .jobhistory-heading-container {
-	display: inline-block;
+	display: flex;
 }
 
 jobhistory-component > .jobhistory-heading-container > .icon.in-progress {


### PR DESCRIPTION
Pausing and resuming agent history background refresh when a dialog is clicked or tab is changed.

Fixes https://github.com/Microsoft/azuredatastudio/issues/3333
Fixes another style issue for spinning wheel when the job history has not loaded yet.