### PR TITLE
Fix broken test

### DIFF
--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -68,7 +68,7 @@ if (context.RunTest) {
 				let clearedOutputs = await notebook.clearAllOutputs();
 				let cells = notebook.document.cells;
 				cells.forEach(cell => {
-					assert(cell.contents && cell.contents.outputs && cell.contents.outputs.length === 0, `Expected cell outputs to be empty. Acutal: '${cell.contents.outputs}'`);
+					assert(cell.contents && cell.contents.outputs && cell.contents.outputs.length === 0, `Expected cell outputs to be empty. Actual: '${cell.contents.outputs}'`);
 				});
 				assert(clearedOutputs, 'Outputs of all the code cells from SQL notebook should be cleared');
 				console.log('After clearing cell outputs');

--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -68,7 +68,7 @@ if (context.RunTest) {
 				let clearedOutputs = await notebook.clearAllOutputs();
 				let cells = notebook.document.cells;
 				cells.forEach(cell => {
-					assert(cell.contents && cell.contents.outputs && cell.contents.outputs.length === 0, `Expected Output: 0, Acutal: '${cell.contents.outputs.length}'`);
+					assert(cell.contents && cell.contents.outputs && cell.contents.outputs.length === 0, `Expected cell outputs to be empty. Acutal: '${cell.contents.outputs}'`);
 				});
 				assert(clearedOutputs, 'Outputs of all the code cells from SQL notebook should be cleared');
 				console.log('After clearing cell outputs');

--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -63,7 +63,7 @@ if (context.RunTest) {
 		test('Clear all outputs - SQL notebook ', async function () {
 			let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata);
 			let cellWithOutputs = notebook.document.cells.find(cell => cell.contents && cell.contents.outputs && cell.contents.outputs.length > 0);
-			console.log("Before clearing cell outputs");
+			console.log('Before clearing cell outputs');
 			if (cellWithOutputs) {
 				let clearedOutputs = await notebook.clearAllOutputs();
 				let cells = notebook.document.cells;
@@ -71,9 +71,11 @@ if (context.RunTest) {
 					assert(cell.contents && cell.contents.outputs && cell.contents.outputs.length === 0, `Expected Output: 0, Acutal: '${cell.contents.outputs.length}'`);
 				});
 				assert(clearedOutputs, 'Outputs of all the code cells from SQL notebook should be cleared');
-				console.log("After clearing cell outputs");
+				console.log('After clearing cell outputs');
 			}
-			assert(cellWithOutputs === undefined, 'Could not find notebook cells with outputs');
+			else {
+				throw new Error('Could not find notebook cells with outputs');
+			}
 		});
 
 


### PR DESCRIPTION
The test would always fail if it was doing the right thing - since it was asserting that there WEREN'T any cells with outputs (the opposite of what it should have been checking).