### PR TITLE
Fix connection dialog 'Saved Connections' refresh timing

### DIFF
--- a/src/sql/parts/objectExplorer/viewlet/treeUpdateUtils.ts
+++ b/src/sql/parts/objectExplorer/viewlet/treeUpdateUtils.ts
@@ -22,7 +22,7 @@ export class TreeUpdateUtils {
 	/**
 	 * Set input for the tree.
 	 */
-	public static structuralTreeUpdate(tree: ITree, viewKey: string, connectionManagementService: IConnectionManagementService, providers?: string[]): void {
+	public static structuralTreeUpdate(tree: ITree, viewKey: string, connectionManagementService: IConnectionManagementService, providers?: string[]): Thenable<void> {
 		let selectedElement: any;
 		let targetsToExpand: any[];
 		if (tree) {
@@ -44,7 +44,7 @@ export class TreeUpdateUtils {
 			treeInput = TreeUpdateUtils.getTreeInput(connectionManagementService, providers);
 		}
 
-		tree.setInput(treeInput).then(() => {
+		return tree.setInput(treeInput).then(() => {
 			// Make sure to expand all folders that where expanded in the previous session
 			if (targetsToExpand) {
 				tree.expandAll(targetsToExpand);

--- a/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
@@ -169,16 +169,16 @@ export class ConnectionDialogWidget extends Modal {
 		this._panel.onTabChange(c => {
 			if (c === savedConnectionTabId && this._savedConnectionTree.getContentHeight() === 0) {
 				// Update saved connection tree
-				TreeUpdateUtils.structuralTreeUpdate(this._savedConnectionTree, 'saved', this._connectionManagementService, this._providers);
-
-				if (this._savedConnectionTree.getContentHeight() > 0) {
-					this._noSavedConnectionBuilder.hide();
-					this._savedConnectionBuilder.show();
-				} else {
-					this._noSavedConnectionBuilder.show();
-					this._savedConnectionBuilder.hide();
-				}
-				this._savedConnectionTree.layout(DOM.getTotalHeight(this._savedConnectionTree.getHTMLElement()));
+				TreeUpdateUtils.structuralTreeUpdate(this._savedConnectionTree, 'saved', this._connectionManagementService, this._providers).then(() => {
+					if (this._savedConnectionTree.getContentHeight() > 0) {
+						this._noSavedConnectionBuilder.hide();
+						this._savedConnectionBuilder.show();
+					} else {
+						this._noSavedConnectionBuilder.show();
+						this._savedConnectionBuilder.hide();
+					}
+					this._savedConnectionTree.layout(DOM.getTotalHeight(this._savedConnectionTree.getHTMLElement()));
+				});
 			}
 		});
 


### PR DESCRIPTION
This fixes https://github.com/Microsoft/azuredatastudio/issues/4325.  The timing of the tree model refresh has changed and now the Saved Connections view is rendered prior to the model update.  This PR changes the view content update to occur after the tree model is finished updating.