### PR TITLE
Change Kernels Dropdown to show Changing instead of Loading On Kernel Change

### DIFF
--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -23,13 +23,14 @@ import { noKernel } from 'sql/workbench/services/notebook/common/sessionManager'
 import { IConnectionDialogService } from 'sql/workbench/services/connection/common/connectionDialogService';
 import { NotebookModel } from 'sql/parts/notebook/models/notebookModel';
 
-const msgLoading = localize('loading', 'Loading kernels...');
-const kernelLabel: string = localize('Kernel', 'Kernel: ');
-const attachToLabel: string = localize('AttachTo', 'Attach to: ');
-const msgLoadingContexts = localize('loadingContexts', 'Loading contexts...');
-const msgAddNewConnection = localize('addNewConnection', 'Add new connection');
-const msgSelectConnection = localize('selectConnection', 'Select connection');
-const msgLocalHost = localize('localhost', 'localhost');
+const msgLoading = localize('loading', "Loading kernels...");
+const msgSwitching = localize('switching', "Switching kernels...");
+const kernelLabel: string = localize('Kernel', "Kernel: ");
+const attachToLabel: string = localize('AttachTo', "Attach to: ");
+const msgLoadingContexts = localize('loadingContexts', "Loading contexts...");
+const msgAddNewConnection = localize('addNewConnection', "Add new connection");
+const msgSelectConnection = localize('selectConnection', "Select connection");
+const msgLocalHost = localize('localhost', "localhost");
 const HIDE_ICON_CLASS = ' hideIcon';
 
 // Action to add a cell to notebook based on cell type(code/markdown).
@@ -250,7 +251,7 @@ export class KernelsDropdown extends SelectBox {
 	}
 
 	public doChangeKernel(displayName: string): void {
-		this.setOptions([msgLoading], 0);
+		this.setOptions([msgSwitching], 0);
 		this.model.changeKernel(displayName);
 	}
 }

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -24,7 +24,7 @@ import { IConnectionDialogService } from 'sql/workbench/services/connection/comm
 import { NotebookModel } from 'sql/parts/notebook/models/notebookModel';
 
 const msgLoading = localize('loading', "Loading kernels...");
-const msgSwitching = localize('switching', "Switching kernels...");
+const msgChanging = localize('changing', "Changing kernel...");
 const kernelLabel: string = localize('Kernel', "Kernel: ");
 const attachToLabel: string = localize('AttachTo', "Attach to: ");
 const msgLoadingContexts = localize('loadingContexts', "Loading contexts...");
@@ -251,7 +251,7 @@ export class KernelsDropdown extends SelectBox {
 	}
 
 	public doChangeKernel(displayName: string): void {
-		this.setOptions([msgSwitching], 0);
+		this.setOptions([msgChanging], 0);
 		this.model.changeKernel(displayName);
 	}
 }


### PR DESCRIPTION
@vickyharp gave feedback that showing "Loading kernels..." is confusing when a kernel change is ongoing.

Synced with @ronychatterjee, and we came up with the string "Switching kernels..." to use in this instance instead. We still show loading initially.