### PR TITLE
Pass connectionid to registered commands from command line

### DIFF
--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -8,15 +8,25 @@
 import * as vscode from 'vscode';
 import * as sqlops from 'sqlops';
 import * as nls from 'vscode-nls';
+
 const localize = nls.loadMessageBundle();
 
 let counter = 0;
 
 export function activate(extensionContext: vscode.ExtensionContext) {
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.new', () => {
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.new', ( connectionId? : string) => {
+
 		let title = `Untitled-${counter++}`;
 		let untitledUri = vscode.Uri.parse(`untitled:${title}`);
-		sqlops.nb.showNotebookDocument(untitledUri).then(success => {
+        let options: sqlops.nb.NotebookShowOptions =  connectionId? {
+			viewColumn : null,
+			preserveFocus : true,
+			preview: null,
+            providerId : null,
+			connectionId : connectionId,
+			defaultKernel : null
+		} : null;
+		sqlops.nb.showNotebookDocument(untitledUri, options).then(success => {
 
 		}, (err: Error) => {
 			vscode.window.showErrorMessage(err.message);

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -8,14 +8,12 @@
 import * as vscode from 'vscode';
 import * as sqlops from 'sqlops';
 import * as nls from 'vscode-nls';
-
 const localize = nls.loadMessageBundle();
 
 let counter = 0;
 
 export function activate(extensionContext: vscode.ExtensionContext) {
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.new', ( connectionId? : string) => {
-
 		let title = `Untitled-${counter++}`;
 		let untitledUri = vscode.Uri.parse(`untitled:${title}`);
         let options: sqlops.nb.NotebookShowOptions =  connectionId? {

--- a/src/sql/workbench/services/commandLine/common/commandLineService.ts
+++ b/src/sql/workbench/services/commandLine/common/commandLineService.ts
@@ -111,7 +111,7 @@ export class CommandLineService implements ICommandLineProcessing {
 				} else {
 					self._connectionManagementService.connectIfNotConnected(self._connectionProfile, 'connection', true)
 						.then(() => {
-							self._commandService.executeCommand(self._commandName, self._connectionProfile).then(() => resolve(), error => reject(error));
+							self._commandService.executeCommand(self._commandName, self._connectionProfile.id).then(() => resolve(), error => reject(error));
 						}, error => {
 							reject(error);
 						});

--- a/src/sqltest/parts/commandLine/commandLineService.test.ts
+++ b/src/sqltest/parts/commandLine/commandLineService.test.ts
@@ -246,7 +246,7 @@ suite('commandLineService tests', () => {
 		connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver'), 'connection', true))
 			.returns(() => new Promise<string>((resolve, reject) => { resolve('unused'); }))
 			.verifiable(TypeMoq.Times.once());
-		commandService.setup(c => c.executeCommand('mycommand', TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver')))
+		commandService.setup(c => c.executeCommand('mycommand', TypeMoq.It.isAnyString()))
 			.returns(() => TPromise.wrap(1))
 			.verifiable(TypeMoq.Times.once());
 		const configurationService = getConfigurationServiceMock(true);


### PR DESCRIPTION
First command to leverage it is new notebook. It turned out we can't serialize the entire ConnectionProfile to the extension so we just pass the id. The id is sufficient for the notebook plugin.