### PR TITLE
Fixed  #4206 and #4207 open and close notebook quickly issue

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterNotebookManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterNotebookManager.ts
@@ -46,7 +46,7 @@ export class JupyterNotebookManager implements nb.NotebookManager, vscode.Dispos
 	}
 
 	dispose() {
-		if (this._sessionManager) {
+		if (this._sessionManager && this.sessionManager.isReady) {
 			this._sessionManager.shutdownAll().then(() => this._sessionManager.dispose());
 		}
 		if (this._serverManager) {

--- a/src/sql/parts/notebook/models/clientSession.ts
+++ b/src/sql/parts/notebook/models/clientSession.ts
@@ -302,7 +302,7 @@ export class ClientSession implements IClientSession {
 	 */
 	public async shutdown(): Promise<void> {
 		// Always try to shut down session
-		if (this._session && this._session.id) {
+		if (this._session && this._session.id && this.notebookManager.sessionManager.isReady) {
 			await this.notebookManager.sessionManager.shutdown(this._session.id);
 		}
 	}

--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -710,7 +710,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			for (let i = 0; i < this.notebookManagers.length; i++) {
 				if (this.notebookManagers[i].sessionManager && this.notebookManagers[i].sessionManager.specs && this.notebookManagers[i].sessionManager.specs.kernels) {
 					let index = this.notebookManagers[i].sessionManager.specs.kernels.findIndex(kernel => kernel.name === kernelSpec.name);
-					if (index >= 0) {
+					if (index >= 0 && this._clientSessions && this._clientSessions.length > 0) {
 						this._activeClientSession = this._clientSessions[i];
 						if (this.notebookManagers[i].providerId !== this._providerId) {
 							this._providerId = this.notebookManagers[i].providerId;


### PR DESCRIPTION
The session is not ready yet when open and close notebook quickly. So clientSession used in NotebookModel.setProviderIdForKerneldispose is not set yet, which cause #4206:
TypeError: Cannot read property '0' of undefine.

And second issue in # 4207: ERR Cannot read property 'shutdownAll' of undefined: TypeError: Cannot read property 'shutdownAll' of undefined
   at JupyterSessionManager.shutdownAll