### PR TITLE
Beginning of fix for notebook perf

### DIFF
--- a/src/sql/parts/modelComponents/queryTextEditor.ts
+++ b/src/sql/parts/modelComponents/queryTextEditor.ts
@@ -16,7 +16,6 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/resourceConfiguration';
-import { IModeService } from 'vs/editor/common/services/modeService';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { IEditorGroupsService } from 'vs/workbench/services/group/common/editorGroupsService';
 import { EditorOptions } from 'vs/workbench/common/editor';
@@ -36,7 +35,7 @@ export class QueryTextEditor extends BaseTextEditor {
 	private _dimension: DOM.Dimension;
 	private _config: editorCommon.IConfiguration;
 	private _minHeight: number = 0;
-	private _maxHeight: number = 10000;
+	private _maxHeight: number = 4000;
 	private _selected: boolean;
 	private _hideLineNumbers: boolean;
 	private _editorWorkspaceConfig;

--- a/src/sql/parts/modelComponents/queryTextEditor.ts
+++ b/src/sql/parts/modelComponents/queryTextEditor.ts
@@ -35,10 +35,12 @@ export class QueryTextEditor extends BaseTextEditor {
 	public static ID = 'modelview.editors.textEditor';
 	private _dimension: DOM.Dimension;
 	private _config: editorCommon.IConfiguration;
-	private _minHeight: number;
+	private _minHeight: number = 0;
+	private _maxHeight: number = 10000;
 	private _selected: boolean;
 	private _editorWorkspaceConfig;
 	private _scrollbarHeight: number;
+
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -155,13 +157,17 @@ export class QueryTextEditor extends BaseTextEditor {
 			}
 		}
 		let editorHeightUsingLines = this._config.editor.lineHeight * (lineCount + numberWrappedLines);
-		let editorHeightUsingMinHeight = Math.max(editorHeightUsingLines, this._minHeight);
+		let editorHeightUsingMinHeight = Math.max(Math.min(editorHeightUsingLines, this._maxHeight), this._minHeight);
 		editorHeightUsingMinHeight = shouldAddHorizontalScrollbarHeight ? editorHeightUsingMinHeight + this._scrollbarHeight : editorHeightUsingMinHeight;
 		this.setHeight(editorHeightUsingMinHeight);
 	}
 
 	public setMinimumHeight(height: number) : void {
 		this._minHeight = height;
+	}
+
+	public setMaximumHeight(height: number) : void {
+		this._maxHeight = height;
 	}
 
 	public toggleEditorSelected(selected: boolean): void {

--- a/src/sql/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/parts/notebook/cellViews/code.component.ts
@@ -178,7 +178,6 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 			this.cellModel.source = this._editorModel.getValue();
 			this.onContentChanged.emit();
 			// TODO see if there's a better way to handle reassessing size.
-
 			setTimeout(() => this._layoutEmitter.fire(), 250);
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {

--- a/src/sql/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/parts/notebook/cellViews/code.component.ts
@@ -65,6 +65,7 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 
 	protected _actionBar: Taskbar;
 	private readonly _minimumHeight = 30;
+	private readonly _maximumHeight = 10000;
 	private _editor: QueryTextEditor;
 	private _editorInput: UntitledEditorInput;
 	private _editorModel: ITextModel;
@@ -132,6 +133,7 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 		this._editor.create(this.codeElement.nativeElement);
 		this._editor.setVisible(true);
 		this._editor.setMinimumHeight(this._minimumHeight);
+		this._editor.setMaximumHeight(this._maximumHeight);
 		let uri = this.createUri();
 		this._editorInput = instantiationService.createInstance(UntitledEditorInput, uri, false, this.cellModel.language, '', '');
 		this._editor.setInput(this._editorInput, undefined);

--- a/src/sql/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/parts/notebook/cellViews/code.component.ts
@@ -65,7 +65,7 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 
 	protected _actionBar: Taskbar;
 	private readonly _minimumHeight = 30;
-	private readonly _maximumHeight = 10000;
+	private readonly _maximumHeight = 4000;
 	private _editor: QueryTextEditor;
 	private _editorInput: UntitledEditorInput;
 	private _editorModel: ITextModel;

--- a/src/sql/parts/notebook/cellViews/codeCell.component.ts
+++ b/src/sql/parts/notebook/cellViews/codeCell.component.ts
@@ -3,11 +3,12 @@
 *  Licensed under the Source EULA. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { OnInit, Component, Input, Inject, forwardRef, ElementRef, ChangeDetectorRef, OnDestroy, ViewChild, SimpleChange, OnChanges } from '@angular/core';
+import { OnInit, Component, Input, Inject, forwardRef, ElementRef, ChangeDetectorRef, OnDestroy, ViewChild, SimpleChange, OnChanges, AfterViewInit } from '@angular/core';
 import { CommonServiceInterface } from 'sql/services/common/commonServiceInterface.service';
 import { CellView } from 'sql/parts/notebook/cellViews/interfaces';
 import { ICellModel } from 'sql/parts/notebook/models/modelInterfaces';
 import { NotebookModel } from 'sql/parts/notebook/models/notebookModel';
+import { CodeComponent } from 'sql/parts/notebook/cellViews/code.component';
 
 
 export const CODE_SELECTOR: string = 'code-cell-component';
@@ -17,8 +18,8 @@ export const CODE_SELECTOR: string = 'code-cell-component';
 	templateUrl: decodeURI(require.toUrl('./codeCell.component.html'))
 })
 
-export class CodeCellComponent extends CellView implements OnInit, OnChanges {
-	@ViewChild('codeCellOutput', { read: ElementRef }) private outputPreview: ElementRef;
+export class CodeCellComponent extends CellView implements OnInit, OnChanges, AfterViewInit {
+	@ViewChild(CodeComponent) private _codeComponent: CodeComponent;
 	@Input() cellModel: ICellModel;
 	@Input() set model(value: NotebookModel) {
 		this._model = value;
@@ -62,8 +63,14 @@ export class CodeCellComponent extends CellView implements OnInit, OnChanges {
 		return this._activeCellId;
 	}
 
+	ngAfterViewInit(): void {
+		this.layout();
+	}
+
 	// Todo: implement layout
 	public layout() {
-
+		if (this._codeComponent) {
+			this._codeComponent.layout();
+		}
 	}
 }

--- a/src/sql/parts/notebook/cellViews/codeCell.component.ts
+++ b/src/sql/parts/notebook/cellViews/codeCell.component.ts
@@ -4,11 +4,9 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { OnInit, Component, Input, Inject, forwardRef, ElementRef, ChangeDetectorRef, OnDestroy, ViewChild, SimpleChange, OnChanges, AfterViewInit } from '@angular/core';
-import { CommonServiceInterface } from 'sql/services/common/commonServiceInterface.service';
 import { CellView } from 'sql/parts/notebook/cellViews/interfaces';
 import { ICellModel } from 'sql/parts/notebook/models/modelInterfaces';
 import { NotebookModel } from 'sql/parts/notebook/models/notebookModel';
-import { CodeComponent } from 'sql/parts/notebook/cellViews/code.component';
 
 
 export const CODE_SELECTOR: string = 'code-cell-component';
@@ -18,8 +16,7 @@ export const CODE_SELECTOR: string = 'code-cell-component';
 	templateUrl: decodeURI(require.toUrl('./codeCell.component.html'))
 })
 
-export class CodeCellComponent extends CellView implements OnInit, OnChanges, AfterViewInit {
-	@ViewChild(CodeComponent) private _codeComponent: CodeComponent;
+export class CodeCellComponent extends CellView implements OnInit, OnChanges {
 	@Input() cellModel: ICellModel;
 	@Input() set model(value: NotebookModel) {
 		this._model = value;
@@ -62,15 +59,7 @@ export class CodeCellComponent extends CellView implements OnInit, OnChanges, Af
 	get activeCellId(): string {
 		return this._activeCellId;
 	}
-
-	ngAfterViewInit(): void {
-		this.layout();
-	}
-
-	// Todo: implement layout
 	public layout() {
-		if (this._codeComponent) {
-			this._codeComponent.layout();
-		}
+
 	}
 }


### PR DESCRIPTION
Fixes #3843. Now includes full fix which limits length and ensures a scrollbar is available

- Set max size for editor. 4000px gets us 200-250 lines before needing a scrollbar. 
- Adds layout updating which should also ensure accurage line highlighting to the right of the editor. What's happening is initial size is slightly off, so need to layout a 2nd time (e.g. layout once, let flex figure things out, then layout a 2nd time). This isn't optimal as there's a minor perf hit but it isn't noticeable overall.

To consider in future PRs:
- Add user configurable setting for max length?
- Handle case where we scroll to bottom but scrollbar is at the top. 
- Consider how intellisense will work on this. We may need to split into a window around the current code when sending to the kernel as it's quite likely that doing a 12K line intellisense request will be too big.