### PR TITLE
Bump html_query_plan to 2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gc-signals": "^0.0.1",
     "getmac": "1.4.1",
     "graceful-fs": "4.1.11",
-    "html-query-plan": "git://github.com/anthonydresser/html-query-plan.git#2.4",
+    "html-query-plan": "git://github.com/anthonydresser/html-query-plan.git#2.6",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
     "iconv-lite": "0.4.23",


### PR DESCRIPTION
Fixes https://github.com/Microsoft/azuredatastudio/issues/3491.  See https://github.com/anthonydresser/html-query-plan/pull/8 for details.