### PR TITLE
Use getErrorMessage to get exception messages in python installation code.

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -260,7 +260,7 @@ export default class JupyterServerInstallation {
 							updateConfig();
 						})
 						.catch(err => {
-							let errorMsg = msgDependenciesInstallationFailed(err);
+							let errorMsg = msgDependenciesInstallationFailed(utils.getErrorMessage(err));
 							op.updateStatus(azdata.TaskStatus.Failed, errorMsg);
 							this.apiWrapper.showErrorMessage(errorMsg);
 							this._installReady.reject(errorMsg);


### PR DESCRIPTION
Was seeing some error messages print out {0} instead of the actual error message.