### PR TITLE
Notebook manages all the connections created in itself.

### DIFF
--- a/src/sql/parts/notebook/models/clientSession.ts
+++ b/src/sql/parts/notebook/models/clientSession.ts
@@ -111,7 +111,8 @@ export class ClientSession implements IClientSession {
 			// TODO #3164 should use URI instead of path for startNew
 			session = await this.notebookManager.sessionManager.startNew({
 				path: this.notebookUri.fsPath,
-				kernelName: kernelName
+				kernelName: kernelName,
+				kernelId: kernelName
 				// TODO add kernel name if saved in the document
 			});
 			session.defaultKernelLoaded = true;

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -341,7 +341,7 @@ export class AttachToDropdown extends SelectBox {
 
 	private updateAttachToDropdown(model: INotebookModel): void {
 		if (this.model.connectionProfile && this.model.connectionProfile.serverName) {
-			let connectionUri = generateUri(this.model.connectionProfile, 'notebook') + '|' + generateUuid();
+			let connectionUri = this.model.notebookUri.toString();
 			this.model.notebookOptions.connectionService.connect(this.model.connectionProfile, connectionUri).then(result => {
 				if (result.connected) {
 					let connectionProfile = new ConnectionProfile(this._capabilitiesService, result.connectionProfile);

--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -33,7 +33,8 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 
 	public constructor(
 		capabilitiesService: ICapabilitiesService,
-		model: string | azdata.IConnectionProfile
+		model: string | azdata.IConnectionProfile,
+		generateId: boolean = false
 	) {
 		super(capabilitiesService, model);
 		if (model && !isString(model)) {
@@ -41,7 +42,7 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 			this.groupFullName = model.groupFullName;
 			this.savePassword = model.savePassword;
 			this.saveProfile = model.saveProfile;
-			this._id = model.id;
+			this._id = !generateId? model.id : generateUuid();
 			this.azureTenantId = model.azureTenantId;
 		} else {
 			//Default for a new connection

--- a/src/sql/platform/connection/common/connectionStatusManager.ts
+++ b/src/sql/platform/connection/common/connectionStatusManager.ts
@@ -128,8 +128,7 @@ export class ConnectionStatusManager {
 		if (connection.connectionProfile.databaseName !== summary.connectionSummary.databaseName) {
 			//Add the ownerUri with database name to the map if not already exists
 			connection.connectionProfile.databaseName = summary.connectionSummary.databaseName;
-			let prefix = Utils.getUriPrefix(summary.ownerUri);
-			let ownerUriWithDbName = Utils.generateUriWithPrefix(connection.connectionProfile, prefix);
+			let ownerUriWithDbName = Utils.generateUriFromExistingUri(connection.connectionProfile, summary.ownerUri);
 			if (!(ownerUriWithDbName in this._connections)) {
 				this._connections[ownerUriWithDbName] = connection;
 			}

--- a/src/sql/platform/connection/common/utils.ts
+++ b/src/sql/platform/connection/common/utils.ts
@@ -116,6 +116,13 @@ export function generateUriWithPrefix(connection: IConnectionProfile, prefix: st
 	return uri;
 }
 
+export function generateUriFromExistingUri(connection: IConnectionProfile, id: string): string {
+	let db = connection.serverName + ':' + connection.databaseName;
+	let uri = id ? id + '|' + db : id;
+
+	return uri;
+}
+
 export function findProfileInGroup(og: IConnectionProfile, groups: ConnectionProfileGroup[]): ConnectionProfile {
 	for (let group of groups) {
 		for (let conn of group.connections) {

--- a/src/sql/platform/connection/common/utils.ts
+++ b/src/sql/platform/connection/common/utils.ts
@@ -118,7 +118,7 @@ export function generateUriWithPrefix(connection: IConnectionProfile, prefix: st
 
 export function generateUriFromExistingUri(connection: IConnectionProfile, id: string): string {
 	let db = connection.serverName + ':' + connection.databaseName;
-	let uri = id ? id + '|' + db : id;
+	let uri = id ? id + ':' + db : id;
 
 	return uri;
 }

--- a/src/sql/platform/connection/common/utils.ts
+++ b/src/sql/platform/connection/common/utils.ts
@@ -110,7 +110,7 @@ export function getUriPrefix(ownerUri: string): string {
 }
 
 export function generateUriWithPrefix(connection: IConnectionProfile, prefix: string): string {
-	let id = connection.getOptionsKey();
+	let id = connection.getOptionsKey() + '|id:' + connection.id;
 	let uri = prefix + (id ? id : connection.serverName + ':' + connection.databaseName);
 
 	return uri;

--- a/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
@@ -81,6 +81,7 @@ export class SqlSessionManager implements nb.SessionManager {
 			let sqlKernel = this._session.kernel as SqlKernel;
 			return sqlKernel.disconnect();
 		}
+		return Promise.resolve();
 	}
 }
 

--- a/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
@@ -77,8 +77,10 @@ export class SqlSessionManager implements nb.SessionManager {
 	}
 
 	shutdown(id: string): Thenable<void> {
-		let sqlKernel = this._session.kernel as SqlKernel;
-		return sqlKernel.disconnect();
+		if (this._session.kernel) {
+			let sqlKernel = this._session.kernel as SqlKernel;
+			return sqlKernel.disconnect();
+		}
 	}
 }
 
@@ -245,7 +247,7 @@ class SqlKernel extends Disposable implements nb.IKernel {
 			}
 			this._queryRunner.runQuery(code);
 		} else if (this._currentConnection && this._currentConnectionProfile) {
-			this._activeConnectionUri = Utils.generateUri(this._currentConnectionProfile, 'notebook') + '|' + generateUuid();
+			this._activeConnectionUri = Utils.generateUri(this._currentConnectionProfile, 'notebook');
 			this._queryRunner = this._instantiationService.createInstance(QueryRunner, this._activeConnectionUri);
 			this._connectionManagementService.connect(this._currentConnectionProfile, this._activeConnectionUri).then((result) => {
 				this.addQueryEventListeners(this._queryRunner);

--- a/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
@@ -224,7 +224,7 @@ class SqlKernel extends Disposable implements nb.IKernel {
 
 	public set connection(conn: IConnectionProfile) {
 		this._currentConnection = conn;
-		this._currentConnectionProfile = new ConnectionProfile(this._capabilitiesService, this._currentConnection);
+		this._currentConnectionProfile = new ConnectionProfile(this._capabilitiesService, this._currentConnection, true);
 		this._queryRunner = undefined;
 	}
 


### PR DESCRIPTION
Notebook creates unique uri for connectionProfile in itself and cache uir for connection managment. So notebook can disconnect them correctly and don’t overwritten any existing connections made from other places. At the same time avoiding the connection is overwritten by others.

Add disconnect and shutdown to SQLKernel and SQLSessionManager to disconnect the runCell connection.

In order to make the connectionProfile with malformed uri (without prefix) to have the same starting uri, I proposed to add generateUriFromExistingUri to add db name for ownerUriWithDbName entry. 

Here are the sample connection cache for QueryEditor connections with the fix
![image](https://user-images.githubusercontent.com/43652751/55664199-77c16f80-57df-11e9-940c-24b99c575f5c.png)

Without fix: the ownerUriWithDbName is generic, which could be overwritten by later connection with the same profile.
![image](https://user-images.githubusercontent.com/43652751/55664225-eb637c80-57df-11e9-8ddd-5834c7fd5542.png)

Notebook connections:
![image](https://user-images.githubusercontent.com/43652751/55664272-983df980-57e0-11e9-8de8-b255dad456cf.png)

1.First two rows for runCell
2. The last two for intellisense
3. The other two for overall document

I kept runCell to use notebook prefix. This will make QueryRunning service add the application name correctly. So it doesn't reuse the document connection. Potentically we can reuse the overall document connection. But it wouldn't have the correct application name in the SQL instance.

Intellisense still couldn't reuse the the document connection. I think Intellisense is banding with editor connection automatically. 
There is specific test failure for this change. I will hold it until we agree on the change.

### Made two more changes for connectionProfile

- Added id to generateUriWithPrefix to make sure no overwritten of cached object in connectionStatusManager.connection

- Added generateId to ConnectionProfile constructor, so even though the IConnectionProfile is the same, we can still generate unique ID for connecitonProrfile, which will be used in the change above.

The motivation for these two changes are:
We can create lots of notebook by right click OE node in Server view. They use the existing IConnectionProfile from OE node. 
We don't want to use add GUID in the conneciton URI when creating connection URI. Notebook runCell will use the same URI for multiple notebooks. If one of them is closed, then all the other notebook would be able to run cell anymore.

If it is confusing and hard to understand. I can walk through them with you in person to explain the problems. Please suggest other possible better solutions.

