### PR TITLE
Put back code to refresh tree when capabilities provider gets new capabilities

### DIFF
--- a/src/sql/parts/objectExplorer/viewlet/serverTreeView.ts
+++ b/src/sql/parts/objectExplorer/viewlet/serverTreeView.ts
@@ -32,6 +32,7 @@ import { TreeNode, TreeItemCollapsibleState } from 'sql/parts/objectExplorer/com
 import { SERVER_GROUP_CONFIG, SERVER_GROUP_AUTOEXPAND_CONFIG } from 'sql/parts/objectExplorer/serverGroupDialog/serverGroup.contribution';
 import { IErrorMessageService } from 'sql/platform/errorMessage/common/errorMessageService';
 import { ServerTreeActionProvider } from 'sql/parts/objectExplorer/viewlet/serverTreeActionProvider';
+import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 
 const $ = builder.$;
 
@@ -54,7 +55,8 @@ export class ServerTreeView {
 		@IObjectExplorerService private _objectExplorerService: IObjectExplorerService,
 		@IThemeService private _themeService: IThemeService,
 		@IErrorMessageService private _errorMessageService: IErrorMessageService,
-		@IConfigurationService private _configurationService: IConfigurationService
+		@IConfigurationService private _configurationService: IConfigurationService,
+		@ICapabilitiesService capabilitiesService: ICapabilitiesService
 	) {
 		this._activeConnectionsFilterAction = this._instantiationService.createInstance(
 			ActiveConnectionsFilterAction,
@@ -64,6 +66,12 @@ export class ServerTreeView {
 		this._treeSelectionHandler = this._instantiationService.createInstance(TreeSelectionHandler);
 		this._onSelectionOrFocusChange = new Emitter();
 		this._actionProvider = this._instantiationService.createInstance(ServerTreeActionProvider);
+		capabilitiesService.onCapabilitiesRegistered(() => {
+			if (this._connectionManagementService.hasRegisteredServers()) {
+				this.refreshTree();
+				this._treeSelectionHandler.onTreeActionStateChange(false);
+			}
+		});
 	}
 
 	/**

--- a/src/sqltest/parts/connection/connectionTreeActions.test.ts
+++ b/src/sqltest/parts/connection/connectionTreeActions.test.ts
@@ -205,7 +205,7 @@ suite('SQL Connection Tree Action tests', () => {
 			return new TPromise((resolve) => resolve({}));
 		});
 
-		let serverTreeView = TypeMoq.Mock.ofType(ServerTreeView, TypeMoq.MockBehavior.Strict, undefined, instantiationService.object, undefined, undefined, undefined);
+		let serverTreeView = TypeMoq.Mock.ofType(ServerTreeView, TypeMoq.MockBehavior.Strict, undefined, instantiationService.object, undefined, undefined, undefined, undefined, capabilitiesService);
 		serverTreeView.setup(x => x.showFilteredTree(TypeMoq.It.isAnyString()));
 		serverTreeView.setup(x => x.refreshTree());
 		let connectionTreeAction: ActiveConnectionsFilterAction = new ActiveConnectionsFilterAction(ActiveConnectionsFilterAction.ID, ActiveConnectionsFilterAction.LABEL, serverTreeView.object, connectionManagementService.object);
@@ -222,7 +222,7 @@ suite('SQL Connection Tree Action tests', () => {
 			return new TPromise((resolve) => resolve({}));
 		});
 
-		let serverTreeView = TypeMoq.Mock.ofType(ServerTreeView, TypeMoq.MockBehavior.Strict, undefined, instantiationService.object, undefined, undefined, undefined);
+		let serverTreeView = TypeMoq.Mock.ofType(ServerTreeView, TypeMoq.MockBehavior.Strict, undefined, instantiationService.object, undefined, undefined, undefined, undefined, capabilitiesService);
 		serverTreeView.setup(x => x.showFilteredTree(TypeMoq.It.isAnyString()));
 		serverTreeView.setup(x => x.refreshTree());
 		let connectionTreeAction: ActiveConnectionsFilterAction = new ActiveConnectionsFilterAction(ActiveConnectionsFilterAction.ID, ActiveConnectionsFilterAction.LABEL, serverTreeView.object, connectionManagementService.object);
@@ -240,7 +240,7 @@ suite('SQL Connection Tree Action tests', () => {
 			return new TPromise((resolve) => resolve({}));
 		});
 
-		let serverTreeView = TypeMoq.Mock.ofType(ServerTreeView, TypeMoq.MockBehavior.Strict, undefined, instantiationService.object, undefined, undefined, undefined);
+		let serverTreeView = TypeMoq.Mock.ofType(ServerTreeView, TypeMoq.MockBehavior.Strict, undefined, instantiationService.object, undefined, undefined, undefined, undefined, capabilitiesService);
 		serverTreeView.setup(x => x.showFilteredTree(TypeMoq.It.isAnyString()));
 		serverTreeView.setup(x => x.refreshTree());
 		let connectionTreeAction: RecentConnectionsFilterAction = new RecentConnectionsFilterAction(RecentConnectionsFilterAction.ID, RecentConnectionsFilterAction.LABEL, serverTreeView.object, connectionManagementService.object);
@@ -257,7 +257,7 @@ suite('SQL Connection Tree Action tests', () => {
 			return new TPromise((resolve) => resolve({}));
 		});
 
-		let serverTreeView = TypeMoq.Mock.ofType(ServerTreeView, TypeMoq.MockBehavior.Strict, undefined, instantiationService.object, undefined, undefined, undefined);
+		let serverTreeView = TypeMoq.Mock.ofType(ServerTreeView, TypeMoq.MockBehavior.Strict, undefined, instantiationService.object, undefined, undefined, undefined, undefined, capabilitiesService);
 		serverTreeView.setup(x => x.showFilteredTree(TypeMoq.It.isAnyString()));
 		serverTreeView.setup(x => x.refreshTree());
 		let connectionTreeAction: RecentConnectionsFilterAction = new RecentConnectionsFilterAction(RecentConnectionsFilterAction.ID, RecentConnectionsFilterAction.LABEL, serverTreeView.object, connectionManagementService.object);

--- a/src/sqltest/stubs/capabilitiesTestService.ts
+++ b/src/sqltest/stubs/capabilitiesTestService.ts
@@ -138,6 +138,10 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 		return Promise.resolve(null);
 	}
 
+	public fireCapabilitiesRegistered(providerFeatures: ProviderFeatures): void {
+		this._onCapabilitiesRegistered.fire(providerFeatures);
+	}
+
 	private _onCapabilitiesRegistered = new Emitter<ProviderFeatures>();
 	public readonly onCapabilitiesRegistered = this._onCapabilitiesRegistered.event;
 }


### PR DESCRIPTION
This should fix #4445 though I didn't have a great repro for it. @kburtram if you can still repro this could you try out this fix?

@anthonydresser the code I'm adding back here was removed in #880 which makes me think this may not be the right long term solution. Is it ok for now or is there something better you'd suggest?