### PR TITLE
#4365: Make notebook dirty when changing kernel

### DIFF
--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -47,6 +47,7 @@ export class NotebookEditorModel extends EditorModel {
 			if (notebook.id === this.notebookUri.toString()) {
 				// Hook to content change events
 				notebook.modelReady.then(() => {
+					this._register(notebook.model.kernelChanged(e => this.updateModel()));
 					this._register(notebook.model.contentChanged(e => this.updateModel()));
 				}, err => undefined);
 			}


### PR DESCRIPTION
Now that Kernel change is refactored, I have integrated kernelChanged event with Save. Notebooks shows dirty when we change kernel. Of course, we still need to work on reverting dirty which would take some investigation.

![image](https://user-images.githubusercontent.com/44002319/54461259-5235ce80-4729-11e9-99d7-e762616571cd.png)
