### PR TITLE
Notebooks: Greatly Reduce Time to Generate HTML Table String

### DIFF
--- a/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
@@ -339,7 +339,6 @@ export class SQLFuture extends Disposable implements FutureInternal {
 			for (let resultSet of batch.resultSetSummaries) {
 				let rowCount = resultSet.rowCount > MAX_ROWS ? MAX_ROWS : resultSet.rowCount;
 				this._queryRunner.getQueryRows(0, rowCount, resultSet.batchId, resultSet.id).then(d => {
-					let columns = resultSet.columnInfo;
 
 					let msg: nb.IIOPubMessage = {
 						channel: 'iopub',
@@ -352,7 +351,7 @@ export class SQLFuture extends Disposable implements FutureInternal {
 							output_type: 'execute_result',
 							metadata: {},
 							execution_count: this._executionCount,
-							data: { 'application/vnd.dataresource+json': this.convertToDataResource(columns, d), 'text/html': this.convertToHtmlTable(columns, d) }
+							data: { 'application/vnd.dataresource+json': this.convertToDataResource(resultSet.columnInfo, d), 'text/html': this.convertToHtmlTable(resultSet.columnInfo, d) }
 						},
 						metadata: undefined,
 						parent_header: undefined
@@ -394,29 +393,23 @@ export class SQLFuture extends Disposable implements FutureInternal {
 	}
 
 	private convertToHtmlTable(columns: IDbColumn[], d: QueryExecuteSubsetResult): string {
-		let data: SQLData = {
-			columns: columns.map(c => escape(c.columnName)),
-			rows: d.resultSubset.rows.map(r => r.map(c => c.displayValue))
-		};
-		let table: HTMLTableElement = document.createElement('table');
-		table.createTHead();
-		table.createTBody();
-		let hrow = <HTMLTableRowElement>table.insertRow();
-		// headers
-		for (let column of data.columns) {
-			let cell = hrow.insertCell();
-			cell.innerHTML = column;
-		}
-
-		for (let row in data.rows) {
-			let hrow = <HTMLTableRowElement>table.insertRow();
-			for (let column in data.columns) {
-				let cell = hrow.insertCell();
-				cell.innerHTML = escape(data.rows[row][column]);
+		let htmlString = '<html>';
+		if (columns.length > 0) {
+			htmlString += '<tr>';
+			for (let column of columns) {
+				htmlString += '<th>' + escape(column.columnName) + '</th>';
 			}
+			htmlString += '</tr>';
 		}
-		let tableHtml = '<table>' + table.innerHTML + '</table>';
-		return tableHtml;
+		for (let row in d.resultSubset.rows) {
+			htmlString += '<tr>';
+			for (let column in columns) {
+				htmlString += '<td>' + escape(d.resultSubset.rows[row][column].displayValue) + '</td>';
+			}
+			htmlString += '</tr>';
+		}
+		htmlString += '</html>';
+		return htmlString;
 	}
 
 	private convertToDisplayMessage(msg: IResultMessage | string): nb.IIOPubMessage {

--- a/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
@@ -373,7 +373,7 @@ export class SQLFuture extends Disposable implements FutureInternal {
 		// no-op
 	}
 
-	private convertToDataResource(columns: IDbColumn[], d: QueryExecuteSubsetResult): IDataResource {
+	private convertToDataResource(columns: IDbColumn[], subsetResult: QueryExecuteSubsetResult): IDataResource {
 		let columnsResources: IDataResourceSchema[] = [];
 		columns.forEach(column => {
 			columnsResources.push({name: escape(column.columnName)});
@@ -382,7 +382,7 @@ export class SQLFuture extends Disposable implements FutureInternal {
 		columnsFields.fields = columnsResources;
 		return {
 			schema: columnsFields,
-			data: d.resultSubset.rows.map(row => {
+			data: subsetResult.resultSubset.rows.map(row => {
 				let rowObject: { [key: string]: any; } = {};
 				row.forEach((val, index) => {
 					rowObject[index] = val.displayValue;

--- a/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
@@ -393,7 +393,7 @@ export class SQLFuture extends Disposable implements FutureInternal {
 	}
 
 	private convertToHtmlTable(columns: IDbColumn[], d: QueryExecuteSubsetResult): string {
-		let htmlString = '<html>';
+		let htmlString = '<table>';
 		if (columns.length > 0) {
 			htmlString += '<tr>';
 			for (let column of columns) {
@@ -408,7 +408,7 @@ export class SQLFuture extends Disposable implements FutureInternal {
 			}
 			htmlString += '</tr>';
 		}
-		htmlString += '</html>';
+		htmlString += '</table>';
 		return htmlString;
 	}
 


### PR DESCRIPTION
@anthonydresser got me thinking about table perf yesterday. He has some good ideas about how we might be able to improve serialization/deserialization for the dataresource MIME type and some suggestions about alternatives to the synchronous way that we're utilizing the queryRunner, both of which we should address soon. 

In this PR, there was some low-hanging fruit with how we're generating a string for an HTML table (in cases where opening a notebook that we've saved in a viewer that doesn't support the dataresource MIME type).

I searched around and it seems like the consensus online is that, for strings, doing str += 'anotherString' is pretty much the fastest way to do string concatenation in javascript. If anyone knows of a way to use a StringBuilder-esque data structure in TypeScript, please let me know, as that has the capability of making this faster still.

Used a simple way of measuring perf just by checking the diff in time using performance.now() at the beginning and end of the convertToHtmlTable method.

Here are the results (in ms):

Before this change: 1802, 1675, 1597, 1838 (average: 1728)
After applying this change: 137, 120, 128, 146 (average: 133)

A little over a 90% reduction in total time for the method. The same query was issued on the same server with 30k rows returned. Verified that the HTML table displays correctly in the Jupyter viewer with this change.