### PR TITLE
Set dashboard DB to master only for MSSQL provider

### DIFF
--- a/src/sql/parts/dashboard/pages/serverDashboardPage.component.ts
+++ b/src/sql/parts/dashboard/pages/serverDashboardPage.component.ts
@@ -48,8 +48,15 @@ export class ServerDashboardPage extends DashboardPage implements OnInit {
 		@Inject(IConfigurationService) configurationService: IConfigurationService
 	) {
 		super(dashboardService, el, _cd, instantiationService, notificationService, angularEventingService, configurationService);
-		// revert back to default database
-		this._letDashboardPromise = this.dashboardService.connectionManagementService.changeDatabase('master');
+
+		// special-case handling for MSSQL data provider
+		let connInfo = this.dashboardService.connectionManagementService.connectionInfo;
+		if (connInfo && connInfo.providerId === 'MSSQL') {
+			// revert back to default database
+			this._letDashboardPromise = this.dashboardService.connectionManagementService.changeDatabase('master');
+		} else {
+			this._letDashboardPromise = Promise.resolve();
+		}
 	}
 
 	ngOnInit() {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/azuredatastudio/issues/3882 by special-casing `MSSQL` provider.