### PR TITLE
fixed the indent for sql snipet same as other snipets

### DIFF
--- a/extensions/mssql/snippets/mssql.json
+++ b/extensions/mssql/snippets/mssql.json
@@ -29,9 +29,9 @@
 			"-- ALTER DATABASE ${1:DatabaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;",
 			"-- Drop the database if it exists",
 			"IF EXISTS (",
-			"  SELECT [name]",
-			"   FROM sys.databases",
-			"   WHERE [name] = N'${1:DatabaseName}'",
+			"\tSELECT [name]",
+			"\t\tFROM sys.databases",
+			"\t\tWHERE [name] = N'${1:DatabaseName}'",
 			")",
 			"DROP DATABASE ${1:DatabaseName}",
 			"GO"


### PR DESCRIPTION
The intend for other sql snipets is used `\t`.
But this snipet is used the space. 
This PR is to change the indent same as other SQL snipets from space to `\t`.