### PR TITLE
Go back to LICENSE.txt for Windows installers

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -1,7 +1,7 @@
 #define LocalizedLanguageFile(Language = "") \
     DirExists(RepoDir + "\licenses") && Language != "" \
-      ? ('; LicenseFile: "' + RepoDir + '\licenses\LICENSE-' + Language + '.rtf"') \
-      : '; LicenseFile: "' + RepoDir + '\LICENSE.rtf"'
+      ? ('; LicenseFile: "' + RepoDir + '\licenses\LICENSE-' + Language + '.txt"') \
+      : '; LicenseFile: "' + RepoDir + '\LICENSE.txt"'
 
 [Setup]
 AppId={#AppId}


### PR DESCRIPTION
The VS Code master merge updated our installer files to look for `LICENSE.rtf` instead of `LICENSE.txt`. I've reverted the change back to what we had before.