### PR TITLE
Add tooltip for table column headers and align header and cell

### DIFF
--- a/src/sql/parts/modelComponents/table.component.ts
+++ b/src/sql/parts/modelComponents/table.component.ts
@@ -57,7 +57,8 @@ export default class TableComponent extends ComponentBase implements IComponent,
 						id: col.value,
 						field: col.value,
 						width: col.width,
-						cssClass: col.cssClass
+						cssClass: col.cssClass,
+						toolTip: col.toolTip
 					};
 				} else {
 					return <Slick.Column<any>>{

--- a/src/sql/parts/modelComponents/table.css
+++ b/src/sql/parts/modelComponents/table.css
@@ -7,3 +7,12 @@
 {
 	text-align: center;
 }
+
+.slick-headerrow-column {
+	padding-left:3px !important;
+}
+
+.slick-cell
+{
+	padding-left:3px !important;
+}

--- a/src/sql/parts/modelComponents/table.css
+++ b/src/sql/parts/modelComponents/table.css
@@ -8,11 +8,7 @@
 	text-align: center;
 }
 
-.slick-headerrow-column {
-	padding-left:3px !important;
-}
-
-.slick-cell
+.align-with-header
 {
 	padding-left:3px !important;
 }

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -499,6 +499,7 @@ declare module 'sqlops' {
 		value: string;
 		width?: number;
 		cssClass?: string;
+		toolTip?: string;
 	}
 
 	export interface TableComponentProperties extends ComponentProperties {


### PR DESCRIPTION
This adds the toolTip option for TableColumn and also aligns the padding left of headers and cells so that it all aligns.

tooltip:
![image](https://user-images.githubusercontent.com/31145923/52369082-b5369600-2a04-11e9-9db1-81ab99871e51.png)


without padding(left) and with padding(right) :
![image](https://user-images.githubusercontent.com/31145923/52368654-cb902200-2a03-11e9-92d8-2fd880a5c949.png)
