### PR TITLE
#4511: Streamline untitled notebook count

### DIFF
--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -39,7 +39,6 @@ const statusView = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.L
 const jupyterNotebookProviderId = 'jupyter';
 const msgSampleCodeDataFrame = localize('msgSampleCodeDataFrame', 'This sample code loads the file into a data frame and shows the first 10 results.');
 
-let untitledCounter = 0;
 
 export async function activate(context: vscode.ExtensionContext): Promise<MssqlExtensionApi> {
 	// lets make sure we support this platform first
@@ -181,18 +180,18 @@ function saveProfileAndCreateNotebook(profile: azdata.IConnectionProfile): Promi
 }
 
 function findNextUntitledEditorName(): string {
-	let nextVal = untitledCounter;
+	let nextVal = 0;
 	// Note: this will go forever if it's coded wrong, or you have inifinite Untitled notebooks!
 	while (true) {
-		let title = `Notebook-${nextVal++}`;
-		let hasTextDoc = vscode.workspace.textDocuments.findIndex(doc => doc.isUntitled && doc.fileName === title) > -1;
+		let title = `Notebook-${nextVal}`;
 		let hasNotebookDoc = azdata.nb.notebookDocuments.findIndex(doc => doc.isUntitled && doc.fileName === title) > -1;
-		if (!hasTextDoc && !hasNotebookDoc) {
-			untitledCounter = nextVal;
+		if (!hasNotebookDoc) {
 			return title;
 		}
+		nextVal++;
 	}
 }
+
 async function handleNewNotebookTask(oeContext?: azdata.ObjectExplorerContext, profile?: azdata.IConnectionProfile): Promise<void> {
 	// Ensure we get a unique ID for the notebook. For now we're using a different prefix to the built-in untitled files
 	// to handle this. We should look into improving this in the future

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -20,7 +20,6 @@ const JUPYTER_NOTEBOOK_PROVIDER = 'jupyter';
 const msgSampleCodeDataFrame = localize('msgSampleCodeDataFrame', 'This sample code loads the file into a data frame and shows the first 10 results.');
 const noNotebookVisible = localize('noNotebookVisible', 'No notebook editor is active');
 
-let untitledCounter = 0;
 
 export let controller: JupyterController;
 
@@ -72,16 +71,15 @@ function newNotebook(connectionProfile: azdata.IConnectionProfile) {
 }
 
 function findNextUntitledEditorName(): string {
-	let nextVal = untitledCounter;
+	let nextVal = 0;
 	// Note: this will go forever if it's coded wrong, or you have infinite Untitled notebooks!
 	while (true) {
-		let title = `Notebook-${nextVal++}`;
-		let hasTextDoc = vscode.workspace.textDocuments.findIndex(doc => doc.isUntitled && doc.fileName === title) > -1;
+		let title = `Notebook-${nextVal}`;
 		let hasNotebookDoc = azdata.nb.notebookDocuments.findIndex(doc => doc.isUntitled && doc.fileName === title) > -1;
-		if (!hasTextDoc && !hasNotebookDoc) {
-			untitledCounter = nextVal;
+		if (!hasNotebookDoc) {
 			return title;
 		}
+		nextVal++;
 	}
 }
 
@@ -137,7 +135,8 @@ async function addCell(cellType: azdata.nb.CellType): Promise<void> {
 async function analyzeNotebook(oeContext?: azdata.ObjectExplorerContext): Promise<void> {
 	// Ensure we get a unique ID for the notebook. For now we're using a different prefix to the built-in untitled files
 	// to handle this. We should look into improving this in the future
-	let untitledUri = vscode.Uri.parse(`untitled:Notebook-${untitledCounter++}`);
+	let title = findNextUntitledEditorName();
+	let untitledUri = vscode.Uri.parse(`untitled:${title}`);
 
 	let editor = await azdata.nb.showNotebookDocument(untitledUri, {
 		connectionProfile: oeContext ? oeContext.connectionProfile : undefined,


### PR DESCRIPTION
Untitled counter starts from zero every time when you open a new notebook. Closed untitled notebooks will be disposed and when you open a new notebook, the count value should be - any available number from zero to max number in notebook editor. 