### PR TITLE
Ported Analyze notebook code from SqlOpsStudio and make it work.

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -31,6 +31,10 @@
 		},
 		"commands": [
 			{
+				"command": "notebook.command.analyzeNotebook",
+				"title": "%notebook.analyzeJupyterNotebook%"
+			},
+			{
 				"command": "notebook.command.new",
 				"title": "%notebook.command.new%",
 				"icon": {
@@ -50,10 +54,20 @@
 		"menus": {
 			"commandPalette": [
 				{
+					"command": "notebook.command.analyzeNotebook"
+				},
+				{
 					"command": "notebook.command.new"
 				},
 				{
 					"command": "notebook.command.open"
+				}
+			],
+			"objectExplorer/item/context": [
+				{
+					"command": "notebook.command.analyzeNotebook",
+					"when": "nodeType=~/^mssqlCluster/ && nodeLabel=~/[^\\s]+(\\.(csv|tsv|txt))$/ && nodeType == mssqlCluster:file",
+					"group": "1notebook@1"
 				}
 			]
 		},

--- a/extensions/notebook/package.nls.json
+++ b/extensions/notebook/package.nls.json
@@ -5,5 +5,6 @@
 	"notebook.pythonPath.description": "Local path to python installation used by Notebooks.",
 	"notebook.sqlKernelEnabled.description": "Enable SQL kernel in notebook editor (Preview). Requires reloading this window to take effect",
 	"notebook.command.new": "New Notebook",
-	"notebook.command.open": "Open Notebook"
+	"notebook.command.open": "Open Notebook",
+	"notebook.analyzeJupyterNotebook": "Analyze in Notebook"
 }

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -14,9 +14,7 @@ const localize = nls.loadMessageBundle();
 
 let counter = 0;
 const notebookConfigKey = 'notebook';
-const sqlKernelEnablebConfig = 'sqlKernelEnabled';
 const pythonPathConfigKey = 'pythonPath';
-const SQL_NOTEBOOK_PROVIDER = 'sql';
 const DEFAULT_NOTEBOOK_PROVIDER = 'builtin';
 const JUPYTER_NOTEBOOK_PROVIDER = 'jupyter';
 const msgSampleCodeDataFrame = localize('msgSampleCodeDataFrame', 'This sample code loads the file into a data frame and shows the first 10 results.');
@@ -72,15 +70,11 @@ async function analyzeNotebook(oeContext?: sqlops.ObjectExplorerContext): Promis
 
 	let config = getConfiguration(notebookConfigKey);
 	if (config) {
-		let providerId: string = SQL_NOTEBOOK_PROVIDER;
-		let sqlKerelEnabled = config[sqlKernelEnablebConfig];
-		if (!sqlKerelEnabled) {
-			let pythonInstalledPath = config[pythonPathConfigKey];
-			if (pythonInstalledPath && fs.existsSync(pythonInstalledPath)) {
-				providerId = JUPYTER_NOTEBOOK_PROVIDER;
-			} else {
-				providerId = DEFAULT_NOTEBOOK_PROVIDER;
-			}
+		let providerId: string = JUPYTER_NOTEBOOK_PROVIDER;
+
+		let pythonInstalledPath = config[pythonPathConfigKey];
+		if (!(pythonInstalledPath && fs.existsSync(pythonInstalledPath))) {
+			providerId = DEFAULT_NOTEBOOK_PROVIDER;
 		}
 
 		let editor = await sqlops.nb.showNotebookDocument(untitledUri, {

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -7,22 +7,31 @@
 
 import * as vscode from 'vscode';
 import * as sqlops from 'sqlops';
+import * as os from 'os';
+import * as fs from 'fs-extra';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
 let counter = 0;
+const notebookConfigKey = 'notebook';
+const sqlKernelEnablebConfig = 'sqlKernelEnabled';
+const pythonPathConfigKey = 'pythonPath';
+const SQL_NOTEBOOK_PROVIDER = 'sql';
+const DEFAULT_NOTEBOOK_PROVIDER = 'builtin';
+const JUPYTER_NOTEBOOK_PROVIDER = 'jupyter';
+const msgSampleCodeDataFrame = localize('msgSampleCodeDataFrame', 'This sample code loads the file into a data frame and shows the first 10 results.');
 
 export function activate(extensionContext: vscode.ExtensionContext) {
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.new', ( connectionId? : string) => {
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.new', (connectionId?: string) => {
 		let title = `Untitled-${counter++}`;
 		let untitledUri = vscode.Uri.parse(`untitled:${title}`);
-        let options: sqlops.nb.NotebookShowOptions =  connectionId? {
-			viewColumn : null,
-			preserveFocus : true,
+		let options: sqlops.nb.NotebookShowOptions = connectionId ? {
+			viewColumn: null,
+			preserveFocus: true,
 			preview: null,
-            providerId : null,
-			connectionId : connectionId,
-			defaultKernel : null
+			providerId: null,
+			connectionId: connectionId,
+			defaultKernel: null
 		} : null;
 		sqlops.nb.showNotebookDocument(untitledUri, options).then(success => {
 
@@ -32,6 +41,9 @@ export function activate(extensionContext: vscode.ExtensionContext) {
 	}));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.open', () => {
 		openNotebook();
+	}));
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.analyzeNotebook', (explorerContext: sqlops.ObjectExplorerContext) => {
+		analyzeNotebook(explorerContext);
 	}));
 
 }
@@ -51,6 +63,66 @@ async function openNotebook(): Promise<void> {
 	} catch (err) {
 		vscode.window.showErrorMessage(err);
 	}
+}
+
+async function analyzeNotebook(oeContext?: sqlops.ObjectExplorerContext): Promise<void> {
+	// Ensure we get a unique ID for the notebook. For now we're using a different prefix to the built-in untitled files
+	// to handle this. We should look into improving this in the future
+	let untitledUri = vscode.Uri.parse(`untitled:Notebook-${counter++}`);
+
+	let config = getConfiguration(notebookConfigKey);
+	if (config) {
+		let providerId: string = SQL_NOTEBOOK_PROVIDER;
+		let sqlKerelEnabled = config[sqlKernelEnablebConfig];
+		if (!sqlKerelEnabled) {
+			let pythonInstalledPath = config[pythonPathConfigKey];
+			if (pythonInstalledPath && fs.existsSync(pythonInstalledPath)) {
+				providerId = JUPYTER_NOTEBOOK_PROVIDER;
+			} else {
+				providerId = DEFAULT_NOTEBOOK_PROVIDER;
+			}
+		}
+
+		let editor = await sqlops.nb.showNotebookDocument(untitledUri, {
+			connectionId: oeContext ? oeContext.connectionProfile.id : '',
+			providerId: providerId
+		});
+		if (oeContext && oeContext.nodeInfo && oeContext.nodeInfo.nodePath) {
+			// Get the file path after '/HDFS'
+			let hdfsPath: string = oeContext.nodeInfo.nodePath.substring(oeContext.nodeInfo.nodePath.indexOf('/HDFS') + '/HDFS'.length);
+			if (hdfsPath.length > 0) {
+				let analyzeCommand = "#" + msgSampleCodeDataFrame + os.EOL + "df = (spark.read.option(\"inferSchema\", \"true\")"
+					+ os.EOL + ".option(\"header\", \"true\")" + os.EOL + ".csv('{0}'))" + os.EOL + "df.show(10)";
+
+				editor.edit(editBuilder => {
+					editBuilder.replace(0, {
+						cell_type: 'code',
+						source: analyzeCommand.replace('{0}', hdfsPath)
+					});
+				});
+
+			}
+		}
+	}
+}
+
+/**
+	* Get the configuration for a extensionName
+	* @param extensionName The string name of the extension to get the configuration for
+	* @param resource The optional URI, as a URI object or a string, to use to get resource-scoped configurations
+	*/
+function getConfiguration(extensionName?: string, resource?: vscode.Uri | string): vscode.WorkspaceConfiguration {
+	if (typeof resource === 'string') {
+		try {
+			resource = this.parseUri(resource);
+		} catch (e) {
+			resource = undefined;
+		}
+	} else if (!resource) {
+		// Fix to avoid adding lots of errors to debug console. Expects a valid resource or null, not undefined
+		resource = null;
+	}
+	return vscode.workspace.getConfiguration(extensionName, resource as vscode.Uri);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
If config.notebook.sqlKernelEnabled is true, use SQL provider
Use Jupyter provider if Python is install, otherwise use buildIn Kernel.