### PR TITLE
Fixed #3954 pass connection info to new notebook flow

### DIFF
--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -102,9 +102,15 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 
 	private updateProfile(): void {
 		this.profile = this.notebookParams ? this.notebookParams.profile : undefined;
+		let profile: IConnectionProfile;
 		if (!this.profile) {
-			// use global connection if possible
-			let profile = TaskUtilities.getCurrentGlobalConnection(this.objectExplorerService, this.connectionManagementService, this.editorService);
+			// Use connectionProfile passed in first
+			if (this._notebookParams.connectionProfileId !== undefined && this._notebookParams.connectionProfileId) {
+				profile = this.connectionManagementService.getConnectionProfileById(this._notebookParams.connectionProfileId);
+			} else {
+				// Second use global connection if possible
+				profile = TaskUtilities.getCurrentGlobalConnection(this.objectExplorerService, this.connectionManagementService, this.editorService);
+			}
 			// TODO use generic method to match kernel with valid connection that's compatible. For now, we only have 1
 			if (profile && profile.providerName) {
 				this.profile = profile;
@@ -481,10 +487,10 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	 */
 	private fillInActionsForCurrentContext(): void {
 		let primary: IAction[] = [];
-		let	secondary: IAction[] = [];
+		let secondary: IAction[] = [];
 		let notebookBarMenu = this.menuService.createMenu(MenuId.NotebookToolbar, this.contextKeyService);
 		let groups = notebookBarMenu.getActions({ arg: null, shouldForwardArgs: true });
-		fillInActions(groups, {primary, secondary}, false, (group: string) => group === undefined);
+		fillInActions(groups, { primary, secondary }, false, (group: string) => group === undefined);
 		this.addPrimaryContributedActions(primary);
 	}
 

--- a/src/sql/parts/notebook/notebookEditor.ts
+++ b/src/sql/parts/notebook/notebookEditor.ts
@@ -92,7 +92,8 @@ export class NotebookEditor extends BaseEditor {
 			input: input,
 			providerId: input.providerId ? input.providerId : DEFAULT_NOTEBOOK_PROVIDER,
 			providers: input.providers ? input.providers : [DEFAULT_NOTEBOOK_PROVIDER],
-			isTrusted: input.isTrusted
+			isTrusted: input.isTrusted,
+			connectionProfileId: input.connectionProfileId
 		};
 		bootstrapAngular(this.instantiationService,
 			NotebookModule,

--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -28,11 +28,13 @@ export class NotebookInputModel extends EditorModel {
 	private _providerId: string;
 	private _standardKernels: IStandardKernelWithProvider[];
 	private _defaultKernel: sqlops.nb.IKernelSpec;
-	constructor(public readonly notebookUri: URI, private readonly handle: number, private _isTrusted: boolean = false, private saveHandler?: ModeViewSaveHandler, provider?: string, private _providers?: string[]) {
+	private _connectionProfileId: string;
+	constructor(public readonly notebookUri: URI, private readonly handle: number, private _isTrusted: boolean = false, private saveHandler?: ModeViewSaveHandler, provider?: string, private _providers?: string[], connectionProfileId?: string) {
 		super();
 		this.dirty = false;
 		this._providerId = provider;
 		this._standardKernels = [];
+		this._connectionProfileId = connectionProfileId;
 	}
 
 	public get providerId(): string {
@@ -51,6 +53,10 @@ export class NotebookInputModel extends EditorModel {
 		this._providers = value;
 	}
 
+	public get connectionProfileId(): string {
+		return this._connectionProfileId;
+	}
+	
 	public get standardKernels(): IStandardKernelWithProvider[] {
 		return this._standardKernels;
 	}
@@ -110,6 +116,7 @@ export class NotebookInput extends EditorInput {
 	// Holds the HTML content for the editor when the editor discards this input and loads another
 	private _parentContainer: HTMLElement;
 	private readonly _layoutChanged: Emitter<void> = this._register(new Emitter<void>());
+	private _connectionProfileId: string;
 	constructor(private _title: string,
 		private _model: NotebookInputModel,
 		@INotebookService private notebookService: INotebookService,
@@ -117,6 +124,7 @@ export class NotebookInput extends EditorInput {
 	) {
 		super();
 		this._model.onDidChangeDirty(() => this._onDidChangeDirty.fire());
+		this._connectionProfileId = this._model.connectionProfileId;
 	}
 
 	public get notebookUri(): URI {
@@ -129,6 +137,10 @@ export class NotebookInput extends EditorInput {
 
 	public get providers(): string[] {
 		return this._model.providers;
+	}
+
+	public get connectionProfileId(): string {
+		return this._connectionProfileId;
 	}
 
 	public get standardKernels(): IStandardKernelWithProvider[] {

--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -28,13 +28,18 @@ export class NotebookInputModel extends EditorModel {
 	private _providerId: string;
 	private _standardKernels: IStandardKernelWithProvider[];
 	private _defaultKernel: sqlops.nb.IKernelSpec;
-	private _connectionProfileId: string;
-	constructor(public readonly notebookUri: URI, private readonly handle: number, private _isTrusted: boolean = false, private saveHandler?: ModeViewSaveHandler, provider?: string, private _providers?: string[], connectionProfileId?: string) {
+	constructor(public readonly notebookUri: URI,
+		private readonly handle: number,
+		private _isTrusted: boolean = false,
+		private saveHandler?: ModeViewSaveHandler,
+		provider?: string,
+		private _providers?: string[],
+		private _connectionProfileId?: string) {
+
 		super();
 		this.dirty = false;
 		this._providerId = provider;
 		this._standardKernels = [];
-		this._connectionProfileId = connectionProfileId;
 	}
 
 	public get providerId(): string {
@@ -56,7 +61,7 @@ export class NotebookInputModel extends EditorModel {
 	public get connectionProfileId(): string {
 		return this._connectionProfileId;
 	}
-	
+
 	public get standardKernels(): IStandardKernelWithProvider[] {
 		return this._standardKernels;
 	}
@@ -116,7 +121,6 @@ export class NotebookInput extends EditorInput {
 	// Holds the HTML content for the editor when the editor discards this input and loads another
 	private _parentContainer: HTMLElement;
 	private readonly _layoutChanged: Emitter<void> = this._register(new Emitter<void>());
-	private _connectionProfileId: string;
 	constructor(private _title: string,
 		private _model: NotebookInputModel,
 		@INotebookService private notebookService: INotebookService,
@@ -124,7 +128,6 @@ export class NotebookInput extends EditorInput {
 	) {
 		super();
 		this._model.onDidChangeDirty(() => this._onDidChangeDirty.fire());
-		this._connectionProfileId = this._model.connectionProfileId;
 	}
 
 	public get notebookUri(): URI {
@@ -140,7 +143,7 @@ export class NotebookInput extends EditorInput {
 	}
 
 	public get connectionProfileId(): string {
-		return this._connectionProfileId;
+		return this._model.connectionProfileId;
 	}
 
 	public get standardKernels(): IStandardKernelWithProvider[] {

--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -272,6 +272,11 @@ export interface IConnectionManagementService {
 	 * Serialize connection string with optional provider
 	 */
 	buildConnectionInfo(connectionString: string, provider?: string): Thenable<sqlops.ConnectionInfo>;
+
+	/**
+	 * Get connection profile by id
+	 */
+	getConnectionProfileById(profileId: string): IConnectionProfile;
 }
 
 export const IConnectionDialogService = createDecorator<IConnectionDialogService>('connectionDialogService');

--- a/src/sql/platform/connection/common/connectionManagementService.ts
+++ b/src/sql/platform/connection/common/connectionManagementService.ts
@@ -1378,6 +1378,14 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		return serverInfo;
 	}
 
+	public getConnectionProfileById(profileId: string): IConnectionProfile {
+		let profile = this._connectionStatusManager.findConnectionByProfileId(profileId);
+		if (!profile) {
+			return undefined;
+		}
+		return profile.connectionProfile;
+	}
+
 	/**
 	 * Get the connection string for the provided connection ID
 	 */

--- a/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
@@ -361,7 +361,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 			pinned: !options.preview
 		};
 		let trusted = uri.scheme === Schemas.untitled;
-		let model = new NotebookInputModel(uri, undefined, trusted, undefined);
+		let model = new NotebookInputModel(uri, undefined, trusted, undefined, undefined, undefined, options.connectionId);
 		let providerId = options.providerId;
 		let providers: string[] = undefined;
 		// Ensure there is always a sensible provider ID for this file type

--- a/src/sql/workbench/services/notebook/common/notebookService.ts
+++ b/src/sql/workbench/services/notebook/common/notebookService.ts
@@ -93,6 +93,7 @@ export interface INotebookParams extends IBootstrapParams {
 	isTrusted: boolean;
 	profile?: IConnectionProfile;
 	modelFactory?: ModelFactory;
+	connectionProfileId?: string;
 }
 
 export interface INotebookEditor {

--- a/src/sqltest/stubs/connectionManagementService.test.ts
+++ b/src/sqltest/stubs/connectionManagementService.test.ts
@@ -265,4 +265,8 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 	buildConnectionInfo(connectionString: string, provider?: string): Thenable<sqlops.ConnectionInfo> {
 		return undefined;
 	}
+
+	getConnectionProfileById(profileId: string): IConnectionProfile {
+		return undefined;
+	}
 }


### PR DESCRIPTION
The problem is: connectionProfileId is not passed into New Notebook flow.
The fix is: plumbing connectionProfileId via NotebookInput.
I have tested the following scenarios:
- New NB from command palette
- New NB from "Data Services" context menu
- New NB from big data cluster dashboard tab
  1. select standalone SQL server in OE
  2. select big data cluster master instance

Attach To: shows the correct server from context

Please let me know if there are other cases. Chris and I are trying to find out new NB from SSMS->ADS
