### PR TITLE
Fix extension bugs from VS Code 1.31 merge

### DIFF
--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -229,7 +229,7 @@ export class ExtensionManagementService extends Disposable implements IExtension
 								// Until there's a gallery for SQL Ops Studio, skip retrieving the metadata from the gallery
 								return this.installExtension({ zipPath, identifierWithVersion, metadata: null }, type, token)
 								.then(
-									local => this._onDidInstallExtension.fire({ identifier, zipPath, local, operation: InstallOperation.Install }),
+									local => { this._onDidInstallExtension.fire({ identifier, zipPath, local, operation: InstallOperation.Install }); return identifier; },
 									error => { this._onDidInstallExtension.fire({ identifier, zipPath, error, operation: InstallOperation.Install }); return Promise.reject(error); }
 								);
 								// return this.getMetadata(getGalleryExtensionId(manifest.publisher, manifest.name))

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
@@ -260,7 +260,8 @@ export class UninstallAction extends ExtensionAction {
 		alert(localize('uninstallExtensionStart', "Uninstalling extension {0} started.", this.extension.displayName));
 
 		return this.extensionsWorkbenchService.uninstall(this.extension).then(() => {
-			alert(localize('uninstallExtensionComplete', "Please reload Visual Studio Code to complete the uninstallation of the extension {0}.", this.extension.displayName));
+			// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+			alert(localize('uninstallExtensionComplete', "Please reload Azure Data Studio to complete the uninstallation of the extension {0}.", this.extension.displayName));
 		});
 	}
 }
@@ -1033,7 +1034,8 @@ export class ReloadAction extends ExtensionAction {
 						// Requires reload to run the updated extension
 						this.enabled = true;
 						this.label = localize('reloadRequired', "Reload Required");
-						this.tooltip = localize('postUpdateTooltip', "Please reload Visual Studio Code to complete the updating of this extension.");
+						// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+						this.tooltip = localize('postUpdateTooltip', "Please reload Azure Data Studio to complete the updating of this extension.");
 					}
 					return;
 				}
@@ -1041,7 +1043,8 @@ export class ReloadAction extends ExtensionAction {
 					// Requires reload to disable the extension
 					this.enabled = true;
 					this.label = localize('reloadRequired', "Reload Required");
-					this.tooltip = localize('postDisableTooltip', "Please reload Visual Studio Code to complete the disabling of this extension.");
+					// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+					this.tooltip = localize('postDisableTooltip', "Please reload Azure Data Studio to complete the disabling of this extension.");
 					return;
 				}
 			} else {
@@ -1049,11 +1052,13 @@ export class ReloadAction extends ExtensionAction {
 					this.enabled = true;
 					if (isEnabled) {
 						this.label = localize('reloadRequired', "Reload Required");
-						this.tooltip = localize('postEnableTooltip', "Please reload Visual Studio Code to complete the enabling of this extension.");
+						// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+						this.tooltip = localize('postEnableTooltip', "Please reload Azure Data Studio to complete the enabling of this extension.");
 					} else {
 						this.label = localize('reloadRequired', "Reload Required");
-						this.tooltip = localize('postInstallTooltip', "Please reload Visual Studio Code to complete the installation of this extension.");
-						alert(localize('installExtensionComplete', "Installing extension {0} is completed. Please reload Visual Studio Code to enable it.", this.extension.displayName));
+						// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+						this.tooltip = localize('postInstallTooltip', "Please reload Azure Data Studio to complete the installation of this extension.");
+						alert(localize('installExtensionComplete', "Installing extension {0} is completed. Please reload Azure Data Studio to enable it.", this.extension.displayName));
 					}
 				}
 			}
@@ -1064,8 +1069,9 @@ export class ReloadAction extends ExtensionAction {
 			// Requires reload to deactivate the extension
 			this.enabled = true;
 			this.label = localize('reloadRequired', "Reload Required");
-			this.tooltip = localize('postUninstallTooltip', "Please reload Visual Studio Code to complete the uninstallation of this extension.");
-			alert(localize('uninstallExtensionComplete', "Please reload Visual Studio Code to complete the uninstallation of the extension {0}.", this.extension.displayName));
+			// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+			this.tooltip = localize('postUninstallTooltip', "Please reload Azure Data Studio to complete the uninstallation of this extension.");
+			alert(localize('uninstallExtensionComplete', "Please reload Azure Data Studio to complete the uninstallation of the extension {0}.", this.extension.displayName));
 			return;
 		}
 	}
@@ -2498,7 +2504,8 @@ export class ReinstallAction extends Action {
 				return this.extensionsWorkbenchService.reinstall(extension)
 					.then(extension => {
 						const requireReload = !(extension.local && this.extensionService.canAddExtension(toExtensionDescription(extension.local)));
-						const message = requireReload ? localize('ReinstallAction.successReload', "Please reload Visual Studio Code to complete reinstalling the extension {0}.", extension.identifier.id)
+						// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+						const message = requireReload ? localize('ReinstallAction.successReload', "Please reload Azure Data Studio to complete reinstalling the extension {0}.", extension.identifier.id)
 							: localize('ReinstallAction.success', "Reinstalling the extension {0} is completed.", extension.identifier.id);
 						const actions = requireReload ? [{
 							label: localize('InstallVSIXAction.reloadNow', "Reload Now"),
@@ -2583,7 +2590,7 @@ export class InstallSpecificVersionOfExtensionAction extends Action {
 				return this.extensionsWorkbenchService.installVersion(extension, version)
 					.then(extension => {
 						const requireReload = !(extension.local && this.extensionService.canAddExtension(toExtensionDescription(extension.local)));
-						const message = requireReload ? localize('InstallAnotherVersionExtensionAction.successReload', "Please reload Visual Studio Code to complete installing the extension {0}.", extension.identifier.id)
+						const message = requireReload ? localize('InstallAnotherVersionExtensionAction.successReload', "Please reload Azure Data Studio to complete installing the extension {0}.", extension.identifier.id)
 							: localize('InstallAnotherVersionExtensionAction.success', "Installing the extension {0} is completed.", extension.identifier.id);
 						const actions = requireReload ? [{
 							label: localize('InstallAnotherVersionExtensionAction.reloadNow', "Reload Now"),

--- a/src/vs/workbench/parts/extensions/test/electron-browser/extensionsActions.test.ts
+++ b/src/vs/workbench/parts/extensions/test/electron-browser/extensionsActions.test.ts
@@ -1091,7 +1091,8 @@ suite('ExtensionsActions Test', () => {
 
 		return new Promise(c => {
 			testObject.onDidChange(() => {
-				if (testObject.enabled && testObject.tooltip === 'Please reload Visual Studio Code to complete the installation of this extension.') {
+				// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+				if (testObject.enabled && testObject.tooltip === 'Please reload Azure Data Studio to complete the installation of this extension.') {
 					c();
 				}
 			});
@@ -1130,7 +1131,8 @@ suite('ExtensionsActions Test', () => {
 
 		return new Promise(c => {
 			testObject.onDidChange(() => {
-				if (testObject.enabled && testObject.tooltip === 'Please reload Visual Studio Code to complete the uninstallation of this extension.') {
+				// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+				if (testObject.enabled && testObject.tooltip === 'Please reload Azure Data Studio to complete the uninstallation of this extension.') {
 					c();
 				}
 			});
@@ -1172,7 +1174,8 @@ suite('ExtensionsActions Test', () => {
 
 		return new Promise(c => {
 			testObject.onDidChange(() => {
-				if (testObject.enabled && testObject.tooltip === 'Please reload Visual Studio Code to complete the updating of this extension.') {
+				// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+				if (testObject.enabled && testObject.tooltip === 'Please reload Azure Data Studio to complete the updating of this extension.') {
 					c();
 				}
 			});
@@ -1217,7 +1220,8 @@ suite('ExtensionsActions Test', () => {
 				.then(() => testObject.update())
 				.then(() => {
 					assert.ok(testObject.enabled);
-					assert.equal('Please reload Visual Studio Code to complete the disabling of this extension.', testObject.tooltip);
+					// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+					assert.equal('Please reload Azure Data Studio to complete the disabling of this extension.', testObject.tooltip);
 				});
 		});
 	});
@@ -1254,7 +1258,8 @@ suite('ExtensionsActions Test', () => {
 							.then(() => testObject.update())
 							.then(() => {
 								assert.ok(testObject.enabled);
-								assert.equal('Please reload Visual Studio Code to complete the enabling of this extension.', testObject.tooltip);
+								// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+								assert.equal('Please reload Azure Data Studio to complete the enabling of this extension.', testObject.tooltip);
 							});
 					});
 			});
@@ -1299,7 +1304,8 @@ suite('ExtensionsActions Test', () => {
 							.then(() => testObject.update())
 							.then(() => {
 								assert.ok(testObject.enabled);
-								assert.equal('Please reload Visual Studio Code to complete the enabling of this extension.', testObject.tooltip);
+								// {{SQL CARBON EDIT}} - replace Visual Studio Code with Azure Data Studio
+								assert.equal('Please reload Azure Data Studio to complete the enabling of this extension.', testObject.tooltip);
 							});
 
 					});


### PR DESCRIPTION
I introduced a couple bugs in the VS Code merge that this fixes:
1. Extensions failed to install because I wasn't returning the right metadata in one of our edits (not sure how it compiled)
2. VS Code added a bunch of pop-ups for extensions when they need to be reloaded and these should have been updated to say Azure Data Studio