### PR TITLE
Notebooks: Always Serialize Execution Count to File

### DIFF
--- a/src/sql/parts/notebook/models/cell.ts
+++ b/src/sql/parts/notebook/models/cell.ts
@@ -420,7 +420,7 @@ export class CellModel implements ICellModel {
 		if (this._cellType === CellTypes.Code) {
 			cellJson.metadata.language = this._language,
 				cellJson.outputs = this._outputs;
-			cellJson.execution_count = this.executionCount;
+			cellJson.execution_count = this.executionCount ? this.executionCount : 0;
 		}
 		return cellJson as nb.ICellContents;
 	}


### PR DESCRIPTION
Fixes #4863. Our notebooks don't open in the Jupyter Notebook viewer without this change.