### PR TITLE
Fix #4930 Text cells are referred to as text and markdown in commands

### DIFF
--- a/src/sql/workbench/parts/notebook/cellToggleMoreActions.ts
+++ b/src/sql/workbench/parts/notebook/cellToggleMoreActions.ts
@@ -31,8 +31,8 @@ export class CellToggleMoreActions {
 			instantiationService.createInstance(DeleteCellAction, 'delete', localize('delete', 'Delete')),
 			instantiationService.createInstance(AddCellFromContextAction,'codeBefore', localize('codeBefore', 'Insert Code before'), CellTypes.Code, false),
 			instantiationService.createInstance(AddCellFromContextAction, 'codeAfter', localize('codeAfter', 'Insert Code after'), CellTypes.Code, true),
-			instantiationService.createInstance(AddCellFromContextAction, 'markdownBefore', localize('markdownBefore', 'Insert Markdown before'), CellTypes.Markdown, false),
-			instantiationService.createInstance(AddCellFromContextAction, 'markdownAfter', localize('markdownAfter', 'Insert Markdown after'), CellTypes.Markdown, true),
+			instantiationService.createInstance(AddCellFromContextAction, 'markdownBefore', localize('markdownBefore', 'Insert Text before'), CellTypes.Markdown, false),
+			instantiationService.createInstance(AddCellFromContextAction, 'markdownAfter', localize('markdownAfter', 'Insert Text after'), CellTypes.Markdown, true),
 			instantiationService.createInstance(ClearCellOutputAction, 'clear', localize('clear', 'Clear output'))
 		);
 	}


### PR DESCRIPTION
Changes:
![image](https://user-images.githubusercontent.com/10819925/55833470-77212580-5acc-11e9-98e9-eb4566224ca6.png)
