### PR TITLE
Notebooks: Fix Selection Issues

### DIFF
--- a/src/sql/parts/notebook/cellViews/placeholderCell.component.html
+++ b/src/sql/parts/notebook/cellViews/placeholderCell.component.html
@@ -7,7 +7,7 @@
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div class="placeholder-cell-component" style="flex: 0 0 auto;">
 		<div class="placeholder-cell-component text">
-			<p>{{clickOn}} <a href="#" (click)="addCell('code')">{{plusCode}}</a> {{or}} <a href="#" (click)="addCell('markdown')">{{plusText}}</a> {{toAddCell}}</p>
+			<p>{{clickOn}} <a href="#" (click)="addCell('code', $event)">{{plusCode}}</a> {{or}} <a href="#" (click)="addCell('markdown', $event)">{{plusText}}</a> {{toAddCell}}</p>
 		</div>
 	</div>
 </div>

--- a/src/sql/parts/notebook/cellViews/placeholderCell.component.ts
+++ b/src/sql/parts/notebook/cellViews/placeholderCell.component.ts
@@ -68,7 +68,10 @@ export class PlaceholderCellComponent extends CellView implements OnInit, OnChan
 		return localize('toAddCell', 'to add a code or text cell');
 	}
 
-	public addCell(cellType: string): void {
+	public addCell(cellType: string, event?: Event): void {
+		if (event) {
+			event.stopPropagation();
+		}
 		let type: CellType = <CellType>cellType;
 		if (!type) {
 			type = 'code';

--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -173,14 +173,14 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	public unselectActiveCell() {
 		if (this.model && this.model.activeCell) {
 			this.model.activeCell.active = false;
+			this.model.activeCell = undefined;
 		}
 		this._changeRef.detectChanges();
 	}
 
 	// Add cell based on cell type
 	public addCell(cellType: CellType) {
-		let newCell = this._model.addCell(cellType);
-		this.selectCell(newCell);
+		this._model.addCell(cellType);
 	}
 
 	// Updates Notebook model's trust details


### PR DESCRIPTION
Fixing 2 bugs here:

- When creating a new cell from the placeholder cell, new cell was not active (issue was that unselectCell() was being called from notebook.component after cell was being created, so calling event.stopPropogation() fixes that)
- When creating a new cell, unselecting the cell then selecting it again did not select the cell properly; to fix, setting model.activeCell to undefined when unselecting ensures that the selection logic always works properly

Additionally, in the notebook component, we don't need to call this.selectCell() explicitly, since this is taken care of in the model.