### PR TITLE
Fix weird exception when no connection is present for SQL kernel, Limit Max Rows to 2000

### DIFF
--- a/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
@@ -188,7 +188,7 @@ class SqlKernel extends Disposable implements nb.IKernel {
 	requestExecute(content: nb.IExecuteRequest, disposeOnDone?: boolean): nb.IFuture {
 		if (this._queryRunner) {
 			this._queryRunner.runQuery(content.code);
-		} else {
+		} else if (this._currentConnection) {
 			let connectionUri = Utils.generateUri(this._currentConnection, 'notebook');
 			this._queryRunner = this._instantiationService.createInstance(QueryRunner, connectionUri, undefined);
 			this._connectionManagementService.connect(this._currentConnection, connectionUri).then((result) =>
@@ -255,7 +255,7 @@ export class SQLFuture extends Disposable implements FutureInternal {
 		super();
 	}
 	get inProgress(): boolean {
-		return !this._queryRunner.hasCompleted;
+		return this._queryRunner && !this._queryRunner.hasCompleted;
 	}
 	set inProgress(val: boolean) {
 		if (this._queryRunner && !val) {
@@ -269,18 +269,22 @@ export class SQLFuture extends Disposable implements FutureInternal {
 	get done(): Thenable<nb.IShellMessage> {
 		let deferred = new Deferred<nb.IShellMessage>();
 		try {
-			this._register(this._queryRunner.onBatchEnd(e => {
-				let msg: nb.IShellMessage = {
-					channel: 'shell',
-					type: 'execute_reply',
-					content: { status: 'ok' },
-					header: undefined,
-					metadata: {},
-					parent_header: undefined
-				};
-				this._msg = msg;
-				deferred.resolve(msg);
-			}));
+			if (this._queryRunner) {
+				this._register(this._queryRunner.onBatchEnd(e => {
+					let msg: nb.IShellMessage = {
+						channel: 'shell',
+						type: 'execute_reply',
+						content: { status: 'ok' },
+						header: undefined,
+						metadata: {},
+						parent_header: undefined
+					};
+					this._msg = msg;
+					deferred.resolve(msg);
+				}));
+			} else {
+				deferred.resolve();
+			}
 		} catch {
 			return Promise.resolve(undefined);
 		}
@@ -298,29 +302,31 @@ export class SQLFuture extends Disposable implements FutureInternal {
 		// no-op
 	}
 	setIOPubHandler(handler: nb.MessageHandler<nb.IIOPubMessage>): void {
-		this._register(this._queryRunner.onBatchEnd(batch => {
-			this._queryRunner.getQueryRows(0, batch.resultSetSummaries[0].rowCount, 0, 0).then(d => {
-				let columns = batch.resultSetSummaries[0].columnInfo;
+		if (this._queryRunner) {
+			this._register(this._queryRunner.onBatchEnd(batch => {
+				this._queryRunner.getQueryRows(0, batch.resultSetSummaries[0].rowCount, 0, 0).then(d => {
+					let columns = batch.resultSetSummaries[0].columnInfo;
 
-				let msg: nb.IIOPubMessage = {
-					channel: 'iopub',
-					type: 'iopub',
-					header: <nb.IHeader>{
-						msg_id: undefined,
-						msg_type: 'execute_result'
-					},
-					content: <nb.IExecuteResult>{
-						output_type: 'execute_result',
-						metadata: {},
-						execution_count: 0,
-						data: { 'application/vnd.dataresource+json': this.convertToDataResource(columns, d), 'text/html': this.convertToHtmlTable(columns, d) }
-					},
-					metadata: undefined,
-					parent_header: undefined
-				};
-				handler.handle(msg);
-			});
-		}));
+					let msg: nb.IIOPubMessage = {
+						channel: 'iopub',
+						type: 'iopub',
+						header: <nb.IHeader>{
+							msg_id: undefined,
+							msg_type: 'execute_result'
+						},
+						content: <nb.IExecuteResult>{
+							output_type: 'execute_result',
+							metadata: {},
+							execution_count: 0,
+							data: { 'application/vnd.dataresource+json': this.convertToDataResource(columns, d), 'text/html': this.convertToHtmlTable(columns, d) }
+						},
+						metadata: undefined,
+						parent_header: undefined
+					};
+					handler.handle(msg);
+				});
+			}));
+		}
 	}
 	registerMessageHook(hook: (msg: nb.IIOPubMessage) => boolean | Thenable<boolean>): void {
 		// no-op

--- a/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
@@ -21,6 +21,7 @@ import { escape } from 'sql/base/common/strings';
 
 export const sqlKernel: string = localize('sqlKernel', 'SQL');
 export const sqlKernelError: string = localize("sqlKernelError", "SQL kernel error");
+export const MAX_ROWS = 2000;
 
 let sqlKernelSpec: nb.IKernelSpec = ({
 	name: sqlKernel,
@@ -304,7 +305,8 @@ export class SQLFuture extends Disposable implements FutureInternal {
 	setIOPubHandler(handler: nb.MessageHandler<nb.IIOPubMessage>): void {
 		if (this._queryRunner) {
 			this._register(this._queryRunner.onBatchEnd(batch => {
-				this._queryRunner.getQueryRows(0, batch.resultSetSummaries[0].rowCount, 0, 0).then(d => {
+				let rowCount = batch.resultSetSummaries[0].rowCount > MAX_ROWS ? MAX_ROWS : batch.resultSetSummaries[0].rowCount;
+				this._queryRunner.getQueryRows(0, rowCount, 0, 0).then(d => {
 					let columns = batch.resultSetSummaries[0].columnInfo;
 
 					let msg: nb.IIOPubMessage = {


### PR DESCRIPTION
Fixes #3856. Matches the Jupyter behavior that we have, where we don't show any message when a connection is required. We no longer will throw a bizarre exception about getOptionsKey being undefined.

Also sets max rows returned to 2000.