### PR TITLE
Notebook: Show Errors and Messages in Output Area

### DIFF
--- a/src/sql/parts/notebook/outputs/common/outputProcessor.ts
+++ b/src/sql/parts/notebook/outputs/common/outputProcessor.ts
@@ -40,8 +40,12 @@ export function getData(output: nb.ICellOutput): JSONObject {
 		}
 	} else if (nbformat.isError(output)) {
 		let traceback = output.traceback ? output.traceback.join('\n') : undefined;
-		bundle['application/vnd.jupyter.stderr'] =
-			traceback || `${output.ename}: ${output.evalue}`;
+		bundle['application/vnd.jupyter.stderr'] = undefined;
+		if (traceback && traceback !== '') {
+			bundle['application/vnd.jupyter.stderr'] = traceback;
+		} else if (output.evalue) {
+			bundle['application/vnd.jupyter.stderr'] = output.ename && output.ename !== '' ? `${output.ename}: ${output.evalue}` : `${output.evalue}`;
+		}
 	}
 	return convertBundle(bundle);
 }


### PR DESCRIPTION
Final UX is still being worked out for messages, but I would like to do this iteratively to avoid a giant PR later on. Fixes #3974.

This PR is pretty simple, just shows messages in the output of each cell (i.e. "(x rows affected")). In addition, this tweaks the error handling such that errors now show up in the output area instead of in a dialog.

In future PRs, we can tweak the error color (since this can have rippling effects on jupyter errors as well), and change the location for messages. In addition, we need more work to support the "Started executing query at Line <x>" message, as we currently pass a string in for the content, but the queryRunner really needs an object implementing ISelectionData instead (otherwise, it erroneously says that the line number always starts at 1).

Error:
<img width="406" alt="image" src="https://user-images.githubusercontent.com/40371649/52744327-47084b00-2f91-11e9-808d-03580a5d4b90.png">

Messages:
<img width="448" alt="image" src="https://user-images.githubusercontent.com/40371649/52744360-62735600-2f91-11e9-844c-7949376b7049.png">