### PR TITLE
#3476 Fix ADS dropdown flickering

### DIFF
--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -154,11 +154,13 @@ export class SelectBox extends vsSelectBox {
 	public showMessage(message: IMessage): void {
 		this.message = message;
 
-		dom.removeClass(this.element, 'idle');
-		dom.removeClass(this.element, 'info');
-		dom.removeClass(this.element, 'warning');
-		dom.removeClass(this.element, 'error');
-		dom.addClass(this.element, this.classForType(message.type));
+		if (this.element) {
+			dom.removeClass(this.element, 'idle');
+			dom.removeClass(this.element, 'info');
+			dom.removeClass(this.element, 'warning');
+			dom.removeClass(this.element, 'error');
+			dom.addClass(this.element, this.classForType(message.type));
+		}
 
 		// ARIA Support
 		let alertText: string;
@@ -213,8 +215,6 @@ export class SelectBox extends vsSelectBox {
 	}
 
 	public hideMessage(): void {
-		this.message = null;
-
 		dom.removeClass(this.element, 'info');
 		dom.removeClass(this.element, 'warning');
 		dom.removeClass(this.element, 'error');
@@ -222,10 +222,12 @@ export class SelectBox extends vsSelectBox {
 
 		this._hideMessage();
 		this.applyStyles();
+
+		this.message = null;
 	}
 
 	private _hideMessage(): void {
-		if (this.contextViewProvider) {
+		if (this.message && this.contextViewProvider) {
 			this.contextViewProvider.hideContextView();
 		}
 	}


### PR DESCRIPTION
#3476
Fix dropdowns flickering every other time they're opened. The hide message code was being invoked which called hideContextView (the actual dropdown part) even if no message was ever displayed. Now we'll delay setting the message to null and only call hideContextView if we actually had a message to display.

Also fixed small issue where messages that didn't have a container would throw an error when trying to call removeClass (since this.element is pulled from the container and thus was undefined.

Tested that the flicker is gone and that messages still show up correctly