### PR TITLE
Fix #4893 New Notebook Can Open Existing Noteboon

### DIFF
--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -75,8 +75,9 @@ function findNextUntitledEditorName(): string {
 	// Note: this will go forever if it's coded wrong, or you have infinite Untitled notebooks!
 	while (true) {
 		let title = `Notebook-${nextVal}`;
+		let hasTextDoc = vscode.workspace.textDocuments.findIndex(doc => doc.isUntitled && doc.fileName === title) > -1;
 		let hasNotebookDoc = azdata.nb.notebookDocuments.findIndex(doc => doc.isUntitled && doc.fileName === title) > -1;
-		if (!hasNotebookDoc) {
+		if (!hasTextDoc && !hasNotebookDoc) {
 			return title;
 		}
 		nextVal++;


### PR DESCRIPTION
Add back check for textDocuments with same name, should've been there anyhow

On rehydration files show as text docs before clicking as only get
changed by customInputConverter code path.
We should look at this long term - ideally we'd update notebookDocuments
with correct values on initial start. #4958 opened to track this.