### PR TITLE
Grid scrolling bugs

### DIFF
--- a/src/sql/base/browser/ui/scrollableSplitview/heightMap.ts
+++ b/src/sql/base/browser/ui/scrollableSplitview/heightMap.ts
@@ -145,7 +145,7 @@ export class HeightMap {
 		viewItem.height = size;
 
 		// update all items after this item
-		for(let j = i + 1; j < this.heightMap.length; j++) {
+		for (let j = i + 1; j < this.heightMap.length; j++) {
 			this.heightMap[j].top -= delta;
 		}
 	}

--- a/src/sql/base/browser/ui/scrollableSplitview/heightMap.ts
+++ b/src/sql/base/browser/ui/scrollableSplitview/heightMap.ts
@@ -140,7 +140,14 @@ export class HeightMap {
 
 		let viewItem = this.heightMap[i];
 
+		let delta = viewItem.height - size;
+
 		viewItem.height = size;
+
+		// update all items after this item
+		for(let j = i + 1; j < this.heightMap.length; j++) {
+			this.heightMap[j].top -= delta;
+		}
 	}
 
 	protected updateTop(item: string, top: number): void {

--- a/src/sql/base/browser/ui/scrollableSplitview/scrollableSplitview.ts
+++ b/src/sql/base/browser/ui/scrollableSplitview/scrollableSplitview.ts
@@ -188,7 +188,6 @@ export class ScrollableSplitView extends HeightMap implements IDisposable {
 		this.scrollable = new ScrollableElement(this.el, { vertical: options.verticalScrollbarVisibility });
 		debounceEvent(this.scrollable.onScroll, (l, e) => e, types.isNumber(this.options.scrollDebounce) ? this.options.scrollDebounce : 25)(e => {
 			this.render(e.scrollTop, e.height);
-			this.relayout();
 			this._onScroll.fire(e.scrollTop);
 		});
 		let domNode = this.scrollable.getDomNode();
@@ -803,6 +802,8 @@ export class ScrollableSplitView extends HeightMap implements IDisposable {
 			deltaUp -= viewDelta;
 			this.updateSize(item.view.id, size);
 			this.dirtyState = true;
+			this.lastRenderTop = 0;
+			this.lastRenderHeight = 0;
 		}
 
 		for (let i = 0, deltaDown = delta; i < downItems.length; i++) {
@@ -813,6 +814,8 @@ export class ScrollableSplitView extends HeightMap implements IDisposable {
 			deltaDown += viewDelta;
 			this.updateSize(item.view.id, size);
 			this.dirtyState = true;
+			this.lastRenderTop = 0;
+			this.lastRenderHeight = 0;
 		}
 
 		return delta;

--- a/src/sql/parts/query/editor/gridPanel.ts
+++ b/src/sql/parts/query/editor/gridPanel.ts
@@ -708,7 +708,7 @@ class GridTable<T> extends Disposable implements IView {
 	}
 
 	public get maximumSize(): number {
-		return Number.POSITIVE_INFINITY; // Math.max(this.maxSize, ACTIONBAR_HEIGHT + BOTTOM_PADDING);
+		return Number.POSITIVE_INFINITY;
 	}
 
 	private loadData(offset: number, count: number): Thenable<T[]> {

--- a/src/sql/parts/query/editor/gridPanel.ts
+++ b/src/sql/parts/query/editor/gridPanel.ts
@@ -35,7 +35,7 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ViewletPanel, IViewletPanelOptions } from 'vs/workbench/browser/parts/views/panelViewlet';
 import { isUndefinedOrNull } from 'vs/base/common/types';
 import { range } from 'vs/base/common/arrays';
-import { Orientation } from 'vs/base/browser/ui/splitview/splitview';
+import { Orientation, Sizing } from 'vs/base/browser/ui/splitview/splitview';
 import { Disposable, IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { generateUuid } from 'vs/base/common/uuid';
 import { TPromise } from 'vs/base/common/winjs.base';
@@ -298,7 +298,7 @@ export class GridPanel extends ViewletPanel {
 		// possible to need a sort?
 
 		if (isUndefinedOrNull(this.maximizedGrid)) {
-			this.splitView.addViews(tables, tables.map(i => i.minimumSize), this.splitView.length);
+			this.splitView.addViews(tables, Sizing.Distribute, this.splitView.length);
 		}
 
 		this.tables = this.tables.concat(tables);
@@ -341,7 +341,7 @@ export class GridPanel extends ViewletPanel {
 			this.maximizedGrid.state.maximized = false;
 			this.maximizedGrid = undefined;
 			this.splitView.removeView(0);
-			this.splitView.addViews(this.tables, this.tables.map(i => i.minimumSize));
+			this.splitView.addViews(this.tables, Sizing.Distribute);
 		}
 	}
 

--- a/src/sql/parts/query/editor/gridPanel.ts
+++ b/src/sql/parts/query/editor/gridPanel.ts
@@ -708,7 +708,7 @@ class GridTable<T> extends Disposable implements IView {
 	}
 
 	public get maximumSize(): number {
-		return Math.max(this.maxSize, ACTIONBAR_HEIGHT + BOTTOM_PADDING);
+		return Number.POSITIVE_INFINITY; // Math.max(this.maxSize, ACTIONBAR_HEIGHT + BOTTOM_PADDING);
 	}
 
 	private loadData(offset: number, count: number): Thenable<T[]> {


### PR DESCRIPTION
I found theres some grid scrolling issues, where grids would disappear during scrolling. I found this is because the class scrollableSplitview wasn't maintaining an updated size during resizing.

fixes #4391

Also fixes the scrollbar bug.
![image](https://user-images.githubusercontent.com/4324725/54167669-1bf60780-4428-11e9-8d6e-57438e79a6b1.png)
![image](https://user-images.githubusercontent.com/4324725/54167686-287a6000-4428-11e9-83de-b7ec7aa7a38a.png)
