### PR TITLE
Update strings for data explorer

### DIFF
--- a/src/sql/workbench/parts/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/parts/dataExplorer/browser/dataExplorer.contribution.ts
@@ -22,7 +22,7 @@ import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editor
 // Viewlet Action
 export class OpenDataExplorerViewletAction extends ShowViewletAction {
 	public static ID = VIEWLET_ID;
-	public static LABEL = localize('showDataExplorer', "Show Data Explorer");
+	public static LABEL = localize('showDataExplorer', "Show Connections");
 
 	constructor(
 		id: string,
@@ -39,7 +39,7 @@ export class OpenDataExplorerViewletAction extends ShowViewletAction {
 const viewletDescriptor = new ViewletDescriptor(
 	DataExplorerViewlet,
 	VIEWLET_ID,
-	localize('workbench.dataExplorer', "Data Explorer"),
+	localize('workbench.dataExplorer', "Connections"),
 	'dataExplorer',
 	0
 );

--- a/src/sql/workbench/parts/dataExplorer/browser/dataExplorerExtensionPoint.ts
+++ b/src/sql/workbench/parts/dataExplorer/browser/dataExplorerExtensionPoint.ts
@@ -156,7 +156,7 @@ class DataExplorerContainerExtensionHandler implements IWorkbenchContribution {
 	}
 
 	private showCollapsed(container: ViewContainer): boolean {
-		return false;
+		return true;
 	}
 }
 


### PR DESCRIPTION
Updates strings for data explorer, doesn't change anything about the extension point
Change default to collpased for extension views.