### PR TITLE
Make sql kernel as default when provider is sql #3995

### DIFF
--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -87,7 +87,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		if (this.notebookOptions.layoutChanged) {
 			this.notebookOptions.layoutChanged(() => this._layoutChanged.fire());
 		}
-		if (this._providerId && (this._providerId.toLowerCase() === SQL_NOTEBOOK_PROVIDER.toLocaleLowerCase())) {
+		if (this._providerId && (this._providerId.toLowerCase() === SQL_NOTEBOOK_PROVIDER.toLowerCase())) {
 			this._defaultKernel = this._sqlKernel;
 		}
 		else {

--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -67,6 +67,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private _kernelDisplayNameToConnectionProviderIds: Map<string, string[]> = new Map<string, string[]>();
 	private _kernelDisplayNameToNotebookProviderIds: Map<string, string> = new Map<string, string>();
 	private _onValidConnectionSelected = new Emitter<boolean>();
+	private readonly _sqlKernel: nb.IKernelSpec = { name: SQL_NOTEBOOK_PROVIDER.toLocaleUpperCase(), display_name: SQL_NOTEBOOK_PROVIDER.toLocaleUpperCase(), language: SQL_NOTEBOOK_PROVIDER.toLowerCase()};
 
 	constructor(private notebookOptions: INotebookModelOptions, startSessionImmediately?: boolean, private connectionProfile?: IConnectionProfile) {
 		super();
@@ -86,7 +87,12 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		if (this.notebookOptions.layoutChanged) {
 			this.notebookOptions.layoutChanged(() => this._layoutChanged.fire());
 		}
-		this._defaultKernel = notebookOptions.defaultKernel;
+		if (this._providerId && (this._providerId.toLowerCase() === SQL_NOTEBOOK_PROVIDER.toLocaleLowerCase())) {
+			this._defaultKernel = this._sqlKernel;
+		}
+		else {
+			this._defaultKernel = notebookOptions.defaultKernel;
+		}
 	}
 
 	public get notebookManagers(): INotebookManager[] {

--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -67,7 +67,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private _kernelDisplayNameToConnectionProviderIds: Map<string, string[]> = new Map<string, string[]>();
 	private _kernelDisplayNameToNotebookProviderIds: Map<string, string> = new Map<string, string>();
 	private _onValidConnectionSelected = new Emitter<boolean>();
-	private readonly _sqlKernel: nb.IKernelSpec = { name: SQL_NOTEBOOK_PROVIDER.toLocaleUpperCase(), display_name: SQL_NOTEBOOK_PROVIDER.toLocaleUpperCase(), language: SQL_NOTEBOOK_PROVIDER.toLowerCase()};
+	private readonly _sqlKernel: nb.IKernelSpec = { name: SQL_NOTEBOOK_PROVIDER.toLocaleUpperCase(), display_name: SQL_NOTEBOOK_PROVIDER.toLocaleUpperCase(), language: SQL_NOTEBOOK_PROVIDER.toLowerCase() };
 
 	constructor(private notebookOptions: INotebookModelOptions, startSessionImmediately?: boolean, private connectionProfile?: IConnectionProfile) {
 		super();


### PR DESCRIPTION
#3995 
- Added sql as the default kernel when provider is sql. There is an existing condition in notebook.component to make provider as 'sql' when sqlKernel feature flag is enabled. 
- This will fix the issue of creating a new notebook from Dashboard and Bigdata connection.
- When sqlops extension is installed on top of ADS, PySpark3 would be the default kernel from  NotebookParams. Now that we cancel the python installation, we need to default it out to sql given that sqlKernel is enabled. 