### PR TITLE
Ensure only one cell shows as running at a time

### DIFF
--- a/src/sql/parts/notebook/models/cell.ts
+++ b/src/sql/parts/notebook/models/cell.ts
@@ -238,6 +238,7 @@ export class CellModel implements ICellModel {
 			// TODO track error state for the cell
 			throw error;
 		} finally {
+			this.disposeFuture();
 			this.fireExecutionStateChanged();
 		}
 
@@ -323,8 +324,7 @@ export class CellModel implements ICellModel {
 		let output: nb.ICellOutput = msg.content as nb.ICellOutput;
 
 		if (!this._future.inProgress) {
-			this._future.dispose();
-			this._future = undefined;
+			this.disposeFuture();
 		}
 	}
 
@@ -485,5 +485,11 @@ export class CellModel implements ICellModel {
 			}
 		}
 		return endpoint;
+	}
+
+	// Dispose and set current future to undefined
+	private disposeFuture() {
+		this._future.dispose();
+		this._future = undefined;
 	}
 }


### PR DESCRIPTION
Fixes #4450.

Since we keep track of one future per cellModel, we weren't disposing it for SQL notebooks, since the handleReply() method isn't implemented. While I could have looked into the implementation there, I like this implementation more, since we ensure that a future is properly disposed without having to wait for a reply message.