### PR TITLE
Sample/notebook api change

### DIFF
--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -197,9 +197,18 @@ async function handleNewNotebookTask(oeContext?: azdata.ObjectExplorerContext, p
 	// to handle this. We should look into improving this in the future
 	let title = findNextUntitledEditorName();
 	let untitledUri = vscode.Uri.parse(`untitled:${title}`);
+	let content: azdata.nb.INotebookContents = {
+		metadata: {
+			kernelspec: { name: 'pyspark3' }
+		},
+		cells: [],
+		nbformat: 4,
+		nbformat_minor: 2
+	};
 	let editor = await azdata.nb.showNotebookDocument(untitledUri, {
 		connectionProfile: profile,
-		preview: false
+		preview: false,
+		initialContent: content
 	});
 	if (oeContext && oeContext.nodeInfo && oeContext.nodeInfo.nodePath) {
 		// Get the file path after '/HDFS'

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -197,21 +197,9 @@ async function handleNewNotebookTask(oeContext?: azdata.ObjectExplorerContext, p
 	// to handle this. We should look into improving this in the future
 	let title = findNextUntitledEditorName();
 	let untitledUri = vscode.Uri.parse(`untitled:${title}`);
-	let content: azdata.nb.INotebookContents = {
-		metadata: {
-			kernelspec: { name: 'pyspark3' }
-		},
-		cells: [{
-			cell_type: 'markdown',
-			source: 'Hello World'
-		}],
-		nbformat: 4,
-		nbformat_minor: 2
-	};
 	let editor = await azdata.nb.showNotebookDocument(untitledUri, {
 		connectionProfile: profile,
-		preview: false,
-		initialContent: content
+		preview: false
 	});
 	if (oeContext && oeContext.nodeInfo && oeContext.nodeInfo.nodePath) {
 		// Get the file path after '/HDFS'

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -201,7 +201,10 @@ async function handleNewNotebookTask(oeContext?: azdata.ObjectExplorerContext, p
 		metadata: {
 			kernelspec: { name: 'pyspark3' }
 		},
-		cells: [],
+		cells: [{
+			cell_type: 'markdown',
+			source: 'Hello World'
+		}],
 		nbformat: 4,
 		nbformat_minor: 2
 	};

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -55,13 +55,26 @@ export function activate(extensionContext: vscode.ExtensionContext) {
 function newNotebook(connectionProfile: azdata.IConnectionProfile) {
 	let title = findNextUntitledEditorName();
 	let untitledUri = vscode.Uri.parse(`untitled:${title}`);
+	let content: azdata.nb.INotebookContents = {
+		metadata: {
+			kernelspec: { name: 'pyspark3', display_name: 'PySpark3', language: 'python' }
+		},
+		cells: [{
+			cell_type: 'markdown',
+			source: 'Hello World'
+		}],
+		nbformat: 4,
+		nbformat_minor: 2
+	};
+
 	let options: azdata.nb.NotebookShowOptions = connectionProfile ? {
 		viewColumn: null,
 		preserveFocus: true,
 		preview: null,
 		providerId: null,
 		connectionProfile: connectionProfile,
-		defaultKernel: null
+		defaultKernel: null,
+		initialContent: content
 	} : null;
 	azdata.nb.showNotebookDocument(untitledUri, options).then(success => {
 

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -4085,6 +4085,11 @@ declare module 'azdata' {
 			 * Default kernel for notebook
 			 */
 			defaultKernel?: nb.IKernelSpec;
+
+			/**
+			 * Optional content used to give an initial notebook state
+			 */
+			initialContent?: nb.INotebookContents | string;
 		}
 
 		/**

--- a/src/sql/workbench/api/node/extHostNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/extHostNotebookDocumentsAndEditors.ts
@@ -169,6 +169,13 @@ export class ExtHostNotebookDocumentsAndEditors implements ExtHostNotebookDocume
 			options.providerId = showOptions.providerId;
 			options.connectionProfile = showOptions.connectionProfile;
 			options.defaultKernel = showOptions.defaultKernel;
+			if (showOptions.initialContent) {
+				if (typeof (showOptions.initialContent) !== 'string') {
+					options.initialContent = JSON.stringify(showOptions.initialContent);
+				} else {
+					options.initialContent = showOptions.initialContent;
+				}
+			}
 		}
 		let id = await this._proxy.$tryShowNotebookDocument(uri, options);
 		let editor = this.getEditor(id);

--- a/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
@@ -399,7 +399,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 		};
 		let isUntitled: boolean = uri.scheme === Schemas.untitled;
 
-		const fileInput = isUntitled ? this._untitledEditorService.createOrGet(uri, notebookModeId) :
+		const fileInput = isUntitled ? this._untitledEditorService.createOrGet(uri, notebookModeId, options.initialContent) :
 										this._editorService.createInput({ resource: uri, language: notebookModeId });
 		let input = this._instantiationService.createInstance(NotebookInput, path.basename(uri.fsPath), uri, fileInput);
 		input.isTrusted = isUntitled;

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -854,6 +854,7 @@ export interface INotebookShowOptions {
 	providerId?: string;
 	connectionProfile?: azdata.IConnectionProfile;
 	defaultKernel?: azdata.nb.IKernelSpec;
+	initialContent?: string;
 }
 
 export interface ExtHostNotebookDocumentsAndEditorsShape {


### PR DESCRIPTION
Draft: this is for discussion among Notebook folks. We need to solve "open notebook and set initial content". I've done the following sample for this, and if approved Gene can use to solve the notebook preview from HDFS issue. What do people think?

Note: Not for checkin as it edits the default New Notebook to add a "Hello World" and set a provider