### PR TITLE
Update 'sqlops' to 'azdata' in Notebook Manager

### DIFF
--- a/src/sql/workbench/services/notebook/sql/sqlNotebookManager.ts
+++ b/src/sql/workbench/services/notebook/sql/sqlNotebookManager.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { nb } from 'sqlops';
+import { nb } from 'azdata';
 
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { INotebookManager, SQL_NOTEBOOK_PROVIDER } from 'sql/workbench/services/notebook/common/notebookService';


### PR DESCRIPTION
It looks like a recent commit is referencing the old extensibility namespace.