### PR TITLE
Fix Windows issues with menu, packaging, and test script

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -78,7 +78,6 @@ Name: "runcode"; Description: "{cm:RunAfter,{#NameShort}}"; GroupDescription: "{
 
 [Files]
 Source: "*"; Excludes: "\CodeSignSummary*.md,\tools,\tools\*,\resources\app\product.json"; DestDir: "{code:GetDestDir}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "tools\*"; DestDir: "{app}\tools"; Flags: ignoreversion
 Source: "{#ProductJsonPath}"; DestDir: "{code:GetDestDir}\resources\app"; Flags: ignoreversion
 
 [Icons]

--- a/scripts/test.bat
+++ b/scripts/test.bat
@@ -29,7 +29,7 @@ if not "%BUILD_BUILDID%" == "" (
 
 rem Otherwise
 if "%BUILD_BUILDID%" == "" (
-	%CODE% .\test\electron\index.js --reporter mocha-junit-reporter %*
+	%CODE% .\test\electron\index.js %*
 )
 popd
 

--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -275,7 +275,9 @@ export function getTitleBarStyle(configurationService: IConfigurationService, en
 		}
 	}
 
-	return 'custom'; // default to custom on all OS
+	// {{SQL CARBON EDIT}} - Always use native toolbar
+	return 'native';
+	// return 'custom'; // default to custom on all OS
 }
 
 export const enum OpenContext {


### PR DESCRIPTION
This fixes #4118 and #3812 by disabling VS Code's custom menu entirely, updating the Windows test script to report results to the command line by default, and removing a line that tried to include some missing files in the Windows installers