### PR TITLE
Add check OE node tests

### DIFF
--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -15,6 +15,9 @@ import assert = require('assert');
 if (context.RunTest) {
 	suite('Object Explorer integration suite', () => {
 		test('BDC instance node label test', async function () {
+			assert(process.env.BDC_BACKEND_HOSTNAME !== undefined &&
+				process.env.BDC_BACKEND_USERNAME !== undefined &&
+				process.env.BDC_BACKEND_PWD !== undefined, 'BDC_BACKEND_HOSTNAME, BDC_BACKEND_USERNAME, BDC_BACKEND_PWD must be set using ./scripts/setbackenvariables.sh or .\\scripts\\setbackendvaraibles.bat');
 			const expectedNodeLabel = ['Databases', 'Security', 'Server Objects', 'Data Services'];
 			let server = await getBdcServer();
 			await VerifyOeNode(server, 6000, expectedNodeLabel);

--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -15,14 +15,14 @@ import assert = require('assert');
 if (context.RunTest) {
 	suite('Object Explorer integration suite', () => {
 		test('BDC instance node label test', async function () {
-			const expectedNodeLable = ['Databases', 'Security', 'Server Objects', 'Data Services'];
+			const expectedNodeLabel = ['Databases', 'Security', 'Server Objects', 'Data Services'];
 			let server = await getBdcServer();
-			await VerifyOeNode(server, 6000, expectedNodeLable);
+			await VerifyOeNode(server, 6000, expectedNodeLabel);
 		});
 		test('Standard alone instance node label test', async function () {
-			const expectedNodeLable = ['Databases', 'Security', 'Server Objects'];
+			const expectedNodeLabel = ['Databases', 'Security', 'Server Objects'];
 			let server = await getDefaultTestingServer();
-			await VerifyOeNode(server, 3000, expectedNodeLable);
+			await VerifyOeNode(server, 3000, expectedNodeLabel);
 		});
 		test('context menu test', async function () {
 			let server = await getDefaultTestingServer();
@@ -53,7 +53,7 @@ async function VerifyOeNode(server: TestServerProfile, timeout: number,expectedN
 	let actualNodeLable = [];
 	let childeren = await nodes[index].getChildren();
 	assert(childeren.length === expectedNodeLable.length, `Expecting node count: ${expectedNodeLable.length}, Actual: ${childeren.length}`);
-	
+
 	childeren.forEach(c => actualNodeLable.push(c.label));
 	assert(expectedNodeLable.toLocaleString() === actualNodeLable.toLocaleString(), `Expected node label: "$'${expectedNodeLable}", Actual: "${actualNodeLable}"`);
 }

--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -8,22 +8,54 @@
 import 'mocha';
 import * as sqlops from 'sqlops';
 import { context } from './testContext';
-import { getDefaultTestingServer } from './testConfig';
+import { getDefaultTestingServer, getBdcServer } from './testConfig';
 import { connectToServer } from './utils';
 import assert = require('assert');
 
 if (context.RunTest) {
-	suite('Object Explorer integration test suite', () => {
-		test('context menu test', async function () {
-			await connectToServer(await getDefaultTestingServer());
+	suite('Object Explorer integration suite', () => {
+		test('nodes label test', async function () {
+			let server = await getBdcServer();
+			await connectToServer(server, 10000);
+
 			let nodes = <sqlops.objectexplorer.ObjectExplorerNode[]>await sqlops.objectexplorer.getActiveConnectionNodes();
-			assert(nodes.length === 1, `expecting 1 active connection, actual: ${nodes.length}`);
-			let actions = await sqlops.objectexplorer.getNodeActions(nodes[0].connectionId, nodes[0].nodePath);
+			assert(nodes.length > 0, `expecting at least one active connection, actual: ${nodes.length}`);
+
+			let index = nodes.findIndex(node => node.nodePath.includes(server.serverName));
+			assert(index !== -1, `Failed to find server: "${server.serverName}" in OE tree`);
+
+			const expectedNodeLable = ['Databases', 'Security', 'Server Objects', 'Data Services'];
+			let actualNodeLable = [];
+			let childeren = await nodes[index].getChildren();
+			assert(childeren.length === expectedNodeLable.length, `expecting node count: ${expectedNodeLable.length}, actual: ${childeren.length}`);
+
+			childeren.forEach(c => actualNodeLable.push(c.label));
+			assert(expectedNodeLable.toLocaleString() === actualNodeLable.toLocaleString(), `Expected nodes label: "$'${expectedNodeLable}", Actual node label: "${actualNodeLable}"`);
+		});
+		test('context menu test', async function () {
+			let server = await getDefaultTestingServer();
+			await connectToServer(server, 3000);
+			let nodes = <sqlops.objectexplorer.ObjectExplorerNode[]>await sqlops.objectexplorer.getActiveConnectionNodes();
+			assert(nodes.length > 0, `expecting at least one active connection, actual: ${nodes.length}`);
+
+			let index = nodes.findIndex(node => node.nodePath.includes(server.serverName));
+			assert(index !== -1, `Failed to find server: "${server.serverName}" in OE tree`);
+
+			let node = nodes[index];
+			let actions = await sqlops.objectexplorer.getNodeActions(node.connectionId, node.nodePath);
 			const expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Launch Profiler'];
 
 			const expectedString = expectedActions.join(',');
 			const actualString = actions.join(',');
 			assert(expectedActions.length === actions.length && expectedString === actualString, `Expected actions: "${expectedString}", Actual actions: "${actualString}"`);
+
+			const expectedNodeLable = ['Databases', 'Security', 'Server Objects'];
+			let actualNodeLable = [];
+			let childeren = await node.getChildren();
+			assert(childeren.length === expectedNodeLable.length, `expecting node count: ${expectedNodeLable.length}, actual: ${childeren.length}`);
+
+			childeren.forEach(c => actualNodeLable.push(c.label));
+			assert(expectedNodeLable.toLocaleString() === actualNodeLable.toLocaleString(), `Expected nodes label: "$'${expectedNodeLable}", Actual node label: "${actualNodeLable}"`);
 		});
 	});
 }

--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -19,7 +19,7 @@ if (context.RunTest) {
 			await connectToServer(server, 6000);
 
 			let nodes = <azdata.objectexplorer.ObjectExplorerNode[]>await azdata.objectexplorer.getActiveConnectionNodes();
-			assert(nodes.length > 0, `expecting at least one active connection, actual: ${nodes.length}`);
+			assert(nodes.length > 0, `Expecting at least one active connection, actual: ${nodes.length}`);
 
 			let index = nodes.findIndex(node => node.nodePath.includes(server.serverName));
 			assert(index !== -1, `Failed to find server: "${server.serverName}" in OE tree`);
@@ -27,16 +27,16 @@ if (context.RunTest) {
 			const expectedNodeLable = ['Databases', 'Security', 'Server Objects', 'Data Services'];
 			let actualNodeLable = [];
 			let childeren = await nodes[index].getChildren();
-			assert(childeren.length === expectedNodeLable.length, `expecting node count: ${expectedNodeLable.length}, actual: ${childeren.length}`);
+			assert(childeren.length === expectedNodeLable.length, `Expecting node count: ${expectedNodeLable.length}, Actual: ${childeren.length}`);
 
 			childeren.forEach(c => actualNodeLable.push(c.label));
-			assert(expectedNodeLable.toLocaleString() === actualNodeLable.toLocaleString(), `Expected nodes label: "$'${expectedNodeLable}", Actual node label: "${actualNodeLable}"`);
+			assert(expectedNodeLable.toLocaleString() === actualNodeLable.toLocaleString(), `Expected nodes label: "$'${expectedNodeLable}", Actual: "${actualNodeLable}"`);
 		});
 		test('context menu test', async function () {
 			let server = await getDefaultTestingServer();
 			await connectToServer(server, 3000);
 			let nodes = <azdata.objectexplorer.ObjectExplorerNode[]>await azdata.objectexplorer.getActiveConnectionNodes();
-			assert(nodes.length > 0, `expecting at least one active connection, actual: ${nodes.length}`);
+			assert(nodes.length > 0, `Expecting at least one active connection, actual: ${nodes.length}`);
 
 			let index = nodes.findIndex(node => node.nodePath.includes(server.serverName));
 			assert(index !== -1, `Failed to find server: "${server.serverName}" in OE tree`);
@@ -52,10 +52,10 @@ if (context.RunTest) {
 			const expectedNodeLable = ['Databases', 'Security', 'Server Objects'];
 			let actualNodeLable = [];
 			let childeren = await node.getChildren();
-			assert(childeren.length === expectedNodeLable.length, `expecting node count: ${expectedNodeLable.length}, actual: ${childeren.length}`);
+			assert(childeren.length === expectedNodeLable.length, `Expecting node count: ${expectedNodeLable.length}, Actual: ${childeren.length}`);
 
 			childeren.forEach(c => actualNodeLable.push(c.label));
-			assert(expectedNodeLable.toLocaleString() === actualNodeLable.toLocaleString(), `Expected nodes label: "$'${expectedNodeLable}", Actual node label: "${actualNodeLable}"`);
+			assert(expectedNodeLable.toLocaleString() === actualNodeLable.toLocaleString(), `Expected nodes label: "$'${expectedNodeLable}", Actual: "${actualNodeLable}"`);
 		});
 	});
 }

--- a/extensions/integration-tests/src/testConfig.ts
+++ b/extensions/integration-tests/src/testConfig.ts
@@ -69,7 +69,7 @@ var TestingServers: TestServerProfile[] = [
 		}),
 	new TestServerProfile(
 		{
-			serverName: process.env.BDC_BACKEND_HOSTNAME + ',' + process.env.BACKEND_PORT,
+			serverName: process.env.BDC_BACKEND_HOSTNAME,
 			userName:  process.env.BDC_BACKEND_USERNAME,
 			password:  process.env.BDC_BACKEND_PWD,
 			authenticationType: AuthenticationType.SqlLogin,

--- a/extensions/integration-tests/src/testConfig.ts
+++ b/extensions/integration-tests/src/testConfig.ts
@@ -66,6 +66,16 @@ var TestingServers: TestServerProfile[] = [
 			database: 'master',
 			provider: ConnectionProvider.SQLServer,
 			version: '2017'
+		}),
+	new TestServerProfile(
+		{
+			serverName: process.env.BACKEND_HOSTNAME + ',' + process.env.BACKEND_PORT,
+			userName:  process.env.BACKEND_USERNAME,
+			password:  process.env.BACKEND_PWD,
+			authenticationType: AuthenticationType.SqlLogin,
+			database: 'master',
+			provider: ConnectionProvider.SQLServer,
+			version: '2019'
 		})
 ];
 
@@ -81,6 +91,11 @@ function getEnumMappingEntry(mapping: any, enumValue: any): INameDisplayNamePair
 export async function getDefaultTestingServer(): Promise<TestServerProfile> {
 	let servers = await getTestingServers();
 	return servers[0];
+}
+
+export async function getBdcServer(): Promise<TestServerProfile> {
+	let servers = await getTestingServers();
+	return servers.filter(s => s.version === '2019')[0];
 }
 
 export async function getTestingServers(): Promise<TestServerProfile[]> {

--- a/extensions/integration-tests/src/testConfig.ts
+++ b/extensions/integration-tests/src/testConfig.ts
@@ -69,9 +69,9 @@ var TestingServers: TestServerProfile[] = [
 		}),
 	new TestServerProfile(
 		{
-			serverName: process.env.BACKEND_HOSTNAME + ',' + process.env.BACKEND_PORT,
-			userName:  process.env.BACKEND_USERNAME,
-			password:  process.env.BACKEND_PWD,
+			serverName: process.env.BDC_BACKEND_HOSTNAME + ',' + process.env.BACKEND_PORT,
+			userName:  process.env.BDC_BACKEND_USERNAME,
+			password:  process.env.BDC_BACKEND_PWD,
 			authenticationType: AuthenticationType.SqlLogin,
 			database: 'master',
 			provider: ConnectionProvider.SQLServer,

--- a/extensions/integration-tests/src/utils.ts
+++ b/extensions/integration-tests/src/utils.ts
@@ -8,7 +8,7 @@ import * as sqlops from 'sqlops';
 import * as vscode from 'vscode';
 import { TestServerProfile } from './testConfig';
 
-export async function connectToServer(server: TestServerProfile) {
+export async function connectToServer(server: TestServerProfile, timeout: number) {
 	let connectionProfile: sqlops.IConnectionProfile = {
 		serverName: server.serverName,
 		databaseName: server.database,
@@ -30,9 +30,9 @@ export async function connectToServer(server: TestServerProfile) {
 
 	//workaround
 	//wait for OE to load
-	await new Promise(c => setTimeout(c, 3000));
+	await new Promise(c => setTimeout(c, timeout));
 }
 
 export async function ensureConnectionViewOpened() {
-	await vscode.commands.executeCommand('workbench.view.dataExplorer');
+	await vscode.commands.executeCommand('dataExplorer.servers.focus');
 }

--- a/scripts/setbackendvariables.cmd
+++ b/scripts/setbackendvariables.cmd
@@ -1,0 +1,5 @@
+@echo off pass in username password hostname of big data cluster
+set BDC_BACKEND_USERNAME=%~1
+set BDC_BACKEND_PWD=%~2
+set BDC_BACKEND_HOSTNAME=%~3
+@echo No problem reading %BDC_BACKEND_HOSTNAME%, password and %BDC_BACKEND_HOSTNAME%

--- a/scripts/setbackendvariables.sh
+++ b/scripts/setbackendvariables.sh
@@ -1,0 +1,6 @@
+# echo pass in username password hostname of big data cluster
+export BDC_BACKEND_USERNAME=$1
+export BDC_BACKEND_PWD=$2
+export BDC_BACKEND_HOSTNAME=$3
+echo No problem reading $BDC_BACKEND_USERNAME, password and $BDC_BACKEND_HOSTNAME
+set

--- a/scripts/sql-test-integration.bat
+++ b/scripts/sql-test-integration.bat
@@ -8,7 +8,7 @@ echo %VSCODEUSERDATADIR%
 echo %VSCODEEXTENSIONSDIR%
 @echo OFF
 
-call .\scripts\code.bat --extensionDevelopmentPath=%~dp0\..\extensions\integration-tests --extensionTestsPath=%~dp0\..\extensions\integration-tests\out --user-data-dir=%VSCODEUSERDATADIR% --extensions-dir=%VSCODEEXTENSIONSDIR%
+call .\scripts\code.bat --extensionDevelopmentPath=%~dp0\..\extensions\integration-tests --extensionTestsPath=%~dp0\..\extensions\integration-tests\out --user-data-dir=%VSCODEUSERDATADIR% --extensions-dir=%VSCODEEXTENSIONSDIR% --remote-debugging-port=9222
 
 if %errorlevel% neq 0 exit /b %errorlevel%
 

--- a/scripts/sql-test-integration.sh
+++ b/scripts/sql-test-integration.sh
@@ -16,7 +16,7 @@ cd $ROOT
 echo $VSCODEUSERDATADIR
 echo $VSCODEEXTDIR
 
-./scripts/code.sh --extensionDevelopmentPath=$ROOT/extensions/integration-tests --extensionTestsPath=$ROOT/extensions/integration-tests/out --user-data-dir=$VSCODEUSERDATADIR --extensions-dir=$VSCODEEXTDIR
+./scripts/code.sh --extensionDevelopmentPath=$ROOT/extensions/integration-tests --extensionTestsPath=$ROOT/extensions/integration-tests/out --user-data-dir=$VSCODEUSERDATADIR --extensions-dir=$VSCODEEXTDIR --remote-debugging-port=9222
 
 
 rm -r $VSCODEUSERDATADIR


### PR DESCRIPTION
Add tests against BDC and standalone instance.

We need to disconnect properly for the active node in OE. So we can simplify the test logic. Create the task: OE integration test needs to add disconnect to close connect properly #4272
