### PR TITLE
Make run cell button float so it's always visible

### DIFF
--- a/src/sql/parts/notebook/cellViews/code.component.html
+++ b/src/sql/parts/notebook/cellViews/code.component.html
@@ -4,8 +4,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 -->
-<div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: row">
-	<div #toolbar class="toolbar" style="flex: 0 0 auto; display: flex; flex-flow:column; width: 40px; min-height: 40px; padding-top: 10px; orientation: portrait">
+<div style="width: 100%; height: 100%; display: flex; flex-flow: row">
+	<div #toolbar class="toolbar" style="flex: 0 0 auto; display: flex; flex-flow:column; width: 40px; min-height: 40px; orientation: portrait">
 	</div>
 	<div #editor class="editor" style="flex: 1 1 auto; overflow: hidden;">
 	</div>

--- a/src/sql/parts/notebook/cellViews/code.css
+++ b/src/sql/parts/notebook/cellViews/code.css
@@ -13,6 +13,12 @@ code-component .toolbar {
 	border-right-width: 1px;
 }
 
+code-component .toolbar .carbon-taskbar {
+	position: sticky;
+	top: 10px;
+	bottom: 30px;
+}
+
 code-component .toolbarIconRun {
 	height: 20px;
 	background-image: url('../media/light/execute_cell.svg');

--- a/src/sql/parts/notebook/cellViews/codeCell.component.html
+++ b/src/sql/parts/notebook/cellViews/codeCell.component.html
@@ -4,7 +4,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 -->
-<div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
+<div style="width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div class="notebook-code" style="flex: 0 0 auto;">
 		<code-component [cellModel]="cellModel" [model]="model" [activeCellId]="activeCellId"></code-component>
 	</div>


### PR DESCRIPTION
- Make the toolbar sticky and remove overflow:hidden which blocked this working.

UI:
Default: run at top of cell like before
![image](https://user-images.githubusercontent.com/10819925/52153844-771a2a80-2630-11e9-9564-e99c9e5df05f.png)

On scroll: run stays at top of visible area
![image](https://user-images.githubusercontent.com/10819925/52153867-8d27eb00-2630-11e9-9063-9d660e95b8b4.png)

Scroll lower: run sticks where it was inside the toolbar area

![image](https://user-images.githubusercontent.com/10819925/52153871-92853580-2630-11e9-912a-56e7d4220071.png)
