### PR TITLE
confirmSave using untitledEditorInput/fileEditorInput

### DIFF
--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -5,7 +5,6 @@
 
 'use strict';
 
-import * as nls from 'vs/nls';
 import { IEditorModel } from 'vs/platform/editor/common/editor';
 import { EditorInput, EditorModel, ConfirmResult } from 'vs/workbench/common/editor';
 import { Emitter, Event } from 'vs/base/common/event';
@@ -22,8 +21,6 @@ import { TextFileEditorModel } from 'vs/workbench/services/textfile/common/textF
 import { Range } from 'vs/editor/common/core/range';
 import { UntitledEditorModel } from 'vs/workbench/common/editor/untitledEditorModel';
 import { Schemas } from 'vs/base/common/network';
-import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
-import { notebookModeId } from 'sql/common/constants';
 import { ITextFileService, ISaveOptions } from 'vs/workbench/services/textfile/common/textfiles';
 import { LocalContentManager } from 'sql/workbench/services/notebook/node/localContentManager';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
@@ -74,10 +71,6 @@ export class NotebookEditorModel extends EditorModel {
 		}
 		this.dirty = dirty;
 		this._onDidChangeDirty.fire();
-	}
-
-	public confirmSave(): Promise<ConfirmResult> {
-		return this.textFileService.confirmSave([this.notebookUri]);
 	}
 
 	/**
@@ -160,7 +153,7 @@ export class NotebookInput extends EditorInput {
 	}
 
 	public confirmSave(): Promise<ConfirmResult> {
-		return this._model.confirmSave();
+		return this._textInput.confirmSave();
 	}
 
 	public revert(): Promise<boolean> {


### PR DESCRIPTION
Now that we are passing untitledEditorInput/fileEditorInput in all the scenarios, changed confirmSave method to use input instead of leveraging TextFileService. This change won't impact the functionality, just code cleanup inline with vscode.