### PR TITLE
Notebooks: Fix for dispose method of undefined when running empty python cell

### DIFF
--- a/src/sql/parts/notebook/models/cell.ts
+++ b/src/sql/parts/notebook/models/cell.ts
@@ -490,7 +490,9 @@ export class CellModel implements ICellModel {
 
 	// Dispose and set current future to undefined
 	private disposeFuture() {
-		this._future.dispose();
+		if (this._future) {
+			this._future.dispose();
+		}
 		this._future = undefined;
 	}
 }


### PR DESCRIPTION
Fixes #4842, which is a regression.