### PR TITLE
Publish update for Redgate SQL Search extension

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -242,8 +242,8 @@
 					},
 					"versions": [
 						{
-							"version": "0.3.0",
-							"lastUpdated": "2/15/2019",
+							"version": "0.3.1",
+							"lastUpdated": "2/25/2019",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -242,8 +242,8 @@
 					},
 					"versions": [
 						{
-							"version": "0.3.0",
-							"lastUpdated": "2/15/2019",
+							"version": "0.3.1",
+							"lastUpdated": "2/25/2019",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [


### PR DESCRIPTION
Note: We seem to be experiencing inconsistent behaviour when viewing the details page of SQL Search Extension in the extension marketplace. Some users see the new up-to-date details page with details about 0.3.0 version. Other users still see 0.2.1 details page even when they have 0.3.0 installed.