### PR TITLE
Fixed #4800 need to use ConnectionProfile in order to get the correct…

### DIFF
--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -637,19 +637,19 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return spec;
 	}
 
-	public async changeContext(server: string, newConnection?: ConnectionProfile, hideErrorMessage?: boolean): Promise<void> {
+	public async changeContext(title: string, newConnection?: ConnectionProfile, hideErrorMessage?: boolean): Promise<void> {
 		try {
 			if (!newConnection) {
-				newConnection = this._activeContexts.otherConnections.find((connection) => connection.serverName === server);
+				newConnection = this._activeContexts.otherConnections.find((connection) => connection.title === title);
 			}
-			if ((!newConnection) && (this._activeContexts.defaultConnection.serverName === server)) {
+			if ((!newConnection) && (this._activeContexts.defaultConnection.title === title)) {
 				newConnection = this._activeContexts.defaultConnection;
 			}
 
-			if (this._activeConnection) {
-				this._otherConnections.push(this._activeConnection);
-			}
 			if (newConnection) {
+				if (this._activeConnection && this._activeConnection.id !== newConnection.id) {
+					this._otherConnections.push(this._activeConnection);
+				}
 				this._activeConnection = newConnection;
 				this.refreshConnections(newConnection);
 				this._activeClientSession.updateConnection(newConnection.toIConnectionProfile()).then(

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -370,8 +370,8 @@ export class AttachToDropdown extends SelectBox {
 				else {
 					connections.push(msgAddNewConnection);
 				}
+				this.setOptions(connections);
 			}
-			this.setOptions(connections);
 		}
 	}
 

--- a/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
@@ -229,9 +229,9 @@ class SqlKernel extends Disposable implements nb.IKernel {
 			}
 			this._queryRunner.runQuery(code);
 		} else if (this._currentConnection) {
-			let connectionUri = Utils.generateUri(this._currentConnection, 'notebook');
+			let connectionUri = Utils.generateUri(this._currentConnectionProfile, 'notebook');
 			this._queryRunner = this._instantiationService.createInstance(QueryRunner, connectionUri);
-			this._connectionManagementService.connect(this._currentConnection, connectionUri).then((result) => {
+			this._connectionManagementService.connect(this._currentConnectionProfile, connectionUri).then((result) => {
 				this.addQueryEventListeners(this._queryRunner);
 				this._queryRunner.runQuery(code);
 			});

--- a/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
@@ -228,7 +228,7 @@ class SqlKernel extends Disposable implements nb.IKernel {
 				this._future.handleDone();
 			}
 			this._queryRunner.runQuery(code);
-		} else if (this._currentConnection) {
+		} else if (this._currentConnection && this._currentConnectionProfile) {
 			let connectionUri = Utils.generateUri(this._currentConnectionProfile, 'notebook');
 			this._queryRunner = this._instantiationService.createInstance(QueryRunner, connectionUri);
 			this._connectionManagementService.connect(this._currentConnectionProfile, connectionUri).then((result) => {


### PR DESCRIPTION
Fixed #4800 
IConnectionProfile's _serverCapabilities) is undefined in ProviderConnectionInfo. It will create a different Uri, which is not in connection cache. So we have to use ConnectionProfile.
With this change we don't leak connection anymore and also no need to create extra connection for runCell.