### PR TITLE
Fix for 4104 : Multiple consecutive spaces in query results cells are condensed into one

### DIFF
--- a/src/sql/base/browser/ui/table/media/table.css
+++ b/src/sql/base/browser/ui/table/media/table.css
@@ -5,6 +5,7 @@
 
 .monaco-table * {
 	box-sizing: border-box;
+    white-space: pre;
 }
 
 .monaco-table {

--- a/src/sql/base/browser/ui/table/media/table.css
+++ b/src/sql/base/browser/ui/table/media/table.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-table * {
-	box-sizing: border-box;
+    box-sizing: border-box;
     white-space: pre;
 }
 

--- a/src/sql/base/browser/ui/table/media/table.css
+++ b/src/sql/base/browser/ui/table/media/table.css
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-table * {
-    box-sizing: border-box;
-    white-space: pre;
+	box-sizing: border-box;
+	white-space: pre;
 }
 
 .monaco-table {

--- a/src/sql/base/common/strings.ts
+++ b/src/sql/base/common/strings.ts
@@ -8,9 +8,8 @@
  * being used e.g. in HTMLElement.innerHTML.
  */
 export function escape(html: string): string {
-	return html.replace(/[<|>|&| |"]/g, function (match) {
+	return html.replace(/[<|>|&|"]/g, function (match) {
 		switch (match) {
-			case ' ': return '&nbsp;';
 			case '<': return '&lt;';
 			case '>': return '&gt;';
 			case '&': return '&amp;';

--- a/src/sql/base/common/strings.ts
+++ b/src/sql/base/common/strings.ts
@@ -8,8 +8,9 @@
  * being used e.g. in HTMLElement.innerHTML.
  */
 export function escape(html: string): string {
-	return html.replace(/[<|>|&|"]/g, function (match) {
+	return html.replace(/[<|>|&| |"]/g, function (match) {
 		switch (match) {
+			case ' ': return '&nbsp;';
 			case '<': return '&lt;';
 			case '>': return '&gt;';
 			case '&': return '&amp;';


### PR DESCRIPTION
This change aims to fix the bug - https://github.com/Microsoft/azuredatastudio/issues/4104 : Multiple consecutive spaces in query results cells are condensed into one (like HTML)

Now it preserves all consecutive spaces in query results - all beginning, trailing and middle spaces will be shown as is. 