### PR TITLE
Fix recent connections list to use <default> DB if no DB is specified

### DIFF
--- a/src/sql/platform/connection/common/connectionManagementService.ts
+++ b/src/sql/platform/connection/common/connectionManagementService.ts
@@ -468,8 +468,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 					// The connected succeeded so add it to our active connections now, optionally adding it to the MRU based on
 					// the options.saveTheConnection setting
 					let connectionMgmtInfo = this._connectionStatusManager.findConnection(uri);
-					let activeConnection = connectionMgmtInfo.connectionProfile;
-					this.tryAddActiveConnection(connectionMgmtInfo, activeConnection, options.saveTheConnection);
+					this.tryAddActiveConnection(connectionMgmtInfo, connection, options.saveTheConnection);
 
 					if (callbacks.onConnectSuccess) {
 						callbacks.onConnectSuccess(options.params);


### PR DESCRIPTION
Fix #4554 The actual connection from the connection profile is populated with master (which is what we use as the default if none is specified). But this populates the MRU entry with a connection to master instead which can cause confusion. 