### PR TITLE
Mitigate (but not fully fix) Run Cell from disconnected notebook

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterKernel.ts
+++ b/extensions/notebook/src/jupyter/jupyterKernel.ts
@@ -63,6 +63,12 @@ export class JupyterKernel implements nb.IKernel {
 		return true;
 	}
 
+	public get requiresConnection(): boolean {
+		// TODO would be good to have a smarter way to do this.
+		// for now only Spark kernels need a connection
+		return !!(this.kernelImpl.name && this.kernelImpl.name.toLowerCase().indexOf('spark') > -1);
+	}
+
 	public get isReady(): boolean {
 		return this.kernelImpl.isReady;
 	}

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -4545,6 +4545,7 @@ declare module 'azdata' {
 			readonly id: string;
 			readonly name: string;
 			readonly supportsIntellisense: boolean;
+			readonly requiresConnection?: boolean;
 			/**
 			 * Test whether the kernel is ready.
 			 */

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -465,6 +465,7 @@ export interface INotebookKernelDetails {
 	readonly id: string;
 	readonly name: string;
 	readonly supportsIntellisense: boolean;
+	readonly requiresConnection: boolean;
 	readonly info?: any;
 }
 

--- a/src/sql/workbench/api/node/extHostNotebook.ts
+++ b/src/sql/workbench/api/node/extHostNotebook.ts
@@ -111,7 +111,8 @@ export class ExtHostNotebook implements ExtHostNotebookShape {
 			id: kernel.id,
 			info: kernel.info,
 			name: kernel.name,
-			supportsIntellisense: kernel.supportsIntellisense
+			supportsIntellisense: kernel.supportsIntellisense,
+			requiresConnection: kernel.requiresConnection
 		};
 		return kernelDetails;
 	}

--- a/src/sql/workbench/api/node/mainThreadNotebook.ts
+++ b/src/sql/workbench/api/node/mainThreadNotebook.ts
@@ -352,6 +352,10 @@ class KernelWrapper implements azdata.nb.IKernel {
 		return this.kernelDetails.supportsIntellisense;
 	}
 
+	get requiresConnection(): boolean {
+		return this.kernelDetails.requiresConnection;
+	}
+
 	get info(): azdata.nb.IInfoReply {
 		return this._info;
 	}

--- a/src/sql/workbench/parts/notebook/models/cell.ts
+++ b/src/sql/workbench/parts/notebook/models/cell.ts
@@ -211,13 +211,7 @@ export class CellModel implements ICellModel {
 			} else {
 				// TODO update source based on editor component contents
 				if (kernel.requiresConnection && !this.notebookModel.activeConnection) {
-					// start with an error case
-					let errorMsg: nb.IStreamResult = {
-						name: 'stderr',
-						output_type: 'stream',
-						text: localize('kernelRequiresConnection', 'Please select a connection to run cells. This kernel requires a connection to run code')
-					};
-					this.handleIOPub(this.createIoPubMessage(errorMsg, 'stream'));
+					this.sendNotification(notificationService, Severity.Error, localize('kernelRequiresConnection', 'Please select a connection to run cells for this kernel'));
 					return false;
 				}
 				let content = this.source;
@@ -254,23 +248,6 @@ export class CellModel implements ICellModel {
 		}
 
 		return true;
-	}
-
-	private createIoPubMessage(errorMsg: nb.IStreamResult, msg_type: string): nb.IIOPubMessage {
-		return {
-			channel: 'iopub',
-			type: 'iopub',
-			content: errorMsg,
-			header: {
-				msg_type: msg_type,
-				msg_id: undefined,
-				session: undefined,
-				username: undefined,
-				version: undefined
-			},
-			metadata: undefined,
-			parent_header: undefined
-		};
 	}
 
 	private async getOrStartKernel(notificationService: INotificationService): Promise<nb.IKernel> {

--- a/src/sql/workbench/parts/notebook/models/cell.ts
+++ b/src/sql/workbench/parts/notebook/models/cell.ts
@@ -211,7 +211,7 @@ export class CellModel implements ICellModel {
 			} else {
 				// TODO update source based on editor component contents
 				if (kernel.requiresConnection && !this.notebookModel.activeConnection) {
-					this.sendNotification(notificationService, Severity.Error, localize('kernelRequiresConnection', 'Please select a connection to run cells for this kernel'));
+					this.sendNotification(notificationService, Severity.Error, localize('kernelRequiresConnection', "Please select a connection to run cells for this kernel"));
 					return false;
 				}
 				let content = this.source;

--- a/src/sql/workbench/services/notebook/common/sessionManager.ts
+++ b/src/sql/workbench/services/notebook/common/sessionManager.ts
@@ -116,6 +116,10 @@ class EmptyKernel implements nb.IKernel {
 		return false;
 	}
 
+	public get requiresConnection(): boolean {
+		return false;
+	}
+
 	public get isReady(): boolean {
 		return true;
 	}

--- a/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
@@ -179,6 +179,10 @@ class SqlKernel extends Disposable implements nb.IKernel {
 		return true;
 	}
 
+	public get requiresConnection(): boolean {
+		return true;
+	}
+
 	public get isReady(): boolean {
 		// should we be checking on the tools service status here?
 		return true;


### PR DESCRIPTION
This is a partial fix that lays groundwork for full "Prompt to connect" if a kernel needs a connection.
I am waiting on Yurong's refactoring of connection handling before doing any of the prompt work.
- Adds kernel metadata about whether a connection is required.
 - For Jupyter, only Spark kernels are listed as requiring a connection
- If this is true and there's no active connection, will show notification and not call execute

In the future, this path will still be used if user is prompted to connect and cancels out.
The future change will be to inject a "connect" handler from notebook.component to the cell callback and use to set connection context