### PR TITLE
Add status messages during command line processing

### DIFF
--- a/src/sql/workbench/services/commandLine/common/commandLineService.ts
+++ b/src/sql/workbench/services/commandLine/common/commandLineService.ts
@@ -21,6 +21,8 @@ import { warn } from 'sql/base/common/log';
 import { ipcRenderer as ipc} from 'electron';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IStatusbarService, StatusbarAlignment } from 'vs/platform/statusbar/common/statusbar';
+import { localize } from 'vs/nls'
 
 export class CommandLineService implements ICommandLineProcessing {
 	public _serviceBrand: any;
@@ -33,7 +35,8 @@ export class CommandLineService implements ICommandLineProcessing {
 		@IObjectExplorerService private _objectExplorerService: IObjectExplorerService,
 		@IEditorService private _editorService: IEditorService,
 		@ICommandService private _commandService: ICommandService,
-		@IConfigurationService private _configurationService: IConfigurationService
+		@IConfigurationService private _configurationService: IConfigurationService,
+		@IStatusbarService private _statusBarService: IStatusbarService
 	) {
 		if (ipc) {
 		    ipc.on('ads:processCommandLine', (event: any, args: ParsedArgs) => this.onLaunched(args));
@@ -85,6 +88,10 @@ export class CommandLineService implements ICommandLineProcessing {
 		}
 		let connectedContext: azdata.ConnectedContext = undefined;
 		if (profile) {
+			if (this._statusBarService)
+			{
+				this._statusBarService.setStatusMessage(localize('connectingLabel','Connecting:')  + profile.serverName, 2500);
+			}
 			try {
 				await this._connectionManagementService.connectIfNotConnected(profile, 'connection', true);
 				// Before sending to extensions, we should a) serialize to IConnectionProfile or things will fail,
@@ -96,8 +103,16 @@ export class CommandLineService implements ICommandLineProcessing {
 			}
 		}
 		if (commandName) {
+			if (this._statusBarService)
+			{
+				this._statusBarService.setStatusMessage(localize('runningCommandLabel','Running command:') + commandName, 2500);
+			}
 			await this._commandService.executeCommand(commandName, connectedContext);
 		} else if (profile) {
+			if (this._statusBarService)
+			{
+				this._statusBarService.setStatusMessage(localize('openingNewQueryLabel','Opening new query:') + profile.serverName, 2500);
+			}
 			// Default to showing new query
 			try {
 				await TaskUtilities.newQuery(profile,

--- a/src/sql/workbench/services/commandLine/common/commandLineService.ts
+++ b/src/sql/workbench/services/commandLine/common/commandLineService.ts
@@ -22,7 +22,7 @@ import { ipcRenderer as ipc} from 'electron';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IStatusbarService, StatusbarAlignment } from 'vs/platform/statusbar/common/statusbar';
-import { localize } from 'vs/nls'
+import { localize } from 'vs/nls';
 
 export class CommandLineService implements ICommandLineProcessing {
 	public _serviceBrand: any;

--- a/src/sql/workbench/services/objectExplorer/common/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/common/objectExplorerService.ts
@@ -466,7 +466,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		if (finalResult) {
 			if (errorMessages.length > 0) {
 				if (errorMessages.length > 1) {
-					errorMessages.unshift(nls.localize('nodeExpansionError', 'Mulitiple errors:'));
+					errorMessages.unshift(nls.localize('nodeExpansionError', 'Multiple errors:'));
 				}
 				errorNode.errorMessage = errorMessages.join('\n');
 				errorNode.label = errorNode.errorMessage;

--- a/src/sqltest/parts/commandLine/commandLineService.test.ts
+++ b/src/sqltest/parts/commandLine/commandLineService.test.ts
@@ -116,7 +116,8 @@ suite('commandLineService tests', () => {
 			undefined,
 			undefined,
 			commandService,
-			configurationService
+			configurationService,
+			undefined
 		);
 		return service;
 	}

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -46,6 +46,8 @@ import { WorkbenchContextKeysHandler } from 'vs/workbench/browser/contextkeys';
 import { coalesce } from 'vs/base/common/arrays';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { Layout } from 'vs/workbench/browser/layout';
+import { ICommandLineProcessing } from 'sql/workbench/services/commandLine/common/commandLine';
+import { CommandLineService } from 'sql/workbench/services/commandLine/common/commandLineService';
 
 export class Workbench extends Layout {
 
@@ -185,6 +187,11 @@ export class Workbench extends Layout {
 		}
 
 		const instantiationService = new InstantiationService(serviceCollection, true);
+
+		// {{SQL CARBON EDIT }}
+		// TODO@Davidshi commandLineService currently has no referents, so force its creation
+		serviceCollection.set(ICommandLineProcessing, instantiationService.createInstance(CommandLineService));
+		// {{SQL CARBON EDIT}} - End
 
 		// Wrap up
 		instantiationService.invokeFunction(accessor => {

--- a/src/vs/workbench/workbench.main.ts
+++ b/src/vs/workbench/workbench.main.ts
@@ -224,8 +224,6 @@ import { IDashboardService } from 'sql/platform/dashboard/browser/dashboardServi
 import { DashboardService } from 'sql/platform/dashboard/browser/dashboardServiceImpl';
 import { NotebookService } from 'sql/workbench/services/notebook/common/notebookServiceImpl';
 import { INotebookService } from 'sql/workbench/services/notebook/common/notebookService';
-import { ICommandLineProcessing } from 'sql/workbench/services/commandLine/common/commandLine';
-import { CommandLineService } from 'sql/workbench/services/commandLine/common/commandLineService';
 import { OEShimService, IOEShimService } from 'sql/parts/objectExplorer/common/objectExplorerViewTreeShim';
 
 registerSingleton(IDashboardService, DashboardService);
@@ -265,7 +263,6 @@ registerSingleton(IInsightsDialogService, InsightsDialogService);
 registerSingleton(INotebookService, NotebookService);
 registerSingleton(IAccountPickerService, AccountPickerService);
 registerSingleton(IProfilerService, ProfilerService);
-registerSingleton(ICommandLineProcessing, CommandLineService);
 registerSingleton(IDacFxService, DacFxService);
 // {{SQL CARBON EDIT}} - End
 


### PR DESCRIPTION
This change adds status messages  during connection and invoking of the commands passed from the command line. Is 2.5 seconds a reasonable length of time to display ? The complexity of tracking item lifetime and dismissing the item based on completion of the operation didn't seem worth the minimal benefit.

I also restored code to force instantiation of the command line service which was removed by https://github.com/Microsoft/azuredatastudio/commit/ed2641ea02e7a368c40a074398265cd075ea4900

There may be a more elegant place to put the service instantiation but this unblocked the scenario for now.