### PR TITLE
Fixed cancel connectionDialog from attach to shows dup "select connec…

### DIFF
--- a/src/sql/parts/notebook/models/notebookModel.ts
+++ b/src/sql/parts/notebook/models/notebookModel.ts
@@ -668,7 +668,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					});
 			} else {
 				this._onValidConnectionSelected.fire(false);
-				throw new Error('No valid connection');
 			}
 		} catch (err) {
 			let msg = notebookUtils.getErrorMessage(err);

--- a/src/sql/parts/notebook/notebookActions.ts
+++ b/src/sql/parts/notebook/notebookActions.ts
@@ -387,7 +387,9 @@ export class AttachToDropdown extends SelectBox {
 					this.selectWithOptionName(msgSelectConnection);
 				}
 				else {
-					connections.push(msgAddNewConnection);
+					if (!connections.includes(msgAddNewConnection)) {
+						connections.push(msgAddNewConnection);
+					}
 				}
 				this.setOptions(connections);
 			}
@@ -396,9 +398,13 @@ export class AttachToDropdown extends SelectBox {
 
 	private loadWithSelectConnection(connections: string[]): string[] {
 		if (connections && connections.length > 0) {
-			connections.unshift(msgSelectConnection);
+			if (!connections.includes(msgSelectConnection)) {
+				connections.unshift(msgSelectConnection);
+			}
 			this.selectWithOptionName(msgSelectConnection);
-			connections.push(msgAddNewConnection);
+			if (!connections.includes(msgAddNewConnection)) {
+				connections.push(msgAddNewConnection);
+			}
 			this.setOptions(connections);
 		}
 		return connections;
@@ -470,7 +476,7 @@ export class AttachToDropdown extends SelectBox {
 				}
 				let connectionUri = this._connectionManagementService.getConnectionUri(connection);
 				let connectionProfile = new ConnectionProfile(this._capabilitiesService, connection);
-				let connectedServer = connectionProfile.title? connectionProfile.title : connectionProfile.serverName;
+				let connectedServer = connectionProfile.title ? connectionProfile.title : connectionProfile.serverName;
 				//Check to see if the same server is already there in dropdown. We only have server names in dropdown
 				if (attachToConnections.some(val => val === connectedServer)) {
 					this.loadAttachToDropdown(this.model, this.getKernelDisplayName());


### PR DESCRIPTION
Add check if select connection is in the attach to list before adding it. 
The problem is if cancel the connection dialog, we may see two "select connection". This is due to recent change.