### PR TITLE
Adds new release yml for bot

### DIFF
--- a/.github/new_release.yml
+++ b/.github/new_release.yml
@@ -1,0 +1,6 @@
+{
+    newReleaseLabel: 'new-release',
+    newReleaseColor: '006b75',
+    daysAfterRelease: 5,
+    perform: true
+}


### PR DESCRIPTION
Adds the necessary yml for the bot to auto tag new release issues for up to 5 days after a new release, then it will auto delete the label from issues.