### PR TITLE
Use max column width when auto-sizing columns

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
@@ -2,6 +2,7 @@
 
 import { mixin, clone } from 'sql/base/common/objects';
 import { isInDOM } from 'vs/base/browser/dom';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export interface IAutoColumnSizeOptions extends Slick.PluginOptions {
 	maxWidth?: number;
@@ -9,7 +10,7 @@ export interface IAutoColumnSizeOptions extends Slick.PluginOptions {
 }
 
 const defaultOptions: IAutoColumnSizeOptions = {
-	maxWidth: 200,
+	maxWidth: 300,
 	autoSizeOnRender: false
 };
 
@@ -20,7 +21,11 @@ export class AutoColumnSize<T> implements Slick.Plugin<T> {
 	private _options: IAutoColumnSizeOptions;
 	private onPostEventHandler = new Slick.EventHandler();
 
-	constructor(options: IAutoColumnSizeOptions = defaultOptions) {
+	constructor(options: IAutoColumnSizeOptions = defaultOptions, configurationService: IConfigurationService) {
+		let configuredMaxWidth = configurationService.getValue<number>('resultsGrid.maxColumnWidth');
+		if (configuredMaxWidth) {
+			defaultOptions.maxWidth = configuredMaxWidth;
+		}
 		this._options = mixin(options, defaultOptions, false);
 	}
 
@@ -146,7 +151,7 @@ export class AutoColumnSize<T> implements Slick.Plugin<T> {
 		let template = this.getMaxTextTemplate(texts, columnDef, colIndex, data, rowEl);
 		let width = this.getTemplateWidth(rowEl, template);
 		this.deleteRow(rowEl);
-		return width;
+		return width > this._options.maxWidth ? this._options.maxWidth : width;
 	}
 
 	private getTemplateWidth(rowEl: JQuery, template: JQuery | HTMLElement): number {

--- a/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
@@ -2,7 +2,6 @@
 
 import { mixin, clone } from 'sql/base/common/objects';
 import { isInDOM } from 'vs/base/browser/dom';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export interface IAutoColumnSizeOptions extends Slick.PluginOptions {
 	maxWidth?: number;
@@ -10,7 +9,7 @@ export interface IAutoColumnSizeOptions extends Slick.PluginOptions {
 }
 
 const defaultOptions: IAutoColumnSizeOptions = {
-	maxWidth: 300,
+	maxWidth: 212,
 	autoSizeOnRender: false
 };
 
@@ -21,11 +20,7 @@ export class AutoColumnSize<T> implements Slick.Plugin<T> {
 	private _options: IAutoColumnSizeOptions;
 	private onPostEventHandler = new Slick.EventHandler();
 
-	constructor(options: IAutoColumnSizeOptions = defaultOptions, configurationService: IConfigurationService) {
-		let configuredMaxWidth = configurationService.getValue<number>('resultsGrid.maxColumnWidth');
-		if (configuredMaxWidth) {
-			defaultOptions.maxWidth = configuredMaxWidth;
-		}
+	constructor(options: IAutoColumnSizeOptions = defaultOptions) {
 		this._options = mixin(options, defaultOptions, false);
 	}
 

--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -380,7 +380,7 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 				};
 			}))
 		};
-		self.plugins.push([rowNumberColumn, new AutoColumnSize(), new AdditionalKeyBindings()]);
+		self.plugins.push([rowNumberColumn, new AutoColumnSize(undefined, this.configurationService), new AdditionalKeyBindings()]);
 		self.dataSet = dataSet;
 
 		// Create a dataSet to render without rows to reduce DOM size

--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -380,7 +380,7 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 				};
 			}))
 		};
-		self.plugins.push([rowNumberColumn, new AutoColumnSize(undefined, this.configurationService), new AdditionalKeyBindings()]);
+		self.plugins.push([rowNumberColumn, new AutoColumnSize({ maxWidth: this.configurationService.getValue<number>('resultsGrid.maxColumnWidth') }), new AdditionalKeyBindings()]);
 		self.dataSet = dataSet;
 
 		// Create a dataSet to render without rows to reduce DOM size

--- a/src/sql/parts/query/editor/gridPanel.ts
+++ b/src/sql/parts/query/editor/gridPanel.ts
@@ -499,7 +499,7 @@ class GridTable<T> extends Disposable implements IView {
 		this.table = this._register(new Table(tableContainer, { dataProvider: this.dataProvider, columns: this.columns }, tableOptions));
 		this.table.setSelectionModel(this.selectionModel);
 		this.table.registerPlugin(new MouseWheelSupport());
-		this.table.registerPlugin(new AutoColumnSize({ autoSizeOnRender: !this.state.columnSizes && this.configurationService.getValue('resultsGrid.autoSizeColumns') }, this.configurationService));
+		this.table.registerPlugin(new AutoColumnSize({ autoSizeOnRender: !this.state.columnSizes && this.configurationService.getValue('resultsGrid.autoSizeColumns'), maxWidth: this.configurationService.getValue<number>('resultsGrid.maxColumnWidth') }));
 		this.table.registerPlugin(copyHandler);
 		this.table.registerPlugin(this.rowNumberColumn);
 		this.table.registerPlugin(new AdditionalKeyBindings());

--- a/src/sql/parts/query/editor/gridPanel.ts
+++ b/src/sql/parts/query/editor/gridPanel.ts
@@ -499,7 +499,7 @@ class GridTable<T> extends Disposable implements IView {
 		this.table = this._register(new Table(tableContainer, { dataProvider: this.dataProvider, columns: this.columns }, tableOptions));
 		this.table.setSelectionModel(this.selectionModel);
 		this.table.registerPlugin(new MouseWheelSupport());
-		this.table.registerPlugin(new AutoColumnSize({ autoSizeOnRender: !this.state.columnSizes && this.configurationService.getValue('resultsGrid.autoSizeColumns') }));
+		this.table.registerPlugin(new AutoColumnSize({ autoSizeOnRender: !this.state.columnSizes && this.configurationService.getValue('resultsGrid.autoSizeColumns') }, this.configurationService));
 		this.table.registerPlugin(copyHandler);
 		this.table.registerPlugin(this.rowNumberColumn);
 		this.table.registerPlugin(new AdditionalKeyBindings());

--- a/src/sql/parts/query/editor/resultsGridContribution.ts
+++ b/src/sql/parts/query/editor/resultsGridContribution.ts
@@ -66,6 +66,11 @@ const resultsGridConfiguration: IConfigurationNode = {
 			type: 'boolean',
 			default: true,
 			description: nls.localize('autoSizeColumns', "Auto size the columns width on inital results. Could have performance problems with large number of columns or large cells")
+		},
+		'resultsGrid.maxColumnWidth': {
+			type: 'number',
+			default: 300,
+			description: nls.localize('maxColumnWidth', "The maximum width in pixels for auto-sized columns")
 		}
 	}
 };

--- a/src/sql/parts/query/editor/resultsGridContribution.ts
+++ b/src/sql/parts/query/editor/resultsGridContribution.ts
@@ -69,7 +69,7 @@ const resultsGridConfiguration: IConfigurationNode = {
 		},
 		'resultsGrid.maxColumnWidth': {
 			type: 'number',
-			default: 300,
+			default: 212,
 			description: nls.localize('maxColumnWidth', "The maximum width in pixels for auto-sized columns")
 		}
 	}


### PR DESCRIPTION
Fixes #4355. This PR just uses the max width setting and exposes it in config, which matches SSMS, but we should think more about smarter ways to resize columns too