### PR TITLE
Change pfs.rimraf() call in insightsutils test due to test failure

### DIFF
--- a/src/sqltest/parts/insights/insightsUtils.test.ts
+++ b/src/sqltest/parts/insights/insightsUtils.test.ts
@@ -173,6 +173,6 @@ suite('Insights Utils tests', function () {
 
 	suiteTeardown(() => {
 		// Clean up our test files
-		return pfs.rimraf(testRootPath);
+		return pfs.rimraf(testRootPath, pfs.RimRafMode.MOVE);
 	});
 });


### PR DESCRIPTION
This particular test has been failing the past couple of days, blocking insiders builds from succeeding. Adding pfs.RimRafMode.MOVE to match many other calls of pfs.rimraf() to see if the test now succeeds.

Note: I cannot repro this failure on my machine, so I am unsure if this will fix the issue; I am just using tests under src/vs/* to see how they leverage this method in their tests.