### PR TITLE
Copy all messages when selecting all

### DIFF
--- a/src/sql/parts/query/editor/actions.ts
+++ b/src/sql/parts/query/editor/actions.ts
@@ -140,6 +140,7 @@ export class CopyMessagesAction extends Action {
 	public run(context: IMessagesActionContext): TPromise<boolean> {
 		if (this.messagePanel.selectAllMessages) {
 			this.clipboardService.writeText(context.selectAllMessages.join('\n'));
+			this.messagePanel.selectAllMessages = false;
 		} else {
 			this.clipboardService.writeText(context.selection.toString());
 		}

--- a/src/sql/parts/query/editor/actions.ts
+++ b/src/sql/parts/query/editor/actions.ts
@@ -20,6 +20,8 @@ import { GridTableState } from 'sql/parts/query/editor/gridPanel';
 import { QueryEditor } from './queryEditor';
 import { CellSelectionModel } from 'sql/base/browser/ui/table/plugins/cellSelectionModel.plugin';
 import { MessagePanel } from 'sql/parts/query/editor/messagePanel';
+import { isWindows } from 'vs/base/common/platform';
+import { removeAnsiEscapeCodes } from 'vs/base/common/strings';
 
 export interface IGridActionContext {
 	cell: { row: number; cell: number; };
@@ -35,7 +37,6 @@ export interface IGridActionContext {
 export interface IMessagesActionContext {
 	selection: Selection;
 	tree: ITree;
-	selectAllMessages: string[];
 }
 
 function mapForNumberColumn(ranges: Slick.Range[]): Slick.Range[] {
@@ -138,32 +139,36 @@ export class CopyMessagesAction extends Action {
 	}
 
 	public run(context: IMessagesActionContext): TPromise<boolean> {
-		if (this.messagePanel.selectAllMessages) {
-			this.clipboardService.writeText(context.selectAllMessages.join('\n'));
-			this.messagePanel.selectAllMessages = false;
-		} else {
-			this.clipboardService.writeText(context.selection.toString());
-		}
+		this.clipboardService.writeText(context.selection.toString());
 		return TPromise.as(true);
 	}
 }
 
-export class SelectAllMessagesAction extends Action {
-	public static ID = 'grid.messages.selectAll';
-	public static LABEL = localize('selectAll', 'Select All');
+const lineDelimiter = isWindows ? '\r\n' : '\n';
+export class CopyAllMessagesAction extends Action {
+	public static ID = 'grid.messages.copyAll';
+	public static LABEL = localize('copyAll', "Copy All");
 
-	constructor(private messagePanel: MessagePanel) {
-		super(SelectAllMessagesAction.ID, SelectAllMessagesAction.LABEL);
+	constructor(
+		private tree: ITree,
+		@IClipboardService private clipboardService: IClipboardService)
+	{
+		super(CopyAllMessagesAction.ID, CopyAllMessagesAction.LABEL);
 	}
 
-	public run(context: IMessagesActionContext): TPromise<boolean> {
-		let range = document.createRange();
-		range.selectNodeContents(context.tree.getHTMLElement());
-		let sel = document.getSelection();
-		sel.removeAllRanges();
-		sel.addRange(range);
-		this.messagePanel.selectAllMessages = true;
-		return TPromise.as(true);
+	public run(): TPromise<any> {
+		let text = '';
+		const navigator = this.tree.getNavigator();
+		// skip first navigator element - the root node
+		while (navigator.next()) {
+			if (text) {
+				text += lineDelimiter;
+			}
+			text += (navigator.current()).message;
+		}
+
+		this.clipboardService.writeText(removeAnsiEscapeCodes(text));
+		return TPromise.as(null);
 	}
 }
 

--- a/src/sql/parts/query/editor/actions.ts
+++ b/src/sql/parts/query/editor/actions.ts
@@ -19,6 +19,7 @@ import { Table } from 'sql/base/browser/ui/table/table';
 import { GridTableState } from 'sql/parts/query/editor/gridPanel';
 import { QueryEditor } from './queryEditor';
 import { CellSelectionModel } from 'sql/base/browser/ui/table/plugins/cellSelectionModel.plugin';
+import { MessagePanel } from 'sql/parts/query/editor/messagePanel';
 
 export interface IGridActionContext {
 	cell: { row: number; cell: number; };
@@ -34,6 +35,7 @@ export interface IGridActionContext {
 export interface IMessagesActionContext {
 	selection: Selection;
 	tree: ITree;
+	selectAllMessages: string[];
 }
 
 function mapForNumberColumn(ranges: Slick.Range[]): Slick.Range[] {
@@ -129,13 +131,18 @@ export class CopyMessagesAction extends Action {
 	public static LABEL = localize('copyMessages', 'Copy');
 
 	constructor(
+		private messagePanel: MessagePanel,
 		@IClipboardService private clipboardService: IClipboardService
 	) {
 		super(CopyMessagesAction.ID, CopyMessagesAction.LABEL);
 	}
 
 	public run(context: IMessagesActionContext): TPromise<boolean> {
-		this.clipboardService.writeText(context.selection.toString());
+		if (this.messagePanel.selectAllMessages) {
+			this.clipboardService.writeText(context.selectAllMessages.join('\n'));
+		} else {
+			this.clipboardService.writeText(context.selection.toString());
+		}
 		return TPromise.as(true);
 	}
 }
@@ -144,7 +151,7 @@ export class SelectAllMessagesAction extends Action {
 	public static ID = 'grid.messages.selectAll';
 	public static LABEL = localize('selectAll', 'Select All');
 
-	constructor() {
+	constructor(private messagePanel: MessagePanel) {
 		super(SelectAllMessagesAction.ID, SelectAllMessagesAction.LABEL);
 	}
 
@@ -154,6 +161,7 @@ export class SelectAllMessagesAction extends Action {
 		let sel = document.getSelection();
 		sel.removeAllRanges();
 		sel.addRange(range);
+		this.messagePanel.selectAllMessages = true;
 		return TPromise.as(true);
 	}
 }

--- a/src/sql/parts/query/editor/messagePanel.ts
+++ b/src/sql/parts/query/editor/messagePanel.ts
@@ -120,7 +120,6 @@ export class MessagePanel extends ViewletPanel {
 			}
 		});
 		this.controller.onKeyDown = (tree, event) => {
-
 			if (event.ctrlKey) {
 				let context: IMessagesActionContext = {
 					selection: null,


### PR DESCRIPTION
Fixes https://github.com/Microsoft/azuredatastudio/issues/3032

The issue was that we were getting the selection from the tree DOM but all the entries are only rendered when the tree is scrolled. Got all the messages now for a special case of "Select All". Fixed for context menu as well as keyboard shortcuts.

Also fixes https://github.com/Microsoft/azuredatastudio/issues/3044