### PR TITLE
GetActiveConnectionCredentials fixes/changes

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -100,7 +100,7 @@ declare module 'azdata' {
 		 * @param {string} connectionId The id of the connection
 		 * @returns {{ [name: string]: string}} A dictionary containing the credentials as they would be included in the connection's options dictionary
 		 */
-		export function getCredentials(connectionId: string): Thenable<{ [name: string]: string }>;
+		export function getCredentials(connectionId: string, promptForMissingPassword?: boolean): Thenable<{ [name: string]: string }>;
 
 		/**
 		 * Get ServerInfo for a connectionId

--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -249,12 +249,15 @@ export interface IConnectionManagementService {
 	removeConnectionProfileCredentials(profile: IConnectionProfile): IConnectionProfile;
 
 	/**
-	 * Get the credentials for a connected connection profile, as they would appear in the options dictionary
+	 * Get the credentials for a connection profile, as they would appear in the options dictionary. This will attempt to load
+	 * the credentials from current saved profiles and if that fails will display the connection dialog if the caller chooses
+	 * so the user can enter the password at that point.
 	 * @param {string} profileId The id of the connection profile to get the password for
+	 * @param {boolean?} promptForMissingPassword Whether to show the connection dialog if a password is required but not found
 	 * @returns {{ [name: string]: string }} A dictionary containing the credentials as they would be included
-	 * in the connection profile's options dictionary, or undefined if the profile is not connected
+	 * in the connection profile's options dictionary, or undefined if the credentials could not be loaded.
 	 */
-	getActiveConnectionCredentials(profileId: string): { [name: string]: string };
+	getConnectionCredentials(profileId: string, promptForMissingPassword?: boolean): Promise<{ [name: string]: string }>;
 
 	/**
 	 * Get the ServerInfo for a connected connection profile

--- a/src/sql/platform/connection/common/connectionStore.ts
+++ b/src/sql/platform/connection/common/connectionStore.ts
@@ -260,6 +260,10 @@ export class ConnectionStore {
 		return this.convertConfigValuesToConnectionProfiles(configValues);
 	}
 
+	public getConnectionFromConfiguration(connectionId: string): ConnectionProfile {
+		return this._connectionConfig.getConnections(true).find(conn => conn.id === connectionId);
+	}
+
 	public getProfileWithoutPassword(conn: IConnectionProfile): ConnectionProfile {
 		if (conn) {
 			let savedConn: ConnectionProfile = ConnectionProfile.fromIConnectionProfile(this._capabilitiesService, conn);

--- a/src/sql/workbench/api/node/extHostConnectionManagement.ts
+++ b/src/sql/workbench/api/node/extHostConnectionManagement.ts
@@ -37,8 +37,8 @@ export class ExtHostConnectionManagement extends ExtHostConnectionManagementShap
 		return this._proxy.$getCurrentConnection();
 	}
 
-	public $getCredentials(connectionId: string): Thenable<{ [name: string]: string }> {
-		return this._proxy.$getCredentials(connectionId);
+	public $getCredentials(connectionId: string, promptForMissingPassword: boolean = false): Thenable<{ [name: string]: string }> {
+		return this._proxy.$getCredentials(connectionId, promptForMissingPassword);
 	}
 
 	public $getServerInfo(connectionId: string): Thenable<azdata.ServerInfo> {

--- a/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
@@ -52,8 +52,8 @@ export class MainThreadConnectionManagement implements MainThreadConnectionManag
 		return Promise.resolve(this.convertConnection(TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._workbenchEditorService, true)));
 	}
 
-	public $getCredentials(connectionId: string): Thenable<{ [name: string]: string }> {
-		return Promise.resolve(this._connectionManagementService.getActiveConnectionCredentials(connectionId));
+	public async $getCredentials(connectionId: string, promptForMissingPassword: boolean = false): Promise<{ [name: string]: string }> {
+		return await this._connectionManagementService.getConnectionCredentials(connectionId, promptForMissingPassword);
 	}
 
 	public $getServerInfo(connectionId: string): Thenable<azdata.ServerInfo> {

--- a/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
@@ -102,8 +102,8 @@ export function createApiFactory(
 				getActiveConnections(): Thenable<azdata.connection.Connection[]> {
 					return extHostConnectionManagement.$getActiveConnections();
 				},
-				getCredentials(connectionId: string): Thenable<{ [name: string]: string }> {
-					return extHostConnectionManagement.$getCredentials(connectionId);
+				getCredentials(connectionId: string, promptForMissingPassword: boolean = false): Thenable<{ [name: string]: string }> {
+					return extHostConnectionManagement.$getCredentials(connectionId, promptForMissingPassword);
 				},
 				getServerInfo(connectionId: string): Thenable<azdata.ServerInfo> {
 					return extHostConnectionManagement.$getServerInfo(connectionId);
@@ -596,8 +596,8 @@ export function createApiFactory(
 				getCurrentConnection(): Thenable<sqlops.connection.Connection> {
 					return extHostConnectionManagement.$getSqlOpsCurrentConnection();
 				},
-				getCredentials(connectionId: string): Thenable<{ [name: string]: string }> {
-					return extHostConnectionManagement.$getCredentials(connectionId);
+				getCredentials(connectionId: string, promptForMissingPassword: boolean = false): Thenable<{ [name: string]: string }> {
+					return extHostConnectionManagement.$getCredentials(connectionId, promptForMissingPassword);
 				},
 				getServerInfo(connectionId: string): Thenable<sqlops.ServerInfo> {
 					return extHostConnectionManagement.$getServerInfo(connectionId);

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -558,7 +558,7 @@ export interface MainThreadDataProtocolShape extends IDisposable {
 export interface MainThreadConnectionManagementShape extends IDisposable {
 	$getActiveConnections(): Thenable<azdata.connection.Connection[]>;
 	$getCurrentConnection(): Thenable<azdata.connection.Connection>;
-	$getCredentials(connectionId: string): Thenable<{ [name: string]: string }>;
+	$getCredentials(connectionId: string, promptForMissingPassword?: boolean): Thenable<{ [name: string]: string }>;
 	$getServerInfo(connectedId: string): Thenable<azdata.ServerInfo>;
 	$openConnectionDialog(providers: string[], initialConnectionProfile?: azdata.IConnectionProfile, connectionCompletionOptions?: azdata.IConnectionCompletionOptions): Thenable<azdata.connection.Connection>;
 	$listDatabases(connectionId: string): Thenable<string[]>;

--- a/src/sqltest/stubs/connectionManagementService.test.ts
+++ b/src/sqltest/stubs/connectionManagementService.test.ts
@@ -250,7 +250,7 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 		return undefined;
 	}
 
-	getActiveConnectionCredentials(profileId: string): { [name: string]: string } {
+	getConnectionCredentials(profileId: string, promptForMissingPassword?: boolean): Promise<{ [name: string]: string }> {
 		return undefined;
 	}
 


### PR DESCRIPTION
Change getCredentials to get a credential even if it's not an active one. Also added option to prompt user for password if needed. This is for the new ADS Windows tools extension since it needs to be able to get the password to launch to SSMSMin even if a connection is not active (right click on a non-active connection). 

Working on adding new tests, existing tests are passing. 