### PR TITLE
Deprecate the modelviewdialog namespace

### DIFF
--- a/extensions/agent/src/dialogs/agentDialog.ts
+++ b/extensions/agent/src/dialogs/agentDialog.ts
@@ -18,7 +18,7 @@ export abstract class AgentDialog<T extends IAgentDialogData> {
 
 	protected _onSuccess: vscode.EventEmitter<T> = new vscode.EventEmitter<T>();
 	public readonly onSuccess: vscode.Event<T> = this._onSuccess.event;
-	public dialog: sqlops.window.modelviewdialog.Dialog;
+	public dialog: sqlops.window.Dialog;
 
 	// Dialog Name for Telemetry
 	public dialogName: string;
@@ -32,11 +32,11 @@ export abstract class AgentDialog<T extends IAgentDialogData> {
 
 	protected abstract async updateModel();
 
-	protected abstract async initializeDialog(dialog: sqlops.window.modelviewdialog.Dialog);
+	protected abstract async initializeDialog(dialog: sqlops.window.Dialog);
 
 	public async openDialog(dialogName?: string) {
 		let event = dialogName ? dialogName : null;
-		this.dialog = sqlops.window.modelviewdialog.createDialog(this.title, event);
+		this.dialog = sqlops.window.createModelViewDialog(this.title, event);
 
 		await this.model.initialize();
 
@@ -48,7 +48,7 @@ export abstract class AgentDialog<T extends IAgentDialogData> {
 		this.dialog.cancelButton.label = AgentDialog.CancelButtonText;
 		this.dialog.cancelButton.onClick(async () => await this.cancel());
 
-		sqlops.window.modelviewdialog.openDialog(this.dialog);
+		sqlops.window.openDialog(this.dialog);
 	}
 
 	protected async execute() {

--- a/extensions/agent/src/dialogs/alertDialog.ts
+++ b/extensions/agent/src/dialogs/alertDialog.ts
@@ -121,9 +121,9 @@ export class AlertDialog extends AgentDialog<AlertData> {
 	private readonly EditAlertDialog = 'EditAlertDialogOpened';
 
 	// UI Components
-	private generalTab: sqlops.window.modelviewdialog.DialogTab;
-	private responseTab: sqlops.window.modelviewdialog.DialogTab;
-	private optionsTab: sqlops.window.modelviewdialog.DialogTab;
+	private generalTab: sqlops.window.DialogTab;
+	private responseTab: sqlops.window.DialogTab;
+	private optionsTab: sqlops.window.DialogTab;
 
 	// General tab controls
 	private nameTextBox: sqlops.InputBoxComponent;
@@ -175,13 +175,13 @@ export class AlertDialog extends AgentDialog<AlertData> {
 		this.dialogName = this.isEdit ? this.EditAlertDialog : this.NewAlertDialog;
 	}
 
-	protected async initializeDialog(dialog: sqlops.window.modelviewdialog.Dialog) {
+	protected async initializeDialog(dialog: sqlops.window.Dialog) {
 		this.databases = await AgentUtils.getDatabases(this.ownerUri);
 		this.databases.unshift(AlertDialog.AllDatabases);
 
-		this.generalTab = sqlops.window.modelviewdialog.createTab(AlertDialog.GeneralTabText);
-		this.responseTab = sqlops.window.modelviewdialog.createTab(AlertDialog.ResponseTabText);
-		this.optionsTab = sqlops.window.modelviewdialog.createTab(AlertDialog.OptionsTabText);
+		this.generalTab = sqlops.window.createTab(AlertDialog.GeneralTabText);
+		this.responseTab = sqlops.window.createTab(AlertDialog.ResponseTabText);
+		this.optionsTab = sqlops.window.createTab(AlertDialog.OptionsTabText);
 
 		this.initializeGeneralTab(this.databases, dialog);
 		this.initializeResponseTab();
@@ -190,7 +190,7 @@ export class AlertDialog extends AgentDialog<AlertData> {
 		dialog.content = [this.generalTab, this.responseTab, this.optionsTab];
 	}
 
-	private initializeGeneralTab(databases: string[], dialog: sqlops.window.modelviewdialog.Dialog) {
+	private initializeGeneralTab(databases: string[], dialog: sqlops.window.Dialog) {
 		this.generalTab.registerContent(async view => {
 			// create controls
 			this.nameTextBox = view.modelBuilder.inputBox().component();

--- a/extensions/agent/src/dialogs/jobDialog.ts
+++ b/extensions/agent/src/dialogs/jobDialog.ts
@@ -73,11 +73,11 @@ export class JobDialog extends AgentDialog<JobData>  {
 	private readonly EditJobDialogEvent: string  = 'EditJobDialogOpened';
 
 	// UI Components
-	private generalTab: sqlops.window.modelviewdialog.DialogTab;
-	private stepsTab: sqlops.window.modelviewdialog.DialogTab;
-	private alertsTab: sqlops.window.modelviewdialog.DialogTab;
-	private schedulesTab: sqlops.window.modelviewdialog.DialogTab;
-	private notificationsTab: sqlops.window.modelviewdialog.DialogTab;
+	private generalTab: sqlops.window.DialogTab;
+	private stepsTab: sqlops.window.DialogTab;
+	private alertsTab: sqlops.window.DialogTab;
+	private schedulesTab: sqlops.window.DialogTab;
+	private notificationsTab: sqlops.window.DialogTab;
 
 	// General tab controls
 	private nameTextBox: sqlops.InputBoxComponent;
@@ -139,11 +139,11 @@ export class JobDialog extends AgentDialog<JobData>  {
 	}
 
 	protected async initializeDialog() {
-		this.generalTab = sqlops.window.modelviewdialog.createTab(this.GeneralTabText);
-		this.stepsTab = sqlops.window.modelviewdialog.createTab(this.StepsTabText);
-		this.alertsTab = sqlops.window.modelviewdialog.createTab(this.AlertsTabText);
-		this.schedulesTab = sqlops.window.modelviewdialog.createTab(this.SchedulesTabText);
-		this.notificationsTab = sqlops.window.modelviewdialog.createTab(this.NotificationsTabText);
+		this.generalTab = sqlops.window.createTab(this.GeneralTabText);
+		this.stepsTab = sqlops.window.createTab(this.StepsTabText);
+		this.alertsTab = sqlops.window.createTab(this.AlertsTabText);
+		this.schedulesTab = sqlops.window.createTab(this.SchedulesTabText);
+		this.notificationsTab = sqlops.window.createTab(this.NotificationsTabText);
 		this.initializeGeneralTab();
 		this.initializeStepsTab();
 		this.initializeAlertsTab();

--- a/extensions/agent/src/dialogs/jobStepDialog.ts
+++ b/extensions/agent/src/dialogs/jobStepDialog.ts
@@ -74,11 +74,11 @@ export class JobStepDialog extends AgentDialog<JobStepData> {
 	// UI Components
 
 	// Dialogs
-	private fileBrowserDialog: sqlops.window.modelviewdialog.Dialog;
+	private fileBrowserDialog: sqlops.window.Dialog;
 
 	// Dialog tabs
-	private generalTab: sqlops.window.modelviewdialog.DialogTab;
-	private advancedTab: sqlops.window.modelviewdialog.DialogTab;
+	private generalTab: sqlops.window.DialogTab;
+	private advancedTab: sqlops.window.DialogTab;
 
 	//Input boxes
 	private nameTextBox: sqlops.InputBoxComponent;
@@ -138,8 +138,8 @@ export class JobStepDialog extends AgentDialog<JobStepData> {
 	}
 
 	private initializeUIComponents() {
-		this.generalTab = sqlops.window.modelviewdialog.createTab(this.GeneralTabText);
-		this.advancedTab = sqlops.window.modelviewdialog.createTab(this.AdvancedTabText);
+		this.generalTab = sqlops.window.createTab(this.GeneralTabText);
+		this.advancedTab = sqlops.window.createTab(this.AdvancedTabText);
 		this.dialog.content = [this.generalTab, this.advancedTab];
 	}
 
@@ -425,8 +425,8 @@ export class JobStepDialog extends AgentDialog<JobStepData> {
 
 	private openFileBrowserDialog() {
 		let fileBrowserTitle = this.FileBrowserDialogTitle + `${this.server}`;
-		this.fileBrowserDialog = sqlops.window.modelviewdialog.createDialog(fileBrowserTitle);
-		let fileBrowserTab = sqlops.window.modelviewdialog.createTab('File Browser');
+		this.fileBrowserDialog = sqlops.window.createModelViewDialog(fileBrowserTitle);
+		let fileBrowserTab = sqlops.window.createTab('File Browser');
 		this.fileBrowserDialog.content =  [fileBrowserTab];
 		fileBrowserTab.registerContent(async (view) => {
 			this.fileBrowserTree = view.modelBuilder.fileBrowserTree()
@@ -470,7 +470,7 @@ export class JobStepDialog extends AgentDialog<JobStepData> {
 		});
 		this.fileBrowserDialog.okButton.label = this.OkButtonText;
 		this.fileBrowserDialog.cancelButton.label = this.CancelButtonText;
-		sqlops.window.modelviewdialog.openDialog(this.fileBrowserDialog);
+		sqlops.window.openDialog(this.fileBrowserDialog);
 	}
 
 	private createTSQLOptions(view) {

--- a/extensions/agent/src/dialogs/operatorDialog.ts
+++ b/extensions/agent/src/dialogs/operatorDialog.ts
@@ -48,8 +48,8 @@ export class OperatorDialog extends AgentDialog<OperatorData> {
 	private readonly EditOperatorDialog = 'EditOperatorDialogOpened';
 
 	// UI Components
-	private generalTab: sqlops.window.modelviewdialog.DialogTab;
-	private notificationsTab: sqlops.window.modelviewdialog.DialogTab;
+	private generalTab: sqlops.window.DialogTab;
+	private notificationsTab: sqlops.window.DialogTab;
 
 	// General tab controls
 	private nameTextBox: sqlops.InputBoxComponent;
@@ -83,9 +83,9 @@ export class OperatorDialog extends AgentDialog<OperatorData> {
 		this.dialogName = this.isEdit ? this.EditOperatorDialog : this.NewOperatorDialog;
 	}
 
-	protected async initializeDialog(dialog: sqlops.window.modelviewdialog.Dialog) {
-		this.generalTab = sqlops.window.modelviewdialog.createTab(OperatorDialog.GeneralTabText);
-		this.notificationsTab = sqlops.window.modelviewdialog.createTab(OperatorDialog.NotificationsTabText);
+	protected async initializeDialog(dialog: sqlops.window.Dialog) {
+		this.generalTab = sqlops.window.createTab(OperatorDialog.GeneralTabText);
+		this.notificationsTab = sqlops.window.createTab(OperatorDialog.NotificationsTabText);
 
 		this.initializeGeneralTab();
 		this.initializeNotificationTab();

--- a/extensions/agent/src/dialogs/pickScheduleDialog.ts
+++ b/extensions/agent/src/dialogs/pickScheduleDialog.ts
@@ -25,7 +25,7 @@ export class PickScheduleDialog {
 
 
 	// UI Components
-	private dialog: sqlops.window.modelviewdialog.Dialog;
+	private dialog: sqlops.window.Dialog;
 	private schedulesTable: sqlops.TableComponent;
 
 	private model: PickScheduleData;
@@ -39,13 +39,13 @@ export class PickScheduleDialog {
 
 	public async showDialog() {
 		await this.model.initialize();
-		this.dialog = sqlops.window.modelviewdialog.createDialog(this.DialogTitle);
+		this.dialog = sqlops.window.createModelViewDialog(this.DialogTitle);
 		this.initializeContent();
 		this.dialog.okButton.onClick(async () => await this.execute());
 		this.dialog.cancelButton.onClick(async () => await this.cancel());
 		this.dialog.okButton.label = this.OkButtonText;
 		this.dialog.cancelButton.label = this.CancelButtonText;
-		sqlops.window.modelviewdialog.openDialog(this.dialog);
+		sqlops.window.openDialog(this.dialog);
 	}
 
 	private initializeContent() {

--- a/extensions/agent/src/dialogs/proxyDialog.ts
+++ b/extensions/agent/src/dialogs/proxyDialog.ts
@@ -40,7 +40,7 @@ export class ProxyDialog extends AgentDialog<ProxyData>  {
 	private readonly EditProxyDialog = 'EditProxyDialogOpened';
 
 	// UI Components
-	private generalTab: sqlops.window.modelviewdialog.DialogTab;
+	private generalTab: sqlops.window.DialogTab;
 
 	// General tab controls
 	private proxyNameTextBox: sqlops.InputBoxComponent;
@@ -71,8 +71,8 @@ export class ProxyDialog extends AgentDialog<ProxyData>  {
 		this.dialogName = this.isEdit ? this.EditProxyDialog : this.NewProxyDialog;
 	}
 
-	protected async initializeDialog(dialog: sqlops.window.modelviewdialog.Dialog) {
-		this.generalTab = sqlops.window.modelviewdialog.createTab(ProxyDialog.GeneralTabText);
+	protected async initializeDialog(dialog: sqlops.window.Dialog) {
+		this.generalTab = sqlops.window.createTab(ProxyDialog.GeneralTabText);
 
 
 		this.initializeGeneralTab();

--- a/extensions/agent/src/dialogs/scheduleDialog.ts
+++ b/extensions/agent/src/dialogs/scheduleDialog.ts
@@ -21,7 +21,7 @@ export class ScheduleDialog {
 	private readonly SchedulesLabelText: string = localize('scheduleDialog.schedules', 'Schedules');
 
 	// UI Components
-	private dialog: sqlops.window.modelviewdialog.Dialog;
+	private dialog: sqlops.window.Dialog;
 	private schedulesTable: sqlops.TableComponent;
 
 	private model: ScheduleData;
@@ -35,14 +35,14 @@ export class ScheduleDialog {
 
 	public async showDialog() {
 		await this.model.initialize();
-		this.dialog = sqlops.window.modelviewdialog.createDialog(this.DialogTitle);
+		this.dialog = sqlops.window.createModelViewDialog(this.DialogTitle);
 		this.initializeContent();
 		this.dialog.okButton.onClick(async () => await this.execute());
 		this.dialog.cancelButton.onClick(async () => await this.cancel());
 		this.dialog.okButton.label = this.OkButtonText;
 		this.dialog.cancelButton.label = this.CancelButtonText;
 
-		sqlops.window.modelviewdialog.openDialog(this.dialog);
+		sqlops.window.openDialog(this.dialog);
 	}
 
 	private initializeContent() {

--- a/extensions/azurecore/src/apiWrapper.ts
+++ b/extensions/azurecore/src/apiWrapper.ts
@@ -47,16 +47,16 @@ export class ApiWrapper {
 		return sqlops.dashboard.registerWebviewProvider(widgetId, handler);
 	}
 
-	public createDialog(title: string): sqlops.window.modelviewdialog.Dialog {
-		return sqlops.window.modelviewdialog.createDialog(title);
+	public createDialog(title: string): sqlops.window.Dialog {
+		return sqlops.window.createModelViewDialog(title);
 	}
 
-	public openDialog(dialog: sqlops.window.modelviewdialog.Dialog): void {
-		return sqlops.window.modelviewdialog.openDialog(dialog);
+	public openDialog(dialog: sqlops.window.Dialog): void {
+		return sqlops.window.openDialog(dialog);
 	}
 
-	public closeDialog(dialog: sqlops.window.modelviewdialog.Dialog): void {
-		return sqlops.window.modelviewdialog.closeDialog(dialog);
+	public closeDialog(dialog: sqlops.window.Dialog): void {
+		return sqlops.window.closeDialog(dialog);
 	}
 
 	public registerTaskHandler(taskId: string, handler: (profile: sqlops.IConnectionProfile) => void): void {
@@ -195,16 +195,16 @@ export class ApiWrapper {
 		return vscode.window.createOutputChannel(name);
 	}
 
-	public createWizardPage(title: string): sqlops.window.modelviewdialog.WizardPage {
-		return sqlops.window.modelviewdialog.createWizardPage(title);
+	public createWizardPage(title: string): sqlops.window.WizardPage {
+		return sqlops.window.createWizardPage(title);
 	}
 
 	public registerCompletionItemProvider(selector: vscode.DocumentSelector, provider: vscode.CompletionItemProvider, ...triggerCharacters: string[]): vscode.Disposable {
 		return vscode.languages.registerCompletionItemProvider(selector, provider, ...triggerCharacters);
 	}
 
-	public createTab(title: string): sqlops.window.modelviewdialog.DialogTab {
-		return sqlops.window.modelviewdialog.createTab(title);
+	public createTab(title: string): sqlops.window.DialogTab {
+		return sqlops.window.createTab(title);
 	}
 
 	// Account APIs

--- a/extensions/big-data-cluster/src/wizards/wizardBase.ts
+++ b/extensions/big-data-cluster/src/wizards/wizardBase.ts
@@ -9,13 +9,13 @@ import { ExtensionContext } from 'vscode';
 
 export abstract class WizardBase<T> {
 
-	protected wizard: sqlops.window.modelviewdialog.Wizard;
+	protected wizard: sqlops.window.Wizard;
 
 	constructor(public model: T, public context: ExtensionContext, private title: string) {
 	}
 
 	public open(): Thenable<void> {
-		this.wizard = sqlops.window.modelviewdialog.createWizard(this.title);
+		this.wizard = sqlops.window.createWizard(this.title);
 		this.initialize();
 		return this.wizard.open();
 	}

--- a/extensions/big-data-cluster/src/wizards/wizardPageBase.ts
+++ b/extensions/big-data-cluster/src/wizards/wizardPageBase.ts
@@ -8,9 +8,9 @@ import * as sqlops from 'sqlops';
 import { WizardBase } from './wizardBase';
 
 export abstract class WizardPageBase<T> {
-	private _page: sqlops.window.modelviewdialog.WizardPage;
+	private _page: sqlops.window.WizardPage;
 
-	public get page(): sqlops.window.modelviewdialog.WizardPage {
+	public get page(): sqlops.window.WizardPage {
 		return this._page;
 	}
 
@@ -19,7 +19,7 @@ export abstract class WizardPageBase<T> {
 	}
 
 	constructor(title: string, description: string, protected model: T, private _wizard: WizardBase<T>) {
-		this._page = sqlops.window.modelviewdialog.createWizardPage(title);
+		this._page = sqlops.window.createWizardPage(title);
 		this._page.description = description;
 		this._page.registerContent((view: sqlops.ModelView) => {
 			return this.initialize(view);

--- a/extensions/import/src/wizard/api/basePage.ts
+++ b/extensions/import/src/wizard/api/basePage.ts
@@ -9,7 +9,7 @@ import { BaseDataModel } from './models';
 
 export abstract class BasePage {
 
-	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly wizardPage: sqlops.window.WizardPage;
 	protected readonly model: BaseDataModel;
 	protected readonly view: sqlops.ModelView;
 

--- a/extensions/import/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/import/src/wizard/api/dacFxConfigPage.ts
@@ -16,7 +16,7 @@ const localize = nls.loadMessageBundle();
 
 export abstract class DacFxConfigPage extends BasePage {
 
-	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly wizardPage: sqlops.window.WizardPage;
 	protected readonly instance: DataTierApplicationWizard;
 	protected readonly model: DacFxDataModel;
 	protected readonly view: sqlops.ModelView;
@@ -28,7 +28,7 @@ export abstract class DacFxConfigPage extends BasePage {
 	protected fileButton: sqlops.ButtonComponent;
 	protected fileExtension: string;
 
-	protected constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
+	protected constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
 		super();
 		this.instance = instance;
 		this.wizardPage = wizardPage;

--- a/extensions/import/src/wizard/api/importPage.ts
+++ b/extensions/import/src/wizard/api/importPage.ts
@@ -12,13 +12,13 @@ import { BasePage } from './basePage';
 
 export abstract class ImportPage extends BasePage {
 
-	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly wizardPage: sqlops.window.WizardPage;
 	protected readonly instance: FlatFileWizard;
 	protected readonly model: ImportDataModel;
 	protected readonly view: sqlops.ModelView;
 	protected readonly provider: FlatFileProvider;
 
-	protected constructor(instance: FlatFileWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: ImportDataModel, view: sqlops.ModelView, provider: FlatFileProvider) {
+	protected constructor(instance: FlatFileWizard, wizardPage: sqlops.window.WizardPage, model: ImportDataModel, view: sqlops.ModelView, provider: FlatFileProvider) {
 		super();
 		this.instance = instance;
 		this.wizardPage = wizardPage;

--- a/extensions/import/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/import/src/wizard/dataTierApplicationWizard.ts
@@ -20,10 +20,10 @@ import { BasePage } from './api/basePage';
 const localize = nls.loadMessageBundle();
 
 class Page {
-	wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	wizardPage: sqlops.window.WizardPage;
 	dacFxPage: BasePage;
 
-	constructor(wizardPage: sqlops.window.modelviewdialog.WizardPage) {
+	constructor(wizardPage: sqlops.window.WizardPage) {
 		this.wizardPage = wizardPage;
 	}
 }
@@ -69,7 +69,7 @@ export enum ExportOperationPath {
 }
 
 export class DataTierApplicationWizard {
-	public wizard: sqlops.window.modelviewdialog.Wizard;
+	public wizard: sqlops.window.Wizard;
 	private connection: sqlops.connection.Connection;
 	private model: DacFxDataModel;
 	public pages: Map<string, Page> = new Map<string, Page>();
@@ -92,15 +92,15 @@ export class DataTierApplicationWizard {
 			this.connection = await sqlops.connection.openConnectionDialog();
 		}
 
-		this.wizard = sqlops.window.modelviewdialog.createWizard('Data-tier Application Wizard');
-		let selectOperationWizardPage = sqlops.window.modelviewdialog.createWizardPage(localize('dacFx.selectOperationPageName', 'Select an Operation'));
-		let deployConfigWizardPage = sqlops.window.modelviewdialog.createWizardPage(localize('dacFx.deployConfigPageName', 'Select Deploy Dacpac Settings'));
-		let deployPlanWizardPage = sqlops.window.modelviewdialog.createWizardPage(localize('dacFx.deployPlanPage', 'Review the deploy plan'));
-		let deployActionWizardPage = sqlops.window.modelviewdialog.createWizardPage(localize('dacFx.deployActionPageName', 'Select Action'));
-		let summaryWizardPage = sqlops.window.modelviewdialog.createWizardPage(localize('dacFx.summaryPageName', 'Summary'));
-		let extractConfigWizardPage = sqlops.window.modelviewdialog.createWizardPage(localize('dacFx.extractConfigPageName', 'Select Extract Dacpac Settings'));
-		let importConfigWizardPage = sqlops.window.modelviewdialog.createWizardPage(localize('dacFx.importConfigPageName', 'Select Import Bacpac Settings'));
-		let exportConfigWizardPage = sqlops.window.modelviewdialog.createWizardPage(localize('dacFx.exportConfigPageName', 'Select Export Bacpac Settings'));
+		this.wizard = sqlops.window.createWizard('Data-tier Application Wizard');
+		let selectOperationWizardPage = sqlops.window.createWizardPage(localize('dacFx.selectOperationPageName', 'Select an Operation'));
+		let deployConfigWizardPage = sqlops.window.createWizardPage(localize('dacFx.deployConfigPageName', 'Select Deploy Dacpac Settings'));
+		let deployPlanWizardPage = sqlops.window.createWizardPage(localize('dacFx.deployPlanPage', 'Review the deploy plan'));
+		let deployActionWizardPage = sqlops.window.createWizardPage(localize('dacFx.deployActionPageName', 'Select Action'));
+		let summaryWizardPage = sqlops.window.createWizardPage(localize('dacFx.summaryPageName', 'Summary'));
+		let extractConfigWizardPage = sqlops.window.createWizardPage(localize('dacFx.extractConfigPageName', 'Select Extract Dacpac Settings'));
+		let importConfigWizardPage = sqlops.window.createWizardPage(localize('dacFx.importConfigPageName', 'Select Import Bacpac Settings'));
+		let exportConfigWizardPage = sqlops.window.createWizardPage(localize('dacFx.exportConfigPageName', 'Select Export Bacpac Settings'));
 
 		this.pages.set('selectOperation', new Page(selectOperationWizardPage));
 		this.pages.set('deployConfig', new Page(deployConfigWizardPage));
@@ -190,7 +190,7 @@ export class DataTierApplicationWizard {
 		this.wizard.open();
 	}
 
-	public registerNavigationValidator(validator: (pageChangeInfo: sqlops.window.modelviewdialog.WizardPageChangeInfo) => boolean) {
+	public registerNavigationValidator(validator: (pageChangeInfo: sqlops.window.WizardPageChangeInfo) => boolean) {
 		this.wizard.registerNavigationValidator(validator);
 	}
 
@@ -306,7 +306,7 @@ export class DataTierApplicationWizard {
 		let ownerUri = await sqlops.connection.getUriForConnection(this.model.server.connectionId);
 		this.wizard.message = {
 			text: localize('dacfx.scriptGeneratingMessage', 'You can view the status of script generation in the Task History once the wizard is closed'),
-			level: sqlops.window.modelviewdialog.MessageLevel.Information,
+			level: sqlops.window.MessageLevel.Information,
 			description: ''
 		};
 

--- a/extensions/import/src/wizard/flatFileWizard.ts
+++ b/extensions/import/src/wizard/flatFileWizard.ts
@@ -20,9 +20,9 @@ const localize = nls.loadMessageBundle();
 
 export class FlatFileWizard {
 	private readonly provider: FlatFileProvider;
-	private wizard: sqlops.window.modelviewdialog.Wizard;
+	private wizard: sqlops.window.Wizard;
 
-	private importAnotherFileButton: sqlops.window.modelviewdialog.Button;
+	private importAnotherFileButton: sqlops.window.Button;
 
 	constructor(provider: FlatFileProvider) {
 		this.provider = provider;
@@ -46,11 +46,11 @@ export class FlatFileWizard {
 			return;
 		}
 
-		this.wizard = sqlops.window.modelviewdialog.createWizard(localize('flatFileImport.wizardName', 'Import flat file wizard'));
-		let page1 = sqlops.window.modelviewdialog.createWizardPage(localize('flatFileImport.page1Name', 'Specify Input File'));
-		let page2 = sqlops.window.modelviewdialog.createWizardPage(localize('flatFileImport.page2Name', 'Preview Data'));
-		let page3 = sqlops.window.modelviewdialog.createWizardPage(localize('flatFileImport.page3Name', 'Modify Columns'));
-		let page4 = sqlops.window.modelviewdialog.createWizardPage(localize('flatFileImport.page4Name', 'Summary'));
+		this.wizard = sqlops.window.createWizard(localize('flatFileImport.wizardName', 'Import flat file wizard'));
+		let page1 = sqlops.window.createWizardPage(localize('flatFileImport.page1Name', 'Specify Input File'));
+		let page2 = sqlops.window.createWizardPage(localize('flatFileImport.page2Name', 'Preview Data'));
+		let page3 = sqlops.window.createWizardPage(localize('flatFileImport.page3Name', 'Modify Columns'));
+		let page4 = sqlops.window.createWizardPage(localize('flatFileImport.page4Name', 'Summary'));
 
 		let fileConfigPage: FileConfigPage;
 
@@ -86,7 +86,7 @@ export class FlatFileWizard {
 		});
 
 
-		this.importAnotherFileButton = sqlops.window.modelviewdialog.createButton(localize('flatFileImport.importNewFile', 'Import new file'));
+		this.importAnotherFileButton = sqlops.window.createButton(localize('flatFileImport.importNewFile', 'Import new file'));
 		this.importAnotherFileButton.onClick(() => {
 			//TODO replace this with proper cleanup for all the pages
 			this.wizard.close();
@@ -129,7 +129,7 @@ export class FlatFileWizard {
 		this.importAnotherFileButton.hidden = !visibility;
 	}
 
-	public registerNavigationValidator(validator: (pageChangeInfo: sqlops.window.modelviewdialog.WizardPageChangeInfo) => boolean) {
+	public registerNavigationValidator(validator: (pageChangeInfo: sqlops.window.WizardPageChangeInfo) => boolean) {
 		this.wizard.registerNavigationValidator(validator);
 	}
 

--- a/extensions/import/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/import/src/wizard/pages/dacFxSummaryPage.ts
@@ -14,7 +14,7 @@ const localize = nls.loadMessageBundle();
 
 export class DacFxSummaryPage extends BasePage {
 
-	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly wizardPage: sqlops.window.WizardPage;
 	protected readonly instance: DataTierApplicationWizard;
 	protected readonly model: DacFxDataModel;
 	protected readonly view: sqlops.ModelView;
@@ -23,7 +23,7 @@ export class DacFxSummaryPage extends BasePage {
 	private table: sqlops.TableComponent;
 	private loader: sqlops.LoadingComponent;
 
-	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
+	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
 		super();
 		this.instance = instance;
 		this.wizardPage = wizardPage;

--- a/extensions/import/src/wizard/pages/deployActionPage.ts
+++ b/extensions/import/src/wizard/pages/deployActionPage.ts
@@ -17,7 +17,7 @@ const localize = nls.loadMessageBundle();
 
 export class DeployActionPage extends DacFxConfigPage {
 
-	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly wizardPage: sqlops.window.WizardPage;
 	protected readonly instance: DataTierApplicationWizard;
 	protected readonly model: DacFxDataModel;
 	protected readonly view: sqlops.ModelView;
@@ -26,7 +26,7 @@ export class DeployActionPage extends DacFxConfigPage {
 	private scriptRadioButton: sqlops.RadioButtonComponent;
 	private form: sqlops.FormContainer;
 
-	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
+	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
 		super(instance, wizardPage, model, view);
 	}
 

--- a/extensions/import/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/import/src/wizard/pages/deployConfigPage.ts
@@ -17,7 +17,7 @@ const localize = nls.loadMessageBundle();
 
 export class DeployConfigPage extends DacFxConfigPage {
 
-	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly wizardPage: sqlops.window.WizardPage;
 	protected readonly instance: DataTierApplicationWizard;
 	protected readonly model: DacFxDataModel;
 	protected readonly view: sqlops.ModelView;
@@ -26,7 +26,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 	private formBuilder: sqlops.FormBuilder;
 	private form: sqlops.FormContainer;
 
-	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
+	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
 		super(instance, wizardPage, model, view);
 		this.fileExtension = '.bacpac';
 	}

--- a/extensions/import/src/wizard/pages/deployPlanPage.ts
+++ b/extensions/import/src/wizard/pages/deployPlanPage.ts
@@ -37,7 +37,7 @@ export class DeployPlanResult {
 }
 
 export class DeployPlanPage extends DacFxConfigPage {
-	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly wizardPage: sqlops.window.WizardPage;
 	protected readonly instance: DataTierApplicationWizard;
 	protected readonly model: DacFxDataModel;
 	protected readonly view: sqlops.ModelView;
@@ -50,7 +50,7 @@ export class DeployPlanPage extends DacFxConfigPage {
 	private dataLossComponentGroup: sqlops.FormComponentGroup;
 	private noDataLossTextComponent: sqlops.FormComponent;
 
-	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
+	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
 		super(instance, wizardPage, model, view);
 	}
 

--- a/extensions/import/src/wizard/pages/exportConfigPage.ts
+++ b/extensions/import/src/wizard/pages/exportConfigPage.ts
@@ -15,14 +15,14 @@ const localize = nls.loadMessageBundle();
 
 export class ExportConfigPage extends DacFxConfigPage {
 
-	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly wizardPage: sqlops.window.WizardPage;
 	protected readonly instance: DataTierApplicationWizard;
 	protected readonly model: DacFxDataModel;
 	protected readonly view: sqlops.ModelView;
 
 	private form: sqlops.FormContainer;
 
-	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
+	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
 		super(instance, wizardPage, model, view);
 		this.fileExtension = '.bacpac';
 	}

--- a/extensions/import/src/wizard/pages/extractConfigPage.ts
+++ b/extensions/import/src/wizard/pages/extractConfigPage.ts
@@ -15,7 +15,7 @@ const localize = nls.loadMessageBundle();
 
 export class ExtractConfigPage extends DacFxConfigPage {
 
-	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly wizardPage: sqlops.window.WizardPage;
 	protected readonly instance: DataTierApplicationWizard;
 	protected readonly model: DacFxDataModel;
 	protected readonly view: sqlops.ModelView;
@@ -23,7 +23,7 @@ export class ExtractConfigPage extends DacFxConfigPage {
 	private form: sqlops.FormContainer;
 	private versionTextBox: sqlops.InputBoxComponent;
 
-	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
+	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
 		super(instance, wizardPage, model, view);
 		this.fileExtension = '.dacpac';
 	}

--- a/extensions/import/src/wizard/pages/fileConfigPage.ts
+++ b/extensions/import/src/wizard/pages/fileConfigPage.ts
@@ -29,7 +29,7 @@ export class FileConfigPage extends ImportPage {
 
 	private tableNames: string[] = [];
 
-	public constructor(instance: FlatFileWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: ImportDataModel, view: sqlops.ModelView, provider: FlatFileProvider) {
+	public constructor(instance: FlatFileWizard, wizardPage: sqlops.window.WizardPage, model: ImportDataModel, view: sqlops.ModelView, provider: FlatFileProvider) {
 		super(instance, wizardPage, model, view, provider);
 	}
 

--- a/extensions/import/src/wizard/pages/importConfigPage.ts
+++ b/extensions/import/src/wizard/pages/importConfigPage.ts
@@ -17,14 +17,14 @@ const localize = nls.loadMessageBundle();
 
 export class ImportConfigPage extends DacFxConfigPage {
 
-	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly wizardPage: sqlops.window.WizardPage;
 	protected readonly instance: DataTierApplicationWizard;
 	protected readonly model: DacFxDataModel;
 	protected readonly view: sqlops.ModelView;
 
 	private form: sqlops.FormContainer;
 
-	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
+	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
 		super(instance, wizardPage, model, view);
 		this.fileExtension = '.bacpac';
 	}

--- a/extensions/import/src/wizard/pages/modifyColumnsPage.ts
+++ b/extensions/import/src/wizard/pages/modifyColumnsPage.ts
@@ -56,7 +56,7 @@ export class ModifyColumnsPage extends ImportPage {
 	private text: sqlops.TextComponent;
 	private form: sqlops.FormContainer;
 
-	public constructor(instance: FlatFileWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: ImportDataModel, view: sqlops.ModelView, provider: FlatFileProvider) {
+	public constructor(instance: FlatFileWizard, wizardPage: sqlops.window.WizardPage, model: ImportDataModel, view: sqlops.ModelView, provider: FlatFileProvider) {
 		super(instance, wizardPage, model, view, provider);
 	}
 

--- a/extensions/import/src/wizard/pages/prosePreviewPage.ts
+++ b/extensions/import/src/wizard/pages/prosePreviewPage.ts
@@ -20,7 +20,7 @@ export class ProsePreviewPage extends ImportPage {
 	private form: sqlops.FormContainer;
 	private refresh: sqlops.ButtonComponent;
 
-	public constructor(instance: FlatFileWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: ImportDataModel, view: sqlops.ModelView, provider: FlatFileProvider) {
+	public constructor(instance: FlatFileWizard, wizardPage: sqlops.window.WizardPage, model: ImportDataModel, view: sqlops.ModelView, provider: FlatFileProvider) {
 		super(instance, wizardPage, model, view, provider);
 	}
 

--- a/extensions/import/src/wizard/pages/selectOperationpage.ts
+++ b/extensions/import/src/wizard/pages/selectOperationpage.ts
@@ -14,7 +14,7 @@ const localize = nls.loadMessageBundle();
 
 export class SelectOperationPage extends BasePage {
 
-	protected readonly wizardPage: sqlops.window.modelviewdialog.WizardPage;
+	protected readonly wizardPage: sqlops.window.WizardPage;
 	protected readonly instance: DataTierApplicationWizard;
 	protected readonly model: DacFxDataModel;
 	protected readonly view: sqlops.ModelView;
@@ -25,7 +25,7 @@ export class SelectOperationPage extends BasePage {
 	private exportRadioButton: sqlops.RadioButtonComponent;
 	private form: sqlops.FormContainer;
 
-	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
+	public constructor(instance: DataTierApplicationWizard, wizardPage: sqlops.window.WizardPage, model: DacFxDataModel, view: sqlops.ModelView) {
 		super();
 		this.instance = instance;
 		this.wizardPage = wizardPage;

--- a/extensions/import/src/wizard/pages/summaryPage.ts
+++ b/extensions/import/src/wizard/pages/summaryPage.ts
@@ -22,7 +22,7 @@ export class SummaryPage extends ImportPage {
 	private loading: sqlops.LoadingComponent;
 	private form: sqlops.FormContainer;
 
-	public constructor(instance: FlatFileWizard, wizardPage: sqlops.window.modelviewdialog.WizardPage, model: ImportDataModel, view: sqlops.ModelView, provider: FlatFileProvider) {
+	public constructor(instance: FlatFileWizard, wizardPage: sqlops.window.WizardPage, model: ImportDataModel, view: sqlops.ModelView, provider: FlatFileProvider) {
 		super(instance, wizardPage, model, view, provider);
 	}
 

--- a/extensions/mssql/src/apiWrapper.ts
+++ b/extensions/mssql/src/apiWrapper.ts
@@ -33,16 +33,16 @@ export class ApiWrapper {
 		return sqlops.dataprotocol.registerFileBrowserProvider(provider);
 	}
 
-	public createDialog(title: string): sqlops.window.modelviewdialog.Dialog {
-		return sqlops.window.modelviewdialog.createDialog(title);
+	public createDialog(title: string): sqlops.window.Dialog {
+		return sqlops.window.createModelViewDialog(title);
 	}
 
-	public openDialog(dialog: sqlops.window.modelviewdialog.Dialog): void {
-		return sqlops.window.modelviewdialog.openDialog(dialog);
+	public openDialog(dialog: sqlops.window.Dialog): void {
+		return sqlops.window.openDialog(dialog);
 	}
 
-	public closeDialog(dialog: sqlops.window.modelviewdialog.Dialog): void {
-		return sqlops.window.modelviewdialog.closeDialog(dialog);
+	public closeDialog(dialog: sqlops.window.Dialog): void {
+		return sqlops.window.closeDialog(dialog);
 	}
 
 	public registerTaskHandler(taskId: string, handler: (profile: sqlops.IConnectionProfile) => void): void {
@@ -113,7 +113,7 @@ export class ApiWrapper {
 		return vscode.window.createOutputChannel(name);
 	}
 
-	public createTab(title: string): sqlops.window.modelviewdialog.DialogTab {
-		return sqlops.window.modelviewdialog.createTab(title);
+	public createTab(title: string): sqlops.window.DialogTab {
+		return sqlops.window.createTab(title);
 	}
 }

--- a/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkAdvancedTab.ts
+++ b/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkAdvancedTab.ts
@@ -14,8 +14,8 @@ import { AppContext } from '../../../appContext';
 import { ApiWrapper } from '../../../apiWrapper';
 
 export class SparkAdvancedTab {
-	private _tab: sqlops.window.modelviewdialog.DialogTab;
-	public get tab(): sqlops.window.modelviewdialog.DialogTab { return this._tab; }
+	private _tab: sqlops.window.DialogTab;
+	public get tab(): sqlops.window.DialogTab { return this._tab; }
 
 	private _referenceFilesInputBox: sqlops.InputBoxComponent;
 	private _referenceJARFilesInputBox: sqlops.InputBoxComponent;

--- a/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkConfigurationTab.ts
+++ b/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkConfigurationTab.ts
@@ -22,8 +22,8 @@ import { SparkFileSource } from './sparkJobSubmissionService';
 const localize = nls.loadMessageBundle();
 
 export class SparkConfigurationTab {
-	private _tab: sqlops.window.modelviewdialog.DialogTab;
-	public get tab(): sqlops.window.modelviewdialog.DialogTab { return this._tab; }
+	private _tab: sqlops.window.DialogTab;
+	public get tab(): sqlops.window.DialogTab { return this._tab; }
 
 	private _jobNameInputBox: sqlops.InputBoxComponent;
 	private _sparkContextLabel: sqlops.TextComponent;

--- a/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkJobSubmissionDialog.ts
+++ b/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkJobSubmissionDialog.ts
@@ -22,7 +22,7 @@ import { SqlClusterConnection } from '../../../objectExplorerNodeProvider/connec
 const localize = nls.loadMessageBundle();
 
 export class SparkJobSubmissionDialog {
-	private _dialog: sqlops.window.modelviewdialog.Dialog;
+	private _dialog: sqlops.window.Dialog;
 	private _dataModel: SparkJobSubmissionModel;
 	private _sparkConfigTab: SparkConfigurationTab;
 	private _sparkAdvancedTab: SparkAdvancedTab;

--- a/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkJobSubmissionModel.ts
+++ b/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkJobSubmissionModel.ts
@@ -39,7 +39,7 @@ export class SparkJobSubmissionModel {
 
 	constructor(
 		private readonly _sqlClusterConnection: SqlClusterConnection,
-		private readonly _dialog: sqlops.window.modelviewdialog.Dialog,
+		private readonly _dialog: sqlops.window.Dialog,
 		private readonly _appContext: AppContext,
 		requestService?: (args: any) => any) {
 
@@ -54,7 +54,7 @@ export class SparkJobSubmissionModel {
 
 	public get connection(): SqlClusterConnection { return this._sqlClusterConnection; }
 	public get dialogService(): SparkJobSubmissionService { return this._dialogService; }
-	public get dialog(): sqlops.window.modelviewdialog.Dialog { return this._dialog; }
+	public get dialog(): sqlops.window.Dialog { return this._dialog; }
 
 	public isJarFile(): boolean {
 		if (this.hdfsSubmitFilePath) {
@@ -65,15 +65,15 @@ export class SparkJobSubmissionModel {
 	}
 
 	public showDialogError(message: string): void {
-		let errorLevel = sqlops.window.modelviewdialog.MessageLevel ? sqlops.window.modelviewdialog.MessageLevel : 0;
+		let errorLevel = sqlops.window.MessageLevel ? sqlops.window.MessageLevel : 0;
 		this._dialog.message = {
 			text: message,
-			level: <sqlops.window.modelviewdialog.MessageLevel>errorLevel
+			level: <sqlops.window.MessageLevel>errorLevel
 		};
 	}
 
 	public showDialogInfo(message: string): void {
-		let infoLevel = sqlops.window.modelviewdialog.MessageLevel ? sqlops.window.modelviewdialog.MessageLevel.Information : 2;
+		let infoLevel = sqlops.window.MessageLevel ? sqlops.window.MessageLevel.Information : 2;
 		this._dialog.message = {
 			text: message,
 			level: infoLevel

--- a/extensions/profiler/client/src/dialogs/profilerCreateSessionDialog.ts
+++ b/extensions/profiler/client/src/dialogs/profilerCreateSessionDialog.ts
@@ -18,7 +18,7 @@ export class CreateSessionDialog {
 	private readonly DialogTitleText: string = localize('createSessionDialog.title', 'Start New Profiler Session');
 
 	// UI Components
-	private dialog: sqlops.window.modelviewdialog.Dialog;
+	private dialog: sqlops.window.Dialog;
 	private templatesBox: sqlops.DropDownComponent;
 	private sessionNameBox: sqlops.InputBoxComponent;
 
@@ -44,14 +44,14 @@ export class CreateSessionDialog {
 	}
 
 	public async showDialog(): Promise<void> {
-		this.dialog = sqlops.window.modelviewdialog.createDialog(this.DialogTitleText);
+		this.dialog = sqlops.window.createModelViewDialog(this.DialogTitleText);
 		this.initializeContent();
 		this.dialog.okButton.onClick(() => this.execute());
 		this.dialog.cancelButton.onClick(() => { });
 		this.dialog.okButton.label = this.CreateButtonText;
 		this.dialog.cancelButton.label = this.CancelButtonText;
 
-		sqlops.window.modelviewdialog.openDialog(this.dialog);
+		sqlops.window.openDialog(this.dialog);
 	}
 
 	private initializeContent(): void {

--- a/samples/extensionSamples/src/controllers/mainController.ts
+++ b/samples/extensionSamples/src/controllers/mainController.ts
@@ -32,7 +32,7 @@ export default class MainController extends ControllerBase {
         let buttonWidget: sqlops.DashboardWebview;
         let count = 0;
 
-        let dialog: sqlops.ModalDialog = sqlops.window.createDialog('Flyout extension');
+        let dialog: sqlops.ModalDialog = sqlops.window.createWebViewDialog('Flyout extension');
         dialog.html = '<div>This is a flyout extension.</div>';
 
         sqlops.dashboard.registerWebviewProvider('webview-count', e => {

--- a/samples/sqlservices/src/controllers/mainController.ts
+++ b/samples/sqlservices/src/controllers/mainController.ts
@@ -148,7 +148,7 @@ export default class MainController implements vscode.Disposable {
 
 		await view.initializeModel(formWrapper);
 	}
-	private async getTabContent(view: sqlops.ModelView, customButton1: sqlops.window.modelviewdialog.Button, customButton2: sqlops.window.modelviewdialog.Button, componentWidth: number | string): Promise<void> {
+	private async getTabContent(view: sqlops.ModelView, customButton1: sqlops.window.Button, customButton2: sqlops.window.Button, componentWidth: number | string): Promise<void> {
 		let inputBox = view.modelBuilder.inputBox()
 			.withProperties({
 				multiline: true,
@@ -377,20 +377,20 @@ export default class MainController implements vscode.Disposable {
 	}
 
 	private openDialog(): void {
-		let dialog = sqlops.window.modelviewdialog.createDialog('Test dialog');
-		let tab1 = sqlops.window.modelviewdialog.createTab('Test tab 1');
+		let dialog = sqlops.window.createModelViewDialog('Test dialog');
+		let tab1 = sqlops.window.createTab('Test tab 1');
 
-		let tab2 = sqlops.window.modelviewdialog.createTab('Test tab 2');
-		let tab3 = sqlops.window.modelviewdialog.createTab('Test tab 3');
+		let tab2 = sqlops.window.createTab('Test tab 2');
+		let tab3 = sqlops.window.createTab('Test tab 3');
 		tab2.content = 'sqlservices';
 		dialog.content = [tab1, tab2, tab3];
 		dialog.okButton.onClick(() => console.log('ok clicked!'));
 		dialog.cancelButton.onClick(() => console.log('cancel clicked!'));
 		dialog.okButton.label = 'ok';
 		dialog.cancelButton.label = 'no';
-		let customButton1 = sqlops.window.modelviewdialog.createButton('Load name');
+		let customButton1 = sqlops.window.createButton('Load name');
 		customButton1.onClick(() => console.log('button 1 clicked!'));
-		let customButton2 = sqlops.window.modelviewdialog.createButton('Load all');
+		let customButton2 = sqlops.window.createButton('Load all');
 		customButton2.onClick(() => console.log('button 2 clicked!'));
 		dialog.customButtons = [customButton1, customButton2];
 		tab1.registerContent(async (view) => {
@@ -400,17 +400,17 @@ export default class MainController implements vscode.Disposable {
 		tab3.registerContent(async (view) => {
 			await this.getTab3Content(view);
 		});
-		sqlops.window.modelviewdialog.openDialog(dialog);
+		sqlops.window.openDialog(dialog);
 	}
 
 	private openWizard(): void {
-		let wizard = sqlops.window.modelviewdialog.createWizard('Test wizard');
-		let page1 = sqlops.window.modelviewdialog.createWizardPage('First wizard page');
-		let page2 = sqlops.window.modelviewdialog.createWizardPage('Second wizard page');
+		let wizard = sqlops.window.createWizard('Test wizard');
+		let page1 = sqlops.window.createWizardPage('First wizard page');
+		let page2 = sqlops.window.createWizardPage('Second wizard page');
 		page2.content = 'sqlservices';
-		let customButton1 = sqlops.window.modelviewdialog.createButton('Load name');
+		let customButton1 = sqlops.window.createButton('Load name');
 		customButton1.onClick(() => console.log('button 1 clicked!'));
-		let customButton2 = sqlops.window.modelviewdialog.createButton('Load all');
+		let customButton2 = sqlops.window.createButton('Load all');
 		customButton2.onClick(() => console.log('button 2 clicked!'));
 		wizard.customButtons = [customButton1, customButton2];
 		page1.registerContent(async (view) => {

--- a/src/sql/platform/dialog/dialogTypes.ts
+++ b/src/sql/platform/dialog/dialogTypes.ts
@@ -80,7 +80,7 @@ export class Dialog extends ModelViewPane {
 	}
 }
 
-export class DialogButton implements sqlops.window.modelviewdialog.Button {
+export class DialogButton implements sqlops.window.Button {
 	private _label: string;
 	private _enabled: boolean;
 	private _hidden: boolean;
@@ -169,13 +169,13 @@ export class Wizard {
 	public cancelButton: DialogButton;
 	public customButtons: DialogButton[];
 	private _currentPage: number;
-	private _pageChangedEmitter = new Emitter<sqlops.window.modelviewdialog.WizardPageChangeInfo>();
+	private _pageChangedEmitter = new Emitter<sqlops.window.WizardPageChangeInfo>();
 	public readonly onPageChanged = this._pageChangedEmitter.event;
 	private _pageAddedEmitter = new Emitter<WizardPage>();
 	public readonly onPageAdded = this._pageAddedEmitter.event;
 	private _pageRemovedEmitter = new Emitter<WizardPage>();
 	public readonly onPageRemoved = this._pageRemovedEmitter.event;
-	private _navigationValidator: (pageChangeInfo: sqlops.window.modelviewdialog.WizardPageChangeInfo) => boolean | Thenable<boolean>;
+	private _navigationValidator: (pageChangeInfo: sqlops.window.WizardPageChangeInfo) => boolean | Thenable<boolean>;
 	private _onMessageChange = new Emitter<DialogMessage>();
 	public readonly onMessageChange = this._onMessageChange.event;
 	private _message: DialogMessage;
@@ -233,7 +233,7 @@ export class Wizard {
 		this._pageRemovedEmitter.fire(removedPage);
 	}
 
-	public registerNavigationValidator(validator: (pageChangeInfo: sqlops.window.modelviewdialog.WizardPageChangeInfo) => boolean | Thenable<boolean>): void {
+	public registerNavigationValidator(validator: (pageChangeInfo: sqlops.window.WizardPageChangeInfo) => boolean | Thenable<boolean>): void {
 		this._navigationValidator = validator;
 	}
 

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -2342,8 +2342,7 @@ declare module 'sqlops' {
 
 	export namespace window {
 		/**
-		 * NOTE: This method will be deprecated in a future release.
-		 * Please use sqlops.window.createWebViewDialog instead
+		 * @deprecated this method has been deprecated and will be removed in a future release, please use sqlops.window.createWebViewDialog instead.
 		 * @param title
 		 */
 		export function createDialog(

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -2342,7 +2342,8 @@ declare module 'sqlops' {
 
 	export namespace window {
 		/**
-		 * creates a dialog
+		 * NOTE: This method will be deprecated in a future release.
+		 * Please use sqlops.window.createWebViewDialog instead
 		 * @param title
 		 */
 		export function createDialog(

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -852,6 +852,10 @@ declare module 'sqlops' {
 	}
 
 	export namespace window {
+		/**
+		 * NOTE: This namespace will be deprecated in a future release.
+		 * Please use the methods under sqlops.window namespace.
+		 */
 		export namespace modelviewdialog {
 			/**
 			 * Create a dialog with the given title
@@ -1180,6 +1184,339 @@ declare module 'sqlops' {
 				registerOperation(operationInfo: BackgroundOperationInfo): void;
 			}
 		}
+
+		/**
+ 		 * creates a web view dialog
+ 		 * @param title
+ 		 */
+		export function createWebViewDialog(title: string): ModalDialog;
+
+		/**
+		 * Create a dialog with the given title
+		 * @param title The title of the dialog, displayed at the top
+		 */
+		export function createModelViewDialog(title: string, dialogName?: string): Dialog;
+
+		/**
+		 * Create a dialog tab which can be included as part of the content of a dialog
+		 * @param title The title of the page, displayed on the tab to select the page
+		 */
+		export function createTab(title: string): DialogTab;
+
+		/**
+		 * Create a button which can be included in a dialog
+		 * @param label The label of the button
+		 */
+		export function createButton(label: string): Button;
+
+		/**
+		 * Opens the given dialog if it is not already open
+		 */
+		export function openDialog(dialog: Dialog): void;
+
+		/**
+		 * Closes the given dialog if it is open
+		 */
+		export function closeDialog(dialog: Dialog): void;
+
+		/**
+		 * Create a wizard page with the given title, for inclusion in a wizard
+		 * @param title The title of the page
+		 */
+		export function createWizardPage(title: string): WizardPage;
+
+		/**
+		 * Create a wizard with the given title and pages
+		 * @param title The title of the wizard
+		 */
+		export function createWizard(title: string): Wizard;
+
+		/**
+		 * Used to control whether a message in a dialog/wizard is displayed as an error,
+		 * warning, or informational message. Default is error.
+		 */
+		export enum MessageLevel {
+			Error = 0,
+			Warning = 1,
+			Information = 2
+		}
+
+		/**
+		 * A message shown in a dialog. If the level is not set it defaults to error.
+		 */
+		export type DialogMessage = {
+			readonly text: string,
+			readonly description?: string,
+			readonly level?: MessageLevel
+		};
+
+		export interface ModelViewPanel {
+			/**
+			 * Register model view content for the dialog.
+			 * Doesn't do anything if model view is already registered
+			 */
+			registerContent(handler: (view: ModelView) => Thenable<void>): void;
+
+			/**
+			 * Returns the model view content if registered. Returns undefined if model review is not registered
+			 */
+			readonly modelView: ModelView;
+
+			/**
+			 * Whether the panel's content is valid
+			 */
+			readonly valid: boolean;
+
+			/**
+			 * Fired whenever the panel's valid property changes
+			 */
+			readonly onValidityChanged: vscode.Event<boolean>;
+		}
+
+		// Model view dialog classes
+		export interface Dialog extends ModelViewPanel {
+			/**
+			 * The title of the dialog
+			 */
+			title: string;
+
+			/**
+			 * The content of the dialog. If multiple tabs are given they will be displayed with tabs
+			 * If a string is given, it should be the ID of the dialog's model view content
+			 */
+			content: string | DialogTab[];
+
+			/**
+			 * The ok button
+			 */
+			okButton: Button;
+
+			/**
+			 * The cancel button
+			 */
+			cancelButton: Button;
+
+			/**
+			 * Any additional buttons that should be displayed
+			 */
+			customButtons: Button[];
+
+			/**
+			 * Set the informational message shown in the dialog. Hidden when the message is
+			 * undefined or the text is empty or undefined. The default level is error.
+			 */
+			message: DialogMessage;
+
+			/**
+			 * Set the dialog name when opening
+			 * the dialog for telemetry
+			 */
+			dialogName?: string;
+
+			/**
+			 * Register a callback that will be called when the user tries to click done. Only
+			 * one callback can be registered at once, so each registration call will clear
+			 * the previous registration.
+			 * @param validator The callback that gets executed when the user tries to click
+			 * done. Return true to allow the dialog to close or false to block it from closing
+			 */
+			registerCloseValidator(validator: () => boolean | Thenable<boolean>): void;
+
+			/**
+			 * Register an operation to run in the background when the dialog is done
+			 * @param operationInfo Operation Information
+			 */
+			registerOperation(operationInfo: BackgroundOperationInfo): void;
+		}
+
+		export interface DialogTab extends ModelViewPanel {
+			/**
+			 * The title of the tab
+			 */
+			title: string;
+
+			/**
+			 * A string giving the ID of the tab's model view content
+			 */
+			content: string;
+		}
+
+		export interface Button {
+			/**
+			 * The label displayed on the button
+			 */
+			label: string;
+
+			/**
+			 * Whether the button is enabled
+			 */
+			enabled: boolean;
+
+			/**
+			 * Whether the button is hidden
+			 */
+			hidden: boolean;
+
+			/**
+			 * Raised when the button is clicked
+			 */
+			readonly onClick: vscode.Event<void>;
+		}
+
+		export interface WizardPageChangeInfo {
+			/**
+			 * The page number that the wizard changed from
+			 */
+			lastPage: number;
+
+			/**
+			 * The new page number or undefined if the user is closing the wizard
+			 */
+			newPage: number;
+		}
+
+		export interface WizardPage extends ModelViewPanel {
+			/**
+			 * The title of the page
+			 */
+			title: string;
+
+			/**
+			 * A string giving the ID of the page's model view content
+			 */
+			content: string;
+
+			/**
+			 * Any additional buttons that should be displayed while the page is open
+			 */
+			customButtons: Button[];
+
+			/**
+			 * Whether the page is enabled. If the page is not enabled, the user will not be
+			 * able to advance to it. Defaults to true.
+			 */
+			enabled: boolean;
+
+			/**
+			 * An optional description for the page. If provided it will be displayed underneath the page title.
+			 */
+			description: string;
+		}
+
+		export interface Wizard {
+			/**
+			 * The title of the wizard
+			 */
+			title: string;
+
+			/**
+			 * The wizard's pages. Pages can be added/removed while the dialog is open by using
+			 * the addPage and removePage methods
+			 */
+			pages: WizardPage[];
+
+			/**
+			 * The index in the pages array of the active page, or undefined if the wizard is
+			 * not currently visible
+			 */
+			readonly currentPage: number;
+
+			/**
+			 * The done button
+			 */
+			doneButton: Button;
+
+			/**
+			 * The cancel button
+			 */
+			cancelButton: Button;
+
+			/**
+			 * The generate script button
+			 */
+			generateScriptButton: Button;
+
+			/**
+			 * The next button
+			 */
+			nextButton: Button;
+
+			/**
+			 * The back button
+			 */
+			backButton: Button;
+
+			/**
+			 * Any additional buttons that should be displayed for all pages of the dialog. If
+			 * buttons are needed for specific pages they can be added using the customButtons
+			 * property on each page.
+			 */
+			customButtons: Button[];
+
+			/**
+			 * When set to false page titles and descriptions will not be displayed at the top
+			 * of each wizard page. The default is true.
+			 */
+			displayPageTitles: boolean;
+
+			/**
+			 * Event fired when the wizard's page changes, containing information about the
+			 * previous page and the new page
+			 */
+			onPageChanged: vscode.Event<WizardPageChangeInfo>;
+
+			/**
+			 * Add a page to the wizard at the given index
+			 * @param page The page to add
+			 * @param index The index in the pages array to add the page at, or undefined to
+			 * add it at the end
+			 */
+			addPage(page: WizardPage, index?: number): Thenable<void>;
+
+			/**
+			 * Remove the page at the given index from the wizard
+			 * @param index The index in the pages array to remove
+			 */
+			removePage(index: number): Thenable<void>;
+
+			/**
+			 * Go to the page at the given index in the pages array.
+			 * @param index The index of the page to go to
+			 */
+			setCurrentPage(index: number): Thenable<void>;
+
+			/**
+			 * Open the wizard. Does nothing if the wizard is already open.
+			 */
+			open(): Thenable<void>;
+
+			/**
+			 * Close the wizard. Does nothing if the wizard is not open.
+			 */
+			close(): Thenable<void>;
+
+			/**
+			 * Register a callback that will be called when the user tries to navigate by
+			 * changing pages or clicking done. Only one callback can be registered at once, so
+			 * each registration call will clear the previous registration.
+			 * @param validator The callback that gets executed when the user tries to
+			 * navigate. Return true to allow the navigation to proceed, or false to
+			 * cancel it.
+			 */
+			registerNavigationValidator(validator: (pageChangeInfo: WizardPageChangeInfo) => boolean | Thenable<boolean>): void;
+
+			/**
+			 * Set the informational message shown in the wizard. Hidden when the message is
+			 * undefined or the text is empty or undefined. The default level is error.
+			 */
+			message: DialogMessage;
+
+			/**
+			 * Register an operation to run in the background when the wizard is done
+			 * @param operationInfo Operation Information
+			 */
+			registerOperation(operationInfo: BackgroundOperationInfo): void;
+		}
 	}
 
 	/**
@@ -1211,7 +1548,7 @@ declare module 'sqlops' {
 		 */
 		export function createModelViewEditor(title: string, options?: ModelViewEditorOptions): ModelViewEditor;
 
-		export interface ModelViewEditor extends window.modelviewdialog.ModelViewPanel {
+		export interface ModelViewEditor extends window.ModelViewPanel {
 			/**
 			 * `true` if there are unpersisted changes.
 			 * This is editable to support extensions updating the dirty status.

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -853,8 +853,7 @@ declare module 'sqlops' {
 
 	export namespace window {
 		/**
-		 * NOTE: This namespace will be deprecated in a future release.
-		 * Please use the methods under sqlops.window namespace.
+		 * @deprecated this namespace has been deprecated and will be removed in a future release, please use the methods under sqlops.window namespace.
 		 */
 		export namespace modelviewdialog {
 			/**

--- a/src/sql/workbench/api/node/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/node/extHostModelViewDialog.ts
@@ -25,7 +25,7 @@ const GENERATE_SCRIPT_LABEL = nls.localize('generateScriptLabel', 'Generate scri
 const NEXT_LABEL = nls.localize('dialogNextLabel', 'Next');
 const PREVIOUS_LABEL = nls.localize('dialogPreviousLabel', 'Previous');
 
-class ModelViewPanelImpl implements sqlops.window.modelviewdialog.ModelViewPanel {
+class ModelViewPanelImpl implements sqlops.window.ModelViewPanel {
 	private _modelView: sqlops.ModelView;
 	private _handle: number;
 	protected _modelViewId: string;
@@ -118,13 +118,13 @@ class ModelViewEditorImpl extends ModelViewPanelImpl implements sqlops.workspace
 	}
 }
 
-class DialogImpl extends ModelViewPanelImpl implements sqlops.window.modelviewdialog.Dialog {
+class DialogImpl extends ModelViewPanelImpl implements sqlops.window.Dialog {
 	public title: string;
-	public content: string | sqlops.window.modelviewdialog.DialogTab[];
-	public okButton: sqlops.window.modelviewdialog.Button;
-	public cancelButton: sqlops.window.modelviewdialog.Button;
-	public customButtons: sqlops.window.modelviewdialog.Button[];
-	private _message: sqlops.window.modelviewdialog.DialogMessage;
+	public content: string | sqlops.window.DialogTab[];
+	public okButton: sqlops.window.Button;
+	public cancelButton: sqlops.window.Button;
+	public customButtons: sqlops.window.Button[];
+	private _message: sqlops.window.DialogMessage;
 	private _closeValidator: () => boolean | Thenable<boolean>;
 	private _operationHandler: BackgroundOperationHandler;
 	private _dialogName: string;
@@ -151,11 +151,11 @@ class DialogImpl extends ModelViewPanelImpl implements sqlops.window.modelviewdi
 		this.content = value;
 	}
 
-	public get message(): sqlops.window.modelviewdialog.DialogMessage {
+	public get message(): sqlops.window.DialogMessage {
 		return this._message;
 	}
 
-	public set message(value: sqlops.window.modelviewdialog.DialogMessage) {
+	public set message(value: sqlops.window.DialogMessage) {
 		this._message = value;
 		this._extHostModelViewDialog.updateDialogContent(this);
 	}
@@ -181,7 +181,7 @@ class DialogImpl extends ModelViewPanelImpl implements sqlops.window.modelviewdi
 	}
 }
 
-class TabImpl extends ModelViewPanelImpl implements sqlops.window.modelviewdialog.DialogTab {
+class TabImpl extends ModelViewPanelImpl implements sqlops.window.DialogTab {
 	constructor(
 		extHostModelViewDialog: ExtHostModelViewDialog,
 		extHostModelView: ExtHostModelViewShape,
@@ -199,7 +199,7 @@ class TabImpl extends ModelViewPanelImpl implements sqlops.window.modelviewdialo
 	}
 }
 
-class ButtonImpl implements sqlops.window.modelviewdialog.Button {
+class ButtonImpl implements sqlops.window.Button {
 	private _label: string;
 	private _enabled: boolean;
 	private _hidden: boolean;
@@ -273,8 +273,8 @@ class BackgroundOperationHandler {
 	}
 }
 
-class WizardPageImpl extends ModelViewPanelImpl implements sqlops.window.modelviewdialog.WizardPage {
-	public customButtons: sqlops.window.modelviewdialog.Button[];
+class WizardPageImpl extends ModelViewPanelImpl implements sqlops.window.WizardPage {
+	public customButtons: sqlops.window.Button[];
 	private _enabled: boolean = true;
 	private _description: string;
 
@@ -319,23 +319,23 @@ export enum WizardPageInfoEventType {
 
 export interface WizardPageEventInfo {
 	eventType: WizardPageInfoEventType;
-	pageChangeInfo: sqlops.window.modelviewdialog.WizardPageChangeInfo;
-	pages?: sqlops.window.modelviewdialog.WizardPage[];
+	pageChangeInfo: sqlops.window.WizardPageChangeInfo;
+	pages?: sqlops.window.WizardPage[];
 }
 
-class WizardImpl implements sqlops.window.modelviewdialog.Wizard {
+class WizardImpl implements sqlops.window.Wizard {
 	private _currentPage: number = undefined;
-	public pages: sqlops.window.modelviewdialog.WizardPage[] = [];
-	public doneButton: sqlops.window.modelviewdialog.Button;
-	public cancelButton: sqlops.window.modelviewdialog.Button;
-	public generateScriptButton: sqlops.window.modelviewdialog.Button;
-	public nextButton: sqlops.window.modelviewdialog.Button;
-	public backButton: sqlops.window.modelviewdialog.Button;
-	public customButtons: sqlops.window.modelviewdialog.Button[];
-	private _pageChangedEmitter = new Emitter<sqlops.window.modelviewdialog.WizardPageChangeInfo>();
+	public pages: sqlops.window.WizardPage[] = [];
+	public doneButton: sqlops.window.Button;
+	public cancelButton: sqlops.window.Button;
+	public generateScriptButton: sqlops.window.Button;
+	public nextButton: sqlops.window.Button;
+	public backButton: sqlops.window.Button;
+	public customButtons: sqlops.window.Button[];
+	private _pageChangedEmitter = new Emitter<sqlops.window.WizardPageChangeInfo>();
 	public readonly onPageChanged = this._pageChangedEmitter.event;
-	private _navigationValidator: (info: sqlops.window.modelviewdialog.WizardPageChangeInfo) => boolean | Thenable<boolean>;
-	private _message: sqlops.window.modelviewdialog.DialogMessage;
+	private _navigationValidator: (info: sqlops.window.WizardPageChangeInfo) => boolean | Thenable<boolean>;
+	private _message: sqlops.window.DialogMessage;
 	private _displayPageTitles: boolean = true;
 	private _operationHandler: BackgroundOperationHandler;
 
@@ -362,11 +362,11 @@ class WizardImpl implements sqlops.window.modelviewdialog.Wizard {
 		return this._currentPage;
 	}
 
-	public get message(): sqlops.window.modelviewdialog.DialogMessage {
+	public get message(): sqlops.window.DialogMessage {
 		return this._message;
 	}
 
-	public set message(value: sqlops.window.modelviewdialog.DialogMessage) {
+	public set message(value: sqlops.window.DialogMessage) {
 		this._message = value;
 		this._extHostModelViewDialog.updateWizard(this);
 	}
@@ -380,7 +380,7 @@ class WizardImpl implements sqlops.window.modelviewdialog.Wizard {
 		this._extHostModelViewDialog.updateWizard(this);
 	}
 
-	public addPage(page: sqlops.window.modelviewdialog.WizardPage, index?: number): Thenable<void> {
+	public addPage(page: sqlops.window.WizardPage, index?: number): Thenable<void> {
 		return this._extHostModelViewDialog.updateWizardPage(page).then(() => {
 			this._extHostModelViewDialog.addPage(this, page, index);
 		});
@@ -402,11 +402,11 @@ class WizardImpl implements sqlops.window.modelviewdialog.Wizard {
 		return this._extHostModelViewDialog.closeWizard(this);
 	}
 
-	public registerNavigationValidator(validator: (pageChangeInfo: sqlops.window.modelviewdialog.WizardPageChangeInfo) => boolean | Thenable<boolean>): void {
+	public registerNavigationValidator(validator: (pageChangeInfo: sqlops.window.WizardPageChangeInfo) => boolean | Thenable<boolean>): void {
 		this._navigationValidator = validator;
 	}
 
-	public validateNavigation(info: sqlops.window.modelviewdialog.WizardPageChangeInfo): Thenable<boolean> {
+	public validateNavigation(info: sqlops.window.WizardPageChangeInfo): Thenable<boolean> {
 		if (this._navigationValidator) {
 			return Promise.resolve(this._navigationValidator(info));
 		} else {
@@ -449,8 +449,8 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		return handle;
 	}
 
-	private getHandle(item: sqlops.window.modelviewdialog.Button | sqlops.window.modelviewdialog.Dialog | sqlops.window.modelviewdialog.DialogTab
-		| sqlops.window.modelviewdialog.ModelViewPanel | sqlops.window.modelviewdialog.Wizard | sqlops.window.modelviewdialog.WizardPage | sqlops.workspace.ModelViewEditor) {
+	private getHandle(item: sqlops.window.Button | sqlops.window.Dialog | sqlops.window.DialogTab
+		| sqlops.window.ModelViewPanel | sqlops.window.Wizard | sqlops.window.WizardPage | sqlops.workspace.ModelViewEditor) {
 		let handle = this._objectHandles.get(item);
 		if (handle === undefined) {
 			handle = ExtHostModelViewDialog.getNewHandle();
@@ -471,7 +471,7 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		}
 	}
 
-	public $onWizardPageChanged(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): void {
+	public $onWizardPageChanged(handle: number, info: sqlops.window.WizardPageChangeInfo): void {
 		let callback = this._pageInfoChangedCallbacks.get(handle);
 		if (callback) {
 			callback({
@@ -484,7 +484,7 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 	public $updateWizardPageInfo(handle: number, pageHandles: number[], currentPageIndex: number): void {
 		let callback = this._pageInfoChangedCallbacks.get(handle);
 		if (callback) {
-			let pages = pageHandles.map(pageHandle => this._objectsByHandle.get(handle) as sqlops.window.modelviewdialog.WizardPage);
+			let pages = pageHandles.map(pageHandle => this._objectsByHandle.get(handle) as sqlops.window.WizardPage);
 			callback({
 				eventType: WizardPageInfoEventType.PageAddedOrRemoved,
 				pageChangeInfo: {
@@ -496,7 +496,7 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		}
 	}
 
-	public $validateNavigation(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): Thenable<boolean> {
+	public $validateNavigation(handle: number, info: sqlops.window.WizardPageChangeInfo): Thenable<boolean> {
 		let wizard = this._objectsByHandle.get(handle) as WizardImpl;
 		return wizard.validateNavigation(info);
 	}
@@ -511,14 +511,14 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		return editor.handleSave();
 	}
 
-	public openDialog(dialog: sqlops.window.modelviewdialog.Dialog): void {
+	public openDialog(dialog: sqlops.window.Dialog): void {
 		let handle = this.getHandle(dialog);
 		this.updateDialogContent(dialog);
 		dialog.dialogName ? this._proxy.$openDialog(handle, dialog.dialogName) :
 			this._proxy.$openDialog(handle);
 	}
 
-	public closeDialog(dialog: sqlops.window.modelviewdialog.Dialog): void {
+	public closeDialog(dialog: sqlops.window.Dialog): void {
 		let handle = this.getHandle(dialog);
 		this._proxy.$closeDialog(handle);
 	}
@@ -529,7 +529,7 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		return editor;
 	}
 
-	public updateDialogContent(dialog: sqlops.window.modelviewdialog.Dialog): void {
+	public updateDialogContent(dialog: sqlops.window.Dialog): void {
 		let handle = this.getHandle(dialog);
 		let tabs = dialog.content;
 		if (tabs && typeof tabs !== 'string') {
@@ -550,7 +550,7 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		});
 	}
 
-	public updateTabContent(tab: sqlops.window.modelviewdialog.DialogTab): void {
+	public updateTabContent(tab: sqlops.window.DialogTab): void {
 		let handle = this.getHandle(tab);
 		this._proxy.$setTabDetails(handle, {
 			title: tab.title,
@@ -558,7 +558,7 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		});
 	}
 
-	public updateButton(button: sqlops.window.modelviewdialog.Button): void {
+	public updateButton(button: sqlops.window.Button): void {
 		let handle = this.getHandle(button);
 		this._proxy.$setButtonDetails(handle, {
 			label: button.label,
@@ -567,12 +567,12 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		});
 	}
 
-	public registerOnClickCallback(button: sqlops.window.modelviewdialog.Button, callback: () => void) {
+	public registerOnClickCallback(button: sqlops.window.Button, callback: () => void) {
 		let handle = this.getHandle(button);
 		this._onClickCallbacks.set(handle, callback);
 	}
 
-	public createDialog(title: string, dialogName?: string, extensionLocation?: URI): sqlops.window.modelviewdialog.Dialog {
+	public createDialog(title: string, dialogName?: string, extensionLocation?: URI): sqlops.window.Dialog {
 		let dialog = new DialogImpl(this, this._extHostModelView, this._extHostTaskManagement, extensionLocation);
 		if (dialogName) {
 			dialog.dialogName = dialogName;
@@ -582,14 +582,14 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		return dialog;
 	}
 
-	public createTab(title: string, extensionLocation?: URI): sqlops.window.modelviewdialog.DialogTab {
+	public createTab(title: string, extensionLocation?: URI): sqlops.window.DialogTab {
 		let tab = new TabImpl(this, this._extHostModelView, extensionLocation);
 		tab.title = title;
 		tab.handle = this.getHandle(tab);
 		return tab;
 	}
 
-	public createButton(label: string): sqlops.window.modelviewdialog.Button {
+	public createButton(label: string): sqlops.window.Button {
 		let button = new ButtonImpl(this);
 		this.getHandle(button);
 		this.registerOnClickCallback(button, button.getOnClickCallback());
@@ -597,7 +597,7 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		return button;
 	}
 
-	public getValidityChangedEvent(panel: sqlops.window.modelviewdialog.ModelViewPanel) {
+	public getValidityChangedEvent(panel: sqlops.window.ModelViewPanel) {
 		let handle = this.getHandle(panel);
 		let emitter = this._validityEmitters.get(handle);
 		if (!emitter) {
@@ -607,24 +607,24 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		return emitter.event;
 	}
 
-	public registerWizardPageInfoChangedCallback(wizard: sqlops.window.modelviewdialog.Wizard, callback: (info: WizardPageEventInfo) => void): void {
+	public registerWizardPageInfoChangedCallback(wizard: sqlops.window.Wizard, callback: (info: WizardPageEventInfo) => void): void {
 		let handle = this.getHandle(wizard);
 		this._pageInfoChangedCallbacks.set(handle, callback);
 	}
 
-	public createWizardPage(title: string, extensionLocation?: URI): sqlops.window.modelviewdialog.WizardPage {
+	public createWizardPage(title: string, extensionLocation?: URI): sqlops.window.WizardPage {
 		let page = new WizardPageImpl(title, this, this._extHostModelView, extensionLocation);
 		page.handle = this.getHandle(page);
 		return page;
 	}
 
-	public createWizard(title: string): sqlops.window.modelviewdialog.Wizard {
+	public createWizard(title: string): sqlops.window.Wizard {
 		let wizard = new WizardImpl(title, this, this._extHostTaskManagement);
 		this.getHandle(wizard);
 		return wizard;
 	}
 
-	public updateWizardPage(page: sqlops.window.modelviewdialog.WizardPage): Thenable<void> {
+	public updateWizardPage(page: sqlops.window.WizardPage): Thenable<void> {
 		let handle = this.getHandle(page);
 		if (page.customButtons) {
 			page.customButtons.forEach(button => this.updateButton(button));
@@ -638,7 +638,7 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		});
 	}
 
-	public updateWizard(wizard: sqlops.window.modelviewdialog.Wizard): Thenable<void> {
+	public updateWizard(wizard: sqlops.window.Wizard): Thenable<void> {
 		let handle = this.getHandle(wizard);
 		wizard.pages.forEach(page => this.updateWizardPage(page));
 		this.updateButton(wizard.backButton);
@@ -664,25 +664,25 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		});
 	}
 
-	public addPage(wizard: sqlops.window.modelviewdialog.Wizard, page: sqlops.window.modelviewdialog.WizardPage, pageIndex?: number): Thenable<void> {
+	public addPage(wizard: sqlops.window.Wizard, page: sqlops.window.WizardPage, pageIndex?: number): Thenable<void> {
 		return this._proxy.$addWizardPage(this.getHandle(wizard), this.getHandle(page), pageIndex);
 	}
 
-	public removePage(wizard: sqlops.window.modelviewdialog.Wizard, pageIndex: number): Thenable<void> {
+	public removePage(wizard: sqlops.window.Wizard, pageIndex: number): Thenable<void> {
 		return this._proxy.$removeWizardPage(this.getHandle(wizard), pageIndex);
 	}
 
-	public setWizardPage(wizard: sqlops.window.modelviewdialog.Wizard, pageIndex: number): Thenable<void> {
+	public setWizardPage(wizard: sqlops.window.Wizard, pageIndex: number): Thenable<void> {
 		return this._proxy.$setWizardPage(this.getHandle(wizard), pageIndex);
 	}
 
-	public openWizard(wizard: sqlops.window.modelviewdialog.Wizard): Thenable<void> {
+	public openWizard(wizard: sqlops.window.Wizard): Thenable<void> {
 		let handle = this.getHandle(wizard);
 		this.updateWizard(wizard);
 		return this._proxy.$openWizard(handle);
 	}
 
-	public closeWizard(wizard: sqlops.window.modelviewdialog.Wizard): Thenable<void> {
+	public closeWizard(wizard: sqlops.window.Wizard): Thenable<void> {
 		let handle = this.getHandle(wizard);
 		return this._proxy.$closeWizard(handle);
 	}

--- a/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
+++ b/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
@@ -286,7 +286,7 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 		this._proxy.$updateWizardPageInfo(handle, wizard.pages.map(page => this._wizardPageHandles.get(page)), wizard.currentPage);
 	}
 
-	private validateNavigation(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): Thenable<boolean> {
+	private validateNavigation(handle: number, info: sqlops.window.WizardPageChangeInfo): Thenable<boolean> {
 		return this._proxy.$validateNavigation(handle, info);
 	}
 

--- a/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
@@ -372,24 +372,31 @@ export function createApiFactory(
 
 			const modelViewDialog: typeof sqlops.window.modelviewdialog = {
 				createDialog(title: string, dialogName?: string): sqlops.window.modelviewdialog.Dialog {
+					console.warn('the method sqlops.window.modelviewdialog.createDialog has been deprecated, replace it with sqlops.window.createModelViewDialog');
 					return extHostModelViewDialog.createDialog(title, dialogName, extension.extensionLocation);
 				},
 				createTab(title: string): sqlops.window.modelviewdialog.DialogTab {
+					console.warn('the method sqlops.window.modelviewdialog.createTab has been deprecated, replace it with sqlops.window.createTab');
 					return extHostModelViewDialog.createTab(title, extension.extensionLocation);
 				},
 				createButton(label: string): sqlops.window.modelviewdialog.Button {
+					console.warn('the method sqlops.window.modelviewdialog.createButton has been deprecated, replace it with sqlops.window.createButton');
 					return extHostModelViewDialog.createButton(label);
 				},
 				openDialog(dialog: sqlops.window.modelviewdialog.Dialog) {
+					console.warn('the method sqlops.window.modelviewdialog.openDialog has been deprecated, replace it with sqlops.window.openDialog');
 					return extHostModelViewDialog.openDialog(dialog);
 				},
 				closeDialog(dialog: sqlops.window.modelviewdialog.Dialog) {
+					console.warn('the method sqlops.window.modelviewdialog.closeDialog has been deprecated, replace it with sqlops.window.closeDialog');
 					return extHostModelViewDialog.closeDialog(dialog);
 				},
 				createWizardPage(title: string): sqlops.window.modelviewdialog.WizardPage {
+					console.warn('the method sqlops.window.modelviewdialog.createWizardPage has been deprecated, replace it with sqlops.window.createWizardPage');
 					return extHostModelViewDialog.createWizardPage(title);
 				},
 				createWizard(title: string): sqlops.window.modelviewdialog.Wizard {
+					console.warn('the method sqlops.window.modelviewdialog.createWizard has been deprecated, replace it with sqlops.window.createWizard');
 					return extHostModelViewDialog.createWizard(title);
 				},
 				MessageLevel: sqlExtHostTypes.MessageLevel
@@ -397,10 +404,36 @@ export function createApiFactory(
 
 			const window: typeof sqlops.window = {
 				createDialog(name: string) {
+					console.warn('the method sqlops.window.createDialog has been deprecated, replace it with sqlops.window.createWebViewDialog');
 					return extHostModalDialogs.createDialog(name);
 				},
-
-				modelviewdialog: modelViewDialog
+				modelviewdialog: modelViewDialog,
+				createWebViewDialog(name: string) {
+					return extHostModalDialogs.createDialog(name);
+				},
+				createModelViewDialog(title: string, dialogName?: string): sqlops.window.Dialog {
+					return extHostModelViewDialog.createDialog(title, dialogName, extension.extensionLocation);
+				},
+				createTab(title: string): sqlops.window.DialogTab {
+					return extHostModelViewDialog.createTab(title, extension.extensionLocation);
+				},
+				createButton(label: string): sqlops.window.Button {
+					return extHostModelViewDialog.createButton(label);
+				},
+				openDialog(dialog: sqlops.window.Dialog) {
+					return extHostModelViewDialog.openDialog(dialog);
+				},
+				closeDialog(dialog: sqlops.window.Dialog) {
+					return extHostModelViewDialog.closeDialog(dialog);
+				},
+				createWizardPage(title: string): sqlops.window.WizardPage {
+					return extHostModelViewDialog.createWizardPage(title);
+				},
+				createWizard(title: string): sqlops.window.Wizard {
+					console.warn('deprecated method');
+					return extHostModelViewDialog.createWizard(title);
+				},
+				MessageLevel: sqlExtHostTypes.MessageLevel
 			};
 
 			const tasks: typeof sqlops.tasks = {

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -734,9 +734,9 @@ export interface MainThreadObjectExplorerShape extends IDisposable {
 export interface ExtHostModelViewDialogShape {
 	$onButtonClick(handle: number): void;
 	$onPanelValidityChanged(handle: number, valid: boolean): void;
-	$onWizardPageChanged(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): void;
+	$onWizardPageChanged(handle: number, info: sqlops.window.WizardPageChangeInfo): void;
 	$updateWizardPageInfo(handle: number, pageHandles: number[], currentPageIndex: number): void;
-	$validateNavigation(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): Thenable<boolean>;
+	$validateNavigation(handle: number, info: sqlops.window.WizardPageChangeInfo): Thenable<boolean>;
 	$validateDialogClose(handle: number): Thenable<boolean>;
 	$handleSave(handle: number): Thenable<boolean>;
 }

--- a/src/sqltest/workbench/api/extHostModelViewDialog.test.ts
+++ b/src/sqltest/workbench/api/extHostModelViewDialog.test.ts
@@ -276,7 +276,7 @@ suite('ExtHostModelViewDialog Tests', () => {
 		// Create the wizard and add a validation that records that it has been called
 		let wizard = extHostModelViewDialog.createWizard('wizard_1');
 		extHostModelViewDialog.updateWizard(wizard);
-		let validationInfo: sqlops.window.modelviewdialog.WizardPageChangeInfo;
+		let validationInfo: sqlops.window.WizardPageChangeInfo;
 		wizard.registerNavigationValidator(info => {
 			validationInfo = info;
 			return true;


### PR DESCRIPTION
most of the changes are simply replace the methods of modelviewdialog namespace with the ones under sqlops.window, only exception is the modelviewdialog.createdialog. we already have a createDialog method under sqlops.window. it is used to create a webview dialog. I marked the sqlops.window.createDialog as deprecated. mapping between createDialog methods:

sqlops.window.modelviewdialog.createDialog => sqlops.window.createModelViewDialog
sqlops.window.createDialog => sqlops.window.createWebViewDialog

https://github.com/Microsoft/azuredatastudio/issues/4061