### PR TITLE
Convert caught error to string in notebook doLoad error message.

### DIFF
--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -224,7 +224,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			this.setLoading(false);
 			this._modelReadyDeferred.resolve(this._model);
 		} catch (error) {
-			this.setViewInErrorState(localize('displayFailed', 'Could not display contents: {0}', error));
+			this.setViewInErrorState(localize('displayFailed', 'Could not display contents: {0}', notebookUtils.getErrorMessage(error)));
 			this.setLoading(false);
 			this._modelReadyDeferred.reject(error);
 		} finally {


### PR DESCRIPTION
I was getting "Cannot display contents: {0}" from doLoad when doing some notebook testing, so I added getErrorMessage to convert the caught error to a string.