### PR TITLE
Added data service context menu: file related operations

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -42,6 +42,32 @@
         ]
       }
     ],
+    "commands": [
+      {
+        "command": "hdfs.uploadFiles",
+        "title": "%hdfs.uploadFiles%"
+      },
+      {
+        "command": "hdfs.mkdir",
+        "title": "%hdfs.mkdir%"
+      },
+      {
+        "command": "hdfs.deleteFiles",
+        "title": "%hdfs.deleteFiles%"
+      },
+      {
+        "command": "hdfs.previewFile",
+        "title": "%hdfs.previewFile%"
+      },
+      {
+        "command": "hdfs.saveFile",
+        "title": "%hdfs.saveFile%"
+      },
+      {
+        "command": "hdfs.copyPath",
+        "title": "%hdfs.copyPath%"
+      }
+    ],
     "outputChannels": [
       "MSSQL"
     ],
@@ -130,6 +156,66 @@
           "default": false
         }
       }
+    },
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "hdfs.uploadFiles",
+          "when": "false"
+        },
+        {
+          "command": "hdfs.mkdir",
+          "when": "false"
+        },
+        {
+          "command": "hdfs.deleteFiles",
+          "when": "false"
+        },
+        {
+          "command": "hdfs.previewFile",
+          "when": "false"
+        },
+        {
+          "command": "hdfs.saveFile",
+          "when": "false"
+        },
+        {
+          "command": "hdfs.copyPath",
+          "when": "false"
+        }
+      ],
+      "objectExplorer/item/context": [
+        {
+          "command": "hdfs.uploadFiles",
+          "when": "nodeType=~/^hdfs/ && nodeType != hdfs:message && nodeType != hdfs:file",
+          "group": "1hdfs@1"
+        },
+        {
+          "command": "hdfs.mkdir",
+          "when": "nodeType=~/^hdfs/ && nodeType != hdfs:message && nodeType != hdfs:file",
+          "group": "1hdfs@1"
+        },
+        {
+          "command": "hdfs.saveFile",
+          "when": "nodeType == hdfs:file",
+          "group": "1hdfs@1"
+        },
+        {
+          "command": "hdfs.previewFile",
+          "when": "nodeType == hdfs:file",
+          "group": "1hdfs@2"
+        },
+        {
+          "command": "hdfs.copyPath",
+          "when": "nodeType=~/^hdfs/ && nodeType != hdfs:connection && nodeType != hdfs:message",
+          "group": "1hdfs@3"
+        },
+        {
+          "command": "hdfs.deleteFiles",
+          "when": "nodeType=~/^hdfs/ && viewItem != hdfs:connection && nodeType != hdfs:message",
+          "group": "1hdfs@4"
+        }
+      ]
     },
     "dashboard": {
       "provider": "MSSQL",

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -4,5 +4,11 @@
 	"json.schemas.fileMatch.desc": "An array of file patterns to match against when resolving JSON files to schemas.",
 	"json.schemas.fileMatch.item.desc": "A file pattern that can contain '*' to match against when resolving JSON files to schemas.",
 	"json.schemas.schema.desc": "The schema definition for the given URL. The schema only needs to be provided to avoid accesses to the schema URL.",
-	"json.format.enable.desc": "Enable/disable default JSON formatter (requires restart)"
+	"json.format.enable.desc": "Enable/disable default JSON formatter (requires restart)",
+	"hdfs.uploadFiles": "Upload files",
+	"hdfs.mkdir": "New directory",
+	"hdfs.deleteFiles": "Delete",
+	"hdfs.previewFile": "Preview",
+	"hdfs.saveFile": "Save",
+	"hdfs.copyPath": "Copy Path"
 }

--- a/extensions/mssql/src/escapeException.ts
+++ b/extensions/mssql/src/escapeException.ts
@@ -1,0 +1,3 @@
+'use strict';
+
+export default require('error-ex')('EscapeException');

--- a/extensions/mssql/src/objectExplorerNodeProvider/connection.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/connection.ts
@@ -195,7 +195,7 @@ export class Connection {
 		}
 		let profile = connectionInfo as sqlops.IConnectionProfile;
 		if (profile) {
-			let result: IEndpoint = await utils.getClusterEndpoint(profile.id, 'Knox');
+			let result: IEndpoint = await utils.getClusterEndpoint(profile.id, constants.hadoopKnoxEndpointName);
 			if (result === undefined || !result.ipAddress || !result.port) {
 				return false;
 			}

--- a/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
@@ -21,7 +21,7 @@ import { AppContext } from '../appContext';
 import * as constants from '../constants';
 
 const outputChannel = vscode.window.createOutputChannel(constants.providerId);
-interface IEndpoint {
+export interface IEndpoint {
 	serviceName: string;
 	ipAddress: string;
 	port: number;
@@ -209,7 +209,7 @@ export class MssqlObjectExplorerNodeProvider extends ProviderBase implements sql
 
 	async findNodeForContext<T extends TreeNode>(explorerContext: sqlops.ObjectExplorerContext): Promise<T> {
 		let node: T = undefined;
-		let session = this.findSessionForConnection(explorerContext.connectionProfile);
+		let session = await this.findSessionForConnection(explorerContext.connectionProfile);
 		if (session) {
 			if (explorerContext.isConnectionNode) {
 				// Note: ideally fix so we verify T matches RootNode and go from there
@@ -222,9 +222,9 @@ export class MssqlObjectExplorerNodeProvider extends ProviderBase implements sql
 		return node;
 	}
 
-	private findSessionForConnection(connectionProfile: sqlops.IConnectionProfile): Session {
+	private async findSessionForConnection(connectionProfile: sqlops.IConnectionProfile): Promise<Session> {
 		for (let session of this.sessionMap.values()) {
-			if (session.connection && session.connection.isMatch(connectionProfile)) {
+			if (session.connection && await session.connection.isMatch(connectionProfile)) {
 				return session;
 			}
 		}

--- a/extensions/mssql/src/prompts/adapter.ts
+++ b/extensions/mssql/src/prompts/adapter.ts
@@ -1,0 +1,111 @@
+'use strict';
+
+// This code is originally from https://github.com/DonJayamanne/bowerVSCode
+// License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
+
+import {window, OutputChannel } from 'vscode';
+import * as nodeUtil from 'util';
+import PromptFactory from './factory';
+import EscapeException from '../escapeException';
+import { IQuestion, IPrompter, IPromptCallback } from './question';
+
+// Supports simple pattern for prompting for user input and acting on this
+export default class CodeAdapter implements IPrompter {
+
+	private outChannel: OutputChannel;
+	private outBuffer: string = '';
+	private messageLevelFormatters = {};
+	constructor() {
+		// TODO Decide whether output channel logging should be saved here?
+		this.outChannel = window.createOutputChannel('test');
+		// this.outChannel.clear();
+	}
+
+	public logError(message: any): void {
+		let line = `error: ${message.message}\n    Code - ${message.code}`;
+
+		this.outBuffer += `${line}\n`;
+		this.outChannel.appendLine(line);
+	}
+
+	private formatMessage(message: any): string {
+		const prefix = `${message.level}: (${message.id}) `;
+		return `${prefix}${message.message}`;
+	}
+
+	public clearLog(): void {
+		this.outChannel.clear();
+	}
+
+	public showLog(): void {
+		this.outChannel.show();
+	}
+
+	// TODO define question interface
+	private fixQuestion(question: any): any {
+		if (question.type === 'checkbox' && Array.isArray(question.choices)) {
+			// For some reason when there's a choice of checkboxes, they aren't formatted properly
+			// Not sure where the issue is
+			question.choices = question.choices.map(item => {
+				if (typeof (item) === 'string') {
+					return { checked: false, name: item, value: item };
+				} else {
+					return item;
+				}
+			});
+		}
+	}
+
+	public promptSingle<T>(question: IQuestion, ignoreFocusOut?: boolean): Promise<T> {
+		let questions: IQuestion[] = [question];
+		return this.prompt(questions, ignoreFocusOut).then( (answers: {[key: string]: T})  => {
+			if (answers) {
+				let response: T = answers[question.name];
+				return response || undefined;
+			}
+		});
+	}
+
+	public prompt<T>(questions: IQuestion[], ignoreFocusOut?: boolean): Promise<{[key: string]: T}> {
+		let answers: {[key: string]: T} = {};
+
+		// Collapse multiple questions into a set of prompt steps
+		let promptResult: Promise<{[key: string]: T}> = questions.reduce((promise: Promise<{[key: string]: T}>, question: IQuestion) => {
+			this.fixQuestion(question);
+
+			return promise.then(() => {
+				return PromptFactory.createPrompt(question, ignoreFocusOut);
+			}).then(prompt => {
+				if (!question.shouldPrompt || question.shouldPrompt(answers) === true) {
+					return prompt.render().then(result => {
+						answers[question.name] = result;
+
+						if (question.onAnswered) {
+							question.onAnswered(result);
+						}
+						return answers;
+					});
+				}
+				return answers;
+			});
+		}, Promise.resolve());
+
+		return promptResult.catch(err => {
+			if (err instanceof EscapeException || err instanceof TypeError) {
+				return undefined;
+			}
+
+			window.showErrorMessage(err.message);
+		});
+	}
+
+	// Helper to make it possible to prompt using callback pattern. Generally Promise is a preferred flow
+	public promptCallback(questions: IQuestion[], callback: IPromptCallback): void {
+		// Collapse multiple questions into a set of prompt steps
+		this.prompt(questions).then(answers => {
+			if (callback) {
+				callback(answers);
+			}
+		});
+	}
+}

--- a/extensions/mssql/src/prompts/checkbox.ts
+++ b/extensions/mssql/src/prompts/checkbox.ts
@@ -1,0 +1,52 @@
+'use strict';
+
+// This code is originally from https://github.com/DonJayamanne/bowerVSCode
+// License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
+
+import { window } from 'vscode';
+import Prompt from './prompt';
+import EscapeException from '../escapeException';
+
+const figures = require('figures');
+
+export default class CheckboxPrompt extends Prompt {
+
+	constructor(question: any, ignoreFocusOut?: boolean) {
+		super(question, ignoreFocusOut);
+	}
+
+	public render(): any {
+		let choices = this._question.choices.reduce((result, choice) => {
+			let choiceName = choice.name || choice;
+			result[`${choice.checked === true ? figures.radioOn : figures.radioOff} ${choiceName}`] = choice;
+			return result;
+		}, {});
+
+		let options = this.defaultQuickPickOptions;
+		options.placeHolder = this._question.message;
+
+		let quickPickOptions = Object.keys(choices);
+		quickPickOptions.push(figures.tick);
+
+		return window.showQuickPick(quickPickOptions, options)
+			.then(result => {
+				if (result === undefined) {
+					throw new EscapeException();
+				}
+
+				if (result !== figures.tick) {
+					choices[result].checked = !choices[result].checked;
+
+					return this.render();
+				}
+
+				return this._question.choices.reduce((result2, choice) => {
+					if (choice.checked === true) {
+						result2.push(choice.value);
+					}
+
+					return result2;
+				}, []);
+			});
+	}
+}

--- a/extensions/mssql/src/prompts/confirm.ts
+++ b/extensions/mssql/src/prompts/confirm.ts
@@ -1,0 +1,36 @@
+'use strict';
+
+// This code is originally from https://github.com/DonJayamanne/bowerVSCode
+// License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
+
+import * as nls from 'vscode-nls';
+const localize = nls.loadMessageBundle();
+
+import { window } from 'vscode';
+import Prompt from './prompt';
+import EscapeException from '../escapeException';
+
+export default class ConfirmPrompt extends Prompt {
+
+	constructor(question: any, ignoreFocusOut?: boolean) {
+		super(question, ignoreFocusOut);
+	}
+
+	public render(): any {
+		let choices: { [id: string]: boolean } = {};
+		choices[localize('msgYes', 'Yes')] = true;
+		choices[localize('msgNo', 'No')] = false;
+
+		let options = this.defaultQuickPickOptions;
+		options.placeHolder = this._question.message;
+
+		return window.showQuickPick(Object.keys(choices), options)
+			.then(result => {
+				if (result === undefined) {
+					throw new EscapeException();
+				}
+
+				return choices[result] || false;
+			});
+	}
+}

--- a/extensions/mssql/src/prompts/expand.ts
+++ b/extensions/mssql/src/prompts/expand.ts
@@ -1,0 +1,78 @@
+'use strict';
+
+// This code is originally from https://github.com/DonJayamanne/bowerVSCode
+// License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
+
+import vscode = require('vscode');
+import Prompt from './prompt';
+import EscapeException from '../escapeException';
+import { INameValueChoice } from './question';
+
+const figures = require('figures');
+
+export default class ExpandPrompt extends Prompt {
+
+	constructor(question: any, ignoreFocusOut?: boolean) {
+		super(question, ignoreFocusOut);
+	}
+
+	public render(): any {
+		// label indicates this is a quickpick item. Otherwise it's a name-value pair
+		if (this._question.choices[0].label) {
+			return this.renderQuickPick(this._question.choices);
+		} else {
+			return this.renderNameValueChoice(this._question.choices);
+		}
+	}
+
+	private renderQuickPick(choices: vscode.QuickPickItem[]): any {
+		let options = this.defaultQuickPickOptions;
+		options.placeHolder = this._question.message;
+
+		return vscode.window.showQuickPick(choices, options)
+			.then(result => {
+				if (result === undefined) {
+					throw new EscapeException();
+				}
+
+				return this.validateAndReturn(result || false);
+			});
+	}
+	private renderNameValueChoice(choices: INameValueChoice[]): any {
+		const choiceMap = this._question.choices.reduce((result, choice) => {
+			result[choice.name] = choice.value;
+			return result;
+		}, {});
+
+		let options = this.defaultQuickPickOptions;
+		options.placeHolder = this._question.message;
+
+		return vscode.window.showQuickPick(Object.keys(choiceMap), options)
+			.then(result => {
+				if (result === undefined) {
+					throw new EscapeException();
+				}
+
+				// Note: cannot be used with 0 or false responses
+				let returnVal = choiceMap[result] || false;
+				return this.validateAndReturn(returnVal);
+			});
+	}
+
+	private validateAndReturn(value: any): any {
+		if (!this.validate(value)) {
+			return this.render();
+		}
+		return value;
+	}
+
+	private validate(value: any): boolean {
+		const validationError = this._question.validate ? this._question.validate(value || '') : undefined;
+
+		if (validationError) {
+			this._question.message = `${figures.warning} ${validationError}`;
+			return false;
+		}
+		return true;
+	}
+}

--- a/extensions/mssql/src/prompts/factory.ts
+++ b/extensions/mssql/src/prompts/factory.ts
@@ -1,0 +1,35 @@
+'use strict';
+
+// This code is originally from https://github.com/DonJayamanne/bowerVSCode
+// License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
+
+import Prompt from './prompt';
+import InputPrompt from './input';
+import PasswordPrompt from './password';
+import ListPrompt from './list';
+import ConfirmPrompt from './confirm';
+import CheckboxPrompt from './checkbox';
+import ExpandPrompt from './expand';
+
+export default class PromptFactory {
+
+	public static createPrompt(question: any, ignoreFocusOut?: boolean): Prompt {
+		switch (question.type || 'input') {
+			case 'string':
+			case 'input':
+				return new InputPrompt(question, ignoreFocusOut);
+			case 'password':
+				return new PasswordPrompt(question, ignoreFocusOut);
+			case 'list':
+				return new ListPrompt(question, ignoreFocusOut);
+			case 'confirm':
+				return new ConfirmPrompt(question, ignoreFocusOut);
+			case 'checkbox':
+				return new CheckboxPrompt(question, ignoreFocusOut);
+			case 'expand':
+				return new ExpandPrompt(question, ignoreFocusOut);
+			default:
+				throw new Error(`Could not find a prompt for question type ${question.type}`);
+		}
+	}
+}

--- a/extensions/mssql/src/prompts/input.ts
+++ b/extensions/mssql/src/prompts/input.ts
@@ -1,0 +1,59 @@
+'use strict';
+
+// This code is originally from https://github.com/DonJayamanne/bowerVSCode
+// License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
+
+import { window, InputBoxOptions } from 'vscode';
+import Prompt from './prompt';
+import EscapeException from '../escapeException';
+
+const figures = require('figures');
+
+export default class InputPrompt extends Prompt {
+
+	protected _options: InputBoxOptions;
+
+	constructor(question: any, ignoreFocusOut?: boolean) {
+		super(question, ignoreFocusOut);
+
+		this._options = this.defaultInputBoxOptions;
+		this._options.prompt = this._question.message;
+	}
+
+	// Helper for callers to know the right type to get from the type factory
+	public static get promptType(): string { return 'input'; }
+
+	public render(): any {
+		// Prefer default over the placeHolder, if specified
+		let placeHolder = this._question.default ? this._question.default : this._question.placeHolder;
+
+		if (this._question.default instanceof Error) {
+			placeHolder = this._question.default.message;
+			this._question.default = undefined;
+		}
+
+		this._options.placeHolder = placeHolder;
+
+		return window.showInputBox(this._options)
+			.then(result => {
+				if (result === undefined) {
+					throw new EscapeException();
+				}
+
+				if (result === '') {
+					// Use the default value, if defined
+					result = this._question.default || '';
+				}
+
+				const validationError = this._question.validate ? this._question.validate(result || '') : undefined;
+
+				if (validationError) {
+					this._question.default = new Error(`${figures.warning} ${validationError}`);
+
+					return this.render();
+				}
+
+				return result;
+			});
+	}
+}

--- a/extensions/mssql/src/prompts/list.ts
+++ b/extensions/mssql/src/prompts/list.ts
@@ -1,0 +1,33 @@
+'use strict';
+
+// This code is originally from https://github.com/DonJayamanne/bowerVSCode
+// License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
+
+import { window } from 'vscode';
+import Prompt from './prompt';
+import EscapeException from '../escapeException';
+
+export default class ListPrompt extends Prompt {
+	constructor(question: any, ignoreFocusOut?: boolean) {
+		super(question, ignoreFocusOut);
+	}
+
+	public render(): any {
+		const choices = this._question.choices.reduce((result, choice) => {
+			result[choice.name] = choice.value;
+			return result;
+		}, {});
+
+		let options = this.defaultQuickPickOptions;
+		options.placeHolder = this._question.message;
+
+		return window.showQuickPick(Object.keys(choices), options)
+			.then(result => {
+				if (result === undefined) {
+					throw new EscapeException();
+				}
+
+				return choices[result];
+			});
+	}
+}

--- a/extensions/mssql/src/prompts/password.ts
+++ b/extensions/mssql/src/prompts/password.ts
@@ -1,0 +1,15 @@
+'use strict';
+
+// This code is originally from https://github.com/DonJayamanne/bowerVSCode
+// License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
+
+import InputPrompt from './input';
+
+export default class PasswordPrompt extends InputPrompt {
+
+    constructor(question: any, ignoreFocusOut?: boolean) {
+        super(question, ignoreFocusOut);
+
+        this._options.password = true;
+    }
+}

--- a/extensions/mssql/src/prompts/progressIndicator.ts
+++ b/extensions/mssql/src/prompts/progressIndicator.ts
@@ -1,0 +1,70 @@
+'use strict';
+
+// This code is originally from https://github.com/DonJayamanne/bowerVSCode
+// License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
+
+import {window, StatusBarItem, StatusBarAlignment} from 'vscode';
+
+export default class ProgressIndicator {
+
+	private _statusBarItem: StatusBarItem;
+
+	constructor() {
+		this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);
+	   }
+
+	private _tasks: string[] = [];
+	public beginTask(task: string): void {
+		this._tasks.push(task);
+		this.displayProgressIndicator();
+	}
+
+	public endTask(task: string): void {
+		if (this._tasks.length > 0) {
+			this._tasks.pop();
+		}
+
+		this.setMessage();
+	}
+
+	private setMessage(): void {
+		if (this._tasks.length === 0) {
+			this._statusBarItem.text = '';
+			this.hideProgressIndicator();
+			return;
+		}
+
+		this._statusBarItem.text = this._tasks[this._tasks.length - 1];
+		this._statusBarItem.show();
+	}
+
+	private _interval: any;
+	private displayProgressIndicator(): void {
+		this.setMessage();
+		this.hideProgressIndicator();
+		this._interval = setInterval(() => this.onDisplayProgressIndicator(), 100);
+	}
+	private hideProgressIndicator(): void {
+		if (this._interval) {
+			clearInterval(this._interval);
+			this._interval = undefined;
+		}
+		this.ProgressCounter = 0;
+	}
+
+	private ProgressText = ['|', '/', '-', '\\', '|', '/', '-', '\\'];
+	private ProgressCounter = 0;
+	private onDisplayProgressIndicator(): void {
+		if (this._tasks.length === 0) {
+			return;
+		}
+
+		let txt = this.ProgressText[this.ProgressCounter];
+		this._statusBarItem.text = this._tasks[this._tasks.length - 1] + ' ' + txt;
+		this.ProgressCounter++;
+
+		if (this.ProgressCounter >= this.ProgressText.length - 1) {
+			this.ProgressCounter = 0;
+		}
+	}
+}

--- a/extensions/mssql/src/prompts/prompt.ts
+++ b/extensions/mssql/src/prompts/prompt.ts
@@ -1,0 +1,33 @@
+'use strict';
+
+// This code is originally from https://github.com/DonJayamanne/bowerVSCode
+// License: https://github.com/DonJayamanne/bowerVSCode/blob/master/LICENSE
+
+import { InputBoxOptions, QuickPickOptions } from 'vscode';
+
+abstract class Prompt {
+
+	protected _question: any;
+	protected _ignoreFocusOut?: boolean;
+
+	constructor(question: any, ignoreFocusOut?: boolean) {
+		this._question = question;
+		this._ignoreFocusOut = ignoreFocusOut ? ignoreFocusOut : false;
+	}
+
+	public abstract render(): any;
+
+	protected get defaultQuickPickOptions(): QuickPickOptions {
+		return {
+			ignoreFocusOut: this._ignoreFocusOut
+		};
+	}
+
+	protected get defaultInputBoxOptions(): InputBoxOptions {
+		return {
+			ignoreFocusOut: this._ignoreFocusOut
+		};
+	}
+}
+
+export default Prompt;

--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -9,8 +9,10 @@ import * as sqlops from 'sqlops';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import * as os from 'os';
-import {workspace, WorkspaceConfiguration} from 'vscode';
+import { workspace, WorkspaceConfiguration } from 'vscode';
 import * as findRemoveSync from 'find-remove';
+import { IEndpoint } from './objectExplorerNodeProvider/objectExplorerNodeProvider';
+import * as constants from './constants';
 
 const configTracingLevel = 'tracingLevel';
 const configLogRetentionMinutes = 'logRetentionMinutes';
@@ -29,56 +31,53 @@ export function getAppDataPath() {
 	}
 }
 
-export function removeOldLogFiles(prefix: string) : JSON {
-	return findRemoveSync(getDefaultLogDir(), {prefix: `${prefix}_`,  age: {seconds: getConfigLogRetentionSeconds()}, limit: getConfigLogFilesRemovalLimit()});
+export function removeOldLogFiles(prefix: string): JSON {
+	return findRemoveSync(getDefaultLogDir(), { prefix: `${prefix}_`, age: { seconds: getConfigLogRetentionSeconds() }, limit: getConfigLogFilesRemovalLimit() });
 }
 
-export function getConfiguration(config: string = extensionConfigSectionName) : WorkspaceConfiguration {
+export function getConfiguration(config: string = extensionConfigSectionName): WorkspaceConfiguration {
 	return workspace.getConfiguration(extensionConfigSectionName);
 }
 
-export function getConfigLogFilesRemovalLimit() : number {
+export function getConfigLogFilesRemovalLimit(): number {
 	let config = getConfiguration();
 	if (config) {
 		return Number((config[configLogFilesRemovalLimit]).toFixed(0));
 	}
-	else
-	{
+	else {
 		return undefined;
 	}
 }
 
-export function getConfigLogRetentionSeconds() : number {
+export function getConfigLogRetentionSeconds(): number {
 	let config = getConfiguration();
 	if (config) {
 		return Number((config[configLogRetentionMinutes] * 60).toFixed(0));
 	}
-	else
-	{
+	else {
 		return undefined;
 	}
 }
 
-export function getConfigTracingLevel() : string {
+export function getConfigTracingLevel(): string {
 	let config = getConfiguration();
 	if (config) {
 		return config[configTracingLevel];
 	}
-	else
-	{
+	else {
 		return undefined;
 	}
 }
 
-export function getDefaultLogDir() : string {
-	return path.join(process.env['VSCODE_LOGS'], '..', '..','mssql');
+export function getDefaultLogDir(): string {
+	return path.join(process.env['VSCODE_LOGS'], '..', '..', 'mssql');
 }
 
-export function getDefaultLogFile(prefix: string, pid: number) : string {
+export function getDefaultLogFile(prefix: string, pid: number): string {
 	return path.join(getDefaultLogDir(), `${prefix}_${pid}.log`);
 }
 
-export function getCommonLaunchArgsAndCleanupOldLogFiles(prefix: string, executablePath: string) : string [] {
+export function getCommonLaunchArgsAndCleanupOldLogFiles(prefix: string, executablePath: string): string[] {
 	let launchArgs = [];
 	launchArgs.push('--log-file');
 	let logFile = getDefaultLogFile(prefix, process.pid);
@@ -182,4 +181,28 @@ export function isObjectExplorerContext(object: any): object is sqlops.ObjectExp
 
 export function getUserHome(): string {
 	return process.env.HOME || process.env.USERPROFILE;
+}
+
+export async function getClusterEndpoint(profileId: string, serviceName: string): Promise<IEndpoint> {
+
+	let serverInfo: sqlops.ServerInfo = undefined;
+	serverInfo = await sqlops.connection.getServerInfo(profileId)
+
+	if (!serverInfo || !serverInfo.options) {
+		return undefined;
+	}
+	let endpoints: IEndpoint[] = serverInfo.options[constants.clusterEndpointsProperty];
+	if (!endpoints || endpoints.length === 0) {
+		return undefined;
+	}
+	let index = endpoints.findIndex(ep => ep.serviceName === serviceName);
+	if (index === -1) {
+		return undefined;
+	}
+	let clusterEndpoint: IEndpoint = {
+		serviceName: endpoints[index].serviceName,
+		ipAddress: endpoints[index].ipAddress,
+		port: endpoints[index].port
+	};
+	return clusterEndpoint;
 }


### PR DESCRIPTION
Added data service context menu: file related operations. All new ts files are ported from SqlOpsStudio. Will remove these functionalities from SqlOpsStudio.

- Fixed the format in utils.ts
- Changed the isMatch function in connection to compare the info from getServerInfo. Right now the credential check is disabled, need to enable it  when unified user is functional from platform team. The work is tracked in Cleanup work section https://github.com/Microsoft/azuredatastudio/issues/3707
