### PR TITLE
Fix #4029 Ensure changeKernels always resolves, even in error states

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerManager.ts
@@ -62,7 +62,7 @@ export class LocalJupyterServerManager implements nb.ServerManager, vscode.Dispo
 			this._onServerStarted.fire();
 
 		} catch (error) {
-			this.apiWrapper.showErrorMessage(localize('startServerFailed', 'Starting local Notebook server failed with error: {0}', utils.getErrorMessage(error)));
+			// this is caught and notified up the stack, no longer showing a message here
 			throw error;
 		}
 	}

--- a/src/sql/parts/notebook/models/clientSession.ts
+++ b/src/sql/parts/notebook/models/clientSession.ts
@@ -9,9 +9,9 @@
 'use strict';
 
 import { nb } from 'azdata';
-import * as nls from 'vs/nls';
 import { URI } from 'vs/base/common/uri';
 import { Event, Emitter } from 'vs/base/common/event';
+import { localize } from 'vs/nls';
 
 import { IClientSession, IKernelPreference, IClientSessionOptions } from './modelInterfaces';
 import { Deferred } from 'sql/base/common/promise';
@@ -70,7 +70,7 @@ export class ClientSession implements IClientSession {
 			await this.initializeSession();
 			await this.updateCachedKernelSpec();
 		} catch (err) {
-			this._errorMessage = notebookUtils.getErrorMessage(err);
+			this._errorMessage = notebookUtils.getErrorMessage(err) || localize('clientSession.unknownError', 'An error occurred while starting the notebook session');
 		}
 		// Always resolving for now. It's up to callers to check for error case
 		this._isReady = true;
@@ -85,7 +85,7 @@ export class ClientSession implements IClientSession {
 		if (serverManager && !serverManager.isStarted) {
 			await serverManager.startServer();
 			if (!serverManager.isStarted) {
-				throw new Error(nls.localize('ServerNotStarted', 'Server did not start for unknown reason'));
+				throw new Error(localize('ServerNotStarted', 'Server did not start for unknown reason'));
 			}
 			this.isServerStarted = serverManager.isStarted;
 		} else {
@@ -118,7 +118,7 @@ export class ClientSession implements IClientSession {
 		} catch (err) {
 			// TODO move registration
 			if (err && err.response && err.response.status === 501) {
-				this.options.notificationService.warn(nls.localize('kernelRequiresConnection', 'Kernel {0} was not found. The default kernel will be used instead.', kernelName));
+				this.options.notificationService.warn(localize('kernelRequiresConnection', 'Kernel {0} was not found. The default kernel will be used instead.', kernelName));
 				session = await this.notebookManager.sessionManager.startNew({
 					path: this.notebookUri.fsPath,
 					kernelName: undefined

--- a/src/sql/parts/notebook/models/clientSession.ts
+++ b/src/sql/parts/notebook/models/clientSession.ts
@@ -70,7 +70,7 @@ export class ClientSession implements IClientSession {
 			await this.initializeSession();
 			await this.updateCachedKernelSpec();
 		} catch (err) {
-			this._errorMessage = notebookUtils.getErrorMessage(err) || localize('clientSession.unknownError', 'An error occurred while starting the notebook session');
+			this._errorMessage = notebookUtils.getErrorMessage(err) || localize('clientSession.unknownError', "An error occurred while starting the notebook session");
 		}
 		// Always resolving for now. It's up to callers to check for error case
 		this._isReady = true;
@@ -85,7 +85,7 @@ export class ClientSession implements IClientSession {
 		if (serverManager && !serverManager.isStarted) {
 			await serverManager.startServer();
 			if (!serverManager.isStarted) {
-				throw new Error(localize('ServerNotStarted', 'Server did not start for unknown reason'));
+				throw new Error(localize('ServerNotStarted', "Server did not start for unknown reason"));
 			}
 			this.isServerStarted = serverManager.isStarted;
 		} else {
@@ -118,7 +118,7 @@ export class ClientSession implements IClientSession {
 		} catch (err) {
 			// TODO move registration
 			if (err && err.response && err.response.status === 501) {
-				this.options.notificationService.warn(localize('kernelRequiresConnection', 'Kernel {0} was not found. The default kernel will be used instead.', kernelName));
+				this.options.notificationService.warn(localize('kernelRequiresConnection', "Kernel {0} was not found. The default kernel will be used instead.", kernelName));
 				session = await this.notebookManager.sessionManager.startNew({
 					path: this.notebookUri.fsPath,
 					kernelName: undefined

--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -354,7 +354,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				cellIndex: index
 			});
 		} else {
-			this.notifyError(localize('deleteCellFailed', 'Failed to delete cell.'));
+			this.notifyError(localize('deleteCellFailed', "Failed to delete cell."));
 		}
 	}
 
@@ -582,12 +582,13 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						await this.updateKernelInfoOnKernelChange(kernel);
 					} catch (err2) {
 						// TODO should we handle this in any way?
+						console.log(`doChangeKernel: ignoring error ${notebookUtils.getErrorMessage(err2)}`);
 					}
 				}
 			}
 		} catch (err) {
 			if (oldDisplayName && restoreOnFail) {
-				this.notifyError(localize('changeKernelFailedRetry', 'Failed to change kernel. Kernel {0} will be used. Error was: {1}', oldDisplayName, notebookUtils.getErrorMessage(err)));
+				this.notifyError(localize('changeKernelFailedRetry', "Failed to change kernel. Kernel {0} will be used. Error was: {1}", oldDisplayName, notebookUtils.getErrorMessage(err)));
 				// Clear out previous kernel
 				let failedProviderId = this.tryFindProviderForKernel(displayName, true);
 				let oldProviderId = this.tryFindProviderForKernel(oldDisplayName, true);
@@ -598,7 +599,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				}
 				return this.doChangeKernel(oldDisplayName, mustSetProvider, false);
 			} else {
-				this.notifyError(localize('changeKernelFailed', 'Failed to change kernel due to error: {0}', notebookUtils.getErrorMessage(err)));
+				this.notifyError(localize('changeKernelFailed', "Failed to change kernel due to error: {0}", notebookUtils.getErrorMessage(err)));
 				this._kernelChangedEmitter.fire({
 					newValue: undefined,
 					oldValue: undefined
@@ -660,7 +661,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				});
 		} catch (err) {
 			let msg = notebookUtils.getErrorMessage(err);
-			this.notifyError(localize('changeContextFailed', 'Changing context failed: {0}', msg));
+			this.notifyError(localize('changeContextFailed', "Changing context failed: {0}", msg));
 		}
 	}
 
@@ -739,7 +740,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	private setErrorState(errMsg: string): void {
 		this._inErrorState = true;
-		let msg = localize('startSessionFailed', 'Could not start session: {0}', errMsg);
+		let msg = localize('startSessionFailed', "Could not start session: {0}", errMsg);
 		this.notifyError(msg);
 
 	}
@@ -766,7 +767,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			}
 			await this.shutdownActiveSession();
 		} catch (err) {
-			this.notifyError(localize('shutdownError', 'An error occurred when closing the notebook: {0}', err));
+			this.notifyError(localize('shutdownError', "An error occurred when closing the notebook: {0}", err));
 		}
 	}
 
@@ -776,7 +777,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				await this._activeClientSession.ready;
 			}
 			catch (err) {
-				this.notifyError(localize('shutdownClientSessionError', 'A client session error occurred when closing the notebook: {0}', err));
+				this.notifyError(localize('shutdownClientSessionError', "A client session error occurred when closing the notebook: {0}", err));
 			}
 			await this._activeClientSession.shutdown();
 			this.clearClientSessionListeners();

--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -250,7 +250,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		this._model = this._register(model);
 		this.updateToolbarComponents(this._model.trustedMode);
 		this._modelRegisteredDeferred.resolve(this._model);
-		await model.startSession(this.model.notebookManager);
+		await model.startSession(this.model.notebookManager, undefined, true);
 		this.detectChanges();
 	}
 

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -235,6 +235,10 @@ export class KernelsDropdown extends SelectBox {
 		this._register(this.model.kernelChanged((changedArgs: azdata.nb.IKernelChangedArgs) => {
 			this.updateKernel(changedArgs.newValue);
 		}));
+		let kernel = this.model.clientSession && this.model.clientSession.kernel;
+		if (kernel && kernel.isReady) {
+			this.updateKernel(kernel);
+		}
 	}
 
 	// Update SelectBox values
@@ -283,22 +287,24 @@ export class AttachToDropdown extends SelectBox {
 	public updateModel(model: INotebookModel): void {
 		this.model = model as NotebookModel;
 		this._register(model.contextsChanged(() => {
-			let kernelDisplayName: string = this.getKernelDisplayName();
-			if (kernelDisplayName) {
-				this.loadAttachToDropdown(this.model, kernelDisplayName);
-			}
+			this.handleContextsChanged();
 		}));
 		this._register(this.model.contextsLoading(() => {
 			this.setOptions([msgLoadingContexts], 0);
 		}));
+		this.handleContextsChanged();
+	}
+
+	private handleContextsChanged(showSelectConnection?: boolean) {
+		let kernelDisplayName: string = this.getKernelDisplayName();
+		if (kernelDisplayName) {
+			this.loadAttachToDropdown(this.model, kernelDisplayName);
+		}
 	}
 
 	private updateAttachToDropdown(model: INotebookModel): void {
 		model.onValidConnectionSelected(validConnection => {
-			let kernelDisplayName: string = this.getKernelDisplayName();
-			if (kernelDisplayName) {
-				this.loadAttachToDropdown(this.model, kernelDisplayName, !validConnection);
-			}
+			this.handleContextsChanged(!validConnection);
 		});
 	}
 

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -236,21 +236,23 @@ export class KernelsDropdown extends SelectBox {
 			this.updateKernel(changedArgs.newValue);
 		}));
 		let kernel = this.model.clientSession && this.model.clientSession.kernel;
-		if (kernel && kernel.isReady) {
-			this.updateKernel(kernel);
-		}
+		this.updateKernel(kernel);
 	}
 
 	// Update SelectBox values
 	public updateKernel(kernel: azdata.nb.IKernel) {
-		if (kernel) {
+		let kernels: string[] = this.model.standardKernelsDisplayName();
+		if (kernel && kernel.isReady) {
 			let standardKernel = this.model.getStandardKernelFromName(kernel.name);
 
-			let kernels: string[] = this.model.standardKernelsDisplayName();
 			if (kernels && standardKernel) {
 				let index = kernels.findIndex((kernel => kernel === standardKernel.displayName));
 				this.setOptions(kernels, index);
 			}
+		} else if (this.model.clientSession.isInErrorState) {
+			let noKernelName = localize('noKernel', "No Kernel");
+			kernels.unshift(noKernelName);
+			this.setOptions(kernels, 0);
 		}
 	}
 
@@ -298,7 +300,9 @@ export class AttachToDropdown extends SelectBox {
 	private handleContextsChanged(showSelectConnection?: boolean) {
 		let kernelDisplayName: string = this.getKernelDisplayName();
 		if (kernelDisplayName) {
-			this.loadAttachToDropdown(this.model, kernelDisplayName);
+			this.loadAttachToDropdown(this.model, kernelDisplayName, showSelectConnection);
+		} else if (this.model.clientSession.isInErrorState) {
+			this.setOptions([localize('noContextAvailable', "None")], 0);
 		}
 	}
 

--- a/src/sql/workbench/api/node/extHostNotebook.ts
+++ b/src/sql/workbench/api/node/extHostNotebook.ts
@@ -81,23 +81,27 @@ export class ExtHostNotebook implements ExtHostNotebookShape {
 
 	$startNewSession(managerHandle: number, options: azdata.nb.ISessionOptions): Thenable<INotebookSessionDetails> {
 		return this._withSessionManager(managerHandle, async (sessionManager) => {
-			let session = await sessionManager.startNew(options);
-			let sessionId = this._addNewAdapter(session);
-			let kernelDetails: INotebookKernelDetails = undefined;
-			if (session.kernel) {
-				kernelDetails = this.saveKernel(session.kernel);
+			try {
+				let session = await sessionManager.startNew(options);
+				let sessionId = this._addNewAdapter(session);
+				let kernelDetails: INotebookKernelDetails = undefined;
+				if (session.kernel) {
+					kernelDetails = this.saveKernel(session.kernel);
+				}
+				let details: INotebookSessionDetails = {
+					sessionId: sessionId,
+					id: session.id,
+					path: session.path,
+					name: session.name,
+					type: session.type,
+					status: session.status,
+					canChangeKernels: session.canChangeKernels,
+					kernelDetails: kernelDetails
+				};
+				return details;
+			} catch (error) {
+				throw typeof(error) === 'string' ? new Error(error) : error;
 			}
-			let details: INotebookSessionDetails = {
-				sessionId: sessionId,
-				id: session.id,
-				path: session.path,
-				name: session.name,
-				type: session.type,
-				status: session.status,
-				canChangeKernels: session.canChangeKernels,
-				kernelDetails: kernelDetails
-			};
-			return details;
 		});
 	}
 

--- a/src/sql/workbench/api/node/extHostNotebook.ts
+++ b/src/sql/workbench/api/node/extHostNotebook.ts
@@ -271,7 +271,16 @@ export class ExtHostNotebook implements ExtHostNotebookShape {
 		if (manager === undefined) {
 			return TPromise.wrapError<R>(new Error(localize('errNoManager', 'No Manager found')));
 		}
-		return TPromise.wrap(callback(manager));
+		return TPromise.wrap(this.callbackWithErrorWrap<R>(callback, manager));
+	}
+
+	private async callbackWithErrorWrap<R>(callback: (manager: NotebookManagerAdapter) => R | PromiseLike<R>, manager: NotebookManagerAdapter): Promise<R> {
+		try {
+			let value = await callback(manager);
+			return value;
+		} catch (error) {
+			throw typeof(error) === 'string' ? new Error(error) : error;
+		}
 	}
 
 	private _withServerManager<R>(handle: number, callback: (manager: azdata.nb.ServerManager) => R | PromiseLike<R>): TPromise<R> {


### PR DESCRIPTION
This is necessary to unblock reverting the kernel on canceling  Python install
- startSession now correctly sets up kernel information, since a kernel is loaded there.
- Remove call to change kernel on session initialize. This isn't needed due to refactor
- Handle kernel change failure by attempting to fall back to old kernel
- ExtensionHost $startNewSession now ensures errors are sent across the wire.
- Update AttachTo and Kernel dropdowns so they handle kernel being available. This is needed since other changes mean the session is likely ready before these get going