### PR TITLE
Added SQL notebook IntelliSense

### DIFF
--- a/src/sql/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/parts/notebook/cellViews/code.component.ts
@@ -122,7 +122,7 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 				if (isActive && this._model.defaultKernel.display_name === notebookConstants.SQL
 					&& this.cellModel.cellType === CellTypes.Code
 					&& this.cellModel.cellUri) {
-					this._model.notebookOptions.connectionService.connect(this._model.activeConnection, this.cellModel.cellUri.toString());
+					this._model.notebookOptions.connectionService.connect(this._model.activeConnection, this.cellModel.cellUri.toString()).catch(e => console.log(e));
 				}
 				this.toggleMoreActionsButton(isActive);
 				if (this._editor) {

--- a/src/sql/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/parts/notebook/cellViews/code.component.ts
@@ -10,7 +10,7 @@ import { CommonServiceInterface } from 'sql/services/common/commonServiceInterfa
 import { AngularDisposable } from 'sql/base/node/lifecycle';
 import { QueryTextEditor } from 'sql/parts/modelComponents/queryTextEditor';
 import { CellToggleMoreActions } from 'sql/parts/notebook/cellToggleMoreActions';
-import { ICellModel } from 'sql/parts/notebook/models/modelInterfaces';
+import { ICellModel, notebookConstants } from 'sql/parts/notebook/models/modelInterfaces';
 import { Taskbar } from 'sql/base/browser/ui/taskbar/taskbar';
 import { RunCellAction, CellContext } from 'sql/parts/notebook/cellViews/codeActions';
 import { NotebookModel } from 'sql/parts/notebook/models/notebookModel';
@@ -23,8 +23,6 @@ import { IProgressService } from 'vs/platform/progress/common/progress';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ITextModel } from 'vs/editor/common/model';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
-import URI from 'vs/base/common/uri';
-import { Schemas } from 'vs/base/common/network';
 import * as DOM from 'vs/base/browser/dom';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { IModelService } from 'vs/editor/common/services/modelService';
@@ -121,6 +119,11 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 			if (propName === 'activeCellId') {
 				let changedProp = changes[propName];
 				let isActive = this.cellModel.id === changedProp.currentValue;
+				if (isActive && this._model.defaultKernel.display_name === notebookConstants.SQL
+					&& this.cellModel.cellType === CellTypes.Code
+					&& this.cellModel.cellUri) {
+					this._model.notebookOptions.connectionService.connect(this._model.activeConnection, this.cellModel.cellUri.toString());
+				}
 				this.toggleMoreActionsButton(isActive);
 				if (this._editor) {
 					this._editor.toggleEditorSelected(isActive);
@@ -156,7 +159,7 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 		this._editor.setVisible(true);
 		this._editor.setMinimumHeight(this._minimumHeight);
 		this._editor.setMaximumHeight(this._maximumHeight);
-		let uri = this.createUri();
+		let uri = this.cellModel.cellUri;
 		this._editorInput = instantiationService.createInstance(UntitledEditorInput, uri, false, this.cellModel.language, '', '');
 		this._editor.setInput(this._editorInput, undefined);
 		this.setFocusAndScroll();
@@ -208,14 +211,6 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 		]);
 
 		this._cellToggleMoreActions.onInit(this.moreActionsElementRef, this.model, this.cellModel);
-	}
-
-
-	private createUri(): URI {
-		let uri = URI.from({ scheme: Schemas.untitled, path: `notebook-editor-${this.cellModel.id}` });
-		// Use this to set the internal (immutable) and public (shared with extension) uri properties
-		this.cellModel.cellUri = uri;
-		return uri;
 	}
 
 	/// Editor Functions

--- a/src/sql/parts/notebook/models/cell.ts
+++ b/src/sql/parts/notebook/models/cell.ts
@@ -18,6 +18,7 @@ import { CellTypes, CellType, NotebookChangeType } from 'sql/parts/notebook/mode
 import { ICellModel } from 'sql/parts/notebook/models/modelInterfaces';
 import { NotebookModel } from 'sql/parts/notebook/models/notebookModel';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { Schemas } from 'vs/base/common/network';
 let modelId = 0;
 
 
@@ -54,6 +55,7 @@ export class CellModel implements ICellModel {
 		} else {
 			this._isTrusted = false;
 		}
+		this.createUri();
 	}
 
 	public equals(other: ICellModel) {
@@ -506,5 +508,11 @@ export class CellModel implements ICellModel {
 
 	private hasLanguage(): boolean {
 		return !!this._language;
+	}
+
+	private createUri(): void {
+		let uri = URI.from({ scheme: Schemas.untitled, path: `notebook-editor-${this.id}` });
+		// Use this to set the internal (immutable) and public (shared with extension) uri properties
+		this.cellUri = uri;
 	}
 }

--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -13,7 +13,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 
 import { CellModel } from './cell';
 import { IClientSession, INotebookModel, IDefaultConnection, INotebookModelOptions, ICellModel, notebookConstants, NotebookContentChange } from './modelInterfaces';
-import { NotebookChangeType, CellType } from 'sql/parts/notebook/models/contracts';
+import { NotebookChangeType, CellType, CellTypes } from 'sql/parts/notebook/models/contracts';
 import { nbversion } from '../notebookConstants';
 import * as notebookUtils from '../notebookUtils';
 import { INotebookManager, SQL_NOTEBOOK_PROVIDER, DEFAULT_NOTEBOOK_PROVIDER } from 'sql/workbench/services/notebook/common/notebookService';
@@ -68,7 +68,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private _kernelDisplayNameToNotebookProviderIds: Map<string, string> = new Map<string, string>();
 	private _onValidConnectionSelected = new Emitter<boolean>();
 
-	constructor(private notebookOptions: INotebookModelOptions, startSessionImmediately?: boolean, private connectionProfile?: IConnectionProfile) {
+	constructor(public notebookOptions: INotebookModelOptions, startSessionImmediately?: boolean, private connectionProfile?: IConnectionProfile) {
 		super();
 		if (!notebookOptions || !notebookOptions.notebookUri || !notebookOptions.notebookManagers) {
 			throw new Error('path or notebook service not defined');
@@ -230,7 +230,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return this._onProviderIdChanged.event;
 	}
 
-	public get onValidConnectionSelected(): Event<boolean>{
+	public get onValidConnectionSelected(): Event<boolean> {
 		return this._onValidConnectionSelected.event;
 	}
 
@@ -292,6 +292,12 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		}
 		// Set newly created cell as active cell
 		this.updateActiveCell(cell);
+
+		if (this._defaultKernel.display_name === notebookConstants.SQL
+			&& cell.cellType === CellTypes.Code
+			&& cell.cellUri) {
+			this.notebookOptions.connectionService.connect(this.activeConnection, cell.cellUri.toString());
+		}
 
 		this._contentChangedEmitter.fire({
 			changeType: NotebookChangeType.CellsAdded,
@@ -430,7 +436,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		// Ensure that the kernel we try to switch to is a valid kernel; if not, use the default
 		let kernelSpecs = this.getKernelSpecs();
 		if (kernelSpecs && kernelSpecs.length > 0 && kernelSpecs.findIndex(k => k.name === kernelSpec.name) < 0) {
-				kernelSpec = kernelSpecs.find(spec => spec.name === this.notebookManager.sessionManager.specs.defaultKernel);
+			kernelSpec = kernelSpecs.find(spec => spec.name === this.notebookManager.sessionManager.specs.defaultKernel);
 		}
 		if (this._activeClientSession && this._activeClientSession.isReady) {
 			return this._activeClientSession.changeKernel(kernelSpec)
@@ -692,8 +698,8 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private getKernelSpecs(): nb.IKernelSpec[] {
 		if (this.notebookManager && this.notebookManager.sessionManager && this.notebookManager.sessionManager.specs &&
 			this.notebookManager.sessionManager.specs.kernels) {
-				return this.notebookManager.sessionManager.specs.kernels;
-			}
+			return this.notebookManager.sessionManager.specs.kernels;
+		}
 		return [];
 	}
 

--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -293,12 +293,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		// Set newly created cell as active cell
 		this.updateActiveCell(cell);
 
-		if (this._defaultKernel.display_name === notebookConstants.SQL
-			&& cell.cellType === CellTypes.Code
-			&& cell.cellUri) {
-			this.notebookOptions.connectionService.connect(this.activeConnection, cell.cellUri.toString());
-		}
-
 		this._contentChangedEmitter.fire({
 			changeType: NotebookChangeType.CellsAdded,
 			cells: [cell],

--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -178,7 +178,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	private disconnect() {
 		if (this._model.defaultKernel.display_name === notebookConstants.SQL) {
 			if (this._model.activeCell && this._model.activeCell.cellType === CellTypes.Code && this._model.activeCell.cellUri) {
-				this.connectionManagementService.disconnect(this._model.activeCell.cellUri.toString());
+				this.connectionManagementService.disconnect(this._model.activeCell.cellUri.toString()).catch(e => console.log(e));
 			}
 		}
 	}

--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -132,6 +132,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	}
 
 	ngOnDestroy() {
+		this.disconnect();
 		this.dispose();
 		if (this.notebookService) {
 			this.notebookService.removeNotebookEditor(this);
@@ -165,11 +166,20 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		}
 		if (cell !== this.model.activeCell) {
 			if (this.model.activeCell) {
+				this.disconnect();
 				this.model.activeCell.active = false;
 			}
 			this._model.activeCell = cell;
 			this._model.activeCell.active = true;
 			this._changeRef.detectChanges();
+		}
+	}
+
+	private disconnect() {
+		if (this._model.defaultKernel.display_name === notebookConstants.SQL) {
+			if (this._model.activeCell && this._model.activeCell.cellType === CellTypes.Code && this._model.activeCell.cellUri) {
+				this.connectionManagementService.disconnect(this._model.activeCell.cellUri.toString());
+			}
 		}
 	}
 


### PR DESCRIPTION
Implemented the simple version intelliSense support as we discussed -- make the connection when the cell is active. If this doesn't look good, let's try the other complicate solutions.

Some notes:
- Didn't put connect into Kernel. Right now Kernel doesn't know active cell. also requestExecute is only string. But if we still need to put it in Kernel, we can definitely plumbing through those. Just SQL Kernel has lots of extra stuff comparing other Kernels.

- CellUri is not set until creating editor. so when addCell, uri is undefined, failed to connect.
  Move createUri to cell.ts and call it in cell constructor

- We have multiple places set activeCell. Should we consolidate them?
