### PR TITLE
Add title for DiffEditor and fix SplitViewContainer

### DIFF
--- a/src/sql/parts/modelComponents/diffeditor.component.ts
+++ b/src/sql/parts/modelComponents/diffeditor.component.ts
@@ -24,11 +24,16 @@ import { SimpleProgressService } from 'vs/editor/standalone/browser/simpleServic
 import { IProgressService } from 'vs/platform/progress/common/progress';
 import { TextDiffEditor } from 'vs/workbench/browser/parts/editor/textDiffEditor';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
-import { TextDiffEditorModel} from 'vs/workbench/common/editor/textDiffEditorModel';
+import { TextDiffEditorModel } from 'vs/workbench/common/editor/textDiffEditorModel';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 
 @Component({
-	template: '',
+	template: `
+	<div *ngIf="_title">
+		<div style="width: 100%; height:100%; padding-left:3px !important; background: #F4F4F4; border: 1px solid #BFBDBD;">
+			{{_title}}
+		</div>
+	</div>`,
 	selector: 'modelview-diff-editor-component'
 })
 export default class DiffEditorComponent extends ComponentBase implements IComponent, OnDestroy {
@@ -43,6 +48,7 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 	private _isAutoResizable: boolean;
 	private _minimumHeight: number;
 	private _instancetiationService: IInstantiationService;
+	protected _title: string;
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef,
@@ -73,8 +79,8 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 		this.editorUriRight = uri2.toString();
 
 		let cancellationTokenSource = new CancellationTokenSource();
-		let editorinput1 =	this._instantiationService.createInstance(UntitledEditorInput, uri1, false, 'plaintext', '', '');
-		let editorinput2 =	this._instantiationService.createInstance(UntitledEditorInput, uri2, false, 'plaintext', '', '');
+		let editorinput1 = this._instantiationService.createInstance(UntitledEditorInput, uri1, false, 'plaintext', '', '');
+		let editorinput2 = this._instantiationService.createInstance(UntitledEditorInput, uri2, false, 'plaintext', '', '');
 		this._editorInput = this._instantiationService.createInstance(DiffEditorInput, 'MyEditor', 'My description', editorinput1, editorinput2, true);
 		this._editor.setInput(this._editorInput, undefined, cancellationTokenSource.token);
 
@@ -91,7 +97,7 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 		this._register(this._editorModel);
 	}
 
-	private createUri(input:string): URI {
+	private createUri(input: string): URI {
 		let uri = URI.from({ scheme: Schemas.untitled, path: `${this.descriptor.type}-${this.descriptor.id}-${input}` });
 		return uri;
 	}
@@ -152,6 +158,7 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 		}
 		this._isAutoResizable = this.isAutoResizable;
 		this._minimumHeight = this.minimumHeight;
+		this._title = this.title;
 		this.layout();
 		this.validate();
 	}
@@ -211,5 +218,13 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 
 	public set editorUriRight(newValue: string) {
 		this.setPropertyFromUI<azdata.EditorProperties, string>((properties, editorUriRight) => { properties.editorUriRight = editorUriRight; }, newValue);
+	}
+
+	public get title(): string {
+		return this.getPropertyOrDefault<azdata.EditorProperties, string>((props) => props.title, undefined);
+	}
+
+	public set title(newValue: string) {
+		this.setPropertyFromUI<azdata.EditorProperties, string>((properties, title) => { properties.title = title; }, newValue);
 	}
 }

--- a/src/sql/parts/modelComponents/splitviewContainer.component.ts
+++ b/src/sql/parts/modelComponents/splitviewContainer.component.ts
@@ -61,8 +61,8 @@ export default class SplitViewContainer extends ContainerBase<FlexItemLayout> im
 	private _width: string;
 	private _position: string;
 	private _splitView: SplitView;
-	private _orientation : Orientation;
-	private _splitViewHeight : number;
+	private _orientation: Orientation;
+	private _splitViewHeight: number;
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef,
@@ -91,7 +91,8 @@ export default class SplitViewContainer extends ContainerBase<FlexItemLayout> im
 		let basicView: SplitPane = new SplitPane();
 		basicView.orientation = orientation;
 		basicView.element = c.getHtml(),
-		basicView.minimumSize = orientation === Orientation.VERTICAL ? c.convertSizeToNumber(c.height) : c.convertSizeToNumber(c.width);
+		basicView.component = c;
+		basicView.minimumSize = 50;
 		basicView.maximumSize = Number.MAX_VALUE;
 		return basicView;
 	}
@@ -111,19 +112,17 @@ export default class SplitViewContainer extends ContainerBase<FlexItemLayout> im
 		this._splitViewHeight = this.convertSizeToNumber(layout.splitViewHeight);
 
 		if (this._componentWrappers) {
-			let i : number = 0;
 			this._componentWrappers.forEach(item => {
 				var component = item.modelStore.getComponent(item.descriptor.id);
 				item.modelStore.validate(component).then(value => {
-					if(value === true){
+					if (value === true) {
 						let view = this.GetCorrespondingView(component, this._orientation);
-						this._splitView.addView(view, Sizing.Split(i));
+						this._splitView.addView(view, Sizing.Distribute);
 					}
-					else{
+					else {
 						console.log('Could not add views inside split view container');
 					}
 				});
-				i++;
 			});
 		}
 		this._splitView.layout(this._splitViewHeight);


### PR DESCRIPTION
Three small changes (and some formatting):
1. Add option to add title to diff editor
Example where the title is set to "Object Definitions":
![image](https://user-images.githubusercontent.com/31145923/55840671-10f2cd80-5ae1-11e9-8a57-71a06730de73.png)


2. The splitter for the SplitViewContainer wasn't showing up because the minimum size was set to the component's current height/width. This sets the minimum size to 50.
3. The component of the SplitPane wasn't getting set, so the height of the components wasn't getting set when the splitter was moved.
