### PR TITLE
update pg extension name

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1311,7 +1311,7 @@
 				},
 				{
 					"extensionId": "34",
-					"extensionName": "postgresql",
+					"extensionName": "azuredatastudio-postgresql",
 					"displayName": "PostgreSQL",
 					"shortDescription": "PostgreSQL extension for Azure Data Studio",
 					"publisher": {

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1311,7 +1311,7 @@
 				},
 				{
 					"extensionId": "34",
-					"extensionName": "postgresql",
+					"extensionName": "azuredatastudio-postgresql",
 					"displayName": "PostgreSQL",
 					"shortDescription": "PostgreSQL extension for Azure Data Studio",
 					"publisher": {


### PR DESCRIPTION
noticed this while looking into the telemetry. I checked the history of PG repo, Anup changed the name of extension after I added the extension to the gallery manifest. I didn't dig into the impact too much, there shouldn't be any impact for user to actually use the extension, but might cause some problem in the future when new pg extension releases.
I have updated the files in the storage account.
