### PR TITLE
#4618: Notebook JSON has extra } after save

### DIFF
--- a/src/sql/parts/notebook/notebookInput.ts
+++ b/src/sql/parts/notebook/notebookInput.ts
@@ -100,7 +100,8 @@ export class NotebookEditorModel extends EditorModel {
 			let content = JSON.stringify(notebookModel.toJSON(), undefined, '    ');
 			let model = this.textEditorModel.textEditorModel;
 			let endLine = model.getLineCount();
-			let endCol = model.getLineLength(endLine);
+			let endCol = model.getLineMaxColumn(endLine);
+
 			this.textEditorModel.textEditorModel.applyEdits([{
 				range: new Range(1, 1, endLine, endCol),
 				text: content


### PR DESCRIPTION
We use 'applyEdits' method from TextModel which would allow us to edit content before save. It essentially replaces the content with the given range. There was an issue in calculating the range of the content to be replaced. We are now using getLineMaxColumn to define endCloumn of the content which returns the max column of end line.