### PR TITLE
Add Deploy Plan page to DacFx wizard

### DIFF
--- a/extensions/import/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/import/src/wizard/dataTierApplicationWizard.ts
@@ -339,6 +339,20 @@ export class DataTierApplicationWizard {
 			|| (this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.summary;
 	}
 
+	public async upgradePlan(): Promise<string> {
+		let service = await DataTierApplicationWizard.getService(this.model.server.providerName);
+		let ownerUri = await sqlops.connection.getUriForConnection(this.model.server.connectionId);
+
+		let result = await service.upgradePlan(this.model.filePath, this.model.database, ownerUri, sqlops.TaskExecutionMode.execute);
+
+		if (!result || !result.success) {
+			vscode.window.showErrorMessage(
+				localize('alertData.importErrorMessage', "Import failed '{0}'", result.errorMessage ? result.errorMessage : 'Unknown'));
+		}
+
+		return result.report;
+	}
+
 	private static async getService(providerName: string): Promise<sqlops.DacFxServicesProvider> {
 		let service = sqlops.dataprotocol.getProvider<sqlops.DacFxServicesProvider>(providerName, sqlops.DataProviderType.DacFxServicesProvider);
 		return service;

--- a/extensions/import/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/import/src/wizard/dataTierApplicationWizard.ts
@@ -366,7 +366,7 @@ export class DataTierApplicationWizard {
 
 		if (!result || !result.success) {
 			vscode.window.showErrorMessage(
-				localize('alertData.importErrorMessage', "Import failed '{0}'", result.errorMessage ? result.errorMessage : 'Unknown'));
+				localize('alertData.deployPlanErrorMessage', "Generating deploy plan failed '{0}'", result.errorMessage ? result.errorMessage : 'Unknown'));
 		}
 
 		return result.report;

--- a/extensions/import/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/import/src/wizard/dataTierApplicationWizard.ts
@@ -341,9 +341,9 @@ export class DataTierApplicationWizard {
 			}
 		} else if (this.isSummaryPage(idx)) {
 			page = this.pages.get('summary');
-		}else if ((this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.deployPlan) {
+		} else if ((this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.deployPlan) {
 			page = this.pages.get('deployPlan');
-		}else if ((this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.deployAction) {
+		} else if ((this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.deployAction) {
 			page = this.pages.get('deployAction');
 		}
 

--- a/extensions/import/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/import/src/wizard/pages/dacFxSummaryPage.ts
@@ -131,7 +131,15 @@ export class DacFxSummaryPage extends BasePage {
 
 		this.table.updateProperties({
 			data: data,
-			columns: [localize('dacfx.settingColumn', 'Setting'), localize('dacfx.valueColumn', 'Value')],
+			columns: [
+				{
+					value: localize('dacfx.settingColumn', 'Setting'),
+					cssClass: 'align-with-header'
+				},
+				{
+					value: localize('dacfx.valueColumn', 'Value'),
+					cssClass: 'align-with-header'
+				}],
 			width: 700,
 			height: 200
 		});

--- a/extensions/import/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/import/src/wizard/pages/dacFxSummaryPage.ts
@@ -131,7 +131,7 @@ export class DacFxSummaryPage extends BasePage {
 
 		this.table.updateProperties({
 			data: data,
-			columns: ['Setting', 'Value'],
+			columns: [localize('dacfx.settingColumn', 'Setting'), localize('dacfx.valueColumn', 'Value')],
 			width: 700,
 			height: 200
 		});

--- a/extensions/import/src/wizard/pages/deployActionPage.ts
+++ b/extensions/import/src/wizard/pages/deployActionPage.ts
@@ -54,6 +54,8 @@ export class DeployActionPage extends DacFxConfigPage {
 	}
 
 	async onPageEnter(): Promise<boolean> {
+		// generate script file path in case the database changed since last time the page was entered
+		this.setDefaultScriptFilePath();
 		return true;
 	}
 
@@ -120,11 +122,7 @@ export class DeployActionPage extends DacFxConfigPage {
 		this.createFileBrowserParts();
 
 		//default filepath
-		let now = new Date();
-		let datetime = now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + '-' + now.getHours() + '-' + now.getMinutes();
-		this.fileTextBox.value= path.join(os.homedir(), this.model.database + '_UpgradeDACScript_' + datetime + '.sql');
-		this.model.scriptFilePath = this.fileTextBox.value;
-
+		this.setDefaultScriptFilePath();
 		this.fileButton.onDidClick(async (click) => {
 			let fileUri = await vscode.window.showSaveDialog(
 				{
@@ -151,21 +149,28 @@ export class DeployActionPage extends DacFxConfigPage {
 		return {
 			title: '',
 			components: [
-			{
-				title: localize('dacfx.generatedScriptLocation','Deployment Script Location'),
-				component: this.fileTextBox,
-				layout: {
-					horizontal: true,
-					componentWidth: 400
-				},
-				actions: [this.fileButton]
-			},],
+				{
+					title: localize('dacfx.generatedScriptLocation', 'Deployment Script Location'),
+					component: this.fileTextBox,
+					layout: {
+						horizontal: true,
+						componentWidth: 400
+					},
+					actions: [this.fileButton]
+				},],
 		};
 	}
 
 	private toggleFileBrowser(enable: boolean): void {
 		this.fileTextBox.enabled = enable;
 		this.fileButton.enabled = enable;
+	}
+
+	private setDefaultScriptFilePath(): void {
+		let now = new Date();
+		let datetime = now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + '-' + now.getHours() + '-' + now.getMinutes();
+		this.fileTextBox.value = path.join(os.homedir(), this.model.database + '_UpgradeDACScript_' + datetime + '.sql');
+		this.model.scriptFilePath = this.fileTextBox.value;
 	}
 
 	public setupNavigationValidator() {

--- a/extensions/import/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/import/src/wizard/pages/deployConfigPage.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as os from 'os';
 import { DacFxDataModel } from '../api/models';
-import { DataTierApplicationWizard } from '../dataTierApplicationWizard';
+import { DataTierApplicationWizard, DeployOperationPath } from '../dataTierApplicationWizard';
 import { DacFxConfigPage } from '../api/dacFxConfigPage';
 
 const localize = nls.loadMessageBundle();
@@ -125,9 +125,9 @@ export class DeployConfigPage extends DacFxConfigPage {
 
 			// add deploy plan and generate script pages
 			let deployPlanPage = this.instance.pages.get('deployPlan');
-			this.instance.wizard.addPage(deployPlanPage.wizardPage, 2);
+			this.instance.wizard.addPage(deployPlanPage.wizardPage, DeployOperationPath.deployPlan);
 			let deployActionPage = this.instance.pages.get('deployAction');
-			this.instance.wizard.addPage(deployActionPage.wizardPage, 3);
+			this.instance.wizard.addPage(deployActionPage.wizardPage, DeployOperationPath.deployAction);
 		});
 
 		newRadioButton.onDidClick(() => {
@@ -137,8 +137,8 @@ export class DeployConfigPage extends DacFxConfigPage {
 			this.model.database = this.databaseTextBox.value;
 
 			// remove deploy plan and generate script pages
-			this.instance.wizard.removePage(3);
-			this.instance.wizard.removePage(2);
+			this.instance.wizard.removePage(DeployOperationPath.deployAction);
+			this.instance.wizard.removePage(DeployOperationPath.deployPlan);
 		});
 
 		//Initialize with upgrade existing true

--- a/extensions/import/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/import/src/wizard/pages/deployConfigPage.ts
@@ -123,6 +123,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 			this.formBuilder.addFormItem(this.databaseDropdownComponent, { horizontal: true, componentWidth: 400 });
 			this.model.database = (<sqlops.CategoryValue>this.databaseDropdown.value).name;
 
+			// add deploy plan and generate script pages
 			let deployPlanPage = this.instance.pages.get('deployPlan');
 			this.instance.wizard.addPage(deployPlanPage.wizardPage, 2);
 			let deployActionPage = this.instance.pages.get('deployAction');
@@ -135,6 +136,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 			this.formBuilder.addFormItem(this.databaseComponent, { horizontal: true, componentWidth: 400 });
 			this.model.database = this.databaseTextBox.value;
 
+			// remove deploy plan and generate script pages
 			this.instance.wizard.removePage(3);
 			this.instance.wizard.removePage(2);
 		});

--- a/extensions/import/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/import/src/wizard/pages/deployConfigPage.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as os from 'os';
 import { DacFxDataModel } from '../api/models';
-import { DataTierApplicationWizard, DeployOperationPath } from '../dataTierApplicationWizard';
+import { DataTierApplicationWizard, DeployOperationPath, Operation } from '../dataTierApplicationWizard';
 import { DacFxConfigPage } from '../api/dacFxConfigPage';
 
 const localize = nls.loadMessageBundle();
@@ -135,6 +135,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 			this.formBuilder.removeFormItem(this.databaseDropdownComponent);
 			this.formBuilder.addFormItem(this.databaseComponent, { horizontal: true, componentWidth: 400 });
 			this.model.database = this.databaseTextBox.value;
+			this.instance.setDoneButton(Operation.deploy);
 
 			// remove deploy plan and generate script pages
 			this.instance.wizard.removePage(DeployOperationPath.deployAction);

--- a/extensions/import/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/import/src/wizard/pages/deployConfigPage.ts
@@ -122,6 +122,11 @@ export class DeployConfigPage extends DacFxConfigPage {
 			this.formBuilder.removeFormItem(this.databaseComponent);
 			this.formBuilder.addFormItem(this.databaseDropdownComponent, { horizontal: true, componentWidth: 400 });
 			this.model.database = (<sqlops.CategoryValue>this.databaseDropdown.value).name;
+
+			let deployPlanPage = this.instance.pages.get('deployPlan');
+			this.instance.wizard.addPage(deployPlanPage.wizardPage, 2);
+			let deployActionPage = this.instance.pages.get('deployAction');
+			this.instance.wizard.addPage(deployActionPage.wizardPage, 3);
 		});
 
 		newRadioButton.onDidClick(() => {
@@ -129,6 +134,9 @@ export class DeployConfigPage extends DacFxConfigPage {
 			this.formBuilder.removeFormItem(this.databaseDropdownComponent);
 			this.formBuilder.addFormItem(this.databaseComponent, { horizontal: true, componentWidth: 400 });
 			this.model.database = this.databaseTextBox.value;
+
+			this.instance.wizard.removePage(3);
+			this.instance.wizard.removePage(2);
 		});
 
 		//Initialize with upgrade existing true

--- a/extensions/import/src/wizard/pages/deployPlanPage.ts
+++ b/extensions/import/src/wizard/pages/deployPlanPage.ts
@@ -1,0 +1,226 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+import * as sqlops from 'sqlops';
+import * as nls from 'vscode-nls';
+import * as parser from 'htmlparser2';
+import { DacFxDataModel } from '../api/models';
+import { DataTierApplicationWizard } from '../dataTierApplicationWizard';
+import { DacFxConfigPage } from '../api/dacFxConfigPage';
+
+const localize = nls.loadMessageBundle();
+
+export enum reportSection {
+	Alert = 'Alert',
+	Operation = 'Operation',
+}
+
+export enum attributeName {
+	Name = 'Name',
+	Value = 'Value',
+	Type = 'Type',
+	Id = 'Id'
+}
+
+export class TableObject {
+	object: string;
+	type: string;
+	dataloss: boolean;
+}
+
+export class DeployPlanPage extends DacFxConfigPage {
+
+	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly instance: DataTierApplicationWizard;
+	protected readonly model: DacFxDataModel;
+	protected readonly view: sqlops.ModelView;
+	private formBuilder: sqlops.FormBuilder;
+	private form: sqlops.FormContainer;
+	private table: sqlops.TableComponent;
+	private loader: sqlops.LoadingComponent;
+	private dataLossComponent: sqlops.FormComponent;
+	private dataLossTextComponent: sqlops.FormComponent;
+	private dataLossComponentGroup: sqlops.FormComponentGroup;
+
+	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
+		super(instance, wizardPage, model, view);
+	}
+
+	async start(): Promise<boolean> {
+		this.table = this.view.modelBuilder.table().component();
+		this.loader = this.view.modelBuilder.loadingComponent().withItem(this.table).component();
+		this.dataLossComponent = await this.createDataLossCheckbox();
+		this.dataLossTextComponent = await this.createDataLossText();
+		this.dataLossComponentGroup = await this.createDataLossComponents();
+
+		this.formBuilder = this.view.modelBuilder.formContainer()
+			.withFormItems(
+				[
+					{
+						component: this.loader,
+						title: ''
+					}
+				], {
+					horizontal: true,
+				});
+		this.form = this.formBuilder.component();
+		await this.view.initializeModel(this.form);
+
+		return true;
+	}
+
+	async onPageEnter(): Promise<boolean> {
+		this.table.data = [];
+		this.formBuilder.removeFormItem(this.dataLossComponentGroup);
+
+		this.loader.loading = true;
+		await this.populateTable();
+		this.loader.loading = false;
+		return true;
+	}
+
+	private async populateTable() {
+		let report = await this.instance.generateDeployPlan();
+		let data = [];
+		let dataLossAlerts = new Map<string, string>();
+		let currentOperation = '';
+		let dataIssueAlert = false;
+		let issue = '';
+		let currentReportSection: reportSection;
+		let currentTableObj: TableObject;
+
+		let p = new parser.Parser({
+			onopentagname(name) {
+				if (name === 'Alert') {
+					currentReportSection = reportSection.Alert;
+				} else if (name === 'Operation') {
+					currentReportSection = reportSection.Operation;
+					currentTableObj = new TableObject();
+				}
+			},
+			onattribute: function (name, value) {
+				if (currentReportSection === reportSection.Alert) {
+					switch (name) {
+						case attributeName.Name: {
+							// only care about showing data loss alerts
+							if (value === 'DataIssue') {
+								dataIssueAlert = true;
+							}
+							break;
+						}
+						case attributeName.Value: {
+							if (dataIssueAlert) {
+								issue = value;
+							}
+						}
+						case attributeName.Id: {
+							if (dataIssueAlert) {
+								dataLossAlerts.set(value, issue);
+							}
+							break;
+						}
+					}
+				} else if (currentReportSection === reportSection.Operation) {
+					switch (name) {
+						case attributeName.Name: {
+							currentOperation = value;
+							break;
+						}
+						case attributeName.Value: {
+							currentTableObj.object = value;
+							break;
+						}
+						case attributeName.Type: {
+							currentTableObj.type = value;
+							break;
+						}
+						case attributeName.Id: {
+							if (dataLossAlerts.get(value)) {
+								currentTableObj.dataloss = true;
+							}
+							break;
+						}
+					}
+				}
+			},
+			onclosetag: function (name) {
+				// add table entry for the operation item
+				if (name === 'Item') {
+					let isDataLoss = currentTableObj.dataloss ? '⚠️' : '';
+					let operation = 'Operation: ' + currentOperation;
+					let objtype = 'Type: ' + currentTableObj.type;
+					let obj = 'Object: ' + currentTableObj.object;
+					data.push([isDataLoss, operation + ', ' + objtype + ', ' + obj]);
+				}
+			}
+		}, { xmlMode: true, decodeEntities: true });
+
+		p.parseChunk(report);
+
+		this.table.updateProperties({
+			data: data,
+			columns: [{
+				value: localize('dacfx.dataLossColumn', 'Data Loss'),
+			},
+			{
+				value: localize('dacfx.actionColumn', 'Action'),
+			}
+		],
+			width: 700,
+			height: 300
+		});
+
+
+		if (dataLossAlerts.size > 0) {
+			this.formBuilder.addFormItem(this.dataLossComponentGroup, {horizontal: true, componentWidth: 400});
+		}
+	}
+
+	private async createDataLossCheckbox(): Promise<sqlops.FormComponent> {
+		let dataLossCheckbox = this.view.modelBuilder.checkBox()
+			.withProperties({
+				label: localize('dacFx.dataLossCheckbox', 'Proceed despite possible data loss'),
+			}).component();
+
+		dataLossCheckbox.onChanged(() => {
+		});
+
+		dataLossCheckbox.checked = true;
+		return {
+			component: dataLossCheckbox,
+			title: '',
+			required: true
+		};
+	}
+
+	private async createDataLossText(): Promise<sqlops.FormComponent> {
+		let dataLossText = this.view.modelBuilder.text()
+			.withProperties({
+				value: localize('dacfx.dataLossText', 'The deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.')
+			}).component();
+
+		return {
+			component: dataLossText,
+			title: '',
+			required: true
+		};
+	}
+
+	private async createDataLossComponents(): Promise<sqlops.FormComponentGroup> {
+		return {
+			title: '',
+			components: [
+			this.dataLossTextComponent,
+			this.dataLossComponent
+		]};
+	}
+
+	public setupNavigationValidator() {
+		this.instance.registerNavigationValidator(() => {
+			return true;
+		});
+	}
+}

--- a/extensions/import/src/wizard/pages/deployPlanPage.ts
+++ b/extensions/import/src/wizard/pages/deployPlanPage.ts
@@ -186,12 +186,12 @@ export class DeployPlanPage extends DacFxConfigPage {
 			{
 				value: localize('dacfx.typeColumn', 'Type'),
 				width: 100,
-				toolTip: localize('dacfx.typeTooltip', 'Type of object')
+				toolTip: localize('dacfx.typeTooltip', 'Type of object that will be affected by deployment')
 			},
 			{
 				value: localize('dacfx.objectColumn', 'Object'),
 				width: 300,
-				toolTip: localize('dacfx.objecTooltip', 'Object name')
+				toolTip: localize('dacfx.objecTooltip', 'Name of object that will be affected by deployment')
 			}];
 
 		if (dataloss) {

--- a/extensions/import/src/wizard/pages/deployPlanPage.ts
+++ b/extensions/import/src/wizard/pages/deployPlanPage.ts
@@ -181,16 +181,19 @@ export class DeployPlanPage extends DacFxConfigPage {
 			{
 				value: localize('dacfx.operationColumn', 'Operation'),
 				width: 75,
+				cssClass: 'align-with-header',
 				toolTip: localize('dacfx.operationTooltip', 'Operation(Create, Alter, Delete) that will occur during deployment')
 			},
 			{
 				value: localize('dacfx.typeColumn', 'Type'),
 				width: 100,
+				cssClass: 'align-with-header',
 				toolTip: localize('dacfx.typeTooltip', 'Type of object that will be affected by deployment')
 			},
 			{
 				value: localize('dacfx.objectColumn', 'Object'),
 				width: 300,
+				cssClass: 'align-with-header',
 				toolTip: localize('dacfx.objecTooltip', 'Name of object that will be affected by deployment')
 			}];
 

--- a/extensions/import/src/wizard/pages/deployPlanPage.ts
+++ b/extensions/import/src/wizard/pages/deployPlanPage.ts
@@ -105,7 +105,7 @@ export class DeployPlanPage extends DacFxConfigPage {
 		if (result.dataLossAlerts.size > 0) {
 			// update message to list how many operations could result in data loss
 			this.dataLossText.updateProperties({
-				value: result.dataLossAlerts.size + localize('dacfx.dataLossTextWithCount', ' of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.')
+				value: localize('dacfx.dataLossTextWithCount', '{0} of the deploy actions listed may result in data loss. Please ensure you have a backup or snapshot available in the event of an issue with the deployment.', result.dataLossAlerts.size)
 			});
 			this.dataLossCheckbox.enabled = true;
 		} else {

--- a/extensions/import/src/wizard/pages/deployPlanPage.ts
+++ b/extensions/import/src/wizard/pages/deployPlanPage.ts
@@ -72,16 +72,14 @@ export class DeployPlanPage extends DacFxConfigPage {
 	}
 
 	async onPageEnter(): Promise<boolean> {
-		this.table.data = [];
-
 		// reset checkbox settings
 		this.formBuilder.addFormItem(this.dataLossComponentGroup, { horizontal: true, componentWidth: 400 });
 		this.dataLossCheckbox.checked = false;
 		this.dataLossCheckbox.enabled = false;
-
 		this.formBuilder.removeFormItem(this.noDataLossTextComponent);
 
 		this.loader.loading = true;
+		this.table.data = [];
 		await this.populateTable();
 		this.loader.loading = false;
 		return true;
@@ -166,22 +164,22 @@ export class DeployPlanPage extends DacFxConfigPage {
 					value: localize('dacfx.dataLossColumn', 'Data Loss'),
 					width: 50,
 					cssClass: 'center-align',
-					toolTip: 'Operations that may result in data loss are marked with a warning sign'
+					toolTip: localize('dacfx.dataLossTooltip', 'Operations that may result in data loss are marked with a warning sign')
 				},
 				{
 					value: localize('dacfx.operationColumn', 'Operation'),
 					width: 75,
-					toolTip: 'Operation that will occur during deployment'
+					toolTip: localize('dacfx.operationTooltip', 'Operation that will occur during deployment')
 				},
 				{
 					value: localize('dacfx.typeColumn', 'Type'),
 					width: 100,
-					toolTip: 'Type of object'
+					toolTip: localize('dacfx.typeTooltip', 'Type of object')
 				},
 				{
 					value: localize('dacfx.objectColumn', 'Object'),
 					width: 300,
-					toolTip: 'Object name'
+					toolTip: localize('dacfx.objecTooltip', 'Object name')
 				}],
 				width: 875,
 				height: 300
@@ -194,17 +192,17 @@ export class DeployPlanPage extends DacFxConfigPage {
 				columns: [{
 					value: localize('dacfx.operationColumn', 'Operation'),
 					width: 75,
-					toolTip: 'Operation that will occur during deployment'
+					toolTip: localize('dacfx.operationTooltip', 'Operation that will occur during deployment')
 				},
 				{
 					value: localize('dacfx.typeColumn', 'Type'),
 					width: 100,
-					toolTip: 'Type of object'
+					toolTip: localize('dacfx.typeTooltip', 'Type of object')
 				},
 				{
 					value: localize('dacfx.objectColumn', 'Object'),
 					width: 300,
-					toolTip: 'Object name'
+					toolTip: localize('dacfx.objecTooltip', 'Object name')
 				}],
 				width: 875,
 				height: 300
@@ -240,7 +238,7 @@ export class DeployPlanPage extends DacFxConfigPage {
 		return {
 			title: '',
 			component: noDataLossText
-		}
+		};
 	}
 
 	private async createDataLossComponents(): Promise<sqlops.FormComponentGroup> {

--- a/extensions/import/src/wizard/pages/selectOperationpage.ts
+++ b/extensions/import/src/wizard/pages/selectOperationpage.ts
@@ -7,7 +7,7 @@
 import * as sqlops from 'sqlops';
 import * as nls from 'vscode-nls';
 import { DacFxDataModel } from '../api/models';
-import { DataTierApplicationWizard, Operation } from '../dataTierApplicationWizard';
+import { DataTierApplicationWizard, Operation, DeployOperationPath, ExtractOperationPath, ImportOperationPath, ExportOperationPath } from '../dataTierApplicationWizard';
 import { BasePage } from '../api/basePage';
 
 const localize = nls.loadMessageBundle();
@@ -73,12 +73,12 @@ export class SelectOperationPage extends BasePage {
 
 			//add deploy pages
 			let configPage = this.instance.pages.get('deployConfig');
-			this.instance.wizard.addPage(configPage.wizardPage, 1);
+			this.instance.wizard.addPage(configPage.wizardPage, DeployOperationPath.deployOptions);
 			let deployPlanPage = this.instance.pages.get('deployPlan');
-			this.instance.wizard.addPage(deployPlanPage.wizardPage, 2);
+			this.instance.wizard.addPage(deployPlanPage.wizardPage, DeployOperationPath.deployPlan);
 			let actionPage = this.instance.pages.get('deployAction');
-			this.instance.wizard.addPage(actionPage.wizardPage, 3);
-			this.addSummaryPage(4);
+			this.instance.wizard.addPage(actionPage.wizardPage, DeployOperationPath.deployAction);
+			this.addSummaryPage(DeployOperationPath.summary);
 
 			// change button text and operation
 			this.instance.setDoneButton(Operation.deploy);
@@ -102,8 +102,8 @@ export class SelectOperationPage extends BasePage {
 
 			// add the extract page
 			let page = this.instance.pages.get('extractConfig');
-			this.instance.wizard.addPage(page.wizardPage, 1);
-			this.addSummaryPage(2);
+			this.instance.wizard.addPage(page.wizardPage, ExtractOperationPath.options);
+			this.addSummaryPage(ExtractOperationPath.summary);
 
 			// change button text and operation
 			this.instance.setDoneButton(Operation.extract);
@@ -127,8 +127,8 @@ export class SelectOperationPage extends BasePage {
 
 			// add the import page
 			let page = this.instance.pages.get('importConfig');
-			this.instance.wizard.addPage(page.wizardPage, 1);
-			this.addSummaryPage(2);
+			this.instance.wizard.addPage(page.wizardPage, ImportOperationPath.options);
+			this.addSummaryPage(ImportOperationPath.summary);
 
 			// change button text and operation
 			this.instance.setDoneButton(Operation.import);
@@ -152,8 +152,8 @@ export class SelectOperationPage extends BasePage {
 
 			// add the export pages
 			let page = this.instance.pages.get('exportConfig');
-			this.instance.wizard.addPage(page.wizardPage, 1);
-			this.addSummaryPage(2);
+			this.instance.wizard.addPage(page.wizardPage, ExportOperationPath.options);
+			this.addSummaryPage(ExportOperationPath.summary);
 
 			// change button text and operation
 			this.instance.setDoneButton(Operation.export);

--- a/extensions/import/src/wizard/pages/selectOperationpage.ts
+++ b/extensions/import/src/wizard/pages/selectOperationpage.ts
@@ -74,9 +74,11 @@ export class SelectOperationPage extends BasePage {
 			//add deploy pages
 			let configPage = this.instance.pages.get('deployConfig');
 			this.instance.wizard.addPage(configPage.wizardPage, 1);
+			let deployPlanPage = this.instance.pages.get('deployPlan');
+			this.instance.wizard.addPage(deployPlanPage.wizardPage, 2);
 			let actionPage = this.instance.pages.get('deployAction');
-			this.instance.wizard.addPage(actionPage.wizardPage, 2);
-			this.addSummaryPage(3);
+			this.instance.wizard.addPage(actionPage.wizardPage, 3);
+			this.addSummaryPage(4);
 
 			// change button text and operation
 			this.instance.setDoneButton(Operation.deploy);

--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.70",
+	"version": "1.5.0-alpha.71",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -339,6 +339,13 @@ export interface GenerateDeployScriptParams {
 	taskExecutionMode: TaskExecutionMode;
 }
 
+export interface UpgradePlanParams {
+	packageFilePath: string;
+	databaseName: string;
+	ownerUri: string;
+	taskExecutionMode: TaskExecutionMode;
+}
+
 export namespace ExportRequest {
 	export const type = new RequestType<ExportParams, sqlops.DacFxResult, void, void>('dacfx/export');
 }
@@ -359,4 +366,7 @@ export namespace GenerateDeployScriptRequest {
 	export const type = new RequestType<GenerateDeployScriptParams, sqlops.DacFxResult, void, void>('dacfx/generateDeploymentScript');
 }
 
+export namespace UpgradePlanRequest {
+	export const type = new RequestType<UpgradePlanParams, sqlops.UpgradePlanResult, void, void>('dacfx/upgradePlan');
+}
 // ------------------------------- < DacFx > ------------------------------------

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -339,7 +339,7 @@ export interface GenerateDeployScriptParams {
 	taskExecutionMode: TaskExecutionMode;
 }
 
-export interface UpgradePlanParams {
+export interface GenerateDeployPlanParams {
 	packageFilePath: string;
 	databaseName: string;
 	ownerUri: string;
@@ -366,7 +366,7 @@ export namespace GenerateDeployScriptRequest {
 	export const type = new RequestType<GenerateDeployScriptParams, sqlops.DacFxResult, void, void>('dacfx/generateDeploymentScript');
 }
 
-export namespace UpgradePlanRequest {
-	export const type = new RequestType<UpgradePlanParams, sqlops.UpgradePlanResult, void, void>('dacfx/upgradePlan');
+export namespace GenerateDeployPlanRequest {
+	export const type = new RequestType<GenerateDeployPlanParams, sqlops.GenerateDeployPlanResult, void, void>('dacfx/generateDeployPlan');
 }
 // ------------------------------- < DacFx > ------------------------------------

--- a/extensions/mssql/src/features.ts
+++ b/extensions/mssql/src/features.ts
@@ -113,7 +113,20 @@ export class DacFxServicesFeature extends SqlOpsFeature<undefined> {
 					return r;
 				},
 				e => {
-					client.logFailedRequest(contracts.DeployRequest.type, e);
+					client.logFailedRequest(contracts.GenerateDeployScriptRequest.type, e);
+					return Promise.resolve(undefined);
+				}
+			);
+		};
+
+		let upgradePlan = (packageFilePath: string, targetDatabaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.UpgradePlanResult> => {
+			let params: contracts.UpgradePlanParams = { packageFilePath: packageFilePath, databaseName: targetDatabaseName, ownerUri: ownerUri, taskExecutionMode: taskExecutionMode };
+			return client.sendRequest(contracts.UpgradePlanRequest.type, params).then(
+				r => {
+					return r;
+				},
+				e => {
+					client.logFailedRequest(contracts.UpgradePlanRequest.type, e);
 					return Promise.resolve(undefined);
 				}
 			);
@@ -125,7 +138,8 @@ export class DacFxServicesFeature extends SqlOpsFeature<undefined> {
 			importBacpac,
 			extractDacpac,
 			deployDacpac,
-			generateDeployScript
+			generateDeployScript,
+			upgradePlan
 		});
 	}
 }

--- a/extensions/mssql/src/features.ts
+++ b/extensions/mssql/src/features.ts
@@ -119,14 +119,14 @@ export class DacFxServicesFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		let upgradePlan = (packageFilePath: string, targetDatabaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.UpgradePlanResult> => {
-			let params: contracts.UpgradePlanParams = { packageFilePath: packageFilePath, databaseName: targetDatabaseName, ownerUri: ownerUri, taskExecutionMode: taskExecutionMode };
-			return client.sendRequest(contracts.UpgradePlanRequest.type, params).then(
+		let generateDeployPlan = (packageFilePath: string, targetDatabaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.GenerateDeployPlanResult> => {
+			let params: contracts.GenerateDeployPlanParams = { packageFilePath: packageFilePath, databaseName: targetDatabaseName, ownerUri: ownerUri, taskExecutionMode: taskExecutionMode };
+			return client.sendRequest(contracts.GenerateDeployPlanRequest.type, params).then(
 				r => {
 					return r;
 				},
 				e => {
-					client.logFailedRequest(contracts.UpgradePlanRequest.type, e);
+					client.logFailedRequest(contracts.GenerateDeployPlanRequest.type, e);
 					return Promise.resolve(undefined);
 				}
 			);
@@ -139,7 +139,7 @@ export class DacFxServicesFeature extends SqlOpsFeature<undefined> {
 			extractDacpac,
 			deployDacpac,
 			generateDeployScript,
-			upgradePlan
+			generateDeployPlan
 		});
 	}
 }

--- a/src/sql/platform/dacfx/common/dacFxService.ts
+++ b/src/sql/platform/dacfx/common/dacFxService.ts
@@ -23,7 +23,7 @@ export interface IDacFxService {
 	extractDacpac(sourceDatabaseName: string, packageFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
 	deployDacpac(packageFilePath: string, targetDatabaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
 	generateDeployScript(packageFilePath: string, targetDatabaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
-	upgradePlan(packageFilePath: string, targetDatabaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
+	generateDeployPlan(packageFilePath: string, targetDatabaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
 }
 
 export class DacFxService implements IDacFxService {
@@ -69,9 +69,9 @@ export class DacFxService implements IDacFxService {
 		});
 	}
 
-	upgradePlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.UpgradePlanResult> {
+	generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.GenerateDeployPlanResult> {
 		return this._runAction(ownerUri, (runner) => {
-			return runner.upgradePlan(packageFilePath, databaseName, ownerUri, taskExecutionMode);
+			return runner.generateDeployPlan(packageFilePath, databaseName, ownerUri, taskExecutionMode);
 		});
 	}
 

--- a/src/sql/platform/dacfx/common/dacFxService.ts
+++ b/src/sql/platform/dacfx/common/dacFxService.ts
@@ -23,6 +23,7 @@ export interface IDacFxService {
 	extractDacpac(sourceDatabaseName: string, packageFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
 	deployDacpac(packageFilePath: string, targetDatabaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
 	generateDeployScript(packageFilePath: string, targetDatabaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
+	upgradePlan(packageFilePath: string, targetDatabaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): void;
 }
 
 export class DacFxService implements IDacFxService {
@@ -65,6 +66,12 @@ export class DacFxService implements IDacFxService {
 	generateDeployScript(packageFilePath: string, databaseName: string, generateDeployScript: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> {
 		return this._runAction(ownerUri, (runner) => {
 			return runner.generateDeployScript(packageFilePath, databaseName, generateDeployScript, ownerUri, taskExecutionMode);
+		});
+	}
+
+	upgradePlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.UpgradePlanResult> {
+		return this._runAction(ownerUri, (runner) => {
+			return runner.upgradePlan(packageFilePath, databaseName, ownerUri, taskExecutionMode);
 		});
 	}
 

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -1634,7 +1634,7 @@ declare module 'sqlops' {
 		operationId: string;
 	}
 
-	export interface UpgradePlanResult extends DacFxResult {
+	export interface GenerateDeployPlanResult extends DacFxResult {
 		report: string;
 	}
 
@@ -1677,7 +1677,7 @@ declare module 'sqlops' {
 		taskExecutionMode: TaskExecutionMode;
 	}
 
-	export interface UpgradePlanParams {
+	export interface GenerateDeployPlan {
 		packageFilePath: string;
 		databaseName: string;
 		ownerUri: string;
@@ -1690,7 +1690,7 @@ declare module 'sqlops' {
 		extractDacpac(databaseName: string, packageFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		deployDacpac(packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		generateDeployScript(packageFilePath: string, databaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
-		upgradePlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<UpgradePlanResult>;
+		generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
 	}
 
 	// Security service interfaces ------------------------------------------------------------------------

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -1634,6 +1634,10 @@ declare module 'sqlops' {
 		operationId: string;
 	}
 
+	export interface UpgradePlanResult extends DacFxResult {
+		report: string;
+	}
+
 	export interface ExportParams {
 		databaseName: string;
 		packageFilePath: string;
@@ -1673,12 +1677,20 @@ declare module 'sqlops' {
 		taskExecutionMode: TaskExecutionMode;
 	}
 
+	export interface UpgradePlanParams {
+		packageFilePath: string;
+		databaseName: string;
+		ownerUri: string;
+		taskExecutionMode: TaskExecutionMode;
+	}
+
 	export interface DacFxServicesProvider extends DataProvider {
 		exportBacpac(databaseName: string, packageFilePath: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		importBacpac(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		extractDacpac(databaseName: string, packageFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		deployDacpac(packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
 		generateDeployScript(packageFilePath: string, databaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<DacFxResult>;
+		upgradePlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: TaskExecutionMode): Thenable<UpgradePlanResult>;
 	}
 
 	// Security service interfaces ------------------------------------------------------------------------

--- a/src/sql/workbench/api/node/mainThreadDataProtocol.ts
+++ b/src/sql/workbench/api/node/mainThreadDataProtocol.ts
@@ -445,6 +445,9 @@ export class MainThreadDataProtocol implements MainThreadDataProtocolShape {
 			},
 			generateDeployScript(packageFilePath: string, databaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> {
 				return self._proxy.$generateDeployScript(handle, packageFilePath, databaseName, scriptFilePath, ownerUri, taskExecutionMode);
+			},
+			upgradePlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.UpgradePlanResult> {
+				return self._proxy.$upgradePlan(handle, packageFilePath, databaseName, ownerUri, taskExecutionMode);
 			}
 		});
 

--- a/src/sql/workbench/api/node/mainThreadDataProtocol.ts
+++ b/src/sql/workbench/api/node/mainThreadDataProtocol.ts
@@ -446,8 +446,8 @@ export class MainThreadDataProtocol implements MainThreadDataProtocolShape {
 			generateDeployScript(packageFilePath: string, databaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> {
 				return self._proxy.$generateDeployScript(handle, packageFilePath, databaseName, scriptFilePath, ownerUri, taskExecutionMode);
 			},
-			upgradePlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.UpgradePlanResult> {
-				return self._proxy.$upgradePlan(handle, packageFilePath, databaseName, ownerUri, taskExecutionMode);
+			generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.GenerateDeployPlanResult> {
+				return self._proxy.$generateDeployPlan(handle, packageFilePath, databaseName, ownerUri, taskExecutionMode);
 			}
 		});
 

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -451,9 +451,9 @@ export abstract class ExtHostDataProtocolShape {
 	$generateDeployScript(handle: number, packageFilePath: string, databaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> { throw ni(); }
 
 	/**
-	 * DacFx upgrade plan
+	 * DacFx generate deploy plan
 	 */
-	$upgradePlan(handle: number, packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.UpgradePlanResult> { throw ni(); }
+	$generateDeployPlan(handle: number, packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.GenerateDeployPlanResult> { throw ni(); }
 
 }
 

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -450,6 +450,11 @@ export abstract class ExtHostDataProtocolShape {
 	 */
 	$generateDeployScript(handle: number, packageFilePath: string, databaseName: string, scriptFilePath: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.DacFxResult> { throw ni(); }
 
+	/**
+	 * DacFx upgrade plan
+	 */
+	$upgradePlan(handle: number, packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: sqlops.TaskExecutionMode): Thenable<sqlops.UpgradePlanResult> { throw ni(); }
+
 }
 
 /**


### PR DESCRIPTION
This adds a page to the DacFx wizard for the deploy scenario. This will show if there could be any potential data loss from the deployment and require the user to check a checkbox to proceed if there could be any data loss.

Data loss:
![dataloss](https://user-images.githubusercontent.com/31145923/52309798-18b5ba80-2956-11e9-91e7-a98bf224c6fa.gif)

No data loss:
![nodataloss](https://user-images.githubusercontent.com/31145923/52309805-1b181480-2956-11e9-825a-0e55fddcea0c.gif)
