### PR TITLE
fix for the extension search issue

### DIFF
--- a/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
@@ -553,14 +553,7 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 			if (searchTexts && searchTexts.length > 0) {
 				searchTexts.forEach(searchText => {
 					if (searchText !== '@allmarketplace') {
-						filteredExtensions = filteredExtensions.filter(
-							e => 	e.extensionName && e.extensionName.includes(searchText) ||
-									e.publisher && e.publisher.publisherName && e.publisher.publisherName.includes(searchText) ||
-									e.publisher && e.publisher.displayName && e.publisher.displayName.includes(searchText) ||
-									e.displayName && e.displayName.includes(searchText) ||
-									e.shortDescription && e.shortDescription.includes(searchText) ||
-									e.extensionId && e.extensionId.includes(searchText)
-						);
+						filteredExtensions = filteredExtensions.filter(e => ExtensionGalleryService.isMatchingExtension(e, searchText));
 					}
 				});
 			}
@@ -569,11 +562,11 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 		// Sorting
 		switch (query.sortBy) {
 			case SortBy.PublisherName:
-				filteredExtensions.sort( (a, b) => ExtensionGalleryService.compareByField(a.publisher, b.publisher, 'publisherName'));
+				filteredExtensions.sort((a, b) => ExtensionGalleryService.compareByField(a.publisher, b.publisher, 'publisherName'));
 				break;
 			case SortBy.Title:
 			default:
-				filteredExtensions.sort( (a, b) => ExtensionGalleryService.compareByField(a, b, 'displayName'));
+				filteredExtensions.sort((a, b) => ExtensionGalleryService.compareByField(a, b, 'displayName'));
 				break;
 		}
 
@@ -585,6 +578,24 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 			filteredExtensions = filteredExtensions.filter(ext => ext.publisher && ext.publisher.displayName === 'Microsoft');
 		}
 		return { galleryExtensions: filteredExtensions, total: actualTotal };
+	}
+
+	// {{SQL CARBON EDIT}}
+	/*
+	 * Checks whether the extension matches the search text
+	 */
+	public static isMatchingExtension(extension: IRawGalleryExtension, searchText: string): boolean {
+		if (!searchText) {
+			return true;
+		}
+		let text = searchText.toLocaleLowerCase();
+		return extension
+			&& (extension.extensionName && extension.extensionName.toLocaleLowerCase().includes(text) ||
+				extension.publisher && extension.publisher.publisherName && extension.publisher.publisherName.toLocaleLowerCase().includes(text) ||
+				extension.publisher && extension.publisher.displayName && extension.publisher.displayName.toLocaleLowerCase().includes(text) ||
+				extension.displayName && extension.displayName.toLocaleLowerCase().includes(text) ||
+				extension.shortDescription && extension.shortDescription.toLocaleLowerCase().includes(text) ||
+				extension.extensionId && extension.extensionId.toLocaleLowerCase().includes(text));
 	}
 
 	public static compareByField(a: any, b: any, fieldName: string): number {
@@ -603,7 +614,7 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 		if (!b || !b[fieldName] && (!a || !a[fieldName])) {
 			return 0;
 		}
-		if (a[fieldName] ===  b[fieldName]) {
+		if (a[fieldName] === b[fieldName]) {
 			return 0;
 		}
 		return a[fieldName] < b[fieldName] ? -1 : 1;

--- a/src/vs/platform/extensionManagement/test/node/extensionGalleryService.test.ts
+++ b/src/vs/platform/extensionManagement/test/node/extensionGalleryService.test.ts
@@ -66,10 +66,10 @@ suite('Extension Gallery Service', () => {
 
 		assert.equal(ExtensionGalleryService.compareByField(a.publisher, b.publisher, 'publisherName'), 0);
 
-		a.publisher = { displayName: undefined, publisherId: undefined, publisherName: undefined};
+		a.publisher = { displayName: undefined, publisherId: undefined, publisherName: undefined };
 		assert.equal(ExtensionGalleryService.compareByField(a.publisher, b.publisher, 'publisherName'), 1);
 
-		b.publisher = { displayName: undefined, publisherId: undefined, publisherName: undefined};
+		b.publisher = { displayName: undefined, publisherId: undefined, publisherName: undefined };
 		assert.equal(ExtensionGalleryService.compareByField(a.publisher, b.publisher, 'publisherName'), 0);
 
 		a.publisher.publisherName = 'a';
@@ -89,5 +89,62 @@ suite('Extension Gallery Service', () => {
 
 		b.displayName = 'test1';
 		assert.equal(ExtensionGalleryService.compareByField(a, b, 'displayName'), 0);
+	});
+
+	// {{SQL CARBON EDIT}}
+	test('isMatchingExtension', () => {
+		let createEmptyExtension = () => {
+			return {
+				extensionId: '',
+				extensionName: '',
+				displayName: '',
+				shortDescription: '',
+				publisher: {
+					displayName: '',
+					publisherId: '',
+					publisherName: ''
+				},
+				versions: [],
+				statistics: [],
+				flags: ''
+			};
+		};
+		let searchText = 'tExt1 withSpace';
+		let matchingText = 'test text1 Withspace test';
+		let notMatchingText = 'test test';
+		let extension;
+
+		assert(!ExtensionGalleryService.isMatchingExtension(undefined, searchText), 'empty extension should not match any search text');
+
+		extension = createEmptyExtension();
+		assert(ExtensionGalleryService.isMatchingExtension(extension, undefined), 'empty search text should match any not null extension');
+
+		extension = createEmptyExtension();
+		extension.extensionName = notMatchingText;
+		assert(!ExtensionGalleryService.isMatchingExtension(extension, searchText), 'invalid search text should not match extension');
+
+		extension = createEmptyExtension();
+		extension.extensionId = matchingText;
+		assert(ExtensionGalleryService.isMatchingExtension(extension, searchText), 'extensionid field should be used for matching');
+
+		extension = createEmptyExtension();
+		extension.extensionName = matchingText;
+		assert(ExtensionGalleryService.isMatchingExtension(extension, searchText), 'extensionName field should be used for matching');
+
+		extension = createEmptyExtension();
+		extension.displayName = matchingText;
+		assert(ExtensionGalleryService.isMatchingExtension(extension, searchText), 'displayName field should be used for matching');
+
+		extension = createEmptyExtension();
+		extension.shortDescription = matchingText;
+		assert(ExtensionGalleryService.isMatchingExtension(extension, searchText), 'shortDescription field should be used for matching');
+
+		extension = createEmptyExtension();
+		extension.publisher.displayName = matchingText;
+		assert(ExtensionGalleryService.isMatchingExtension(extension, searchText), 'publisher displayName field should be used for matching');
+
+		extension = createEmptyExtension();
+		extension.publisher.publisherName = matchingText;
+		assert(ExtensionGalleryService.isMatchingExtension(extension, searchText), 'publisher publisherName field should be used for matching');
 	});
 });


### PR DESCRIPTION
#4596 
Issue: extension search function is broken
Root cause: the search text has been changed to lower case, but when we are doing the matching we didn't  change the source to lower case.

Fix: use lower case of the target properties to match with the processed search text.

Test: Added UnitTest to cover the matching function.