### PR TITLE
Fix #4460: Add dacfx wizard to server and database folder context menus

### DIFF
--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -37,6 +37,16 @@
 					"command": "dacFx.start",
 					"when": "connectionProvider == MSSQL && nodeType && nodeType == Database",
 					"group": "export"
+				},
+				{
+					"command": "dacFx.start",
+					"when": "connectionProvider == MSSQL && nodeType && nodeType == Server",
+					"group": "export"
+				},
+				{
+					"command": "dacFx.start",
+					"when": "connectionProvider == MSSQL && nodeType && nodeType == Folder && nodeLabel == 'Databases'",
+					"group": "export"
 				}
 			]
 		}

--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -45,9 +45,9 @@ if (context.RunTest) {
 			let expectedActions;
 
 			if (process.platform === 'win32') {
-				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Launch Profiler', 'Properties'];
+				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Data-tier Application wizard', 'Launch Profiler', 'Properties'];
 			} else {
-				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Launch Profiler'];
+				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Data-tier Application wizard', 'Launch Profiler'];
 			}
 
 			const expectedString = expectedActions.join(',');


### PR DESCRIPTION
This adds the Data-tier Application wizard to the context menus of servers and database folders, fixing #4460.

![image](https://user-images.githubusercontent.com/31145923/55922980-63eb8400-5bb8-11e9-8f6c-aa0076b59944.png)

![image](https://user-images.githubusercontent.com/31145923/55923007-7f568f00-5bb8-11e9-94ec-ce12bffca2a9.png)
