### PR TITLE
Notebook fixes: Fix #4129, fix #4116, Fix #3913, fix empty results error 

### DIFF
--- a/src/sql/parts/modelComponents/queryTextEditor.ts
+++ b/src/sql/parts/modelComponents/queryTextEditor.ts
@@ -81,6 +81,7 @@ export class QueryTextEditor extends BaseTextEditor {
 			options.hideCursorInOverviewRuler = true;
 			if (!this._selected) {
 				options.renderLineHighlight = 'none';
+				options.parameterHints = { enabled: false };
 			}
 			if (this._hideLineNumbers) {
 				options.lineNumbers = 'off';

--- a/src/sql/parts/modelComponents/queryTextEditor.ts
+++ b/src/sql/parts/modelComponents/queryTextEditor.ts
@@ -82,6 +82,7 @@ export class QueryTextEditor extends BaseTextEditor {
 			if (!this._selected) {
 				options.renderLineHighlight = 'none';
 				options.parameterHints = { enabled: false };
+				options.matchBrackets = false;
 			}
 			if (this._hideLineNumbers) {
 				options.lineNumbers = 'off';

--- a/src/sql/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/parts/notebook/cellViews/code.component.ts
@@ -32,6 +32,7 @@ import { CellTypes } from 'sql/parts/notebook/models/contracts';
 import { OVERRIDE_EDITOR_THEMING_SETTING } from 'sql/workbench/services/notebook/common/notebookService';
 import * as notebookUtils from 'sql/parts/notebook/notebookUtils';
 import { UntitledEditorModel } from 'vs/workbench/common/editor/untitledEditorModel';
+import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 
 export const CODE_SELECTOR: string = 'code-component';
 const MARKDOWN_CLASS = 'markdown';
@@ -139,12 +140,17 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 	private updateConnectionState(isConnected: boolean) {
 		if (this.isSqlCodeCell()) {
 			let cellUri = this.cellModel.cellUri.toString();
-			if (!isConnected && this._model.notebookOptions.connectionService.isConnected(cellUri)) {
-				this._model.notebookOptions.connectionService.disconnect(cellUri).catch(e => console.log(e));
+			let connectionService = this.connectionService;
+			if (!isConnected && connectionService && connectionService.isConnected(cellUri)) {
+				connectionService.disconnect(cellUri).catch(e => console.log(e));
 			} else if (this._model.activeConnection && this._model.activeConnection.id !== '-1') {
-				this._model.notebookOptions.connectionService.connect(this._model.activeConnection, cellUri).catch(e => console.log(e));
+				connectionService.connect(this._model.activeConnection, cellUri).catch(e => console.log(e));
 			}
 		}
+	}
+
+	private get connectionService(): IConnectionManagementService {
+		return this._model && this._model.notebookOptions && this._model.notebookOptions.connectionService;
 	}
 
 	private isSqlCodeCell() {

--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -134,7 +134,6 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	}
 
 	ngOnDestroy() {
-		this.disconnect();
 		this.dispose();
 		if (this.notebookService) {
 			this.notebookService.removeNotebookEditor(this);
@@ -168,20 +167,11 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		}
 		if (cell !== this.model.activeCell) {
 			if (this.model.activeCell) {
-				this.disconnect();
 				this.model.activeCell.active = false;
 			}
 			this._model.activeCell = cell;
 			this._model.activeCell.active = true;
 			this._changeRef.detectChanges();
-		}
-	}
-
-	private disconnect() {
-		if (this._model.defaultKernel.display_name === notebookConstants.SQL) {
-			if (this._model.activeCell && this._model.activeCell.cellType === CellTypes.Code && this._model.activeCell.cellUri) {
-				this.connectionManagementService.disconnect(this._model.activeCell.cellUri.toString()).catch(e => console.log(e));
-			}
 		}
 	}
 

--- a/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as os from 'os';
-import { nb, QueryExecuteSubsetResult, IDbColumn, BatchSummary, IResultMessage } from 'sqlops';
+import { nb, QueryExecuteSubsetResult, IDbColumn, BatchSummary, IResultMessage, ResultSetSummary } from 'sqlops';
 import { localize } from 'vs/nls';
 import * as strings from 'vs/base/common/strings';
 import { FutureInternal, ILanguageMagic } from 'sql/parts/notebook/models/modelInterfaces';
@@ -400,27 +400,43 @@ export class SQLFuture extends Disposable implements FutureInternal {
 			this.handleMessage(strings.format(elapsedTimeLabel, batch.executionElapsed));
 			for (let resultSet of batch.resultSetSummaries) {
 				let rowCount = resultSet.rowCount > this.configuredMaxRows ? this.configuredMaxRows : resultSet.rowCount;
-				this._queryRunner.getQueryRows(0, rowCount, resultSet.batchId, resultSet.id).then(d => {
-
-					let msg: nb.IIOPubMessage = {
-						channel: 'iopub',
-						type: 'iopub',
-						header: <nb.IHeader>{
-							msg_id: undefined,
-							msg_type: 'execute_result'
-						},
-						content: <nb.IExecuteResult>{
-							output_type: 'execute_result',
-							metadata: {},
-							execution_count: this._executionCount,
-							data: { 'application/vnd.dataresource+json': this.convertToDataResource(resultSet.columnInfo, d), 'text/html': this.convertToHtmlTable(resultSet.columnInfo, d) }
-						},
-						metadata: undefined,
-						parent_header: undefined
-					};
-					this.ioHandler.handle(msg);
-				});
+				// TODO should we chain the promises so that result sets are guaranteed to show in serial? What if backend processes #2 before #1?
+				this.sendResultSetAsIOPub(rowCount, resultSet);
 			}
+		}
+	}
+
+	private async sendResultSetAsIOPub(rowCount: number, resultSet: ResultSetSummary): Promise<void> {
+		try {
+			let subsetResult: QueryExecuteSubsetResult;
+			if (rowCount > 0) {
+				subsetResult = await this._queryRunner.getQueryRows(0, rowCount, resultSet.batchId, resultSet.id);
+			} else {
+				subsetResult = { message: '', resultSubset: { rowCount: 0, rows: [] }};
+			}
+			let msg: nb.IIOPubMessage = {
+				channel: 'iopub',
+				type: 'iopub',
+				header: <nb.IHeader>{
+					msg_id: undefined,
+					msg_type: 'execute_result'
+				},
+				content: <nb.IExecuteResult>{
+					output_type: 'execute_result',
+					metadata: {},
+					execution_count: this._executionCount,
+					data: {
+						'application/vnd.dataresource+json': this.convertToDataResource(resultSet.columnInfo, subsetResult),
+						'text/html': this.convertToHtmlTable(resultSet.columnInfo, subsetResult)
+					}
+				},
+				metadata: undefined,
+				parent_header: undefined
+			};
+			this.ioHandler.handle(msg);
+		} catch (err) {
+			// TODO should we output this somewhere else?
+			console.log(`Error getting query rows for notebook: ${err}`);
 		}
 	}
 

--- a/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
@@ -398,11 +398,11 @@ export class SQLFuture extends Disposable implements FutureInternal {
 	public handleBatchEnd(batch: BatchSummary): void {
 		if (this.ioHandler) {
 			this.handleMessage(strings.format(elapsedTimeLabel, batch.executionElapsed));
-			this.processResultsSets(batch);
+			this.processResultSets(batch);
 		}
 	}
 
-	private async processResultsSets(batch: BatchSummary): Promise<void> {
+	private async processResultSets(batch: BatchSummary): Promise<void> {
 		try {
 			for (let resultSet of batch.resultSetSummaries) {
 				let rowCount = resultSet.rowCount > this.configuredMaxRows ? this.configuredMaxRows : resultSet.rowCount;


### PR DESCRIPTION
- Fixes #4129 Overlapping command help windows in notebook
  - Do not show parameter hints for inactive cells, to avoid them hanging around when no longer selected
- Fixes #4116 Notebooks: Intellisense Doesn't Work using Add New Connection
  - Move connect/disconnect logic to 1 place (code component) instead of 2
  - Handle the case where you connect after choosing active cell. We now hook to the event and update connection
- Fix issues in sql session manager where result outputs 0 rows. This was failing to show the empty resultset contents, which is a regression vs. query editor. It also put unhandled error on the debug console
- Fix #3913 Notebook: words selected in other cells should be unselected on cell change

Note: after fix, now looks as follows. Need to do follow up to get correct grid min height

![image](https://user-images.githubusercontent.com/10819925/53280226-9e629580-36cc-11e9-8f40-59cd913caeee.png)

