### PR TITLE
Add New Notebook Task from Server Dashboard

### DIFF
--- a/src/sql/workbench/parts/dashboard/pages/serverDashboardPage.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/pages/serverDashboardPage.contribution.ts
@@ -78,7 +78,7 @@ const defaultVal = [
 	{
 		name: 'Tasks',
 		widget: {
-			'tasks-widget': [{ name: 'restore', when: '!mssql:iscloud' }, 'configureDashboard', 'newQuery']
+			'tasks-widget': [{ name: 'restore', when: '!mssql:iscloud' }, 'configureDashboard', 'newQuery', 'mssqlCluster.task.newNotebook']
 		},
 		gridItemConfig: {
 			sizex: 1,


### PR DESCRIPTION
Partial fix for #4838 to get a task in the server dashboard for New Notebook. This has been brought up as a usability/discovery issue:

<img width="269" alt="image" src="https://user-images.githubusercontent.com/40371649/55906574-6e425980-5b89-11e9-92a6-2565bdebe47f.png">

For the Database Dashboard, this is more problematic; the dashboard shows a horizontal scrollbar when I try to add it there, since its size is static. I'd prefer to leave that alone for now.