### PR TITLE
Fixed #4181 and #4167 change kernel issue between SQL and Sparks #4238

### DIFF
--- a/src/sql/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/parts/notebook/cellViews/code.component.ts
@@ -137,13 +137,13 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 		}
 	}
 
-	private updateConnectionState(isConnected: boolean) {
+	private updateConnectionState(shouldConnect: boolean) {
 		if (this.isSqlCodeCell()) {
 			let cellUri = this.cellModel.cellUri.toString();
 			let connectionService = this.connectionService;
-			if (!isConnected && connectionService && connectionService.isConnected(cellUri)) {
+			if (!shouldConnect && connectionService && connectionService.isConnected(cellUri)) {
 				connectionService.disconnect(cellUri).catch(e => console.log(e));
-			} else if (this._model.activeConnection && this._model.activeConnection.id !== '-1') {
+			} else if (shouldConnect && this._model.activeConnection && this._model.activeConnection.id !== '-1') {
 				connectionService.connect(this._model.activeConnection, cellUri).catch(e => console.log(e));
 			}
 		}

--- a/src/sql/parts/notebook/models/clientSession.ts
+++ b/src/sql/parts/notebook/models/clientSession.ts
@@ -225,10 +225,10 @@ export class ClientSession implements IClientSession {
 	/**
 	 * Change the current kernel associated with the document.
 	 */
-	async changeKernel(options: nb.IKernelSpec): Promise<nb.IKernel> {
+	async changeKernel(options: nb.IKernelSpec, oldValue?: nb.IKernel): Promise<nb.IKernel> {
 		this._kernelChangeCompleted = new Deferred<void>();
 		this._isReady = false;
-		let oldKernel = this.kernel;
+		let oldKernel = oldValue? oldValue: this.kernel;
 		let newKernel = this.kernel;
 
 		let kernel = await this.doChangeKernel(options);

--- a/src/sql/parts/notebook/models/modelInterfaces.ts
+++ b/src/sql/parts/notebook/models/modelInterfaces.ts
@@ -141,7 +141,8 @@ export interface IClientSession extends IDisposable {
 	 * Change the current kernel associated with the document.
 	 */
 	changeKernel(
-		options: nb.IKernelSpec
+		options: nb.IKernelSpec,
+		oldKernel?: nb.IKernel
 	): Promise<nb.IKernel>;
 
 	/**

--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -630,9 +630,11 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				let connectionService = this.notebookOptions.connectionService;
 				if (this._otherConnections) {
 					this._otherConnections.forEach(conn => connectionService.disconnect(conn).catch(e => console.log(e)));
+					this._otherConnections = [];
 				}
 				if (this._activeConnection) {
 					this.notebookOptions.connectionService.disconnect(this._activeConnection).catch(e => console.log(e));
+					this._activeConnection = undefined;
 				}
 			}
 			if (this._activeClientSession) {
@@ -644,6 +646,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				await this._activeClientSession.shutdown();
 				this._clientSessions = undefined;
 				this._activeClientSession = undefined;
+
 			}
 		} catch (err) {
 			this.notifyError(localize('shutdownError', 'An error occurred when closing the notebook: {0}', err));


### PR DESCRIPTION
The problems are:

* When change Kernel across provider for example from PySpark3 to SQL, setProviderIdForKernel switches Kernel first. So this.kernel is set SQL already in ClientSession.changeKernel. Then oldKernel and newKernel are the same, we don't have oldKernel info.
  The fix is cache the old session in model before switch and use it to get the correct context
* SQL Kenerl could make multiple connects from "Add new connection". While we didn't track them, those connections will stay when close the notebook.
  The fix is saving the connections made from "Add new connection" in model. And disconnect them and activeConnection when close notebook

Problem is not solved yet in this PR:

* Jupytper is not disposed when switch kernel from spark to SQL. Haven't found good way to solve it.