### PR TITLE
Add needs repro closer bot

### DIFF
--- a/.github/needs_more_info.yml
+++ b/.github/needs_more_info.yml
@@ -1,6 +1,6 @@
 {
   daysUntilClose: 7,
-  needsMoreInfoLabel: 'more info',
-  perform: false,
-  closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity. See also our [issue reporting](https://aka.ms/vscodeissuereporting) guidelines.\n\nHappy Coding!"
+  needsMoreInfoLabel: 'needs repro',
+  perform: true,
+  closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity in the last 7 days. If you have more info to help resolve the issue, leave a comment"
 }

--- a/.github/needs_more_info.yml
+++ b/.github/needs_more_info.yml
@@ -1,6 +1,6 @@
 {
   daysUntilClose: 7,
-  needsMoreInfoLabel: 'needs info',
+  needsMoreInfoLabel: 'needs more info',
   perform: true,
   closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity in the last 7 days. If you have more info to help resolve the issue, leave a comment"
 }

--- a/.github/needs_more_info.yml
+++ b/.github/needs_more_info.yml
@@ -1,6 +1,6 @@
 {
   daysUntilClose: 7,
-  needsMoreInfoLabel: 'needs repro',
+  needsMoreInfoLabel: 'needs info',
   perform: true,
   closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity in the last 7 days. If you have more info to help resolve the issue, leave a comment"
 }


### PR DESCRIPTION
Changes the message that it leaves per @yualan and enables. Right now it will only listen for the `needs repro` label, we may want to make it `needs info` and change the `needs repro` label to `needs info`.

For a list of issues that this will close atm: refer to #4209