### PR TITLE
Fix bug minimizing a maximized result grid

### DIFF
--- a/src/sql/base/browser/ui/scrollableSplitview/scrollableSplitview.ts
+++ b/src/sql/base/browser/ui/scrollableSplitview/scrollableSplitview.ts
@@ -221,6 +221,7 @@ export class ScrollableSplitView extends HeightMap implements IDisposable {
 
 		this.state = State.Busy;
 
+		let currentIndex = index;
 		for (let i = 0; i < views.length; i++) {
 			let size: number | Sizing;
 			if (Array.isArray(sizes)) {
@@ -267,9 +268,9 @@ export class ScrollableSplitView extends HeightMap implements IDisposable {
 			}
 
 			const item: IViewItem = { onAdd, onRemove, view, container, size: viewSize, layout, disposable, height: viewSize, top: 0, width: 0 };
-			this.viewItems.splice(index, 0, item);
+			this.viewItems.splice(currentIndex, 0, item);
 
-			this.onInsertItems(new ArrayIterator([item]), index > 0 ? this.viewItems[index - 1].view.id : undefined);
+			this.onInsertItems(new ArrayIterator([item]), currentIndex > 0 ? this.viewItems[currentIndex - 1].view.id : undefined);
 
 			// Add sash
 			if (this.options.enableResizing && this.viewItems.length > 1) {
@@ -296,10 +297,11 @@ export class ScrollableSplitView extends HeightMap implements IDisposable {
 				const disposable = combinedDisposable([onStartDisposable, onChangeDisposable, onEndDisposable, onDidResetDisposable, sash]);
 				const sashItem: ISashItem = { sash, disposable };
 
-				this.sashItems.splice(index - 1, 0, sashItem);
+				this.sashItems.splice(currentIndex - 1, 0, sashItem);
 			}
 
 			container.appendChild(view.element);
+			currentIndex++;
 		}
 
 		let highPriorityIndex: number | undefined;
@@ -314,6 +316,14 @@ export class ScrollableSplitView extends HeightMap implements IDisposable {
 		if (!types.isArray(sizes) && sizes.type === 'distribute') {
 			this.distributeViewSizes();
 		}
+
+		// Re-render the views. Set lastRenderTop and lastRenderHeight to undefined since
+		// this isn't actually scrolling up or down
+		let scrollTop = this.lastRenderTop;
+		let viewHeight = this.lastRenderHeight;
+		this.lastRenderTop = undefined;
+		this.lastRenderHeight = undefined;
+		this.render(scrollTop, viewHeight);
 	}
 
 	addView(view: IView, size: number | Sizing, index = this.viewItems.length): void {

--- a/src/sql/parts/query/editor/gridPanel.ts
+++ b/src/sql/parts/query/editor/gridPanel.ts
@@ -194,7 +194,7 @@ export class GridPanel extends ViewletPanel {
 				p = p.concat(e.resultSetSummaries.filter(c => c.complete));
 			}
 			return p;
-		}, []).reverse());
+		}, []));
 		this.maximumBodySize = this.tables.reduce((p, c) => {
 			return p + c.maximumSize;
 		}, 0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3817,9 +3817,9 @@ html-comment-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
   integrity sha1-ZouTd26q5V696POtRkswekljYl4=
 
-"html-query-plan@git://github.com/anthonydresser/html-query-plan.git#2.4":
-  version "2.4.0"
-  resolved "git://github.com/anthonydresser/html-query-plan.git#e8e0ded622d7afd6070f291101566ecaaca32cc5"
+"html-query-plan@git://github.com/anthonydresser/html-query-plan.git#2.6":
+  version "2.5.0"
+  resolved "git://github.com/anthonydresser/html-query-plan.git#c524feb824e4960897ad875a37af068376a2b4a3"
 
 "htmlparser2@>= 3.7.3 < 4.0.0", htmlparser2@^3.9.1:
   version "3.9.2"


### PR DESCRIPTION
Fixes #3993. `ScrollableSplitView`'s `addViews` method expected views in reverse order (the last one in the array passed in would end up at the top), but the views were not being passed in reverse order when minimizing a maximized result set. I've changed `addViews` to expect them in a normal order and updated code where needed.