### PR TITLE
Add toolbar separator

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -2585,6 +2585,7 @@ declare module 'azdata' {
 	export interface ToolbarComponent {
 		component: Component;
 		title?: string;
+		toolbarSeparatorAfter?: boolean;
 	}
 
 	/**

--- a/src/sql/base/browser/ui/taskbar/media/taskbar.css
+++ b/src/sql/base/browser/ui/taskbar/media/taskbar.css
@@ -68,9 +68,8 @@
 
 .taskbarSeparator {
 	width: 1px;
-	background-color:#555;
-	margin-right: 6px;
-	margin-top: 3px;
+	background-color:#EAEAEA;
+	margin: 6px 8px;
 }
 
 .taskbarTextSeparator {

--- a/src/sql/base/browser/ui/taskbar/media/taskbar.css
+++ b/src/sql/base/browser/ui/taskbar/media/taskbar.css
@@ -68,7 +68,7 @@
 
 .taskbarSeparator {
 	width: 1px;
-	background-color:#EAEAEA;
+	background-color:#A5A5A5;
 	margin: 6px 8px;
 }
 

--- a/src/sql/parts/modelComponents/toolbarContainer.component.ts
+++ b/src/sql/parts/modelComponents/toolbarContainer.component.ts
@@ -38,7 +38,7 @@ export class ToolbarItem {
 					<model-component-wrapper  [descriptor]="item.descriptor" [modelStore]="modelStore" >
 					</model-component-wrapper>
 				</div>
-				<div *ngIf="shouldShowToolbarSeparator(item)"class="toolbarSeparator" >
+				<div *ngIf="shouldShowToolbarSeparator(item)" class="toolbarSeparator" >
 				</div>
 			</div>
 			</ng-container>
@@ -89,6 +89,9 @@ export default class ToolbarContainer extends ContainerBase<ToolbarItemConfig> i
 	}
 
 	public shouldShowToolbarSeparator(item: ToolbarItem): boolean {
+		if (!item || !item.config) {
+			return false;
+		}
 		return item.config.toolbarSeparatorAfter;
 	}
 

--- a/src/sql/parts/modelComponents/toolbarContainer.component.ts
+++ b/src/sql/parts/modelComponents/toolbarContainer.component.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import 'vs/css!./toolbarLayout';
+import 'vs/css!../../../sql/base/browser/ui/taskbar/media/taskbar';
 
 import {
 	Component, Input, Inject, ChangeDetectorRef, forwardRef,

--- a/src/sql/parts/modelComponents/toolbarContainer.component.ts
+++ b/src/sql/parts/modelComponents/toolbarContainer.component.ts
@@ -18,6 +18,7 @@ import { CommonServiceInterface } from 'sql/services/common/commonServiceInterfa
 
 export interface ToolbarItemConfig {
 	title?: string;
+	toolbarSeparatorAfter?: boolean;
 }
 
 export class ToolbarItem {
@@ -36,6 +37,8 @@ export class ToolbarItem {
 				<div class="modelview-toolbar-component">
 					<model-component-wrapper  [descriptor]="item.descriptor" [modelStore]="modelStore" >
 					</model-component-wrapper>
+				</div>
+				<div *ngIf="shouldShowToolbarSeparator(item)"class="toolbarSeparator" >
 				</div>
 			</div>
 			</ng-container>
@@ -83,6 +86,10 @@ export default class ToolbarContainer extends ContainerBase<ToolbarItemConfig> i
 
 	public shouldShowTitle(item: ToolbarItem): boolean {
 		return this.hasTitle(item) && this.isHorizontal();
+	}
+
+	public shouldShowToolbarSeparator(item: ToolbarItem): boolean {
+		return item.config.toolbarSeparatorAfter;
 	}
 
 	private hasTitle(item: ToolbarItem): boolean {

--- a/src/sql/parts/modelComponents/toolbarContainer.component.ts
+++ b/src/sql/parts/modelComponents/toolbarContainer.component.ts
@@ -38,7 +38,7 @@ export class ToolbarItem {
 					<model-component-wrapper  [descriptor]="item.descriptor" [modelStore]="modelStore" >
 					</model-component-wrapper>
 				</div>
-				<div *ngIf="shouldShowToolbarSeparator(item)" class="toolbarSeparator" >
+				<div *ngIf="shouldShowToolbarSeparator(item)" class="taskbarSeparator" >
 				</div>
 			</div>
 			</ng-container>

--- a/src/sql/parts/modelComponents/toolbarLayout.css
+++ b/src/sql/parts/modelComponents/toolbarLayout.css
@@ -71,9 +71,3 @@
 	-o-transform: scale(1.272019649, 1.272019649);
 	transform: scale(1.272019649, 1.272019649);
 }
-
-.modelview-toolbar-container .toolbarSeparator {
-	width: 1px;
-	background-color:#EAEAEA;
-	margin: 6px 8px;
-}

--- a/src/sql/parts/modelComponents/toolbarLayout.css
+++ b/src/sql/parts/modelComponents/toolbarLayout.css
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
- .modelview-toolbar-container {
+.modelview-toolbar-container {
 	display: flex;
 	justify-content: flex-start;
 	line-height: 1.4em;

--- a/src/sql/parts/modelComponents/toolbarLayout.css
+++ b/src/sql/parts/modelComponents/toolbarLayout.css
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.modelview-toolbar-container {
+ .modelview-toolbar-container {
 	display: flex;
 	justify-content: flex-start;
 	line-height: 1.4em;
@@ -72,7 +72,7 @@
 	transform: scale(1.272019649, 1.272019649);
 }
 
-.toolbarSeparator {
+.modelview-toolbar-container .toolbarSeparator {
 	width: 1px;
 	background-color:#EAEAEA;
 	margin: 6px 8px;

--- a/src/sql/parts/modelComponents/toolbarLayout.css
+++ b/src/sql/parts/modelComponents/toolbarLayout.css
@@ -71,3 +71,9 @@
 	-o-transform: scale(1.272019649, 1.272019649);
 	transform: scale(1.272019649, 1.272019649);
 }
+
+.toolbarSeparator {
+	width: 1px;
+	background-color:#EAEAEA;
+	margin: 6px 8px;
+}

--- a/src/sql/workbench/api/node/extHostModelView.ts
+++ b/src/sql/workbench/api/node/extHostModelView.ts
@@ -414,7 +414,8 @@ class ToolbarContainerBuilder extends GenericContainerBuilder<azdata.ToolbarCont
 		let componentWrapper = toolbarComponent.component as ComponentWrapper;
 
 		return new InternalItemConfig(componentWrapper, {
-			title: toolbarComponent.title
+			title: toolbarComponent.title,
+			toolbarSeparatorAfter: toolbarComponent.toolbarSeparatorAfter
 		});
 	}
 


### PR DESCRIPTION
This adds the option to add a toolbar separator after a toolbar component

![image](https://user-images.githubusercontent.com/31145923/55662279-beef3680-57c6-11e9-8a85-48eb1426689c.png)
