### PR TITLE
Add bytes dependency to mssql

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -18,6 +18,7 @@
     "update-grammar": "node ../../build/npm/update-grammar.js Microsoft/vscode-mssql syntaxes/SQL.plist ./syntaxes/sql.tmLanguage.json"
   },
   "dependencies": {
+    "bytes": "^3.1.0",
     "clipboardy": "^1.2.3",
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#0.2.15",
     "opener": "^1.4.3",
@@ -28,8 +29,7 @@
     "vscode-nls": "2.0.2",
     "webhdfs": "^1.1.1"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "contributes": {
     "languages": [
       {

--- a/extensions/mssql/yarn.lock
+++ b/extensions/mssql/yarn.lock
@@ -99,6 +99,11 @@ buffer@^3.0.1:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+bytes@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"


### PR DESCRIPTION
Fixes #3864 by adding a dependency that wasn't brought over from the SQL Server 2019 extension to the MSSQL extension.

Not really sure how it still builds without that dependency but MSSQL fails to activate in packaged builds without it 🤷‍♂️ 