### PR TITLE
Revert SQL Tools Service to 1.5.0-alpha.71

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.73",
+	"version": "1.5.0-alpha.71",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",


### PR DESCRIPTION
Reverting SQL Tools Service for issue https://github.com/Microsoft/azuredatastudio/issues/4392.  It looks like something with the Managed Batch Parser refactor introduces this issue (since it was the only change included in the previous vbump).