### PR TITLE
Add Another Assert for Notebook Test when Server Cannot Be Found

### DIFF
--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -101,9 +101,10 @@ async function openNotebook(content: azdata.nb.INotebookContents, kernelMetadata
 	let notebookConfig = vscode.workspace.getConfiguration('notebook');
 	notebookConfig.update('pythonPath', getConfigValue(EnvironmentVariable_PYTHON_PATH), 1);
 	let server = await getBdcServer();
+	assert(server && server.serverName, 'No server could be found in openNotebook');
 	await connectToServer(server, 6000);
-	let pythonNotebook = Object.assign({}, content, { metadata: kernelMetadata });
-	let uri = writeNotebookToFile(pythonNotebook, testName);
+	let notebookJson = Object.assign({}, content, { metadata: kernelMetadata });
+	let uri = writeNotebookToFile(notebookJson, testName);
 	console.log(uri);
 	let notebook = await azdata.nb.showNotebookDocument(uri);
 	console.log('Notebook is opened');


### PR DESCRIPTION
In getBdcServer(), we do the following:

```
let servers = await getTestingServers();
return servers.filter(s => s.version === '2019')[0];
```

Adding an assert that that actually returns something (so that we know we're passing something "real" into connectToServer(), and making another variable name clearer).