### PR TITLE
adding hover text for dashboard serach grid items

### DIFF
--- a/src/sql/parts/dashboard/widgets/explorer/explorerTree.ts
+++ b/src/sql/parts/dashboard/widgets/explorer/explorerTree.ts
@@ -288,6 +288,7 @@ export class ExplorerRenderer implements tree.IRenderer {
 		} else {
 			templateData.label.innerText = element.databaseName;
 		}
+		templateData.label.title = templateData.label.innerText;
 	}
 
 	public disposeTemplate(tree: tree.ITree, templateId: string, templateData: IListTemplate): void {


### PR DESCRIPTION
Fix for issue : Search widget in Manage dashboard truncates long names with no hovertext to show full name  (Ref for issue: https://github.com/Microsoft/azuredatastudio/issues/3075)