### PR TITLE
FIX #4513 Notebook stuck at changing kernel

### DIFF
--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -567,11 +567,17 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	}
 
 	private async doChangeKernel(displayName: string, mustSetProvider: boolean = true, restoreOnFail: boolean = true): Promise<void> {
+		if (!displayName) {
+			// Can't change to an undefined kernel
+			return;
+		}
 		let oldDisplayName = this._activeClientSession && this._activeClientSession.kernel ? this._activeClientSession.kernel.name : undefined;
 		try {
 			let changeKernelNeeded = true;
 			if (mustSetProvider) {
-				changeKernelNeeded = await this.setProviderIdAndStartSession(displayName);
+				let providerChanged = await this.tryStartSessionByChangingProviders(displayName);
+				// If provider was changed, no need to update kernels since a brand new session was created.
+				changeKernelNeeded = !providerChanged;
 			}
 			if (changeKernelNeeded) {
 				let spec = this.findSpec(displayName);
@@ -831,7 +837,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	 * Set _providerId and start session if it is new provider
 	 * @param displayName Kernel dispay name
 	 */
-	private async setProviderIdAndStartSession(displayName: string): Promise<boolean> {
+	private async tryStartSessionByChangingProviders(displayName: string): Promise<boolean> {
 		if (displayName) {
 			if (this._activeClientSession && this._activeClientSession.isReady) {
 				this._oldKernel = this._activeClientSession.kernel;
@@ -855,7 +861,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return false;
 	}
 
-	private tryFindProviderForKernel(displayName: string, alwaysReturnId: boolean = false) {
+	private tryFindProviderForKernel(displayName: string, alwaysReturnId: boolean = false): string {
 		if (!displayName) {
 			return undefined;
 		}

--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -576,7 +576,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			let changeKernelNeeded = true;
 			if (mustSetProvider) {
 				let providerChanged = await this.tryStartSessionByChangingProviders(displayName);
-				// If provider was changed, no need to update kernels since a brand new session was created.
+				// If provider was changed, a new session with new kernel is already created. We can skip calling changeKernel.
 				changeKernelNeeded = !providerChanged;
 			}
 			if (changeKernelNeeded) {


### PR DESCRIPTION
- Intra-provider kernel change didn't happen because we only tried changing kernel on new session creation.
- Inverted the logic (e.g. did the right thing) and renamed the method so it's clearer what we're doing & what the boolean value should be
- Manually tested all the known scenarios