### PR TITLE
Remove an outdated showErrorMessage assert from Jupyter Server Manager unit tests.

### DIFF
--- a/extensions/notebook/src/test/model/serverManager.test.ts
+++ b/extensions/notebook/src/test/model/serverManager.test.ts
@@ -56,7 +56,6 @@ describe('Local Jupyter Server Manager', function (): void {
 		let error = 'Error!!';
 		deferredInstall.reject(error);
 		await testUtils.assertThrowsAsync(() => serverManager.startServer(), undefined);
-		mockApiWrapper.verify(a => a.showErrorMessage(TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
 	it('Should configure and start install', async function (): Promise<void> {


### PR DESCRIPTION
We no longer call showErrorMessage from the startServer method, so this assert was causing unit tests to fail.