### PR TITLE
#4565: Open notebook from Dashboard - can't close dirty notebook 

### DIFF
--- a/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
@@ -371,7 +371,8 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 		};
 		let isUntitled: boolean = uri.scheme === Schemas.untitled;
 
-		const fileInput: UntitledEditorInput = isUntitled ? this._untitledEditorService.createOrGet(uri, notebookModeId) : undefined;
+		const fileInput = isUntitled ? this._untitledEditorService.createOrGet(uri, notebookModeId) :
+										this._editorService.createInput({resource: uri, language: notebookModeId});
 		let input = this._instantiationService.createInstance(NotebookInput, path.basename(uri.fsPath), uri, fileInput);
 		input.isTrusted = isUntitled;
 		input.defaultKernel = options.defaultKernel;

--- a/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
@@ -32,7 +32,6 @@ import { NotebookChangeType, CellTypes } from 'sql/parts/notebook/models/contrac
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
 import { notebookModeId } from 'sql/common/constants';
-import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
 
 class MainThreadNotebookEditor extends Disposable {
 	private _contentChangedEmitter = new Emitter<NotebookContentChange>();


### PR DESCRIPTION
When we open and edit a note book form Dash board -> SQL Bigdata Cluster tab, right now the dirty notebook can't be closed. Reason being, we are not handling the titled notebooks from MainThreadNotebookDocumentsAndEditors. 
Created fileEditorInput for existing notebooks which is similar to CustomInputConverter. Had to plum through the code and to understand what would happen when we open a notebook from file menu Vs dashboard. One line code change though :)