### PR TITLE
Notebooks: Fix left table border to be dotted, no longer have table border on div

### DIFF
--- a/src/sql/parts/notebook/notebook.css
+++ b/src/sql/parts/notebook/notebook.css
@@ -86,7 +86,10 @@
 }
 
 .notebookEditor .notebook-cellTable {
-	border: 1px silver solid;
 	margin-left: 20px;
 	margin-top: 10px;
+}
+
+.notebookEditor .notebook-cellTable .ui-widget-content.slick-row {
+	border-left: 1px silver dotted;
 }


### PR DESCRIPTION
Fix left table border to be dotted, no longer have table border on div. Fixes #3988.

Problem previously was that there is a minimum size for the grid's div, so if tabular data came back that was too small for the div, a border would be much too large for the table.

Here's how this looks after the change:

<img width="284" alt="image" src="https://user-images.githubusercontent.com/40371649/52605993-d0027380-2e25-11e9-92da-48a83c411b56.png">

I also tried adding a left border to the 1st column header. That experiment did not go well; all other columns were shifted over by a px or 2, making them out of alignment.