### PR TITLE
render xml properly in the grid

### DIFF
--- a/src/sql/parts/grid/services/sharedServices.ts
+++ b/src/sql/parts/grid/services/sharedServices.ts
@@ -66,7 +66,7 @@ export function textFormatter(row: number, cell: any, value: any, columnDef: any
 }
 
 /**
- * Provide slick grid cell with encoded ariaLabel and text.
+ * Provide slick grid cell with encoded ariaLabel and plain text.
  * text will be escaped by the textFormatter and ariaLabel will be consumed by slickgrid directly.
  */
 export function slickGridDataItemColumnValueExtractor(value: any, columnDef: any): { text: string; ariaLabel: string; } {

--- a/src/sql/parts/grid/services/sharedServices.ts
+++ b/src/sql/parts/grid/services/sharedServices.ts
@@ -52,12 +52,25 @@ export function textFormatter(row: number, cell: any, value: any, columnDef: any
 		} else {
 			cellClasses += ' missing-value';
 		}
-	} else if (typeof value === 'string') {
-		valueToDisplay = escape(value.length > 250 ? value.slice(0, 250) + '...' : value);
+	} else if (typeof value === 'string' || value.text) {
+		if (value.text) {
+			valueToDisplay = value.text;
+		} else {
+			valueToDisplay = value;
+		}
+		valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
 		titleValue = valueToDisplay;
 	}
 
 	return `<span title="${titleValue}" class="${cellClasses}">${valueToDisplay}</span>`;
+}
+
+export function slickGridDataItemColumnValueExtractor(value: any, columnDef: any): { text: string; ariaLabel: string; } {
+	let displayValue = value[columnDef.field];
+	return {
+		text: displayValue,
+		ariaLabel: displayValue ? escape(displayValue) : displayValue
+	}
 }
 
 /** The following code is a rewrite over the both formatter function using dom builder

--- a/src/sql/parts/grid/services/sharedServices.ts
+++ b/src/sql/parts/grid/services/sharedServices.ts
@@ -70,7 +70,7 @@ export function slickGridDataItemColumnValueExtractor(value: any, columnDef: any
 	return {
 		text: displayValue,
 		ariaLabel: displayValue ? escape(displayValue) : displayValue
-	}
+	};
 }
 
 /** The following code is a rewrite over the both formatter function using dom builder

--- a/src/sql/parts/grid/services/sharedServices.ts
+++ b/src/sql/parts/grid/services/sharedServices.ts
@@ -52,7 +52,7 @@ export function textFormatter(row: number, cell: any, value: any, columnDef: any
 		} else {
 			cellClasses += ' missing-value';
 		}
-	} else if (typeof value === 'string' || value.text) {
+	} else if (typeof value === 'string' || (value && value.text)) {
 		if (value.text) {
 			valueToDisplay = value.text;
 		} else {
@@ -65,6 +65,10 @@ export function textFormatter(row: number, cell: any, value: any, columnDef: any
 	return `<span title="${titleValue}" class="${cellClasses}">${valueToDisplay}</span>`;
 }
 
+/**
+ * Provide slick grid cell with encoded ariaLabel and text.
+ * text will be escaped by the textFormatter and ariaLabel will be consumed by slickgrid directly.
+ */
 export function slickGridDataItemColumnValueExtractor(value: any, columnDef: any): { text: string; ariaLabel: string; } {
 	let displayValue = value[columnDef.field];
 	return {

--- a/src/sql/parts/profiler/editor/controller/profilerTableEditor.ts
+++ b/src/sql/parts/profiler/editor/controller/profilerTableEditor.ts
@@ -25,7 +25,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { Event, Emitter } from 'vs/base/common/event';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { Dimension } from 'vs/base/browser/dom';
-import { textFormatter } from 'sql/parts/grid/services/sharedServices';
+import { textFormatter, slickGridDataItemColumnValueExtractor } from 'sql/parts/grid/services/sharedServices';
 import { PROFILER_MAX_MATCHES } from 'sql/parts/profiler/editor/controller/profilerFindWidget';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { IStatusbarService, StatusbarAlignment, IStatusbarEntry } from 'vs/platform/statusbar/common/statusbar';
@@ -88,7 +88,9 @@ export class ProfilerTableEditor extends BaseEditor implements IProfilerControll
 					}
 				}
 			}
-		});
+		}, {
+				dataItemColumnValueExtractor: slickGridDataItemColumnValueExtractor
+			});
 		this._profilerTable.setSelectionModel(new RowSelectionModel());
 		attachTableStyler(this._profilerTable, this._themeService);
 

--- a/src/sql/parts/profiler/editor/profilerEditor.ts
+++ b/src/sql/parts/profiler/editor/profilerEditor.ts
@@ -365,7 +365,10 @@ export class ProfilerEditor extends BaseEditor {
 					formatter: textFormatter
 				}
 			]
-		}, { forceFitColumns: true, dataItemColumnValueExtractor: slickGridDataItemColumnValueExtractor });
+		}, {
+				forceFitColumns: true,
+				dataItemColumnValueExtractor: slickGridDataItemColumnValueExtractor
+			});
 
 		this._detailTableData.onRowCountChange(() => {
 			this._detailTable.updateRowCount();

--- a/src/sql/parts/profiler/editor/profilerEditor.ts
+++ b/src/sql/parts/profiler/editor/profilerEditor.ts
@@ -15,7 +15,7 @@ import { ProfilerTableEditor, ProfilerTableViewState } from './controller/profil
 import * as Actions from 'sql/parts/profiler/contrib/profilerActions';
 import { CONTEXT_PROFILER_EDITOR, PROFILER_TABLE_COMMAND_SEARCH } from './interfaces';
 import { SelectBox } from 'sql/base/browser/ui/selectBox/selectBox';
-import { textFormatter } from 'sql/parts/grid/services/sharedServices';
+import { textFormatter, slickGridDataItemColumnValueExtractor } from 'sql/parts/grid/services/sharedServices';
 import { ProfilerResourceEditor } from './profilerResourceEditor';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { ITextModel } from 'vs/editor/common/model';
@@ -365,7 +365,7 @@ export class ProfilerEditor extends BaseEditor {
 					formatter: textFormatter
 				}
 			]
-		}, { forceFitColumns: true });
+		}, { forceFitColumns: true, dataItemColumnValueExtractor: slickGridDataItemColumnValueExtractor });
 
 		this._detailTableData.onRowCountChange(() => {
 			this._detailTable.updateRowCount();

--- a/src/sql/parts/profiler/editor/profilerInput.ts
+++ b/src/sql/parts/profiler/editor/profilerInput.ts
@@ -258,7 +258,7 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 				let columnName = this._columnMapping[key];
 				if (columnName) {
 					let value = e.values[key];
-					data[columnName] = escape(value);
+					data[columnName] = value;
 				}
 			}
 			newEvents.push(data);

--- a/src/sql/parts/profiler/editor/profilerInput.ts
+++ b/src/sql/parts/profiler/editor/profilerInput.ts
@@ -18,7 +18,6 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { Event, Emitter } from 'vs/base/common/event';
 import { generateUuid } from 'vs/base/common/uuid';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
-import { escape } from 'sql/base/common/strings';
 import * as types from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import Severity from 'vs/base/common/severity';


### PR DESCRIPTION
#4648

Root cause: we escaped the strings in profiler as a result the xml cannot be displayed properly.
Fix: remove the escape call in profiler, this is safe since the underlying slickgrid already have the escaping logic.
