### PR TITLE
Turn-on auto-size columns by default

### DIFF
--- a/src/sql/parts/query/editor/resultsGridContribution.ts
+++ b/src/sql/parts/query/editor/resultsGridContribution.ts
@@ -64,7 +64,7 @@ const resultsGridConfiguration: IConfigurationNode = {
 		},
 		'resultsGrid.autoSizeColumns': {
 			type: 'boolean',
-			default: false,
+			default: true,
 			description: nls.localize('autoSizeColumns', "Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells")
 		}
 	}


### PR DESCRIPTION
Column auto-size needs to be on by default since this is a common friction point.  If there are side-effects let's get those fixed.  We can always disable directly in the release branch for March if absolutely required.