### PR TITLE
Fix #3485: Flatfile and Dacfx wizards don't default to selected connection

### DIFF
--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -91,7 +91,15 @@ export class DataTierApplicationWizard {
 		if (!this.connection) {
 			// @TODO: remove cast once azdata update complete - karlb 3/1/2019
 			this.connection = <azdata.connection.ConnectionProfile><any>await azdata.connection.openConnectionDialog();
+
+			// don't open the wizard if connection dialog is cancelled
+			if (!this.connection) {
+				vscode.window.showErrorMessage(localize('dacfx.needConnection', 'Please connect to a server before using this wizard.'));
+				return;
+			}
 		}
+
+		this.model.serverId = this.connection.connectionId;
 
 		this.wizard = azdata.window.createWizard('Data-tier Application Wizard');
 		let selectOperationWizardPage = azdata.window.createWizardPage(localize('dacFx.selectOperationPageName', 'Select an Operation'));

--- a/extensions/import/src/wizard/flatFileWizard.ts
+++ b/extensions/import/src/wizard/flatFileWizard.ts
@@ -46,6 +46,9 @@ export class FlatFileWizard {
 			return;
 		}
 
+		let currentConnection = await azdata.connection.getCurrentConnection();
+		model.serverId = currentConnection.connectionId;
+
 		this.wizard = azdata.window.createWizard(localize('flatFileImport.wizardName', 'Import flat file wizard'));
 		let page1 = azdata.window.createWizardPage(localize('flatFileImport.page1Name', 'Specify Input File'));
 		let page2 = azdata.window.createWizardPage(localize('flatFileImport.page2Name', 'Preview Data'));


### PR DESCRIPTION
The flatfile and Dacfx wizards weren't defaulting to the selected connection when launched from the command palette. This fixes #3485 