### PR TITLE
Rewrite Spark UI link when using unified connection

### DIFF
--- a/extensions/mssql/src/sqlClusterLookUp.ts
+++ b/extensions/mssql/src/sqlClusterLookUp.ts
@@ -11,6 +11,7 @@ import * as UUID from 'vscode-languageclient/lib/utils/uuid';
 import { AppContext } from './appContext';
 import { SqlClusterConnection } from './objectExplorerNodeProvider/connection';
 import { ICommandObjectExplorerContext } from './objectExplorerNodeProvider/command';
+import { IEndpoint } from './utils';
 import { MssqlObjectExplorerNodeProvider } from './objectExplorerNodeProvider/objectExplorerNodeProvider';
 
 
@@ -116,12 +117,6 @@ function connToConnectionParam(connection: azdata.connection.Connection): Connec
 		}
 	);
 	return <ConnectionParam>result;
-}
-
-interface IEndpoint {
-	serviceName: string;
-	ipAddress: string;
-	port: number;
 }
 
 class ConnectionParam implements azdata.connection.Connection, azdata.IConnectionProfile, azdata.ConnectionInfo

--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -218,7 +218,7 @@ export async function getClusterEndpoint(profileId: string, serviceName: string)
 	return clusterEndpoint;
 }
 
-interface IEndpoint {
+export interface IEndpoint {
 	serviceName: string;
 	ipAddress: string;
 	port: number;

--- a/extensions/notebook/src/common/utils.ts
+++ b/extensions/notebook/src/common/utils.ts
@@ -88,6 +88,12 @@ export enum Platform {
 	Others
 }
 
+export interface IEndpoint {
+	serviceName: string;
+	ipAddress: string;
+	port: number;
+}
+
 export function getOSPlatform(): Platform {
 	switch (process.platform) {
 		case 'win32':

--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -242,7 +242,7 @@ export class JupyterSession implements nb.ISession {
 
 			//Update server info with bigdata endpoint - Unified Connection
 			if (connection.providerName === SQL_PROVIDER) {
-				let clusterEndpoint: IEndpoint = await this.getClusterEndpoint(connection.id, KNOX_ENDPOINT);
+				let clusterEndpoint: utils.IEndpoint = await this.getClusterEndpoint(connection.id, KNOX_ENDPOINT);
 				if (!clusterEndpoint) {
 					let kernelDisplayName: string = await this.getKernelDisplayName();
 					return Promise.reject(new Error(localize('connectionNotValid', 'Spark kernels require a connection to a SQL Server big data cluster master instance.')));
@@ -303,12 +303,12 @@ export class JupyterSession implements nb.ISession {
 		return port;
 	}
 
-	private async getClusterEndpoint(profileId: string, serviceName: string): Promise<IEndpoint> {
+	private async getClusterEndpoint(profileId: string, serviceName: string): Promise<utils.IEndpoint> {
 		let serverInfo: ServerInfo = await connection.getServerInfo(profileId);
 		if (!serverInfo || !serverInfo.options) {
 			return undefined;
 		}
-		let endpoints: IEndpoint[] = serverInfo.options['clusterEndpoints'];
+		let endpoints: utils.IEndpoint[] = serverInfo.options['clusterEndpoints'];
 		if (!endpoints || endpoints.length === 0) {
 			return undefined;
 		}
@@ -318,12 +318,6 @@ export class JupyterSession implements nb.ISession {
 
 interface ICredentials {
 	'url': string;
-}
-
-interface IEndpoint {
-	serviceName: string;
-	ipAddress: string;
-	port: number;
 }
 
 interface ISparkMagicConfig {

--- a/src/sql/parts/notebook/cellViews/codeActions.ts
+++ b/src/sql/parts/notebook/cellViews/codeActions.ts
@@ -15,6 +15,7 @@ import { INotificationService, Severity } from 'vs/platform/notification/common/
 import { NotebookModel } from 'sql/parts/notebook/models/notebookModel';
 import { getErrorMessage } from 'sql/parts/notebook/notebookUtils';
 import { ICellModel, CellExecutionState } from 'sql/parts/notebook/models/modelInterfaces';
+import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 import { MultiStateAction, IMultiStateData, IActionStateData } from 'sql/parts/notebook/notebookActions';
 
 let notebookMoreActionMsg = localize('notebook.failed', "Please select active cell and try again");
@@ -68,7 +69,8 @@ export class RunCellAction extends MultiStateAction<CellExecutionState> {
 	public static LABEL = 'Run cell';
 	private _executionChangedDisposable: IDisposable;
 	private _context: CellContext;
-	constructor(context: CellContext, @INotificationService private notificationService: INotificationService) {
+	constructor(context: CellContext, @INotificationService private notificationService: INotificationService,
+		@IConnectionManagementService private connectionManagementService: IConnectionManagementService) {
 		super(RunCellAction.ID, new IMultiStateData<CellExecutionState>([
 			{ key: CellExecutionState.Hidden, value: { label: emptyExecutionCountLabel, className: '', tooltip: '', hideIcon: true }},
 			{ key: CellExecutionState.Stopped, value: { label: '', className: 'toolbarIconRun', tooltip: localize('runCell', 'Run cell') }},
@@ -89,7 +91,7 @@ export class RunCellAction extends MultiStateAction<CellExecutionState> {
 			return;
 		}
 		try {
-			await this._context.cell.runCell(this.notificationService);
+			await this._context.cell.runCell(this.notificationService, this.connectionManagementService);
 		} catch (error) {
 			let message = getErrorMessage(error);
 			this.notificationService.error(message);

--- a/src/sql/parts/notebook/models/cell.ts
+++ b/src/sql/parts/notebook/models/cell.ts
@@ -20,6 +20,7 @@ import { ICellModelOptions, IModelFactory, FutureInternal, CellExecutionState } 
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { MssqlProviderId } from 'sql/common/constants';
 import { Schemas } from 'vs/base/common/network';
 let modelId = 0;
 
@@ -470,10 +471,14 @@ export class CellModel implements ICellModel {
 	// TODO: this will be refactored out into the notebooks extension as a contribution point
 	private getKnoxEndpoint(activeConnection: IConnectionProfile): notebookUtils.IEndpoint {
 		let endpoint;
-		if (this._connectionManagementService) {
+		if (this._connectionManagementService && activeConnection && activeConnection.providerName === MssqlProviderId) {
 			let serverInfo: ServerInfo = this._connectionManagementService.getServerInfo(activeConnection.id);
-			let endpoints: notebookUtils.IEndpoint[] = serverInfo.options['clusterEndpoints'];
-			endpoint = endpoints.find(ep => ep.serviceName.toLowerCase() === 'knox');
+			if (serverInfo && serverInfo.options && serverInfo.options['clusterEndpoints']) {
+				let endpoints: notebookUtils.IEndpoint[] = serverInfo.options['clusterEndpoints'];
+				if (endpoints && endpoints.length > 0) {
+					endpoint = endpoints.find(ep => ep.serviceName.toLowerCase() === 'knox');
+				}
+			}
 		}
 		return endpoint;
 	}

--- a/src/sql/parts/notebook/models/cell.ts
+++ b/src/sql/parts/notebook/models/cell.ts
@@ -6,17 +6,19 @@
 
 'use strict';
 
-import { nb } from 'azdata';
+import { nb, ServerInfo } from 'azdata';
 
 import { Event, Emitter } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 
-import { ICellModelOptions, IModelFactory, FutureInternal, CellExecutionState } from './modelInterfaces';
 import * as notebookUtils from '../notebookUtils';
 import { CellTypes, CellType, NotebookChangeType } from 'sql/parts/notebook/models/contracts';
-import { ICellModel } from 'sql/parts/notebook/models/modelInterfaces';
 import { NotebookModel } from 'sql/parts/notebook/models/notebookModel';
+import { ICellModel } from 'sql/parts/notebook/models/modelInterfaces';
+import { ICellModelOptions, IModelFactory, FutureInternal, CellExecutionState } from './modelInterfaces';
+import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
+import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { Schemas } from 'vs/base/common/network';
 let modelId = 0;
@@ -38,6 +40,7 @@ export class CellModel implements ICellModel {
 	private _executionCount: number | undefined;
 	private _cellUri: URI;
 	public id: string;
+	private _connectionManagementService: IConnectionManagementService;
 
 	constructor(private factory: IModelFactory, cellData?: nb.ICellContents, private _options?: ICellModelOptions) {
 		this.id = `${modelId++}`;
@@ -181,8 +184,11 @@ export class CellModel implements ICellModel {
 		return CellExecutionState.Hidden;
 	}
 
-	public async runCell(notificationService?: INotificationService): Promise<boolean> {
+	public async runCell(notificationService?: INotificationService, connectionManagementService?: IConnectionManagementService): Promise<boolean> {
 		try {
+			if (connectionManagementService) {
+				this._connectionManagementService = connectionManagementService;
+			}
 			if (this.cellType !== CellTypes.Code) {
 				// TODO should change hidden state to false if we add support
 				// for this property
@@ -371,7 +377,8 @@ export class CellModel implements ICellModel {
 				if (result && result.data && result.data['text/html']) {
 					let model = (this as CellModel).options.notebook as NotebookModel;
 					if (model.activeConnection) {
-						let host = model.activeConnection.serverName;
+						let endpoint = this.getKnoxEndpoint(model.activeConnection);
+						let host = endpoint && endpoint.ipAddress ? endpoint.ipAddress : model.activeConnection.serverName;
 						let html = result.data['text/html'];
 						html = html.replace(/(https?:\/\/mssql-master.*\/proxy)(.*)/g, function (a, b, c) {
 							let ret = '';
@@ -457,5 +464,17 @@ export class CellModel implements ICellModel {
 		let uri = URI.from({ scheme: Schemas.untitled, path: `notebook-editor-${this.id}` });
 		// Use this to set the internal (immutable) and public (shared with extension) uri properties
 		this.cellUri = uri;
+	}
+
+	// Get Knox endpoint from IConnectionProfile
+	// TODO: this will be refactored out into the notebooks extension as a contribution point
+	private getKnoxEndpoint(activeConnection: IConnectionProfile): notebookUtils.IEndpoint {
+		let endpoint;
+		if (this._connectionManagementService) {
+			let serverInfo: ServerInfo = this._connectionManagementService.getServerInfo(activeConnection.id);
+			let endpoints: notebookUtils.IEndpoint[] = serverInfo.options['clusterEndpoints'];
+			endpoint = endpoints.find(ep => ep.serviceName.toLowerCase() === 'knox');
+		}
+		return endpoint;
 	}
 }

--- a/src/sql/parts/notebook/models/modelInterfaces.ts
+++ b/src/sql/parts/notebook/models/modelInterfaces.ts
@@ -444,7 +444,7 @@ export interface ICellModel {
 	readonly onExecutionStateChange: Event<CellExecutionState>;
 	setFuture(future: FutureInternal): void;
 	readonly executionState: CellExecutionState;
-	runCell(notificationService?: INotificationService): Promise<boolean>;
+	runCell(notificationService?: INotificationService, connectionManagementService?: IConnectionManagementService): Promise<boolean>;
 	setOverrideLanguage(language: string);
 	equals(cellModel: ICellModel): boolean;
 	toJSON(): nb.ICellContents;

--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -552,7 +552,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		await this.modelReady;
 		let uriString = cell.cellUri.toString();
 		if (this._model.cells.findIndex(c => c.cellUri.toString() === uriString) > -1) {
-			return cell.runCell(this.notificationService);
+			return cell.runCell(this.notificationService, this.connectionManagementService);
 		} else {
 			return Promise.reject(new Error(localize('cellNotFound', 'cell with URI {0} was not found in this model', uriString)));
 		}

--- a/src/sql/parts/notebook/notebookUtils.ts
+++ b/src/sql/parts/notebook/notebookUtils.ts
@@ -101,6 +101,12 @@ export interface IStandardKernelWithProvider {
 	readonly notebookProvider: string;
 }
 
+export interface IEndpoint {
+	serviceName: string;
+	ipAddress: string;
+	port: number;
+}
+
 export function tryMatchCellMagic(input: string): string {
 	if (!input) {
 		return input;


### PR DESCRIPTION
Fixes #4021.

Also ensures that the million IEndpoint interfaces are at least in common utils classes.