### PR TITLE
Fix issues due to missing notebook values (specs and cells)

### DIFF
--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -546,8 +546,12 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return kernel;
 	}
 
-	private getDisplayNameFromSpecName(kernelid: string): string {
-		let newKernel = this.notebookManager.sessionManager.specs.kernels.find(kernel => kernel.name === kernelid);
+	private getDisplayNameFromSpecName(kernel: nb.IKernel): string {
+		let specs = this.notebookManager.sessionManager.specs;
+		if (!specs || !specs.kernels) {
+			return kernel.name;
+		}
+		let newKernel = this.notebookManager.sessionManager.specs.kernels.find(kernel => kernel.name === kernel.name);
 		let newKernelDisplayName;
 		if (newKernel) {
 			newKernelDisplayName = newKernel.display_name;
@@ -586,7 +590,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	private async loadActiveContexts(kernelChangedArgs: nb.IKernelChangedArgs): Promise<void> {
 		if (kernelChangedArgs && kernelChangedArgs.newValue && kernelChangedArgs.newValue.name) {
-			let kernelDisplayName = this.getDisplayNameFromSpecName(kernelChangedArgs.newValue.name);
+			let kernelDisplayName = this.getDisplayNameFromSpecName(kernelChangedArgs.newValue);
 			this._activeContexts = await NotebookContexts.getContextsForKernel(this.notebookOptions.connectionService, this.getApplicableConnectionProviderIds(kernelDisplayName), kernelChangedArgs, this.connectionProfile);
 			this._contextsChangedEmitter.fire();
 			if (this.contexts.defaultConnection !== undefined && this.contexts.defaultConnection.serverName !== undefined) {

--- a/src/sql/workbench/services/notebook/node/localContentManager.ts
+++ b/src/sql/workbench/services/notebook/node/localContentManager.ts
@@ -71,8 +71,10 @@ namespace v4 {
 			nbformat_minor: contents.nbformat_minor
 		};
 
-		for (let cell of contents.cells) {
-			notebook.cells.push(readCell(cell));
+		if (contents.cells) {
+			for (let cell of contents.cells) {
+				notebook.cells.push(readCell(cell));
+			}
 		}
 
 		return notebook;


### PR DESCRIPTION
 - Fix #3844 Failed to open Notebook with saved invalid kernel
- Fix #3955 Attach To: stuck at "Loading contexts... 
- Specs can be null on early load of Jupyter kernels
- Cells were missing in some reference test .ipynb files. We should be resilient to malformed files if possible.