### PR TITLE
Use upper case PATH for jupyter environment variables.

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -214,7 +214,7 @@ export default class JupyterServerInstallation {
 		this.pythonBinPath = path.join(pythonSourcePath, pythonBinPathSuffix);
 
 		// Store paths to python libraries required to run jupyter.
-		this.pythonEnvVarPath = process.env.Path;
+		this.pythonEnvVarPath = process.env['PATH'];
 
 		let delimiter = path.delimiter;
 		if (process.platform === constants.winPlatform) {


### PR DESCRIPTION
process.env.Path is undefined on Linux, so the whole path wasn't being included.