### PR TITLE
#4363: Reopen notebook editors when ADS launched

### DIFF
--- a/src/sql/parts/common/customInputConverter.ts
+++ b/src/sql/parts/common/customInputConverter.ts
@@ -14,7 +14,7 @@ import { QueryInput } from 'sql/parts/query/common/queryInput';
 import { IQueryEditorOptions } from 'sql/workbench/services/queryEditor/common/queryEditorService';
 import { QueryPlanInput } from 'sql/parts/queryPlan/queryPlanInput';
 import { NotebookInput } from 'sql/parts/notebook/notebookInput';
-import { DEFAULT_NOTEBOOK_PROVIDER, INotebookService } from 'sql/workbench/services/notebook/common/notebookService';
+import { INotebookService } from 'sql/workbench/services/notebook/common/notebookService';
 import { ResourceEditorInput } from 'vs/workbench/common/editor/resourceEditorInput';
 import { notebookModeId } from 'sql/common/constants';
 
@@ -57,14 +57,12 @@ export function convertEditorInput(input: EditorInput, options: IQueryEditorOpti
 		//Notebook
 		uri = getNotebookEditorUri(input, instantiationService);
 		if (uri) {
-			return withService<INotebookService, NotebookInput>(instantiationService, INotebookService, notebookService => {
-				let fileName: string = 'untitled';
-				if (input) {
-					fileName = input.getName();
-				}
-				let notebookInput: NotebookInput = instantiationService.createInstance(NotebookInput, fileName, uri);
-				return notebookInput;
-			});
+			let fileName: string = 'untitled';
+			if (input) {
+				fileName = input.getName();
+			}
+			let notebookInput: NotebookInput = instantiationService.createInstance(NotebookInput, fileName, uri, input);
+			return notebookInput;
 		}
 	}
 	return input;

--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -28,6 +28,7 @@ import { notebookModeId } from 'sql/common/constants';
 import { ITextFileService, ISaveOptions } from 'vs/workbench/services/textfile/common/textfiles';
 import { LocalContentManager } from 'sql/workbench/services/notebook/node/localContentManager';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
+import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
 
 export type ModeViewSaveHandler = (handle: number) => Thenable<boolean>;
 
@@ -142,6 +143,7 @@ export class NotebookInput extends EditorInput {
 
 	constructor(private _title: string,
 		private resource: URI,
+		private _notebookEditorInput: UntitledEditorInput,
 		@ITextModelService private textModelService: ITextModelService,
 		@IUntitledEditorService untitledEditorService: IUntitledEditorService,
 		@IInstantiationService private instantiationService: IInstantiationService,
@@ -152,6 +154,10 @@ export class NotebookInput extends EditorInput {
 		this.resource = resource;
 		this._standardKernels = [];
 		this.assignProviders();
+	}
+
+	public get notebookEditorInput(): UntitledEditorInput {
+		return this._notebookEditorInput;
 	}
 
 	public confirmSave(): TPromise<ConfirmResult> {
@@ -258,7 +264,7 @@ export class NotebookInput extends EditorInput {
 		} else {
 			let textOrUntitledEditorModel: UntitledEditorModel | IEditorModel;
 			if (this.resource.scheme === Schemas.untitled) {
-				textOrUntitledEditorModel = await this._untitledEditorService.loadOrCreate({ resource: this.resource, modeId: notebookModeId });
+				textOrUntitledEditorModel = await this._notebookEditorInput.resolve();
 			}
 			else {
 				const textEditorModelReference = await this.textModelService.createModelReference(this.resource);

--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -143,7 +143,7 @@ export class NotebookInput extends EditorInput {
 
 	constructor(private _title: string,
 		private resource: URI,
-		private _notebookEditorInput: UntitledEditorInput,
+		private _textInput: UntitledEditorInput,
 		@ITextModelService private textModelService: ITextModelService,
 		@IUntitledEditorService untitledEditorService: IUntitledEditorService,
 		@IInstantiationService private instantiationService: IInstantiationService,
@@ -156,8 +156,8 @@ export class NotebookInput extends EditorInput {
 		this.assignProviders();
 	}
 
-	public get notebookEditorInput(): UntitledEditorInput {
-		return this._notebookEditorInput;
+	public get textInput(): UntitledEditorInput {
+		return this._textInput;
 	}
 
 	public confirmSave(): TPromise<ConfirmResult> {
@@ -264,7 +264,7 @@ export class NotebookInput extends EditorInput {
 		} else {
 			let textOrUntitledEditorModel: UntitledEditorModel | IEditorModel;
 			if (this.resource.scheme === Schemas.untitled) {
-				textOrUntitledEditorModel = await this._notebookEditorInput.resolve();
+				textOrUntitledEditorModel = await this._textInput.resolve();
 			}
 			else {
 				const textEditorModelReference = await this.textModelService.createModelReference(this.resource);

--- a/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
@@ -367,7 +367,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 		};
 		let isUntitled: boolean = uri.scheme === Schemas.untitled;
 
-		const fileInput: UntitledEditorInput = isUntitled ? this._untitledEditorService.createOrGet( uri, notebookModeId) : undefined;
+		const fileInput: UntitledEditorInput = isUntitled ? this._untitledEditorService.createOrGet(uri, notebookModeId) : undefined;
 		let input = this._instantiationService.createInstance(NotebookInput, uri.fsPath, uri, fileInput);
 		input.isTrusted = isUntitled;
 		input.defaultKernel = options.defaultKernel;

--- a/src/vs/workbench/common/editor/editorGroup.ts
+++ b/src/vs/workbench/common/editor/editorGroup.ts
@@ -626,7 +626,7 @@ export class EditorGroup extends Disposable {
 			if (e instanceof QueryInput) {
 				return e.sql;
 			} else if (e instanceof NotebookInput) {
-				return e.notebookEditorInput;
+				return e.textInput;
 			}
 			return e;
 		});
@@ -658,7 +658,7 @@ export class EditorGroup extends Disposable {
 			if (e instanceof QueryInput) {
 				return e.sql;
 			} else if (e instanceof NotebookInput) {
-				return e.notebookEditorInput;
+				return e.textInput;
 			}
 			return e;
 		});

--- a/src/vs/workbench/common/editor/editorGroup.ts
+++ b/src/vs/workbench/common/editor/editorGroup.ts
@@ -16,6 +16,7 @@ import { ResourceMap } from 'vs/base/common/map';
 import { QueryInput } from 'sql/parts/query/common/queryInput';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
 import * as CustomInputConverter from 'sql/parts/common/customInputConverter';
+import { NotebookInput } from 'sql/parts/notebook/notebookInput';
 
 const EditorOpenPositioning = {
 	LEFT: 'left',
@@ -624,6 +625,8 @@ export class EditorGroup extends Disposable {
 		let editors = this.editors.map(e => {
 			if (e instanceof QueryInput) {
 				return e.sql;
+			} else if (e instanceof NotebookInput) {
+				return e.notebookEditorInput;
 			}
 			return e;
 		});
@@ -654,6 +657,8 @@ export class EditorGroup extends Disposable {
 		let mru = this.mru.map(e => {
 			if (e instanceof QueryInput) {
 				return e.sql;
+			} else if (e instanceof NotebookInput) {
+				return e.notebookEditorInput;
 			}
 			return e;
 		});

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -528,10 +528,10 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		if (!untitledInput.resource || typeof untitledInput.filePath === 'string' || (untitledInput.resource instanceof URI && untitledInput.resource.scheme === Schemas.untitled)) {
 			// {{SQL CARBON EDIT}}
 
-			let mode: string = getFileMode( this.instantiationService, untitledInput.resource);
+			let modeId: string = untitledInput.language ? untitledInput.language : getFileMode( this.instantiationService, untitledInput.resource);
 			return convertEditorInput(this.untitledEditorService.createOrGet(
 				untitledInput.filePath ? URI.file(untitledInput.filePath) : untitledInput.resource,
-				mode,
+				modeId,
 				untitledInput.contents,
 				untitledInput.encoding
 			), undefined, this.instantiationService);


### PR DESCRIPTION
Fixed the issue of notebook editors(untitled and titled) not being reopened in a proper way. 
Injected UntitledEditorInput into NotebookInput and made code changes accordingly. Now we have UntitledEditorInput for untitled notebooks and FileEditorInput for existing notebooks at run time. Since these two guys have the editor registration in vscode, notebooks would be reopened with built in behavior.

@kburtram : I would request you not to work on the mitigation plan incase you are on it.

Now that we have editorInputs available in NotebookInput, I will spend some time to reuse these inputs wherever needed. Eg: confrimSave, isDirty etc.

Please see below screenshot 

![image](https://user-images.githubusercontent.com/44002319/54253490-9009db80-450c-11e9-862c-0ce4f2e5d28a.png)
