### PR TITLE
Fix Data Explorer context menu items visibility

### DIFF
--- a/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
+++ b/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
@@ -3,10 +3,10 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { NodeContextKey } from 'sql/workbench/parts/dataExplorer/common/nodeContext';
 import { localize } from 'vs/nls';
 import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { DISCONNECT_COMMAND_ID, MANAGE_COMMAND_ID, NEW_QUERY_COMMAND_ID, REFRESH_COMMAND_ID } from './nodeCommands';
+import { ContextKeyDefinedExpr, ContextKeyExpr, ContextKeyEqualsExpr } from 'vs/platform/contextkey/common/contextkey';
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: 'connection',
@@ -15,7 +15,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		id: DISCONNECT_COMMAND_ID,
 		title: localize('disconnect', 'Disconnect')
 	},
-	when: NodeContextKey.IsConnected
+	when: new ContextKeyEqualsExpr('isConnected', true)
 });
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
@@ -25,7 +25,24 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		id: NEW_QUERY_COMMAND_ID,
 		title: localize('newQuery', 'New Query')
 	},
-	when: NodeContextKey.IsConnectable
+	when: ContextKeyExpr.and(
+		new ContextKeyDefinedExpr('isConnectable'),
+		new ContextKeyEqualsExpr('isConnectable', true),
+		new ContextKeyDefinedExpr('viewItem'),
+		new ContextKeyEqualsExpr('viewItem', 'Database'))
+});
+
+MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
+	group: 'connection',
+	command: {
+		id: NEW_QUERY_COMMAND_ID,
+		title: localize('newQuery', 'New Query')
+	},
+	when: ContextKeyExpr.and(
+		new ContextKeyDefinedExpr('isConnectable'),
+		new ContextKeyEqualsExpr('isConnectable', true),
+		new ContextKeyDefinedExpr('viewItem'),
+		new ContextKeyEqualsExpr('viewItem', 'azure.resource.itemType.databaseServer'))
 });
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
@@ -35,7 +52,11 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		id: MANAGE_COMMAND_ID,
 		title: localize('manage', 'Manage')
 	},
-	when: NodeContextKey.IsConnectable
+	when: ContextKeyExpr.and(
+		new ContextKeyDefinedExpr('isConnectable'),
+		new ContextKeyEqualsExpr('isConnectable', true),
+		new ContextKeyDefinedExpr('viewItem'),
+		new ContextKeyEqualsExpr('viewItem', 'azure.resource.itemType.databaseServer'))
 });
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {

--- a/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
+++ b/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
@@ -19,7 +19,10 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	when: NodeContextKey.IsConnected
 });
 
-// For Database nodes under a Server in the SQL Servers folder
+// The weird regex is because we want this to generically apply to Database and Server nodes but right now
+// there isn't a consistent standard for the values there. We can't just search for database or server being
+// in the string at all because there's lots of node types which have those values (such as ServerLevelLogin)
+// that we don't want these menu items showing up on.
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: 'connection',
 	order: 2,
@@ -29,7 +32,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	},
 	when: ContextKeyExpr.and(
 		NodeContextKey.IsConnectable,
-		new ContextKeyRegexExpr('viewItem', /Database|azure.resource.itemType.database|azure.resource.itemType.databaseServer/))
+		new ContextKeyRegexExpr('viewItem', /.+itemType\.database.*|^database$/i))
 });
 
 // Note that we don't show this for Databases under Server nodes (viewItem == Database) because
@@ -43,7 +46,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	},
 	when: ContextKeyExpr.and(
 		NodeContextKey.IsConnectable,
-		new ContextKeyRegexExpr('viewItem', /azure.resource.itemType.databaseServer|azure.resource.itemType.database/))
+		new ContextKeyRegexExpr('viewItem', /.+itemType\.database.*/i))
 });
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {

--- a/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
+++ b/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
@@ -6,7 +6,7 @@
 import { localize } from 'vs/nls';
 import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { DISCONNECT_COMMAND_ID, MANAGE_COMMAND_ID, NEW_QUERY_COMMAND_ID, REFRESH_COMMAND_ID } from './nodeCommands';
-import { ContextKeyDefinedExpr, ContextKeyExpr, ContextKeyEqualsExpr } from 'vs/platform/contextkey/common/contextkey';
+import { ContextKeyDefinedExpr, ContextKeyExpr, ContextKeyEqualsExpr, ContextKeyRegexExpr } from 'vs/platform/contextkey/common/contextkey';
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: 'connection',
@@ -32,37 +32,11 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		new ContextKeyDefinedExpr('isConnectable'),
 		new ContextKeyEqualsExpr('isConnectable', true),
 		new ContextKeyDefinedExpr('viewItem'),
-		new ContextKeyEqualsExpr('viewItem', 'Database'))
+		new ContextKeyRegexExpr('viewItem', /Database|azure.resource.itemType.database|azure.resource.itemType.databaseServer/))
 });
 
-// For database nodes under the SQL Databases folder
-MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
-	group: 'connection',
-	order: 2,
-	command: {
-		id: NEW_QUERY_COMMAND_ID,
-		title: localize('newQuery', 'New Query')
-	},
-	when: ContextKeyExpr.and(
-		new ContextKeyDefinedExpr('isConnectable'),
-		new ContextKeyEqualsExpr('isConnectable', true),
-		new ContextKeyDefinedExpr('viewItem'),
-		new ContextKeyEqualsExpr('viewItem', 'azure.resource.itemType.database'))
-});
-
-MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
-	group: 'connection',
-	command: {
-		id: NEW_QUERY_COMMAND_ID,
-		title: localize('newQuery', 'New Query')
-	},
-	when: ContextKeyExpr.and(
-		new ContextKeyDefinedExpr('isConnectable'),
-		new ContextKeyEqualsExpr('isConnectable', true),
-		new ContextKeyDefinedExpr('viewItem'),
-		new ContextKeyEqualsExpr('viewItem', 'azure.resource.itemType.databaseServer'))
-});
-
+// Note that we don't show this for Databases under Server nodes (viewItem == Database) because
+// of an issue there where the connection always being master instead of the actual DB
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: 'connection',
 	order: 1,
@@ -74,24 +48,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		new ContextKeyDefinedExpr('isConnectable'),
 		new ContextKeyEqualsExpr('isConnectable', true),
 		new ContextKeyDefinedExpr('viewItem'),
-		new ContextKeyEqualsExpr('viewItem', 'azure.resource.itemType.databaseServer'))
-});
-
-// For database nodes under the SQL Databases folder
-// Note that we don't show this for Databases under Server nodes because of an issue there
-// where the connection always being master instead of the actual DB
-MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
-	group: 'connection',
-	order: 1,
-	command: {
-		id: MANAGE_COMMAND_ID,
-		title: localize('manage', 'Manage')
-	},
-	when: ContextKeyExpr.and(
-		new ContextKeyDefinedExpr('isConnectable'),
-		new ContextKeyEqualsExpr('isConnectable', true),
-		new ContextKeyDefinedExpr('viewItem'),
-		new ContextKeyEqualsExpr('viewItem', 'azure.resource.itemType.database'))
+		new ContextKeyRegexExpr('viewItem', /azure.resource.itemType.databaseServer|azure.resource.itemType.database/))
 });
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {

--- a/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
+++ b/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
@@ -15,9 +15,12 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		id: DISCONNECT_COMMAND_ID,
 		title: localize('disconnect', 'Disconnect')
 	},
-	when: new ContextKeyEqualsExpr('isConnected', true)
+	when: ContextKeyExpr.and(
+		new ContextKeyDefinedExpr('isConnected'),
+		new ContextKeyEqualsExpr('isConnected', true))
 });
 
+// For Database nodes under a Server in the SQL Servers folder
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: 'connection',
 	order: 2,
@@ -30,6 +33,21 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		new ContextKeyEqualsExpr('isConnectable', true),
 		new ContextKeyDefinedExpr('viewItem'),
 		new ContextKeyEqualsExpr('viewItem', 'Database'))
+});
+
+// For database nodes under the SQL Databases folder
+MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
+	group: 'connection',
+	order: 2,
+	command: {
+		id: NEW_QUERY_COMMAND_ID,
+		title: localize('newQuery', 'New Query')
+	},
+	when: ContextKeyExpr.and(
+		new ContextKeyDefinedExpr('isConnectable'),
+		new ContextKeyEqualsExpr('isConnectable', true),
+		new ContextKeyDefinedExpr('viewItem'),
+		new ContextKeyEqualsExpr('viewItem', 'azure.resource.itemType.database'))
 });
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
@@ -57,6 +75,23 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		new ContextKeyEqualsExpr('isConnectable', true),
 		new ContextKeyDefinedExpr('viewItem'),
 		new ContextKeyEqualsExpr('viewItem', 'azure.resource.itemType.databaseServer'))
+});
+
+// For database nodes under the SQL Databases folder
+// Note that we don't show this for Databases under Server nodes because of an issue there
+// where the connection always being master instead of the actual DB
+MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
+	group: 'connection',
+	order: 1,
+	command: {
+		id: MANAGE_COMMAND_ID,
+		title: localize('manage', 'Manage')
+	},
+	when: ContextKeyExpr.and(
+		new ContextKeyDefinedExpr('isConnectable'),
+		new ContextKeyEqualsExpr('isConnectable', true),
+		new ContextKeyDefinedExpr('viewItem'),
+		new ContextKeyEqualsExpr('viewItem', 'azure.resource.itemType.database'))
 });
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {

--- a/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
+++ b/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
@@ -6,7 +6,8 @@
 import { localize } from 'vs/nls';
 import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { DISCONNECT_COMMAND_ID, MANAGE_COMMAND_ID, NEW_QUERY_COMMAND_ID, REFRESH_COMMAND_ID } from './nodeCommands';
-import { ContextKeyDefinedExpr, ContextKeyExpr, ContextKeyEqualsExpr, ContextKeyRegexExpr } from 'vs/platform/contextkey/common/contextkey';
+import { ContextKeyExpr, ContextKeyRegexExpr } from 'vs/platform/contextkey/common/contextkey';
+import { NodeContextKey } from 'sql/workbench/parts/dataExplorer/common/nodeContext';
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: 'connection',
@@ -15,9 +16,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		id: DISCONNECT_COMMAND_ID,
 		title: localize('disconnect', 'Disconnect')
 	},
-	when: ContextKeyExpr.and(
-		new ContextKeyDefinedExpr('isConnected'),
-		new ContextKeyEqualsExpr('isConnected', true))
+	when: NodeContextKey.IsConnected
 });
 
 // For Database nodes under a Server in the SQL Servers folder
@@ -29,9 +28,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		title: localize('newQuery', 'New Query')
 	},
 	when: ContextKeyExpr.and(
-		new ContextKeyDefinedExpr('isConnectable'),
-		new ContextKeyEqualsExpr('isConnectable', true),
-		new ContextKeyDefinedExpr('viewItem'),
+		NodeContextKey.IsConnectable,
 		new ContextKeyRegexExpr('viewItem', /Database|azure.resource.itemType.database|azure.resource.itemType.databaseServer/))
 });
 
@@ -45,9 +42,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		title: localize('manage', 'Manage')
 	},
 	when: ContextKeyExpr.and(
-		new ContextKeyDefinedExpr('isConnectable'),
-		new ContextKeyEqualsExpr('isConnectable', true),
-		new ContextKeyDefinedExpr('viewItem'),
+		NodeContextKey.IsConnectable,
 		new ContextKeyRegexExpr('viewItem', /azure.resource.itemType.databaseServer|azure.resource.itemType.database/))
 });
 


### PR DESCRIPTION
Fix #4910 The when clause wasn't set up correctly - you need to use the classes like ContextKeyDefinedExpr to build up the expressions. Previously they would show up for all nodes in the tree, with this change it's scoped down to just being on the Server and Database nodes.

Note that I purposely left out Manage from DBs under Server nodes because of #4994 which means they'll always use the first connection you use to connect to the Dashboard and so you'll never be able to view the dashboards for other DBs.