### PR TITLE
Fix #4447 remove unnecessary dacpac extension error message

### DIFF
--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -94,7 +94,6 @@ export class DataTierApplicationWizard {
 
 			// don't open the wizard if connection dialog is cancelled
 			if (!this.connection) {
-				vscode.window.showErrorMessage(localize('dacfx.needConnection', 'Please connect to a server before using this wizard.'));
 				return;
 			}
 		}


### PR DESCRIPTION
Fixing #4447. This removes the error message "Please connect to a server before using this wizard" that was showing after the connection dialog is cancelled.