### PR TITLE
Fix bug where git extension fails in packaged builds

### DIFF
--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -172,32 +172,30 @@ async function checkGitVersion(_info: IGit): Promise<void> {
 
 	return;
 
-	/*
-	const config = workspace.getConfiguration('git');
-	const shouldIgnore = config.get<boolean>('ignoreLegacyWarning') === true;
+	// const config = workspace.getConfiguration('git');
+	// const shouldIgnore = config.get<boolean>('ignoreLegacyWarning') === true;
 
-	if (shouldIgnore) {
-		return;
-	}
+	// if (shouldIgnore) {
+	// 	return;
+	// }
 
-	if (!/^[01]/.test(info.version)) {
-		return;
-	}
+	// if (!/^[01]/.test(info.version)) {
+	// 	return;
+	// }
 
-	const update = localize('updateGit', "Update Git");
-	const neverShowAgain = localize('neverShowAgain', "Don't Show Again");
+	// const update = localize('updateGit', "Update Git");
+	// const neverShowAgain = localize('neverShowAgain', "Don't Show Again");
 
-	const choice = await window.showWarningMessage(
-		localize('git20', "You seem to have git {0} installed. Code works best with git >= 2", info.version),
-		update,
-		neverShowAgain
-	);
+	// const choice = await window.showWarningMessage(
+	// 	localize('git20', "You seem to have git {0} installed. Code works best with git >= 2", info.version),
+	// 	update,
+	// 	neverShowAgain
+	// );
 
-	if (choice === update) {
-		commands.executeCommand('vscode.open', Uri.parse('https://git-scm.com/'));
-	} else if (choice === neverShowAgain) {
-		await config.update('ignoreLegacyWarning', true, true);
-	}
-	// {{SQL CARBON EDIT}}
-	*/
+	// if (choice === update) {
+	// 	commands.executeCommand('vscode.open', Uri.parse('https://git-scm.com/'));
+	// } else if (choice === neverShowAgain) {
+	// 	await config.update('ignoreLegacyWarning', true, true);
+	// }
+	// {{SQL CARBON EDIT}} - End
 }


### PR DESCRIPTION
Fixes #4235 where the git extension was failing to activate.

I don't fully understand the root cause and we should investigate it further since it could affect other files in the future. It's some issue with how we process and use web pack on extensions that caused `undefinedundefined` to get inserted in the middle of the minified file.

The built version of `extensions/git/src/main.ts` has a line at the end `//# sourceMappingURL=main.js.map`. We have code in `build/lib/extensions.ts` and elsewhere that rewrites the `sourceMappingURL` comment and I think somehow it was getting messed up, possibly due to the block comment interfering with whatever regular expressions we use to find that line. When I ran webpack on the extension directly the file came out correctly so I don't think it's a webpack bug.