### PR TITLE
#4441:Revert notebook editor when "don't save" selected

### DIFF
--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -164,6 +164,10 @@ export class NotebookInput extends EditorInput {
 		return this._model.confirmSave();
 	}
 
+	public revert(): TPromise<boolean> {
+		return this._textInput.revert();
+	}
+
 	public get notebookUri(): URI {
 		return this.resource;
 	}


### PR DESCRIPTION
Adding revert method from UntitledEditorInput and FileEditorInput. 
This would delete notebook editor from cache when "don't save" is selected  part of "Confirm Save" functionality.