### PR TITLE
Stop cell content from moving around on hover

### DIFF
--- a/src/sql/parts/notebook/notebookStyles.ts
+++ b/src/sql/parts/notebook/notebookStyles.ts
@@ -13,8 +13,8 @@ import { editorLineHighlight, editorLineHighlightBorder } from 'vs/editor/common
 export function registerNotebookThemes(overrideEditorThemeSetting: boolean): IDisposable {
 	return registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 
-		let lightBoxShadow = '0px 4px 6px 0px rgba(0,0,0,0.14)';
-		let darkBoxShadow = '0 4px 6px 0px rgba(0, 0, 0, 1)';
+		let lightBoxShadow = '0px 4px 6px 0px rgba(0, 0, 0, 0.14)';
+		let darkBoxShadow = '0px 4px 6px 0px rgba(0, 0, 0, 1)';
 		let addBorderToInactiveCodeCells = true;
 
 		// Active border
@@ -99,7 +99,7 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean): IDi
 			collector.addRule(`
 				.notebookEditor .notebook-cell {
 					border-color: ${inactiveBorder};
-					border-width: 0px;
+					border-width: 1px;
 				}
 				.notebookEditor .notebook-cell.active {
 					border-width: 1px;


### PR DESCRIPTION
Fix for #4156, one of @twright-msft's asks.

Changing the border-width here was the culprit. After this change, here's a screenshot (how do you attach a video?):

![image](https://user-images.githubusercontent.com/40371649/53442531-7da18500-39d7-11e9-8692-21112b6f9dd4.png)

