### PR TITLE
Improve notebook editor height calculations

### DIFF
--- a/src/sql/parts/modelComponents/queryTextEditor.ts
+++ b/src/sql/parts/modelComponents/queryTextEditor.ts
@@ -45,7 +45,6 @@ export class QueryTextEditor extends BaseTextEditor {
 		@IStorageService storageService: IStorageService,
 		@ITextResourceConfigurationService configurationService: ITextResourceConfigurationService,
 		@IThemeService themeService: IThemeService,
-		@IModeService modeService: IModeService,
 		@ITextFileService textFileService: ITextFileService,
 		@IEditorGroupsService editorGroupService: IEditorGroupsService,
 		@IEditorService protected editorService: IEditorService,
@@ -120,7 +119,7 @@ export class QueryTextEditor extends BaseTextEditor {
 		return editorWidget.getScrollHeight();
 	}
 
-	public setHeightToScrollHeight(): void {
+	public setHeightToScrollHeight(configChanged?: boolean): void {
 		let editorWidget = this.getControl() as ICodeEditor;
 		if (!this._config) {
 			this._config = new Configuration(undefined, editorWidget.getDomNode());
@@ -135,18 +134,20 @@ export class QueryTextEditor extends BaseTextEditor {
 		// that the viewportColumn will always be greater than any character's column in an editor.
 		let numberWrappedLines = 0;
 		let shouldAddHorizontalScrollbarHeight = false;
-		if (!this._editorWorkspaceConfig) {
+		if (!this._editorWorkspaceConfig || configChanged) {
 			this._editorWorkspaceConfig = this.workspaceConfigurationService.getValue('editor');
 		}
 		let wordWrapEnabled: boolean = this._editorWorkspaceConfig && this._editorWorkspaceConfig['wordWrap'] && this._editorWorkspaceConfig['wordWrap'] === 'on' ? true : false;
 		if (wordWrapEnabled) {
 			for (let line = 1; line <= lineCount; line++) {
+				// 4 columns is equivalent to the viewport column width and the edge of the editor
 				if (editorWidgetModel.getLineMaxColumn(line) >= this._config.editor.layoutInfo.viewportColumn + 4) {
 					numberWrappedLines += Math.ceil(editorWidgetModel.getLineMaxColumn(line) / this._config.editor.layoutInfo.viewportColumn);
 				}
 			}
 		} else {
 			for (let line = 1; line <= lineCount; line++) {
+				// The horizontal scrollbar always appears 1 column past the viewport column when word wrap is disabled
 				if (editorWidgetModel.getLineMaxColumn(line) >= this._config.editor.layoutInfo.viewportColumn + 1) {
 					shouldAddHorizontalScrollbarHeight = true;
 					break;

--- a/src/sql/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/parts/notebook/cellViews/code.component.ts
@@ -30,6 +30,7 @@ import { IModeService } from 'vs/editor/common/services/modeService';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export const CODE_SELECTOR: string = 'code-component';
 
@@ -83,6 +84,7 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 		@Inject(IContextMenuService) private contextMenuService: IContextMenuService,
 		@Inject(IContextViewService) private contextViewService: IContextViewService,
 		@Inject(INotificationService) private notificationService: INotificationService,
+		@Inject(IConfigurationService) private _configurationService: IConfigurationService
 	) {
 		super();
 		this._cellToggleMoreActions = this._instantiationService.createInstance(CellToggleMoreActions);
@@ -148,6 +150,11 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 			this._editor.setHeightToScrollHeight();
 			this.cellModel.source = this._editorModel.getValue();
 			this.onContentChanged.emit();
+		}));
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('editor.wordWrap')) {
+				this._editor.setHeightToScrollHeight(true);
+			}
 		}));
 		this._register(this.model.layoutChanged(this.layout, this));
 		this.layout();


### PR DESCRIPTION
Now that word wrap is off by default, we weren't calculating editor height correctly; now we support it better when word wrap is off and on.

Fixes #3947 

I banged my head on how to avoid the magic numbers (like adding 4 to the viewport column), but am unsure how we can calculate that "properly". Things like non-monospaced fonts can absolutely break the calculations, but they could previously as well. I'm confident that we're doing a step in the right direction, though :).