### PR TITLE
#3585: Canceled message when changing kernel

### DIFF
--- a/src/sql/parts/notebook/models/cell.ts
+++ b/src/sql/parts/notebook/models/cell.ts
@@ -233,8 +233,8 @@ export class CellModel implements ICellModel {
 			let message: string;
 			if (error.message === 'Canceled') {
 				// swallow the error
-				message = localize('executionCanceled', 'Query execution is canceled');
-			}else{
+				message = localize('executionCanceled', 'Query execution was canceled');
+			} else {
 				message = notebookUtils.getErrorMessage(error);
 			}
 			this.sendNotification(notificationService, Severity.Error, message);

--- a/src/sql/parts/notebook/models/cell.ts
+++ b/src/sql/parts/notebook/models/cell.ts
@@ -230,13 +230,15 @@ export class CellModel implements ICellModel {
 				}
 			}
 		} catch (error) {
+			let message: string;
 			if (error.message === 'Canceled') {
 				// swallow the error
+				message = localize('executionCanceled', 'Query execution is canceled');
+			}else{
+				message = notebookUtils.getErrorMessage(error);
 			}
-			let message = notebookUtils.getErrorMessage(error);
 			this.sendNotification(notificationService, Severity.Error, message);
 			// TODO track error state for the cell
-			throw error;
 		} finally {
 			this.fireExecutionStateChanged();
 		}

--- a/src/sql/parts/notebook/models/cell.ts
+++ b/src/sql/parts/notebook/models/cell.ts
@@ -232,7 +232,6 @@ export class CellModel implements ICellModel {
 		} catch (error) {
 			let message: string;
 			if (error.message === 'Canceled') {
-				// swallow the error
 				message = localize('executionCanceled', 'Query execution was canceled');
 			} else {
 				message = notebookUtils.getErrorMessage(error);


### PR DESCRIPTION
This is to fix #3585. Improved the error handling by adding a message 'Query execution is canceled' when changing kernel, while execution is in progress. Please let me know the wording if something needs to be added.