### PR TITLE
Issue #4278 - Fix extra spacing in the file search view

### DIFF
--- a/src/sql/parts/grid/media/flexbox.css
+++ b/src/sql/parts/grid/media/flexbox.css
@@ -39,11 +39,6 @@
     max-height: fit-content;
 }
 
-.messages {
-    flex: 1 100 0;
-    min-height: 25%;
-}
-
 .minHeight {
     min-height: fit-content;
 }


### PR DESCRIPTION
Issue #4278 A recent changes in the VSCode layout for that viewlet caused the min-height property to affect the display (the property was set on that class before but the layout prevented it from actually being displayed as it was).

I removed the style for the messages class completely since I couldn't find a place that we actually used that ourselves - and anyways having styling on such a common name like messages isn't really a good practice since it applies to everything in ADS.