### PR TITLE
Added 'serverMajorVersion' key to context which is missed currently and caused failure for loading 'Create External Table' menu

### DIFF
--- a/src/sql/parts/connection/common/connectionContextKey.ts
+++ b/src/sql/parts/connection/common/connectionContextKey.ts
@@ -12,13 +12,11 @@ export class ConnectionContextKey implements IContextKey<IConnectionProfile> {
 
 	static Provider = new RawContextKey<string>('connectionProvider', undefined);
 	static Server = new RawContextKey<string>('serverName', undefined);
-	static ServerMajorVersion = new RawContextKey<string>('serverMajorVersion', undefined);
 	static Database = new RawContextKey<string>('databaseName', undefined);
 	static Connection = new RawContextKey<IConnectionProfile>('connection', undefined);
 
 	private _providerKey: IContextKey<string>;
 	private _serverKey: IContextKey<string>;
-	private _serverMajorVersion: IContextKey<string>;
 	private _databaseKey: IContextKey<string>;
 	private _connectionKey: IContextKey<IConnectionProfile>;
 
@@ -27,7 +25,6 @@ export class ConnectionContextKey implements IContextKey<IConnectionProfile> {
 	) {
 		this._providerKey = ConnectionContextKey.Provider.bindTo(contextKeyService);
 		this._serverKey = ConnectionContextKey.Server.bindTo(contextKeyService);
-		this._serverMajorVersion = ConnectionContextKey.ServerMajorVersion.bindTo(contextKeyService);
 		this._databaseKey = ConnectionContextKey.Database.bindTo(contextKeyService);
 		this._connectionKey = ConnectionContextKey.Connection.bindTo(contextKeyService);
 	}
@@ -36,15 +33,12 @@ export class ConnectionContextKey implements IContextKey<IConnectionProfile> {
 		this._connectionKey.set(value);
 		this._providerKey.set(value && value.providerName);
 		this._serverKey.set(value && value.serverName);
-		let majorVersion = value && value.options && value.options['serverMajorVersion'];
-		this._serverMajorVersion.set(majorVersion && `${majorVersion}`);
 		this._databaseKey.set(value && value.databaseName);
 	}
 
 	reset(): void {
 		this._providerKey.reset();
 		this._serverKey.reset();
-		this._serverMajorVersion.reset();
 		this._databaseKey.reset();
 		this._connectionKey.reset();
 	}

--- a/src/sql/parts/connection/common/connectionContextKey.ts
+++ b/src/sql/parts/connection/common/connectionContextKey.ts
@@ -12,11 +12,13 @@ export class ConnectionContextKey implements IContextKey<IConnectionProfile> {
 
 	static Provider = new RawContextKey<string>('connectionProvider', undefined);
 	static Server = new RawContextKey<string>('serverName', undefined);
+	static ServerMajorVersion = new RawContextKey<string>('serverMajorVersion', undefined);
 	static Database = new RawContextKey<string>('databaseName', undefined);
 	static Connection = new RawContextKey<IConnectionProfile>('connection', undefined);
 
 	private _providerKey: IContextKey<string>;
 	private _serverKey: IContextKey<string>;
+	private _serverMajorVersion: IContextKey<string>;
 	private _databaseKey: IContextKey<string>;
 	private _connectionKey: IContextKey<IConnectionProfile>;
 
@@ -25,6 +27,7 @@ export class ConnectionContextKey implements IContextKey<IConnectionProfile> {
 	) {
 		this._providerKey = ConnectionContextKey.Provider.bindTo(contextKeyService);
 		this._serverKey = ConnectionContextKey.Server.bindTo(contextKeyService);
+		this._serverMajorVersion = ConnectionContextKey.ServerMajorVersion.bindTo(contextKeyService);
 		this._databaseKey = ConnectionContextKey.Database.bindTo(contextKeyService);
 		this._connectionKey = ConnectionContextKey.Connection.bindTo(contextKeyService);
 	}
@@ -33,12 +36,16 @@ export class ConnectionContextKey implements IContextKey<IConnectionProfile> {
 		this._connectionKey.set(value);
 		this._providerKey.set(value && value.providerName);
 		this._serverKey.set(value && value.serverName);
+		let majorVersion = value && value.options && value.options['serverMajorVersion'];
+		this._serverMajorVersion.set(majorVersion && `${majorVersion}`);
+		this._serverKey.set(value && value.serverName);
 		this._databaseKey.set(value && value.databaseName);
 	}
 
 	reset(): void {
 		this._providerKey.reset();
 		this._serverKey.reset();
+		this._serverMajorVersion.reset();
 		this._databaseKey.reset();
 		this._connectionKey.reset();
 	}

--- a/src/sql/parts/connection/common/connectionContextKey.ts
+++ b/src/sql/parts/connection/common/connectionContextKey.ts
@@ -38,7 +38,6 @@ export class ConnectionContextKey implements IContextKey<IConnectionProfile> {
 		this._serverKey.set(value && value.serverName);
 		let majorVersion = value && value.options && value.options['serverMajorVersion'];
 		this._serverMajorVersion.set(majorVersion && `${majorVersion}`);
-		this._serverKey.set(value && value.serverName);
 		this._databaseKey.set(value && value.databaseName);
 	}
 

--- a/src/sql/parts/connection/common/serverInfoContextKey.ts
+++ b/src/sql/parts/connection/common/serverInfoContextKey.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { RawContextKey, IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { ServerInfo } from 'azdata';
+
+export class ServerInfoContextKey implements IContextKey<ServerInfo> {
+
+	static ServerInfoObj = new RawContextKey<ServerInfo>('serverInfoObj', undefined);
+	static ServerMajorVersion = new RawContextKey<string>('serverMajorVersion', undefined);
+
+	private _serverInfoObj: IContextKey<ServerInfo>;
+	private _serverMajorVersion: IContextKey<string>;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService
+	) {
+		this._serverInfoObj = ServerInfoContextKey.ServerInfoObj.bindTo(contextKeyService);
+		this._serverMajorVersion = ServerInfoContextKey.ServerMajorVersion.bindTo(contextKeyService);
+	}
+
+	set(value: ServerInfo) {
+		this._serverInfoObj.set(value);
+		let majorVersion = value && value.serverMajorVersion;
+		this._serverMajorVersion.set(majorVersion && `${majorVersion}`);
+	}
+
+	reset(): void {
+		this._serverMajorVersion.reset();
+	}
+
+	public get(): ServerInfo {
+		return this._serverInfoObj.get();
+	}
+}

--- a/src/sql/parts/connection/common/serverInfoContextKey.ts
+++ b/src/sql/parts/connection/common/serverInfoContextKey.ts
@@ -10,21 +10,21 @@ import { ServerInfo } from 'azdata';
 
 export class ServerInfoContextKey implements IContextKey<ServerInfo> {
 
-	static ServerInfoObj = new RawContextKey<ServerInfo>('serverInfoObj', undefined);
+	static ServerInfo = new RawContextKey<ServerInfo>('serverInfo', undefined);
 	static ServerMajorVersion = new RawContextKey<string>('serverMajorVersion', undefined);
 
-	private _serverInfoObj: IContextKey<ServerInfo>;
+	private _serverInfo: IContextKey<ServerInfo>;
 	private _serverMajorVersion: IContextKey<string>;
 
 	constructor(
 		@IContextKeyService contextKeyService: IContextKeyService
 	) {
-		this._serverInfoObj = ServerInfoContextKey.ServerInfoObj.bindTo(contextKeyService);
+		this._serverInfo = ServerInfoContextKey.ServerInfo.bindTo(contextKeyService);
 		this._serverMajorVersion = ServerInfoContextKey.ServerMajorVersion.bindTo(contextKeyService);
 	}
 
 	set(value: ServerInfo) {
-		this._serverInfoObj.set(value);
+		this._serverInfo.set(value);
 		let majorVersion = value && value.serverMajorVersion;
 		this._serverMajorVersion.set(majorVersion && `${majorVersion}`);
 	}
@@ -34,6 +34,6 @@ export class ServerInfoContextKey implements IContextKey<ServerInfo> {
 	}
 
 	public get(): ServerInfo {
-		return this._serverInfoObj.get();
+		return this._serverInfo.get();
 	}
 }

--- a/src/sql/parts/objectExplorer/viewlet/serverTreeActionProvider.ts
+++ b/src/sql/parts/objectExplorer/viewlet/serverTreeActionProvider.ts
@@ -34,6 +34,7 @@ import { TreeNodeContextKey } from 'sql/parts/objectExplorer/viewlet/treeNodeCon
 import { IQueryManagementService } from 'sql/platform/query/common/queryManagement';
 import { IScriptingService } from 'sql/platform/scripting/common/scriptingService';
 import * as constants from 'sql/common/constants';
+import { ServerInfoContextKey } from 'sql/parts/connection/common/serverInfoContextKey';
 
 /**
  *  Provides actions for the server tree elements
@@ -132,13 +133,13 @@ export class ServerTreeActionProvider extends ContributableActionProvider {
 	private getContextKeyService(context: ObjectExplorerContext): IContextKeyService {
 		let scopedContextService = this._contextKeyService.createScoped();
 		let connectionContextKey = new ConnectionContextKey(scopedContextService);
-		let connectionProfile = context.profile;
-		let serverInfo = this._connectionManagementService.getServerInfo(connectionProfile.id);
-		if (serverInfo && serverInfo.serverMajorVersion) {
-			connectionProfile.options  = Object.assign(connectionProfile.options || {},
-				{ serverMajorVersion: serverInfo.serverMajorVersion });
-		}
+		let connectionProfile = context && context.profile;
 		connectionContextKey.set(connectionProfile);
+		let serverInfoContextKey = new ServerInfoContextKey(scopedContextService);
+		if (connectionProfile.id) {
+			let serverInfo = this._connectionManagementService.getServerInfo(connectionProfile.id);
+			serverInfoContextKey.set(serverInfo);
+		}
 		let treeNodeContextKey = new TreeNodeContextKey(scopedContextService);
 		if (context.treeNode) {
 			treeNodeContextKey.set(context.treeNode);

--- a/src/sql/parts/objectExplorer/viewlet/serverTreeActionProvider.ts
+++ b/src/sql/parts/objectExplorer/viewlet/serverTreeActionProvider.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 'use strict';
+import * as azdata from 'azdata';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { ITree } from 'vs/base/parts/tree/browser/tree';
 import { ContributableActionProvider } from 'vs/workbench/browser/actions';
@@ -15,8 +16,7 @@ import { fillInActions } from 'vs/platform/actions/browser/menuItemActionItem';
 import {
 	DisconnectConnectionAction, AddServerAction,
 	DeleteConnectionAction, RefreshAction, EditServerGroupAction
-}
-	from 'sql/parts/objectExplorer/viewlet/connectionTreeAction';
+} from 'sql/parts/objectExplorer/viewlet/connectionTreeAction';
 import {
 	ObjectExplorerActionUtilities, ManageConnectionAction, OEAction
 } from 'sql/parts/objectExplorer/viewlet/objectExplorerActions';
@@ -132,7 +132,13 @@ export class ServerTreeActionProvider extends ContributableActionProvider {
 	private getContextKeyService(context: ObjectExplorerContext): IContextKeyService {
 		let scopedContextService = this._contextKeyService.createScoped();
 		let connectionContextKey = new ConnectionContextKey(scopedContextService);
-		connectionContextKey.set(context.profile);
+		let connectionProfile = context.profile;
+		let serverInfo = this._connectionManagementService.getServerInfo(connectionProfile.id);
+		if (serverInfo && serverInfo.serverMajorVersion) {
+			connectionProfile.options  = Object.assign(connectionProfile.options || {},
+				{ serverMajorVersion: serverInfo.serverMajorVersion });
+		}
+		connectionContextKey.set(connectionProfile);
 		let treeNodeContextKey = new TreeNodeContextKey(scopedContextService);
 		if (context.treeNode) {
 			treeNodeContextKey.set(context.treeNode);


### PR DESCRIPTION
Currently context key indicating server major version is not loaded when wizard is launched until  `mssql:serverMajorVersion` key is loaded to context when dashboard opens up.
The missing key causes failure to show "Create External Table" menu on right click on database node before opening dashboard because "Create External Table" menu is set to be shown when server major version is >= 15.
This PR  loads `serverMajorVersion` key to context regardless of dashboard opening so that the extension menu can operate correctly.

![image](https://user-images.githubusercontent.com/19577035/54252749-2a682000-4509-11e9-906c-e6029d3b5410.png)
