### PR TITLE
Fix backup 

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -74,6 +74,7 @@ const defaultOptions: IModalOptions = {
 export abstract class Modal extends Disposable implements IThemable {
 	protected _useDefaultMessageBoxLocation: boolean = true;
 	protected _messageElement: HTMLElement;
+	protected _modalOptions: IModalOptions;
 	private _messageIcon: HTMLElement;
 	private _messageSeverity: Builder;
 	private _messageSummary: Builder;
@@ -114,7 +115,6 @@ export abstract class Modal extends Disposable implements IThemable {
 	private _keydownListener: IDisposable;
 	private _resizeListener: IDisposable;
 
-	private _modalOptions: IModalOptions;
 	private _backButton: Button;
 
 	private _modalShowingContext: IContextKey<Array<string>>;

--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -178,7 +178,7 @@ export class OptionsDialog extends Modal {
 		}
 	}
 
-	public get options(): IOptionsDialogOptions {
+	private get options(): IOptionsDialogOptions {
 		return this._modalOptions as IOptionsDialogOptions;
 	}
 

--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -107,7 +107,8 @@ export class OptionsDialog extends Modal {
 			attachButtonStyler(this.backButton, this._themeService, { buttonBackground: SIDE_BAR_BACKGROUND, buttonHoverBackground: SIDE_BAR_BACKGROUND });
 		}
 		let okButton = this.addFooterButton(localize('optionsDialog.ok', 'OK'), () => this.ok());
-		let closeButton = this.addFooterButton(this.options.cancelLabel || localize('optionsDialog.cancel', 'Cancel'), () => this.cancel());
+		let cancelLabel = this.options && this.options.cancelLabel ? this.options.cancelLabel :  localize('optionsDialog.cancel', 'Cancel');
+		let closeButton = this.addFooterButton(cancelLabel, () => this.cancel());
 		// Theme styler
 		attachButtonStyler(okButton, this._themeService);
 		attachButtonStyler(closeButton, this._themeService);

--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -107,7 +107,7 @@ export class OptionsDialog extends Modal {
 			attachButtonStyler(this.backButton, this._themeService, { buttonBackground: SIDE_BAR_BACKGROUND, buttonHoverBackground: SIDE_BAR_BACKGROUND });
 		}
 		let okButton = this.addFooterButton(localize('optionsDialog.ok', 'OK'), () => this.ok());
-		let closeButton = this.addFooterButton(this.options.cancelLabel ||  localize('optionsDialog.cancel', 'Cancel'), () => this.cancel());
+		let closeButton = this.addFooterButton(this.options.cancelLabel || localize('optionsDialog.cancel', 'Cancel'), () => this.cancel());
 		// Theme styler
 		attachButtonStyler(okButton, this._themeService);
 		attachButtonStyler(closeButton, this._themeService);

--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -87,7 +87,7 @@ export class OptionsDialog extends Modal {
 	constructor(
 		title: string,
 		name: string,
-		private options: IOptionsDialogOptions,
+		options: IOptionsDialogOptions,
 		@IPartService partService: IPartService,
 		@IWorkbenchThemeService private _workbenchThemeService: IWorkbenchThemeService,
 		@IContextViewService private _contextViewService: IContextViewService,
@@ -107,8 +107,7 @@ export class OptionsDialog extends Modal {
 			attachButtonStyler(this.backButton, this._themeService, { buttonBackground: SIDE_BAR_BACKGROUND, buttonHoverBackground: SIDE_BAR_BACKGROUND });
 		}
 		let okButton = this.addFooterButton(localize('optionsDialog.ok', 'OK'), () => this.ok());
-		let cancelLabel = this.options && this.options.cancelLabel ? this.options.cancelLabel :  localize('optionsDialog.cancel', 'Cancel');
-		let closeButton = this.addFooterButton(cancelLabel, () => this.cancel());
+		let closeButton = this.addFooterButton(this.options.cancelLabel ||  localize('optionsDialog.cancel', 'Cancel'), () => this.cancel());
 		// Theme styler
 		attachButtonStyler(okButton, this._themeService);
 		attachButtonStyler(closeButton, this._themeService);
@@ -177,6 +176,10 @@ export class OptionsDialog extends Modal {
 					this._register(styler.attachInputBoxStyler(<InputBox>widget, this._themeService));
 			}
 		}
+	}
+
+	public get options(): IOptionsDialogOptions {
+		return this._modalOptions as IOptionsDialogOptions;
 	}
 
 	public get optionValues(): { [name: string]: any } {


### PR DESCRIPTION
Options is not mandatory in the workflow. Added an additional check to see whether options is available before we check the cancelLabel.

Fix for error when clicked on Backup\Restore button:

Unhandled Promise rejection: Cannot read property 'cancelLabel' of undefined ; Zone: <root> ; Task: Promise.then ; Value: TypeError: Cannot read property 'cancelLabel' of undefined
    at OptionsDialog.render (workbench.main.js:300769)
    at BackupUiService.showBackupDialog (workbench.main.js:306616)
    at BackupUiService.showBackup (workbench.main.js:306585)
    at new ZoneAwarePromise (C:\Users\azureuser\AppData\Local\Programs\Azure Data Studio\resources\app\node_modules\zone.js\dist\zone-node.js:891)
   at BackupUiService.showBackup (workbench.main.js:306584)
    at exports.showBackup (workbench.main.js:162654)
    at new ZoneAwarePromise (C:\Users\azureuser\AppData\Local\Programs\Azure Data Studio\resources\app\node_modules\zone.js\dist\zone-node.js:891)
    at Object.showBackup (workbench.main.js:162653)
    at BackupAction.runTask (workbench.main.js:256925)
    at new Promise_ctor (workbench.main.js:17971)
    at BackupAction.runTask (workbench.main.js:256924)
    at handler (workbench.main.js:98494)
    at InstantiationService.invokeFunction (workbench.main.js:100090)
    at CommandService._tryExecuteCommand (workbench.main.js:198434)
    at workbench.main.js:198424
    at CompletePromise_ctor.CompletePromise_then [as then] (workbench.main.js:17896)
    at CommandService.executeCommand (workbench.main.js:198424)


