### PR TITLE
Bring over code-url-handler.desktop

### DIFF
--- a/resources/linux/code-url-handler.desktop
+++ b/resources/linux/code-url-handler.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=@@NAME_LONG@@ - URL Handler
+Comment=Azure Data Studio
+GenericName=Text Editor
+Exec=/usr/share/@@NAME@@/@@NAME@@ --open-url %U
+Icon=@@ICON@@
+Type=Application
+NoDisplay=true
+StartupNotify=true
+Categories=Utility;TextEditor;Development;IDE;
+MimeType=x-scheme-handler/@@URLPROTOCOL@@;
+Keywords=azuredatastudio;


### PR DESCRIPTION
This file got missed in a previous VS Code merge. It wasn't causing problems but now Linux packaged builds fail when they can't find it.