### PR TITLE
Notebook server shutdown error

### DIFF
--- a/src/sql/parts/notebook/models/clientSession.ts
+++ b/src/sql/parts/notebook/models/clientSession.ts
@@ -305,10 +305,6 @@ export class ClientSession implements IClientSession {
 		if (this._session && this._session.id) {
 			await this.notebookManager.sessionManager.shutdown(this._session.id);
 		}
-		let serverManager = this.notebookManager.serverManager;
-		if (serverManager) {
-			await serverManager.stopServer();
-		}
 	}
 
 	/**

--- a/src/sqltest/parts/notebook/model/clientSession.test.ts
+++ b/src/sqltest/parts/notebook/model/clientSession.test.ts
@@ -181,22 +181,4 @@ describe('Client Session', function (): void {
 		mockSessionManager.verify(s => s.shutdown(TypeMoq.It.isValue(expectedId)), TypeMoq.Times.once());
 	});
 
-
-	it('Should stop server if server is set', async function (): Promise<void> {
-		// Given a kernel has been started
-		serverManager.isStarted = true;
-		serverManager.result = Promise.resolve();
-		mockSessionManager.setup(s => s.isReady).returns(() => true);
-		mockSessionManager.setup(s => s.shutdown(TypeMoq.It.isAny())).returns(() => Promise.resolve());
-
-		await session.initialize();
-
-		// When I call shutdown
-		await session.shutdown();
-
-		// Then
-		should(serverManager.calledEnd).be.true();
-	});
-
-
 });


### PR DESCRIPTION
stopServer method in the sqlops extension is called twice, one from session object and the other one from notebook.component. Removed code from ClientSession.