### PR TITLE
Add scripted object name to query editor tab display

### DIFF
--- a/src/sql/parts/query/common/queryInput.ts
+++ b/src/sql/parts/query/common/queryInput.ts
@@ -169,7 +169,7 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 	public getEncoding(): string { return this._sql.getEncoding(); }
 	public suggestFileName(): string { return this._sql.suggestFileName(); }
 
-	public getName(longForm?:boolean): string {
+	public getName(longForm?: boolean): string {
 		if (this._configurationService.getValue('sql.showConnectionInfoInTitle')) {
 			let profile = this._connectionManagementService.getConnectionProfile(this.uri);
 			let title = '';

--- a/src/sql/parts/query/common/queryInput.ts
+++ b/src/sql/parts/query/common/queryInput.ts
@@ -144,6 +144,7 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 	public showQueryResultsEditor(): void { this._showQueryResultsEditor.fire(); }
 	public updateSelection(selection: ISelectionData): void { this._updateSelection.fire(selection); }
 	public getTypeId(): string { return QueryInput.ID; }
+	// Description is shown beside the tab name in the combobox of open editors
 	public getDescription(): string { return this._description; }
 	public supportsSplitEditor(): boolean { return false; }
 	public getModeId(): string { return QueryInput.SCHEMA; }
@@ -168,24 +169,31 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 	public getEncoding(): string { return this._sql.getEncoding(); }
 	public suggestFileName(): string { return this._sql.suggestFileName(); }
 
-	public getName(): string {
+	public getName(longForm?:boolean): string {
 		if (this._configurationService.getValue('sql.showConnectionInfoInTitle')) {
 			let profile = this._connectionManagementService.getConnectionProfile(this.uri);
 			let title = '';
+			if (this._description && this._description !== '') {
+			    title = this._description + ' ';
+			}
 			if (profile) {
 				if (profile.userName) {
-					title = `${profile.serverName}.${profile.databaseName} (${profile.userName})`;
+					title += `${profile.serverName}.${profile.databaseName} (${profile.userName})`;
 				} else {
-					title = `${profile.serverName}.${profile.databaseName} (${profile.authenticationType})`;
+					title += `${profile.serverName}.${profile.databaseName} (${profile.authenticationType})`;
 				}
 			} else {
-				title = localize('disconnected', 'disconnected');
+				title += localize('disconnected', 'disconnected');
 			}
-
-			return this._sql.getName() + ` - ${trimTitle(title)}`;
+			return this._sql.getName() + (longForm ?  (' - ' + title) : ` - ${trimTitle(title)}`);
 		} else {
 			return this._sql.getName();
 		}
+	}
+
+	// Called to get the tooltip of the tab
+	public getTitle() {
+		return this.getName(true);
 	}
 
 	public get hasAssociatedFilePath(): boolean { return this._sql.hasAssociatedFilePath; }

--- a/src/sql/workbench/common/taskUtilities.ts
+++ b/src/sql/workbench/common/taskUtilities.ts
@@ -223,7 +223,8 @@ export function script(connectionProfile: IConnectionProfile, metadata: azdata.O
 					let script: string = result.script;
 
 					if (script) {
-						queryEditorService.newSqlEditor(script, connectionProfile.providerName).then((owner) => {
+						let description = (metadata.schema && metadata.schema !== '') ? `${metadata.schema}.${metadata.name}`  : metadata.name;
+						queryEditorService.newSqlEditor(script, connectionProfile.providerName, undefined, description).then((owner) => {
 							// Connect our editor to the input connection
 							let options: IConnectionCompletionOptions = {
 								params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: owner },

--- a/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
@@ -74,7 +74,7 @@ export class QueryEditorService implements IQueryEditorService {
 	/**
 	 * Creates new untitled document for SQL query and opens in new editor tab
 	 */
-	public newSqlEditor(sqlContent?: string, connectionProviderName?: string, isDirty?: boolean): Promise<IConnectableInput> {
+	public newSqlEditor(sqlContent?: string, connectionProviderName?: string, isDirty?: boolean, objectName?: string): Promise<IConnectableInput> {
 		return new Promise<IConnectableInput>(async (resolve, reject) => {
 			try {
 				// Create file path and file URI
@@ -92,7 +92,7 @@ export class QueryEditorService implements IQueryEditorService {
 				}
 
 				const queryResultsInput: QueryResultsInput = this._instantiationService.createInstance(QueryResultsInput, docUri.toString());
-				let queryInput: QueryInput = this._instantiationService.createInstance(QueryInput, '', fileInput, queryResultsInput, connectionProviderName);
+				let queryInput: QueryInput = this._instantiationService.createInstance(QueryInput, objectName, fileInput, queryResultsInput, connectionProviderName);
 
 				this._editorService.openEditor(queryInput, { pinned: true })
 					.then((editor) => {

--- a/src/sql/workbench/services/queryEditor/common/queryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/common/queryEditorService.ts
@@ -23,7 +23,7 @@ export interface IQueryEditorService {
 	_serviceBrand: any;
 
 	// Creates new untitled document for SQL queries and opens it in a new editor tab
-	newSqlEditor(sqlContent?: string, connectionProviderName?: string, isDirty?: boolean): Promise<IConnectableInput>;
+	newSqlEditor(sqlContent?: string, connectionProviderName?: string, isDirty?: boolean, objectName?:string ): Promise<IConnectableInput>;
 
 	// Creates a new query plan document
 	newQueryPlanEditor(xmlShowPlan: string): Promise<any>;


### PR DESCRIPTION
When script create or script drop is used to open a sql editor, we use the object name as the Description of the editor, which shows up in the drop down list of open editors. We also include the object name in the text of the tab itself when sql.showConnectionInfoInTitle config is true.
This commit also fixes the tooltip of the tab and the title bar to display non-truncated text.
![image](https://user-images.githubusercontent.com/2224906/54205224-4d181b80-44ac-11e9-9063-2d8aacfa4c00.png)

![image](https://user-images.githubusercontent.com/2224906/54205290-73d65200-44ac-11e9-9bfe-989766e290ff.png)
