### PR TITLE
#3897: Unified connection integration - sql connection improvements

### DIFF
--- a/src/sql/parts/notebook/models/modelInterfaces.ts
+++ b/src/sql/parts/notebook/models/modelInterfaces.ts
@@ -378,6 +378,9 @@ export interface INotebookModel {
 	pushEditOperations(edits: ISingleNotebookEditOperation[]): void;
 
 	getApplicableConnectionProviderIds(kernelName: string): string[];
+
+	/** Event fired once we get call back from ConfigureConnection method in sqlops extension */
+	readonly onValidConnectionSelected: Event<boolean>;
 }
 
 export interface NotebookContentChange {

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -262,7 +262,7 @@ export class AttachToDropdown extends SelectBox {
 	}
 
 	// Load "Attach To" dropdown with the values corresponding to Kernel dropdown
-	public async loadAttachToDropdown(model: INotebookModel, currentKernel: string, defaultSelectConnection?: boolean): Promise<void> {
+	public async loadAttachToDropdown(model: INotebookModel, currentKernel: string, showSelectConnection?: boolean): Promise<void> {
 		let connProviderIds = this.model.getApplicableConnectionProviderIds(currentKernel);
 		if ((connProviderIds && connProviderIds.length === 0) || currentKernel === noKernel) {
 			this.setOptions([msgLocalHost]);
@@ -270,7 +270,7 @@ export class AttachToDropdown extends SelectBox {
 		else {
 			let connections = this.getConnections(model);
 			this.enable();
-			if (defaultSelectConnection) {
+			if (showSelectConnection) {
 				connections = this.loadWithSelectConnection(connections);
 			}
 			else {

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -215,8 +215,11 @@ export class AttachToDropdown extends SelectBox {
 		super([msgLoadingContexts], msgLoadingContexts, contextViewProvider, container, { labelText: attachToLabel, labelOnTop: false } as ISelectBoxOptionsWithLabel);
 		if (modelRegistered) {
 			modelRegistered
-				.then((model) => this.updateModel(model))
-				.catch((err) => {
+				.then(model => {
+					this.updateModel(model);
+					this.updateAttachtoDropdown(model);
+				})
+				.catch(err => {
 					// No-op for now
 				});
 		}
@@ -229,16 +232,43 @@ export class AttachToDropdown extends SelectBox {
 	public updateModel(model: INotebookModel): void {
 		this.model = model;
 		model.contextsChanged(() => {
-			if (this.model.clientSession.kernel && this.model.clientSession.kernel.name) {
-				let nameLower = this.model.clientSession.kernel.name.toLowerCase();
-				let currentKernelSpec = this.model.specs.kernels.find(kernel => kernel.name && kernel.name.toLowerCase() === nameLower);
-				this.loadAttachToDropdown(this.model, currentKernelSpec.display_name);
+			let kernelDisplayName: string = this.getKernelDisplayName();
+			if (kernelDisplayName) {
+				this.loadAttachToDropdown(this.model, kernelDisplayName);
 			}
 		});
 	}
 
+	private updateAttachtoDropdown(model: INotebookModel): void {
+		this.model = model;
+		model.onValidConnectionSelected(validConnection => {
+			let kernelDisplayName: string = this.getKernelDisplayName();
+			if (kernelDisplayName) {
+				if (!validConnection) {
+					this.loadAttachToDropdown(this.model, kernelDisplayName, true);
+				}
+				else {
+					//load without 'Select connection'
+					this.loadAttachToDropdown(this.model, kernelDisplayName, false);
+				}
+			}
+		});
+	}
+
+	private getKernelDisplayName(): string {
+		let kernelDisplayName: string;
+		if (this.model.clientSession.kernel && this.model.clientSession.kernel.name) {
+			let nameLower = this.model.clientSession.kernel.name.toLowerCase();
+			let currentKernelSpec = this.model.specs.kernels.find(kernel => kernel.name && kernel.name.toLowerCase() === nameLower);
+			if (currentKernelSpec) {
+				kernelDisplayName = currentKernelSpec.display_name;
+			}
+		}
+		return kernelDisplayName;
+	}
+
 	// Load "Attach To" dropdown with the values corresponding to Kernel dropdown
-	public async loadAttachToDropdown(model: INotebookModel, currentKernel: string): Promise<void> {
+	public async loadAttachToDropdown(model: INotebookModel, currentKernel: string, defaultSelectConnection?: boolean): Promise<void> {
 		let connProviderIds = this.model.getApplicableConnectionProviderIds(currentKernel);
 		if ((connProviderIds && connProviderIds.length === 0) || currentKernel === noKernel) {
 			this.setOptions([msgLocalHost]);
@@ -246,16 +276,30 @@ export class AttachToDropdown extends SelectBox {
 		else {
 			let connections = this.getConnections(model);
 			this.enable();
-			if (connections.length === 1 && connections[0] === msgAddNewConnection) {
-				connections.unshift(msgSelectConnection);
-				this.selectWithOptionName(msgSelectConnection);
+			if (defaultSelectConnection) {
+				connections = this.loadWithSelectConnection(connections);
 			}
 			else {
-				connections.push(msgAddNewConnection);
+				if (connections.length === 1 && connections[0] === msgAddNewConnection) {
+					connections.unshift(msgSelectConnection);
+					this.selectWithOptionName(msgSelectConnection);
+				}
+				else {
+					connections.push(msgAddNewConnection);
+				}
 			}
 			this.setOptions(connections);
 		}
+	}
 
+	private loadWithSelectConnection(connections: string[]): string[] {
+		if (connections && connections.length > 0) {
+			connections.unshift(msgSelectConnection);
+			this.selectWithOptionName(msgSelectConnection);
+			connections.push(msgAddNewConnection);
+			this.setOptions(connections);
+		}
+		return connections;
 	}
 
 	//Get connections from context

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -217,7 +217,7 @@ export class AttachToDropdown extends SelectBox {
 			modelRegistered
 				.then(model => {
 					this.updateModel(model);
-					this.updateAttachtoDropdown(model);
+					this.updateAttachToDropdown(model);
 				})
 				.catch(err => {
 					// No-op for now
@@ -239,25 +239,19 @@ export class AttachToDropdown extends SelectBox {
 		});
 	}
 
-	private updateAttachtoDropdown(model: INotebookModel): void {
+	private updateAttachToDropdown(model: INotebookModel): void {
 		this.model = model;
 		model.onValidConnectionSelected(validConnection => {
 			let kernelDisplayName: string = this.getKernelDisplayName();
 			if (kernelDisplayName) {
-				if (!validConnection) {
-					this.loadAttachToDropdown(this.model, kernelDisplayName, true);
-				}
-				else {
-					//load without 'Select connection'
-					this.loadAttachToDropdown(this.model, kernelDisplayName, false);
-				}
+				this.loadAttachToDropdown(this.model, kernelDisplayName, !validConnection);
 			}
 		});
 	}
 
 	private getKernelDisplayName(): string {
 		let kernelDisplayName: string;
-		if (this.model.clientSession.kernel && this.model.clientSession.kernel.name) {
+		if (this.model.clientSession && this.model.clientSession.kernel && this.model.clientSession.kernel.name) {
 			let currentKernelName = this.model.clientSession.kernel.name.toLowerCase();
 			let currentKernelSpec = this.model.specs.kernels.find(kernel => kernel.name && kernel.name.toLowerCase() === currentKernelName);
 			if (currentKernelSpec) {

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -258,8 +258,8 @@ export class AttachToDropdown extends SelectBox {
 	private getKernelDisplayName(): string {
 		let kernelDisplayName: string;
 		if (this.model.clientSession.kernel && this.model.clientSession.kernel.name) {
-			let nameLower = this.model.clientSession.kernel.name.toLowerCase();
-			let currentKernelSpec = this.model.specs.kernels.find(kernel => kernel.name && kernel.name.toLowerCase() === nameLower);
+			let currentKernelName = this.model.clientSession.kernel.name.toLowerCase();
+			let currentKernelSpec = this.model.specs.kernels.find(kernel => kernel.name && kernel.name.toLowerCase() === currentKernelName);
 			if (currentKernelSpec) {
 				kernelDisplayName = currentKernelSpec.display_name;
 			}

--- a/src/sqltest/parts/notebook/common.ts
+++ b/src/sqltest/parts/notebook/common.ts
@@ -89,7 +89,11 @@ export class NotebookModelStub implements INotebookModel {
     }
     getApplicableConnectionProviderIds(kernelName: string): string[] {
         throw new Error('Method not implemented.');
-    }
+	}
+	get onValidConnectionSelected(): Event<boolean>
+	{
+		throw new Error('method not implemented.');
+	}
 }
 
 export class NotebookManagerStub implements INotebookManager {


### PR DESCRIPTION
- 'Attach to' dropdown would be defaulted to 'Select connection' if sql(only) connection is selected for Spark kernels
    - User will have the ability to add a new connection
    - User can toggle existing connections
- Add 'Select connection' to dropdown if an invalid connection is selected. In this case sql connection.
- Remove 'Select connection' from dropdown if a valid bigdata connection is selected.
- Show error message to user upon selecting a sql connection for Spark kernels