### PR TITLE
Connection extensibility API review

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -15,22 +15,22 @@ declare module 'azdata' {
 		export class ConnectionProfile {
 			providerId: string;
 			connectionId: string;
-			connectionName: string;
 			serverName: string;
-			databaseName: string;
-			userName: string;
-			password: string;
-			authenticationType: string;
-			savePassword: boolean;
-			groupFullName: string;
-			groupId: string;
-			saveProfile: boolean;
+			friendlyName?: string;
+			databaseName?: string;
+			username?: string;
+			password?: string;
+			authenticationType?: string;
+			savePassword?: boolean;
+			groupFullName?: string;
+			groupId?: string;
+			saveProfile?: boolean;
 			azureTenantId?: string;
 
 			/**
 			 * Get connection string
 			 */
-			getConnectionString(includePassword: boolean): Thenable<string>;
+			toConnectionString(includePassword: boolean): Thenable<string>
 
 			/**
 			 * Get the credentials for an active connection
@@ -40,9 +40,15 @@ declare module 'azdata' {
 			getCredentials(): Thenable<{ [name: string]: string }>;
 
 			/**
+			* Indicates whether the connection profile is in a connected state
+			* @returns {boolean} true if the profile is connected
+			*/
+			isConnected(): Thenable<boolean>;
+
+			/**
 			 * create a connection profile from an options map
 			 */
-			static from(options: any[]): ConnectionProfile;
+			static from(options: Map<string, any>): ConnectionProfile;
 		}
 
 		/**
@@ -53,12 +59,7 @@ declare module 'azdata' {
 		/**
 		 * Get all connections
 		*/
-		export function getConnections(): Thenable<ConnectionProfile[]>;
-
-		/**
-		 * Get all active connections
-		*/
-		export function getActiveConnections(): Thenable<ConnectionProfile[]>;
+		export function getConnections(isConnected?: boolean): Thenable<ConnectionProfile[]>;
 
 		/**
 		 * Get connection profile from connectionId

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -27,12 +27,42 @@ declare module 'azdata' {
 			saveProfile: boolean;
 			azureTenantId?: string;
 
-			static createFrom(options: any[]): ConnectionProfile;
+			/**
+			 * Get connection string
+			 */
+			getConnectionString(includePassword: boolean): Thenable<string>;
+
+			/**
+			 * Get the credentials for an active connection
+			 * @param {string} connectionId The id of the connection
+			 * @returns {{ [name: string]: string}} A dictionary containing the credentials as they would be included in the connection's options dictionary
+			 */
+			getCredentials(): Thenable<{ [name: string]: string }>;
+
+			/**
+			 * create a connection profile from an options map
+			 */
+			static from(options: any[]): ConnectionProfile;
 		}
 
 		/**
 		 * Get the current connection based on the active editor or Object Explorer selection
 		*/
 		export function getCurrentConnection(): Thenable<ConnectionProfile>;
+
+		/**
+		 * Get all connections
+		*/
+		export function getConnections(): Thenable<ConnectionProfile[]>;
+
+		/**
+		 * Get all active connections
+		*/
+		export function getActiveConnections(): Thenable<ConnectionProfile[]>;
+
+		/**
+		 * Get connection profile from connectionId
+		*/
+		export function getConnectionProfile(connectionId: string): Thenable<ConnectionProfile>;
 	}
 }

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -96,6 +96,11 @@ declare module 'azdata' {
 		export function getConnectionString(connectionId: string, includePassword: boolean): Thenable<string>;
 
 		/**
+		 * Get all active connections
+		*/
+		export function getActiveConnections(): Thenable<Connection[]>;
+
+		/**
 		 * Get the credentials for an active connection
 		 * @param {string} connectionId The id of the connection
 		 * @returns {{ [name: string]: string}} A dictionary containing the credentials as they would be included in the connection's options dictionary

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -524,23 +524,49 @@ export interface ISingleNotebookEditOperation {
 }
 
 export class ConnectionProfile {
-
 	providerId: string;
 	connectionId: string;
-	connectionName: string;
 	serverName: string;
-	databaseName: string;
-	userName: string;
-	password: string;
-	authenticationType: string;
-	savePassword: boolean;
-	groupFullName: string;
-	groupId: string;
-	saveProfile: boolean;
+	friendlyName?: string;
+	databaseName?: string;
+	username?: string;
+	password?: string;
+	authenticationType?: string;
+	savePassword?: boolean;
+	groupFullName?: string;
+	groupId?: string;
+	saveProfile?: boolean;
 	azureTenantId?: string;
 
-	static createFrom(options: any[]): ConnectionProfile {
+	// any additional options
+	[name: string]: any;
+
+	static from(options: Map<string, any>): ConnectionProfile {
 		// create from options
+		return undefined;
+	}
+
+	/**
+	* Convert to a connection string
+	*/
+	toConnectionString(includePassword: boolean): Thenable<string> {
+		return undefined;
+	}
+
+	/**
+	* Get the credentials for an active connection
+	* @param {string} connectionId The id of the connection
+	* @returns {{ [name: string]: string}} A dictionary containing the credentials as they would be included in the connection's options dictionary
+	*/
+	getCredentials(): Thenable<{ [name: string]: string }> {
+		return undefined;
+	}
+
+	/**
+	* Indicates whether the connection profile is in a connected state
+	* @returns {boolean} true if the profile is connected
+	*/
+	isConnected(): Thenable<boolean> {
 		return undefined;
 	}
 }

--- a/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
@@ -97,6 +97,12 @@ export function createApiFactory(
 				getCurrentConnection(): Thenable<azdata.connection.ConnectionProfile> {
 					return extHostConnectionManagement.$getCurrentConnection();
 				},
+				getConnections(isConnected?: boolean): Thenable<azdata.connection.ConnectionProfile[]> {
+					return undefined;
+				},
+				getConnectionProfile(connectionId: string): Thenable<azdata.connection.ConnectionProfile> {
+					return undefined;
+				},
 
 				// "sqlops" back-compat APIs
 				getActiveConnections(): Thenable<azdata.connection.Connection[]> {


### PR DESCRIPTION
## Connection Extensibility APIs
This PR contains proposals for the following Connection extensibility APIs.
* Add a  new `ConnectionProfile` interface to replace various other connection interfaces
* Move getConnectionString and getCredentials into the ConnectionProfile class
* Add a `getConnectionProfile` method to `connection` namespace

Current API
```TypeScript
/* This interface is to support the internal representation of connections which
is treated as a property bag for various scenarios.  Should this be exposed over 
extensibility API? */
export interface ConnectionInfo {
	options: { [name: string]: any };
}

export interface IConnectionProfile extends ConnectionInfo {
	connectionName: string;
	serverName: string;
	databaseName: string;
	userName: string;
	password: string;
	authenticationType: string;
	savePassword: boolean;
	groupFullName: string;
	groupId: string;
	providerName: string;
	saveProfile: boolean;
	id: string;
	azureTenantId?: string;
}

/**
* Interface for representing a connection when working with connection APIs
*/
export interface Connection extends ConnectionInfo {
	/**
	* The name of the provider managing the connection (e.g. MSSQL)
	*/
	providerName: string;

	/**
	* A unique identifier for the connection
	*/
	connectionId: string;
}

export namespace connection {

	/**
	 * Get the current connection based on the active editor or Object Explorer selection
	*/
	export function getCurrentConnection(): Thenable<Connection>;

	/**
	* Get connection string
	*/
	export function getConnectionString(connectionId: string, includePassword: boolean): Thenable<string>;

	/**
	* Get the credentials for an active connection
	* @param {string} connectionId The id of the connection
	* @returns {{ [name: string]: string}} A dictionary containing the credentials as they would be included in the connection's options dictionary
	*/
	export function getCredentials(connectionId: string): Thenable<{ [name: string]: string }>;

}
```

Proposed API
```TypeScript
export namespace connection {
	/**
	* Connection profile primary class
	*/
	export class ConnectionProfile {
		// private constructor
		providerId: string;
		connectionId: string;
		friendlyName?: string;
		serverName: string;
		databaseName?: string;
		username?: string;
		password?: string;
		authenticationType?: string;
		savePassword?: boolean;
		groupFullName?: string;
		groupId?: string;
		saveProfile: boolean;
		azureTenantId?: string;

 		// any additional options
		[name: string]: any;

		/**
		* Convert to a connection string
		*/
		toConnectionString(includePassword: boolean): Thenable<string>;

		/**
		* Get the credentials for an active connection
		* @param {string} connectionId The id of the connection
		* @returns {{ [name: string]: string}} A dictionary containing the credentials as they would be included in the connection's options dictionary
		*/
		getCredentials(): Thenable<{ [name: string]: string }>;

		/**
		* Indicates whether the connection profile is in a connected state
		* @returns {boolean} true if the profile is connected
		*/
		isConnected(): Thenable<boolean>;

// **Discussion**
// how to handle items in options that aren't in the above properties.  i.e., provider specific options
// idea 1: add an options property to class
// idea 2: set the options directly on the class in an type-unsafe way, providers can have interfaces
//    that derive from ConnectionProfile that add additional properties and consumer can 
//    check-and-downcast to the provider-specific interface

		/**
		* create a connection profile from an options map
		*/
		static from(options: Map<string, any>): ConnectionProfile;
	}

	// should this be a property that is actively kept up-to-date (not thenable)
	// export currentConnection: ConnectionProfile;

	/**
	* Get the active connection based on the active editor or Object Explorer selection
	*/
	export function getActiveConnection(): Thenable<ConnectionProfile>;

	/**
	* Get known connection profiles
	* @param {boolean} isConnected Only return connected ConnectionProfiles
	* @returns {ConnectionProfile[]} Known connection profiles
	*/
	export function getConnections(isConnected? boolean): Thenable<ConnectionProfile[]>;

// **Discussion**
// Is this method needed?  Won't caller already have a ConnectionProfile if they have a connectionId?  
// i.e. where did the connectionId come from?  At a high-level we could update the API so that this 
// is basically true.  Though currently we have some non-connection classes that have connectionId 
// public property, and it ignores that often the profile may not be easily accessible where you
// want to access the connection (for example, the caller is buried down a deep call sequence).
// I think if we're moving global methods that currently take a connectionId into ConnectionProfile methods
// it makes sense to provide an easy way to convert connectionIds to ConnectionProfiles for simplicity.

	/**
	* Get connection profile from connectionId
	*/
	export function getConnectionProfile(connectionId: string): Thenable<ConnectionProfile>;
}	
```

Sample Usage
```TypeScript
let options = new Map<string, any>();
options['serverName'] = 'server';
options['database'] = 'database';
options['save_password'] = true;

// currently options is defined as any[], should it be Map<string, string>?
let profile = connection.ConnectionProfile.from(options); 

// get connection string
let connectionString = profile.toConnectionString();

// get credentials
profile.getCredentials().then((credentials) => {
});

// get the current connection
connection.getCurrentConnection().then((connection) => {
});

// get all connections
connection.getConnections().then((connections) => {
});

function getNodeConnection(node: objectexplorer.ObjectExplorerNode): ConnectionProfile {
  let nodeConnectionProfile = connection.getConnectionProfile(node.connectionId);
  return nodeConnectionProfile;
}
```

Alternate API Proposals
```TypeScript
export namespace connection {


// should this be bool
  export enum ConnectionState {
    All = 0,  // remove this is this is a state in ConnectionProfile
    Connected = 1,
    Disconnected = 2 // ???
  }

// discussion: does it make sense to add another parameter: providerId? 
// should ConnectionState be a property of ConnectionProfile??
// how to filter an array of ConnectionProfile based on state

  /**
  * Get connections that are in the provided connection state.  e.g., Active, All, etc.
  */
  export function getConnections(state?: ConnectionState): Thenable<ConnectionProfile[]>;

// or

  export function getConnections(isConnected? boolean): Thenable<ConnectionProfile[]>;

// or 
  export function getConnections(): Thenable<ConnectionProfile[]>;

// or 

 export function getConnections(model?: ConnectionProfile): Thenable<ConnectionProfile[]>;

}
```
