### PR TITLE
Notebooks: Fix install packages not always showing on startup

### DIFF
--- a/src/sql/parts/notebook/notebook.component.ts
+++ b/src/sql/parts/notebook/notebook.component.ts
@@ -223,10 +223,6 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 
 	private async loadModel(): Promise<void> {
 		await this.awaitNonDefaultProvider();
-		let providerId = 'sql'; // this is tricky; really should also depend on the connection profile
-		this.setContextKeyServiceWithProviderId(providerId);
-		this.fillInActionsForCurrentContext();
-
 		let model = new NotebookModel({
 			factory: this.modelFactory,
 			notebookUri: this._notebookParams.notebookUri,
@@ -249,6 +245,8 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		this.updateToolbarComponents(this._model.trustedMode);
 		this._modelRegisteredDeferred.resolve(this._model);
 		await model.startSession(this.model.notebookManager, undefined, true);
+		this.setContextKeyServiceWithProviderId(model.providerId);
+		this.fillInActionsForCurrentContext();
 		this.detectChanges();
 	}
 


### PR DESCRIPTION
Fixes #4559. Waiting until the notebook provider has been 100% set (after the session has started) to determine whether to add providerId-specific items to the toolbar (which currently only includes Install Packages).