### PR TITLE
Check error in webhdfs.sendRequest before trying to check response code.

### DIFF
--- a/extensions/mssql/src/objectExplorerNodeProvider/webhdfs.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/webhdfs.ts
@@ -213,11 +213,12 @@ export class WebHDFS {
 
 		request(requestParams, (error, response, body) => {
 			if (!callback) { return; }
-			if (this.isSuccess(response)) {
-				callback(undefined, response);
-			} else if (error || this.isError(response)) {
+
+			if (error || this.isError(response)) {
 				let hdfsError = this.parseError(response, body, error);
 				callback(hdfsError, response);
+			} else if (this.isSuccess(response)) {
+				callback(undefined, response);
 			} else {
 				let hdfsError = new HdfsError(
 					localize('webhdfs.unexpectedRedirect', 'Unexpected Redirect'),


### PR DESCRIPTION
If we get an error from request, then the response object may be null in the request callback. So we need to check the error before trying to check the response.