### PR TITLE
Remove watch script and use 'yarn watch' instead

### DIFF
--- a/scripts/watch.bat
+++ b/scripts/watch.bat
@@ -1,4 +1,0 @@
-CALL gulp --max_old_space_size=2000 watch || goto :error
-:error
-echo Failed with error #%errorlevel%
-exit /b %errorlevel%


### PR DESCRIPTION
It appears `--max_old_space_size` is too small in this bat file and it makes watch very slow.  I've switched to `yarn watch` which has a higher value set, so let's remove this duplicate way to launch watch