### PR TITLE
#4339: Fix - Notebooks show dirty when loaded(Open/New notebook)

### DIFF
--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -43,7 +43,6 @@ export class NotebookEditorModel extends EditorModel {
 				// Hook to content change events
 				notebook.modelReady.then(() => {
 					this._register(notebook.model.contentChanged(e => this.updateModel()));
-					this._register(notebook.model.kernelChanged(e => this.updateModel()));
 				}, err => undefined);
 			}
 		}));


### PR DESCRIPTION
Removed model update on kernel change event as it is triggered twice after model gets loaded. It introduced anew issue that when we change kernel, editor doesn't show dirty. Created a tracking issue https://github.com/Microsoft/azuredatastudio/issues/4365. Will work on it after the kernel refactoring is complete