### PR TITLE
Fix ##3479 ctrl+a select active cell output or preview markdown

### DIFF
--- a/src/sql/workbench/parts/notebook/cellViews/codeCell.component.html
+++ b/src/sql/workbench/parts/notebook/cellViews/codeCell.component.html
@@ -9,7 +9,7 @@
 		<code-component [cellModel]="cellModel" [model]="model" [activeCellId]="activeCellId"></code-component>
 	</div>
 	<div style="flex: 0 0 auto; width: 100%; height: 100%; display: block">
-		<output-area-component *ngIf="cellModel.outputs && cellModel.outputs.length > 0" [cellModel]="cellModel">
+		<output-area-component *ngIf="cellModel.outputs && cellModel.outputs.length > 0" [cellModel]="cellModel" [activeCellId]="activeCellId">
 		</output-area-component>
 	</div>
 </div>

--- a/src/sql/workbench/parts/notebook/cellViews/output.component.html
+++ b/src/sql/workbench/parts/notebook/cellViews/output.component.html
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 -->
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
-	<div style="flex: 0 0 auto; user-select: initial;">
-		<div #output ></div>
+	<div style="flex: 0 0 auto; user-select: none;">
+		<div #output class="output" ></div>
 	</div>
 </div>

--- a/src/sql/workbench/parts/notebook/cellViews/output.component.html
+++ b/src/sql/workbench/parts/notebook/cellViews/output.component.html
@@ -6,6 +6,6 @@
 -->
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div style="flex: 0 0 auto; user-select: none;">
-		<div #output class="output" ></div>
+		<div #output class="output-userselect" ></div>
 	</div>
 </div>

--- a/src/sql/workbench/parts/notebook/cellViews/output.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/output.component.ts
@@ -17,7 +17,7 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 import * as DOM from 'vs/base/browser/dom';
 
 export const OUTPUT_SELECTOR: string = 'output-component';
-export const USER_SELECT_CLASS ='actionselect';
+const USER_SELECT_CLASS ='actionselect';
 
 @Component({
 	selector: OUTPUT_SELECTOR,
@@ -87,8 +87,7 @@ export class OutputComponent extends AngularDisposable implements OnInit {
 		return this._trusted;
 	}
 
-	@Input()
-	set trustedMode(value: boolean) {
+	@Input() set trustedMode(value: boolean) {
 		this._trusted = value;
 		if (this._initialized) {
 			this.renderOutput();

--- a/src/sql/workbench/parts/notebook/cellViews/output.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/output.component.ts
@@ -54,14 +54,12 @@ export class OutputComponent extends AngularDisposable implements OnInit {
 
 		for (let propName in changes) {
 			if (propName === 'activeCellId') {
-				let changedProp = changes[propName];
-				let isActive = this.cellModel.id === changedProp.currentValue;
-				this.toggleUserSelect(isActive);
+				this.toggleUserSelect(this.isActive());
 				break;
 			}
 		}
 	}
-	
+
 	private toggleUserSelect(userSelect: boolean): void {
 		if (!this.outputElement) {
 			return;

--- a/src/sql/workbench/parts/notebook/cellViews/output.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/output.component.ts
@@ -5,7 +5,7 @@
 import 'vs/css!./code';
 import 'vs/css!./media/output';
 
-import { OnInit, Component, Input, Inject, ElementRef, ViewChild } from '@angular/core';
+import { OnInit, Component, Input, Inject, ElementRef, ViewChild, SimpleChange } from '@angular/core';
 import { AngularDisposable } from 'sql/base/node/lifecycle';
 import { nb } from 'azdata';
 import { ICellModel } from 'sql/workbench/parts/notebook/models/modelInterfaces';
@@ -14,8 +14,10 @@ import { MimeModel } from 'sql/workbench/parts/notebook/outputs/common/mimemodel
 import * as outputProcessor from 'sql/workbench/parts/notebook/outputs/common/outputProcessor';
 import { RenderMimeRegistry } from 'sql/workbench/parts/notebook/outputs/registry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
+import * as DOM from 'vs/base/browser/dom';
 
 export const OUTPUT_SELECTOR: string = 'output-component';
+export const USER_SELECT_CLASS ='actionselect';
 
 @Component({
 	selector: OUTPUT_SELECTOR,
@@ -28,6 +30,7 @@ export class OutputComponent extends AngularDisposable implements OnInit {
 	private _trusted: boolean;
 	private _initialized: boolean = false;
 	private readonly _minimumHeight = 30;
+	private _activeCellId: string;
 	registry: RenderMimeRegistry;
 
 
@@ -45,6 +48,29 @@ export class OutputComponent extends AngularDisposable implements OnInit {
 		this.cellModel.notebookModel.layoutChanged(() => {
 			this.renderOutput();
 		});
+	}
+
+	ngOnChanges(changes: { [propKey: string]: SimpleChange }) {
+
+		for (let propName in changes) {
+			if (propName === 'activeCellId') {
+				let changedProp = changes[propName];
+				let isActive = this.cellModel.id === changedProp.currentValue;
+				this.toggleUserSelect(isActive);
+				break;
+			}
+		}
+	}
+	
+	private toggleUserSelect(userSelect: boolean): void {
+		if (!this.outputElement) {
+			return;
+		}
+		if (userSelect) {
+			DOM.addClass(this.outputElement.nativeElement, USER_SELECT_CLASS);
+		} else {
+			DOM.removeClass(this.outputElement.nativeElement, USER_SELECT_CLASS);
+		}
 	}
 
 	private renderOutput() {
@@ -69,6 +95,14 @@ export class OutputComponent extends AngularDisposable implements OnInit {
 		if (this._initialized) {
 			this.renderOutput();
 		}
+	}
+
+	@Input() set activeCellId(value: string) {
+		this._activeCellId = value;
+	}
+
+	get activeCellId(): string {
+		return this._activeCellId;
 	}
 
 	protected createRenderedMimetype(options: MimeModel.IOptions, node: HTMLElement): void {
@@ -99,5 +133,8 @@ export class OutputComponent extends AngularDisposable implements OnInit {
 				Object.keys(options.data).join(', ');
 			//this.setState({ node: node });
 		}
+	}
+	protected isActive() {
+		return this.cellModel && this.cellModel.id === this.activeCellId;
 	}
 }

--- a/src/sql/workbench/parts/notebook/cellViews/outputArea.component.html
+++ b/src/sql/workbench/parts/notebook/cellViews/outputArea.component.html
@@ -6,7 +6,7 @@
 -->
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div #outputarea class="notebook-output" style="flex: 0 0 auto;">
-		<output-component *ngFor="let output of cellModel.outputs" [cellOutput]="output" [trustedMode] = "cellModel.trustedMode" [cellModel]="cellModel">
+		<output-component *ngFor="let output of cellModel.outputs" [cellOutput]="output" [trustedMode] = "cellModel.trustedMode" [cellModel]="cellModel" [activeCellId]="activeCellId">
 		</output-component>
 	</div>
 </div>

--- a/src/sql/workbench/parts/notebook/cellViews/outputArea.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/outputArea.component.ts
@@ -20,6 +20,8 @@ export class OutputAreaComponent extends AngularDisposable implements OnInit {
 	@ViewChild('outputarea', { read: ElementRef }) private outputArea: ElementRef;
 	@Input() cellModel: ICellModel;
 
+	private _activeCellId: string;
+
 	private readonly _minimumHeight = 30;
 
 	constructor(
@@ -39,6 +41,14 @@ export class OutputAreaComponent extends AngularDisposable implements OnInit {
 				}
 			}));
 		}
+	}
+
+	@Input() set activeCellId(value: string) {
+		this._activeCellId = value;
+	}
+
+	get activeCellId(): string {
+		return this._activeCellId;
 	}
 
 	private updateTheme(theme: IColorTheme): void {

--- a/src/sql/workbench/parts/notebook/cellViews/outputArea.css
+++ b/src/sql/workbench/parts/notebook/cellViews/outputArea.css
@@ -11,3 +11,7 @@ output-area-component .notebook-output {
 	user-select: text;
 	padding: 5px 20px 0px;
 }
+
+.output.actionselect {
+	user-select: text;
+}

--- a/src/sql/workbench/parts/notebook/cellViews/outputArea.css
+++ b/src/sql/workbench/parts/notebook/cellViews/outputArea.css
@@ -12,6 +12,6 @@ output-area-component .notebook-output {
 	padding: 5px 20px 0px;
 }
 
-.output.actionselect {
+.output-userselect.actionselect {
 	user-select: text;
 }

--- a/src/sql/workbench/parts/notebook/cellViews/textCell.component.html
+++ b/src/sql/workbench/parts/notebook/cellViews/textCell.component.html
@@ -11,7 +11,7 @@
 		</code-component>
 	</div>
 	<div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: row">
-		<div #preview class ="notebook-preview" style="flex: 1 1 auto; user-select: initial;" (dblclick)="toggleEditMode()">
+		<div #preview class ="notebook-preview" style="flex: 1 1 auto" (dblclick)="toggleEditMode()">
 		</div>
 		<div #moreactions class="moreActions" style="flex: 0 0 auto; display: flex; flex-flow:column;width: 20px; min-height: 20px; max-height: 20px; padding-top: 0px; orientation: portrait">
 		</div>

--- a/src/sql/workbench/parts/notebook/cellViews/textCell.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/textCell.component.ts
@@ -24,7 +24,7 @@ import { NotebookModel } from 'sql/workbench/parts/notebook/models/notebookModel
 import { CellToggleMoreActions } from 'sql/workbench/parts/notebook/cellToggleMoreActions';
 
 export const TEXT_SELECTOR: string = 'text-cell-component';
-export const USER_SELECT_CLASS ='actionselect';
+const USER_SELECT_CLASS ='actionselect';
 
 @Component({
 	selector: TEXT_SELECTOR,

--- a/src/sql/workbench/parts/notebook/cellViews/textCell.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/textCell.component.ts
@@ -14,6 +14,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { Emitter } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
+import * as DOM from 'vs/base/browser/dom';
 
 import { CommonServiceInterface } from 'sql/services/common/commonServiceInterface.service';
 import { CellView } from 'sql/workbench/parts/notebook/cellViews/interfaces';
@@ -23,6 +24,7 @@ import { NotebookModel } from 'sql/workbench/parts/notebook/models/notebookModel
 import { CellToggleMoreActions } from 'sql/workbench/parts/notebook/cellToggleMoreActions';
 
 export const TEXT_SELECTOR: string = 'text-cell-component';
+export const USER_SELECT_CLASS ='actionselect';
 
 @Component({
 	selector: TEXT_SELECTOR,
@@ -176,9 +178,22 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	private updateMoreActions(): void {
 		if (!this.isEditMode && (this.isActive() || this._hover)) {
 			this.toggleMoreActionsButton(true);
+			this.toggleUserSelect(true);
 		}
 		else {
 			this.toggleMoreActionsButton(false);
+			this.toggleUserSelect(false);
+		}
+	}
+
+	private toggleUserSelect(userSelect: boolean): void {
+		if (!this.output) {
+			return;
+		}
+		if (userSelect) {
+			DOM.addClass(this.output.nativeElement, USER_SELECT_CLASS);
+		} else {
+			DOM.removeClass(this.output.nativeElement, USER_SELECT_CLASS);
 		}
 	}
 

--- a/src/sql/workbench/parts/notebook/cellViews/textCell.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/textCell.component.ts
@@ -113,6 +113,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			if (propName === 'activeCellId') {
 				let changedProp = changes[propName];
 				this._activeCellId = changedProp.currentValue;
+				this.toggleUserSelect(this.isActive());
 				// If the activeCellId is undefined (i.e. in an active cell update), don't unnecessarily set editMode to false;
 				// it will be set to true in a subsequent call to toggleEditMode()
 				if (changedProp.previousValue !== undefined) {
@@ -178,11 +179,9 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	private updateMoreActions(): void {
 		if (!this.isEditMode && (this.isActive() || this._hover)) {
 			this.toggleMoreActionsButton(true);
-			this.toggleUserSelect(true);
 		}
 		else {
 			this.toggleMoreActionsButton(false);
-			this.toggleUserSelect(false);
 		}
 	}
 

--- a/src/sql/workbench/parts/notebook/cellViews/textCell.css
+++ b/src/sql/workbench/parts/notebook/cellViews/textCell.css
@@ -13,6 +13,6 @@ text-cell-component .notebook-preview {
 	padding-right: 8px;
 }
 
-.notebook-preview.actionselect{
+.notebook-preview.actionselect {
 	user-select: text;
 }

--- a/src/sql/workbench/parts/notebook/cellViews/textCell.css
+++ b/src/sql/workbench/parts/notebook/cellViews/textCell.css
@@ -8,7 +8,11 @@ text-cell-component {
 }
 
 text-cell-component .notebook-preview {
-	user-select: initial;
+	user-select: none;
 	padding-left: 8px;
 	padding-right: 8px;
+}
+
+.notebook-preview.actionselect{
+	user-select: text;
 }


### PR DESCRIPTION
If no cell is active, Ctrl+A wouldn’t select anything global.

- Code cell is active
1) Mouse/cursor is in editor, Ctrl+A will select the code content.
2) Mouse/cursor is not in editor, Ctrl+A selects the output
![image](https://user-images.githubusercontent.com/43652751/55917474-48767e00-5ba4-11e9-8c37-8e90091e815d.png)


- Markdown is active
1) In preview mode, Ctrl+A selects the text content.
2) In edit mode
    	Mouse/cursor is in editor, Ctrl+A selects the text in the editor
![image](https://user-images.githubusercontent.com/43652751/55917481-52987c80-5ba4-11e9-9090-7cfc3f0e0b2b.png)

    	Mouse/cursor is not in editor, , Ctrl+A selects the text in the preview section
![image](https://user-images.githubusercontent.com/43652751/55917522-7491ff00-5ba4-11e9-9c39-eb78d53ecaff.png)



