### PR TITLE
Add config for running extension tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -147,7 +147,23 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			]
-		}
+        },
+        {
+			"type": "chrome",
+			"request": "launch",
+            "name": "Run Extension Tests",
+			"windows": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions.bat"
+			},
+			"osx": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions.sh"
+			},
+			"linux": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions.sh"
+            },
+			"webRoot": "${workspaceFolder}",
+			"timeout": 45000
+		},
 	],
 	"compounds": [
 		{
@@ -156,7 +172,14 @@
 				"Attach to azuredatastudio",
 				"Run Unit Tests"
 			]
-		},
+        },
+        {
+            "name": "Debug Extension Tests",
+            "configurations": [
+                "Attach to Extension Host",
+                "Run Extension Tests"
+            ]
+        },
 		{
 			"name": "Debug azuredatastudio Main and Renderer",
 			"configurations": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -151,12 +151,12 @@
         {
 			"type": "chrome",
 			"request": "launch",
-            "name": "Run Extension Tests",
+            "name": "Run Extension Unit Tests",
 			"windows": {
-				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions.bat"
+				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions-unit.bat"
 			},
 			"osx": {
-				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions.sh"
+				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions-unit.sh"
 			},
 			"linux": {
 				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions.sh"
@@ -174,10 +174,10 @@
 			]
         },
         {
-            "name": "Debug Extension Tests",
+            "name": "Debug Extension Unit Tests",
             "configurations": [
                 "Attach to Extension Host",
-                "Run Extension Tests"
+                "Run Extension Unit Tests"
             ]
         },
 		{

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -147,11 +147,11 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			]
-        },
-        {
+		},
+		{
 			"type": "chrome",
 			"request": "launch",
-            "name": "Run Extension Unit Tests",
+			"name": "Run Extension Unit Tests",
 			"windows": {
 				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions-unit.bat"
 			},
@@ -159,8 +159,8 @@
 				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions-unit.sh"
 			},
 			"linux": {
-				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions.sh"
-            },
+				"runtimeExecutable": "${workspaceFolder}/scripts/test-extensions-unit.sh"
+			},
 			"webRoot": "${workspaceFolder}",
 			"timeout": 45000
 		},
@@ -172,14 +172,14 @@
 				"Attach to azuredatastudio",
 				"Run Unit Tests"
 			]
-        },
-        {
-            "name": "Debug Extension Unit Tests",
-            "configurations": [
-                "Attach to Extension Host",
-                "Run Extension Unit Tests"
-            ]
-        },
+		},
+		{
+			"name": "Debug Extension Unit Tests",
+			"configurations": [
+				"Attach to Extension Host",
+				"Run Extension Unit Tests"
+			]
+		},
 		{
 			"name": "Debug azuredatastudio Main and Renderer",
 			"configurations": [

--- a/scripts/test-extensions-unit.bat
+++ b/scripts/test-extensions-unit.bat
@@ -1,3 +1,5 @@
+:: Runs unit tests for Extensions
+
 setlocal
 
 pushd %~dp0\..

--- a/scripts/test-extensions-unit.sh
+++ b/scripts/test-extensions-unit.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+# Runs unit tests for Extensions
 set -e
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/test-extensions.bat
+++ b/scripts/test-extensions.bat
@@ -1,0 +1,20 @@
+setlocal
+
+pushd %~dp0\..
+
+set VSCODEUSERDATADIR=%TMP%\adsuser-%RANDOM%-%TIME:~6,5%
+set VSCODEEXTENSIONSDIR=%TMP%\adsext-%RANDOM%-%TIME:~6,5%
+echo %VSCODEUSERDATADIR%
+echo %VSCODEEXTENSIONSDIR%
+@echo OFF
+
+call .\scripts\code.bat --extensionDevelopmentPath=%~dp0\..\extensions\notebook --extensionTestsPath=%~dp0\..\extensions\notebook\out\test --user-data-dir=%VSCODEUSERDATADIR% --extensions-dir=%VSCODEEXTENSIONSDIR% --remote-debugging-port=9222
+
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+rmdir /s /q %VSCODEUSERDATADIR%
+rmdir /s /q %VSCODEEXTENSIONSDIR%
+
+popd
+
+endlocal


### PR DESCRIPTION
Add .bat for running extension unit tests (not full integration tests, currently only Notebook) and set up launch.json with 2 new launch configs for running & debugging extension tests.