### PR TITLE
Allow code coverage command to succeed again

### DIFF
--- a/test/all.js
+++ b/test/all.js
@@ -129,7 +129,7 @@ function main() {
 				});
 			}
 
-			let remapIgnores = /\b((winjs\.base)|(marked)|(raw\.marked)|(nls)|(css))\.js$/;
+			let remapIgnores = /\b((winjs\.base)|(filters\.perf\.data)|(performance)|(marked)|(raw\.marked)|(nls)|(css))\.js$/;
 
 			var remappedCoverage = i_remap(global.__coverage__, { exclude: remapIgnores }).getFinalCoverage();
 
@@ -170,6 +170,7 @@ function main() {
 			collector.add(finalCoverage);
 
 			var coveragePath = path.join(path.dirname(__dirname), '.build', 'coverage');
+			console.log('coverage folder is at: '.concat(coveragePath));
 			var reportTypes = [];
 			if (argv.run || argv.runGlob) {
 				// single file running


### PR DESCRIPTION
After this change we're excluding the following 2 .js files which don't have corresponding js map files:

Excluding: "/Users/chlafren/azuredatastudio/out/vs/base/test/common/filters.perf.data.js"
Excluding: "/Users/chlafren/azuredatastudio/out/vs/base/common/performance.js"

Then just printing out a simple message about where the coverage folder is, so that other folks don't have to hunt anymore 😄.

Command for creating this folder for code coverage is scripts/test.<sh|bat> --coverage