### PR TITLE
Show running state in cell toolbar immediately when cell is run

### DIFF
--- a/src/sql/parts/notebook/models/cell.ts
+++ b/src/sql/parts/notebook/models/cell.ts
@@ -212,12 +212,12 @@ export class CellModel implements ICellModel {
 				// TODO update source based on editor component contents
 				let content = this.source;
 				if (content) {
-					this.fireExecutionStateChanged();
 					let future = await kernel.requestExecute({
 						code: content,
 						stop_on_error: true
 					}, false);
 					this.setFuture(future as FutureInternal);
+					this.fireExecutionStateChanged();
 					// For now, await future completion. Later we should just track and handle cancellation based on model notifications
 					let result: nb.IExecuteReplyMsg = <nb.IExecuteReplyMsg><any>await future.done;
 					if (result && result.content) {


### PR DESCRIPTION
Fixes #4483.

When getting the current executionState, we were looking for the existence of a future to determine if a cell was running. However, we were firing the executionStateChanged event too early (before a future existed). Because of this, we wouldn't show a cell as running until we stopped hovering over the button (and the event had been fired by that point where a future existed).

This is a usability issue that like 3 people have brought up today alone. Not a regression, but we really should fix for the release. It's a 1 line change and helps responsiveness tremendously.