### PR TITLE
Add null check to extensionIdentifier to show reload notification

### DIFF
--- a/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
@@ -699,7 +699,11 @@ export class ExtensionsWorkbenchService implements IExtensionsWorkbenchService, 
 		// {{SQL CARBON EDIT}}
 		let extensionPolicy = this.configurationService.getValue<string>(ExtensionsPolicyKey);
 		if (typeof extension === 'string') {
-			return this.installWithProgress(() => this.extensionService.install(URI.file(extension)).then(extensionIdentifier => this.checkAndEnableDisabledDependencies(extensionIdentifier)));
+			return this.installWithProgress(() => this.extensionService.install(URI.file(extension)).then(extensionIdentifier => {
+				if (extensionIdentifier) {
+					this.checkAndEnableDisabledDependencies(extensionIdentifier);
+				}
+			}));
 		}
 
 		if (!(extension instanceof Extension)) {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/azuredatastudio/issues/4196 by adding a null check before access `extensionIdentifier`.  As far as I can tell, this method has been mostly rewritten in the latest VS Code branch so it's a good candidate for rewrite during the next merge.  In the meantime this gets the VSIX side-loading experience back to before the 1.30 merge.