### PR TITLE
Fix missing Azure account name

### DIFF
--- a/src/sql/parts/accountManagement/accountDialog/media/accountDialog.css
+++ b/src/sql/parts/accountManagement/accountDialog/media/accountDialog.css
@@ -102,7 +102,3 @@
 .account-view .monaco-list .monaco-list-row.focused .list-row .actions-container{
 	display: block;
 }
-
-.account-view .monaco-list .monaco-list-row {
-
-}

--- a/src/sql/parts/accountManagement/accountDialog/media/accountDialog.css
+++ b/src/sql/parts/accountManagement/accountDialog/media/accountDialog.css
@@ -51,6 +51,7 @@
 
 .account-view .list-row {
 	padding: 12px;
+	line-height: 18px !important;
 }
 
 .account-view .list-row .icon {
@@ -100,4 +101,8 @@
 .account-view .monaco-list .monaco-list-row.selected .list-row .actions-container,
 .account-view .monaco-list .monaco-list-row.focused .list-row .actions-container{
 	display: block;
+}
+
+.account-view .monaco-list .monaco-list-row {
+
 }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/azuredatastudio/issues/4551.  It looks like something is explicitly setting monaco-list-rows to 77px.  The old height is 18px.  This seems the most targeted fix with least opportunity for side-effects.