### PR TITLE
Bump sqltoolservice to release 69 to fix #3839 doesn't have model.sys.assemblies

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.68",
+	"version": "1.5.0-alpha.69",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",


### PR DESCRIPTION
Bump sqltoolservice to release 69 to fix #3839 doesn't have model.sys.assemblies