### PR TITLE
pulling max bytes of data through the webhdfs api

### DIFF
--- a/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
@@ -181,7 +181,7 @@ export class HdfsFileSource implements IFileSource {
 	public readFile(path: string, maxBytes?: number): Promise<Buffer> {
 		return new Promise((resolve, reject) => {
 			let error: HdfsError = undefined;
-			let remoteFileStream = this.client.createReadStream(path);
+			let remoteFileStream = this.client.createReadStream(path, maxBytes ? {'length': maxBytes} : {});
 			remoteFileStream.on('error', (err) => {
 				error = <HdfsError>err;
 				reject(error);

--- a/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
@@ -195,9 +195,11 @@ export class HdfsFileSource implements IFileSource {
 					error = <HdfsError>err;
 					if (error.message.includes('Stream exceeded specified max')) {
 						// We have data > maxbytes, show we're truncating
-						let previewNote: string = '########################### NOTICE: This file has been truncated at '+ bytes(maxBytes) +' for preview ########################### \r\n';
+						let previewNote: string = '#################################################################################################################### \r\n'+
+						'########################### NOTICE: This file has been truncated at '+ bytes(maxBytes) +' for preview ################################ \r\n' +
+						'#################################################################################################################### \r\n';
 						data.splice(0, 0, Buffer.from(previewNote, 'utf-8'));
-						vscode.window.showWarningMessage(localize('maxSizeReached', "Preview only loads {0} data of the file and truncates the rest.", bytes(maxBytes)));
+						vscode.window.showWarningMessage(localize('maxSizeReached', "The file has been truncated at {0} for preview.", bytes(maxBytes)));
 						resolve(Buffer.concat(data));
 					} else {
 						reject(error);


### PR DESCRIPTION
Issue: When preview is clicked on files larger than 30MB, it does not load the file and hangs. 
Fix: Only load 30MB data when they click on preview. Specifying the length param while making the api request would achieve this.