### PR TITLE
Fix #3734 - Codecell content disappers when tabbing editors

### DIFF
--- a/src/sql/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/parts/notebook/cellViews/code.component.ts
@@ -194,7 +194,7 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 				this._editor.setHeightToScrollHeight(true);
 			}
 		}));
-		this._register(this.model.layoutChanged(() => this._layoutEmitter.fire, this));
+		this._register(this.model.layoutChanged(() => this._layoutEmitter.fire(), this));
 		this.layout();
 	}
 


### PR DESCRIPTION
layoutEmitter.fire should be a method but accessed as a property in code.component.ts.
Codecell content is now visible even if we navigate between notebooks. See below.
![image](https://user-images.githubusercontent.com/44002319/53283242-0e3a4580-36f8-11e9-9274-3a3f2cc701fb.png)
![image](https://user-images.githubusercontent.com/44002319/53283245-1d20f800-36f8-11e9-99a7-4c13f8499f76.png)
![image](https://user-images.githubusercontent.com/44002319/53283249-388c0300-36f8-11e9-9561-ebf808933cca.png)
