### PR TITLE
Add reverse color option to text diff editor

### DIFF
--- a/src/sql/editor/browser/diffEditorHelper.ts
+++ b/src/sql/editor/browser/diffEditorHelper.ts
@@ -1,0 +1,28 @@
+import * as editorCommon from 'vs/editor/common/editorCommon';
+
+export class DiffEditorHelper {
+	public static reverseLineChanges(lineChanges: editorCommon.ILineChange[]): editorCommon.ILineChange[] {
+		let reversedLineChanges = lineChanges.map(linechange => {
+			return {
+				modifiedStartLineNumber: linechange.originalStartLineNumber,
+				modifiedEndLineNumber: linechange.originalEndLineNumber,
+				originalStartLineNumber: linechange.modifiedStartLineNumber,
+				originalEndLineNumber: linechange.modifiedEndLineNumber,
+				charChanges: (linechange.charChanges) ?
+					linechange.charChanges.map(charchange => {
+						return {
+							originalStartColumn: charchange.modifiedStartColumn,
+							originalEndColumn: charchange.modifiedEndColumn,
+							modifiedStartColumn: charchange.originalStartColumn,
+							modifiedEndColumn: charchange.originalEndColumn,
+							modifiedStartLineNumber: charchange.originalStartLineNumber,
+							modifiedEndLineNumber: charchange.originalEndLineNumber,
+							originalStartLineNumber: charchange.modifiedStartLineNumber,
+							originalEndLineNumber: charchange.modifiedEndLineNumber,
+						};
+					}) : undefined
+			};
+		});
+		return reversedLineChanges;
+	}
+}

--- a/src/sql/editor/browser/diffEditorHelper.ts
+++ b/src/sql/editor/browser/diffEditorHelper.ts
@@ -1,7 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 import * as editorCommon from 'vs/editor/common/editorCommon';
 
-export class DiffEditorHelper {
-	public static reverseLineChanges(lineChanges: editorCommon.ILineChange[]): editorCommon.ILineChange[] {
+/**
+ * Swaps the original and modified line changes
+ * @param lineChanges The line changes to be reversed
+ */
+export function reverseLineChanges(lineChanges: editorCommon.ILineChange[]): editorCommon.ILineChange[] {
 		let reversedLineChanges = lineChanges.map(linechange => {
 			return {
 				modifiedStartLineNumber: linechange.originalStartLineNumber,
@@ -25,4 +33,3 @@ export class DiffEditorHelper {
 		});
 		return reversedLineChanges;
 	}
-}

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -41,7 +41,7 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { defaultInsertColor, defaultRemoveColor, diffBorder, diffInserted, diffInsertedOutline, diffRemoved, diffRemovedOutline, scrollbarShadow } from 'vs/platform/theme/common/colorRegistry';
 import { ITheme, IThemeService, getThemeTypeSelector, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 // {{SQL CARBON EDIT}}
-import { DiffEditorHelper } from 'sql/editor/browser/DiffEditorHelper';
+import { reverseLineChanges } from 'sql/editor/browser/DiffEditorHelper';
 
 interface IEditorDiffDecorations {
 	decorations: IModelDeltaDecoration[];
@@ -1224,7 +1224,7 @@ abstract class DiffEditorWidgetStyle extends Disposable implements IDiffEditorWi
 
 		// {{SQL CARBON EDIT}}
 		if (reverse) {
-			lineChanges = DiffEditorHelper.reverseLineChanges(lineChanges);
+			lineChanges = reverseLineChanges(lineChanges);
 			[originalEditor, modifiedEditor] = [modifiedEditor, originalEditor];
 		}
 

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -744,6 +744,11 @@ export interface IDiffEditorOptions extends IEditorOptions {
 	 * Defaults to false.
 	 */
 	originalEditable?: boolean;
+
+	/**
+	 * Adding option to reverse coloring in diff editor
+	 */
+	reverse?: boolean;
 }
 
 export const enum RenderMinimap {

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -745,6 +745,7 @@ export interface IDiffEditorOptions extends IEditorOptions {
 	 */
 	originalEditable?: boolean;
 
+	// {{SQL CARBON EDIT}}
 	/**
 	 * Adding option to reverse coloring in diff editor
 	 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3079,7 +3079,6 @@ declare namespace monaco.editor {
 		 * Defaults to false.
 		 */
 		originalEditable?: boolean;
-
 		/**
 		 * Adding option to reverse coloring in diff editor
 		 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3079,6 +3079,11 @@ declare namespace monaco.editor {
 		 * Defaults to false.
 		 */
 		originalEditable?: boolean;
+
+		/**
+		 * Adding option to reverse coloring in diff editor
+		 */
+		reverse?: boolean;
 	}
 
 	export enum RenderMinimap {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -42,6 +42,7 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 
 	private diffNavigator: DiffNavigator;
 	private diffNavigatorDisposables: IDisposable[] = [];
+	private reverseColor: boolean;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -69,7 +70,15 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 		return nls.localize('textDiffEditor', "Text Diff Editor");
 	}
 
+	reverseColoring(): void {
+		this.reverseColor = true;
+	}
+
 	createEditorControl(parent: HTMLElement, configuration: ICodeEditorOptions): IDiffEditor {
+		if (this.reverseColor) {
+			(configuration as IDiffEditorOptions).reverse = true;
+		}
+
 		return this.instantiationService.createInstance(DiffEditorWidget, parent, configuration);
 	}
 

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -42,6 +42,7 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 
 	private diffNavigator: DiffNavigator;
 	private diffNavigatorDisposables: IDisposable[] = [];
+	// {{SQL CARBON EDIT}}
 	private reverseColor: boolean;
 
 	constructor(
@@ -70,11 +71,13 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 		return nls.localize('textDiffEditor', "Text Diff Editor");
 	}
 
+	// {{SQL CARBON EDIT}}
 	reverseColoring(): void {
 		this.reverseColor = true;
 	}
 
 	createEditorControl(parent: HTMLElement, configuration: ICodeEditorOptions): IDiffEditor {
+		// {{SQL CARBON EDIT}}
 		if (this.reverseColor) {
 			(configuration as IDiffEditorOptions).reverse = true;
 		}


### PR DESCRIPTION
This changeset adds the color reversing option as an optional parameter for the diff editor. This is needed for the schema compare extension since it uses the text diff editor and needs the colors to be reversed.

![image](https://user-images.githubusercontent.com/31145923/55500346-fd38fa00-55fc-11e9-83cf-3960ad41f341.png)

![image](https://user-images.githubusercontent.com/31145923/55500357-04600800-55fd-11e9-991a-056727c85997.png)

![image](https://user-images.githubusercontent.com/31145923/55500361-088c2580-55fd-11e9-87e0-3fdf466fcbd7.png)
