### PR TITLE
Fixed #4167 ChangeKernel depends on kernel.Id difference. Right now S…

### DIFF
--- a/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/common/sqlSessionManager.ts
@@ -127,7 +127,8 @@ export class SqlSession implements nb.ISession {
 	}
 
 	changeKernel(kernelInfo: nb.IKernelSpec): Thenable<nb.IKernel> {
-		return Promise.resolve(this.kernel);
+		this._kernel = this._instantiationService.createInstance(SqlKernel);
+		return Promise.resolve(this._kernel);
 	}
 
 	configureKernel(kernelInfo: nb.IKernelSpec): Thenable<void> {


### PR DESCRIPTION
Fixed #4167 ChangeKernel depends on kernel.Id difference. Right now SQLSession doesn't create a new Sqlkernel in changeKernel. So for sqlKernel change, we always show "Select Connection" even thought 
there are sql connections available. 
So my fix is following JupyterSession implementation, create a new SqlKernel.
