### PR TITLE
Bump SQL Tools to 1.5.0-alpha.85 to get invalid dacpac version fix

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.84",
+	"version": "1.5.0-alpha.85",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",


### PR DESCRIPTION
Bump SqlToolsService version to[ 1.5.0-alpha.85 ](https://github.com/Microsoft/sqltoolsservice/releases/tag/v1.5.0-alpha.85)to get the fix for an invalid dacpac version crashing SqlToolsService
