### PR TITLE
Make "Double-click to edit" in empty markdown cell a bit nicer looking

### DIFF
--- a/src/sql/parts/notebook/cellViews/textCell.component.ts
+++ b/src/sql/parts/notebook/cellViews/textCell.component.ts
@@ -129,15 +129,15 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	private updatePreview() {
 		if (this._content !== this.cellModel.source || this.cellModel.source.length === 0) {
 			if (!this.cellModel.source && !this.isEditMode) {
-				(<HTMLElement>this.output.nativeElement).innerHTML = localize('doubleClickEdit', 'Double-click to edit');
+				this._content = localize('doubleClickEdit', 'Double-click to edit');
 			} else {
 				this._content = this.sanitizeContent(this.cellModel.source);
-				// todo: pass in the notebook filename instead of undefined value
-				this._commandService.executeCommand<string>('notebook.showPreview', undefined, this._content).then((htmlcontent) => {
-					let outputElement = <HTMLElement>this.output.nativeElement;
-					outputElement.innerHTML = htmlcontent;
-				});
 			}
+			// todo: pass in the notebook filename instead of undefined value
+			this._commandService.executeCommand<string>('notebook.showPreview', undefined, this._content).then((htmlcontent) => {
+				let outputElement = <HTMLElement>this.output.nativeElement;
+				outputElement.innerHTML = htmlcontent;
+			});
 		}
 	}
 


### PR DESCRIPTION
@ronychatterjee has been asking for this for quite a while. Until we have new UX for markdown cells, I think this makes it a bit nicer looking.

Tested notebook save/open, markdown cells both with content and no content, double-clicking when the double-click message appears opens an empty markdown editor. Fix seems relatively safe.

Before:
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/40371649/53065271-d9bc5480-347f-11e9-976e-728566a38610.png">


After: 
![image](https://user-images.githubusercontent.com/40371649/53065207-8f3ad800-347f-11e9-8887-f511b5111858.png)