### PR TITLE
Fix the "Failed to show notebook document" errors

### DIFF
--- a/src/sql/workbench/api/node/extHostNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/extHostNotebookDocumentsAndEditors.ts
@@ -109,7 +109,7 @@ export class ExtHostNotebookDocumentsAndEditors implements ExtHostNotebookDocume
 					this._mainContext.getProxy(SqlMainContext.MainThreadNotebookDocumentsAndEditors),
 					data.id,
 					documentData,
-					typeConverters.ViewColumn.to(data.editorPosition)
+					typeof data.editorPosition === 'number' ? typeConverters.ViewColumn.to(data.editorPosition) : undefined
 				);
 				this._editors.set(data.id, editor);
 			}

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -840,7 +840,7 @@ export interface INotebookModelChangedData {
 export interface INotebookEditorAddData {
 	id: string;
 	documentUri: UriComponents;
-	editorPosition: EditorViewColumn;
+	editorPosition: EditorViewColumn | undefined;
 }
 
 export interface INotebookShowOptions {


### PR DESCRIPTION
Fixes #4635.

A VS Code merge redefined editorPosition in ITextEditorAddData (i.e. where it can now explicitly be undefined):

```
export interface ITextEditorAddData {
	id: string;
	documentUri: UriComponents;
	options: IResolvedTextEditorConfiguration;
	selections: ISelection[];
	visibleRanges: IRange[];
	editorPosition: EditorViewColumn | undefined;
}
```

in extHostDocumentsAndEditors, instead of relying solely on 

`typeConverters.ViewColumn.to(data.editorPosition)`

now that editorPosition can be undefined, we need to check for that when passing in viewColumn information into the ExtHostTextEditor constructor:

`typeof data.editorPosition === 'number' ? typeConverters.ViewColumn.to(data.editorPosition) : undefined`

Just copying over those changes from extHostDocuments* to extHostNotebookDocuments*. Nothing crazy here 😃.
