### PR TITLE
Fix issue: input change on dropdownbox not reflected to 'dropdownbox.value' in extension

### DIFF
--- a/src/sql/base/browser/ui/editableDropdown/dropdown.ts
+++ b/src/sql/base/browser/ui/editableDropdown/dropdown.ts
@@ -211,6 +211,7 @@ export class Dropdown extends Disposable {
 				this._filter.filterString = e;
 				this._layoutTree();
 			}
+			this._onValueChange.fire(e);
 		});
 
 		this._register(this._contextView);


### PR DESCRIPTION
Fixed issue: input change on dropdownbox not reflected to 'dropdownbox.value' in extension no matter if the changed string is in the dropdown list or not.