### PR TITLE
Fixed bug that connectionId changed when connectionProfile cloning with database name added

### DIFF
--- a/src/sql/parts/objectExplorer/viewlet/treeUpdateUtils.ts
+++ b/src/sql/parts/objectExplorer/viewlet/treeUpdateUtils.ts
@@ -274,7 +274,7 @@ export class TreeUpdateUtils {
 		let connectionProfile = treeNode.getConnectionProfile();
 		let databaseName = treeNode.getDatabaseName();
 		if (databaseName !== undefined && connectionProfile.databaseName !== databaseName) {
-			connectionProfile = connectionProfile.cloneWithDatabase(databaseName);
+			connectionProfile = connectionProfile.cloneWithDatabase(databaseName, false);
 		}
 		return connectionProfile;
 	}

--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -116,8 +116,8 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 		return instance;
 	}
 
-	public cloneWithDatabase(databaseName: string): ConnectionProfile {
-		let instance = this.cloneWithNewId();
+	public cloneWithDatabase(databaseName: string, newId: boolean = true): ConnectionProfile {
+		let instance = newId ? this.cloneWithNewId() : this.clone();
 		instance.databaseName = databaseName;
 		return instance;
 	}


### PR DESCRIPTION
Finding database node by `sqlops.objectexplorer.findNode()` does not work when a task is kicked off by `right-click database > Manage`.
It works only when `right-click server > Manage`.
That is because `connectionId` of `Connection` object in these cases are different.

The root cause of the connectionId change is `connectionProfile.cloneWithDatabase()` ***always***  generates new `connectionId` for cloned profile.
`right-click database > Manage` triggers this code spot for cloning with database name added, and the output connectionProfile from this ***always*** has new connectionId.

This fix makes new id as optional so that we can clone with the same connectionId as original one.
