### PR TITLE
Fix Issue when OE connection Disconnects on Notebook Close

### DIFF
--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -437,6 +437,7 @@ export class AttachToDropdown extends SelectBox {
 				}
 				this.select(index);
 
+				this.model.addAttachToConnectionsToBeDisposed(connectionProfile);
 				// Call doChangeContext to set the newly chosen connection in the model
 				this.doChangeContext(connectionProfile);
 			});

--- a/src/sql/platform/connection/common/connectionManagementService.ts
+++ b/src/sql/platform/connection/common/connectionManagementService.ts
@@ -379,7 +379,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	 * otherwise tries to make a connection and returns the owner uri when connection is complete
 	 * The purpose is connection by default
 	 */
-	public connectIfNotConnected(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection', saveConnection: boolean = false): Promise<string> {
+	public connectIfNotConnected(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection' | 'notebook', saveConnection: boolean = false): Promise<string> {
 		return new Promise<string>((resolve, reject) => {
 			let ownerUri: string = Utils.generateUri(connection, purpose);
 			if (this._connectionStatusManager.isConnected(ownerUri)) {
@@ -1156,7 +1156,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	 * Finds existing connection for given profile and purpose is any exists.
 	 * The purpose is connection by default
 	 */
-	public findExistingConnection(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection'): ConnectionProfile {
+	public findExistingConnection(connection: IConnectionProfile, purpose?: 'dashboard' | 'insights' | 'connection' | 'notebook'): ConnectionProfile {
 		let connectionUri = Utils.generateUri(connection, purpose);
 		let existingConnection = this._connectionStatusManager.findConnection(connectionUri);
 		if (existingConnection && this._connectionStatusManager.isConnected(connectionUri)) {

--- a/src/sql/platform/connection/common/utils.ts
+++ b/src/sql/platform/connection/common/utils.ts
@@ -17,7 +17,8 @@ export const uriPrefixes = {
 	default: 'connection://',
 	connection: 'connection://',
 	dashboard: 'dashboard://',
-	insights: 'insights://'
+	insights: 'insights://',
+	notebook: 'notebook://'
 };
 
 


### PR DESCRIPTION
Fixes #4383.

I spent a decent amount of time thinking about this problem, and came up with the following solution due to the following reasons:

- We only currently connect using the ConnectionManagementService in SQL (for the purposes of IntelliSense) for all of the notebooks code, and for the Add new connection scenario in the Attach To
- Any new connections from notebooks (besides Attach To [is there a way to include a purpose to simplify this code even more?]) should include the 'notebook' tag when generating the connection URI (we already do this today)
- I don't want to create new connections when they aren't strictly necessary, and would much prefer pruning them instead of creating new ones

Therefore, when we're closing the notebook, we should only be disconnecting from connections that were created in the notebook, and those that were created in Attach To (since those won't be reused).