### PR TITLE
'Attach to' with Spark kernel resets to sql connection on cancelling connection dialog

### DIFF
--- a/src/sql/parts/notebook/models/modelInterfaces.ts
+++ b/src/sql/parts/notebook/models/modelInterfaces.ts
@@ -341,7 +341,7 @@ export interface INotebookModel {
 	/**
 	 * Change the current context (if applicable)
 	 */
-	changeContext(host: string, connection?: IConnectionProfile): Promise<void>;
+	changeContext(host: string, connection?: IConnectionProfile, hideErrorMessage?: boolean): Promise<void>;
 
 	/**
 	 * Find a cell's index given its model

--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -444,7 +444,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return Promise.resolve();
 	}
 
-	public async changeContext(server: string, newConnection?: IConnectionProfile): Promise<void> {
+	public async changeContext(server: string, newConnection?: IConnectionProfile, hideErrorMessage?: boolean): Promise<void> {
 		try {
 			if (!newConnection) {
 				newConnection = this._activeContexts.otherConnections.find((connection) => connection.serverName === server);
@@ -462,7 +462,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				},
 				error => {
 					if (error) {
-						this.notifyError(notebookUtils.getErrorMessage(error));
+						if (!hideErrorMessage) {
+							this.notifyError(notebookUtils.getErrorMessage(error));
+						}
 						//Selected a wrong connection, Attach to should be defaulted with 'Select connection'
 						this._onValidConnectionSelected.fire(false);
 					}

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -392,11 +392,11 @@ export class AttachToDropdown extends SelectBox {
 		return otherConnections;
 	}
 
-	public doChangeContext(connection?: ConnectionProfile): void {
+	public doChangeContext(connection?: ConnectionProfile, hideErrorMessage?: boolean): void {
 		if (this.value === msgAddNewConnection) {
 			this.openConnectionDialog();
 		} else {
-			this.model.changeContext(this.value, connection).then(ok => undefined, err => this._notificationService.error(getErrorMessage(err)));
+			this.model.changeContext(this.value, connection, hideErrorMessage).then(ok => undefined, err => this._notificationService.error(getErrorMessage(err)));
 		}
 	}
 
@@ -412,7 +412,7 @@ export class AttachToDropdown extends SelectBox {
 				let attachToConnections = this.values;
 				if (!connection) {
 					this.loadAttachToDropdown(this.model, this.getKernelDisplayName());
-					this.doChangeContext();
+					this.doChangeContext(undefined, true);
 					return;
 				}
 				let connectionProfile = new ConnectionProfile(this._capabilitiesService, connection);

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -412,6 +412,7 @@ export class AttachToDropdown extends SelectBox {
 				let attachToConnections = this.values;
 				if (!connection) {
 					this.loadAttachToDropdown(this.model, this.getKernelDisplayName());
+					this.doChangeContext();
 					return;
 				}
 				let connectionProfile = new ConnectionProfile(this._capabilitiesService, connection);

--- a/src/sqltest/parts/notebook/common.ts
+++ b/src/sqltest/parts/notebook/common.ts
@@ -69,7 +69,7 @@ export class NotebookModelStub implements INotebookModel {
     changeKernel(displayName: string): void {
         throw new Error('Method not implemented.');
     }
-    changeContext(host: string, connection?: IConnectionProfile): Promise<void> {
+    changeContext(host: string, connection?: IConnectionProfile, hideErrorMessage?: boolean): Promise<void> {
         throw new Error('Method not implemented.');
     }
     findCellIndex(cellModel: ICellModel): number {


### PR DESCRIPTION
1. Connect ADS to a SQL server(sql only)
2. Create a new notebook by enabling sql kernel feature flag
3. Change kernel to PySpark3, click on 'Add new connection'
4. Connection dialog will be opened, cancel it.
 Issue: 'Attach to' shows sql connection.
Expected: 'Select Connection' should be shown with connection invalid message.

![image](https://user-images.githubusercontent.com/44002319/52673621-2b8c3a00-2ed6-11e9-85eb-74fdb157a35b.png)
