### PR TITLE
Fix  #4500 Untitled notebook reopen doesn't show dirty

### DIFF
--- a/src/sql/workbench/parts/notebook/notebookInput.ts
+++ b/src/sql/workbench/parts/notebook/notebookInput.ts
@@ -61,7 +61,7 @@ export class NotebookEditorModel extends EditorModel {
 		return model.getValue();
 	}
 
-	get isDirty(): boolean {
+	isDirty(): boolean {
 		return this.textEditorModel.isDirty();
 	}
 
@@ -256,7 +256,7 @@ export class NotebookInput extends EditorInput {
 	}
 
 	async resolve(): Promise<NotebookEditorModel> {
-		if (this._model && this._model.isModelCreated()) {
+		if (this._model) {
 			return Promise.resolve(this._model);
 		} else {
 			let textOrUntitledEditorModel: UntitledEditorModel | IEditorModel;
@@ -318,7 +318,9 @@ export class NotebookInput extends EditorInput {
 	 */
 	isDirty(): boolean {
 		if (this._model) {
-			return this._model.isDirty;
+			return this._model.isDirty();
+		} else if (this._textInput) {
+			return this._textInput.isDirty();
 		}
 		return false;
 	}

--- a/src/sql/workbench/parts/notebook/notebookInput.ts
+++ b/src/sql/workbench/parts/notebook/notebookInput.ts
@@ -26,6 +26,7 @@ import { LocalContentManager } from 'sql/workbench/services/notebook/node/localC
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { IDisposable } from 'vs/base/common/lifecycle';
 
 export type ModeViewSaveHandler = (handle: number) => Thenable<boolean>;
 
@@ -135,6 +136,7 @@ export class NotebookInput extends EditorInput {
 	private _untitledEditorModel: UntitledEditorModel;
 	private _contentManager: IContentManager;
 	private _providersLoaded: Promise<void>;
+	private _dirtyListener: IDisposable;
 
 	constructor(private _title: string,
 		private resource: URI,
@@ -148,6 +150,9 @@ export class NotebookInput extends EditorInput {
 		this.resource = resource;
 		this._standardKernels = [];
 		this._providersLoaded = this.assignProviders();
+		if (this._textInput) {
+			this.hookDirtyListener(this._textInput.onDidChangeDirty, () => this._onDidChangeDirty.fire());
+		}
 	}
 
 	public get textInput(): UntitledEditorInput {
@@ -268,9 +273,25 @@ export class NotebookInput extends EditorInput {
 				textOrUntitledEditorModel = await textEditorModelReference.object.load();
 			}
 			this._model = this.instantiationService.createInstance(NotebookEditorModel, this.resource, textOrUntitledEditorModel);
-			this._model.onDidChangeDirty(() => this._onDidChangeDirty.fire());
+			this.hookDirtyListener(this._model.onDidChangeDirty, () => this._onDidChangeDirty.fire());
 			return this._model;
 		}
+	}
+
+	private hookDirtyListener(dirtyEvent: Event<void>, listener: (e: any) => void): void {
+		let disposable = dirtyEvent(listener);
+		if (this._dirtyListener) {
+			this._dirtyListener.dispose();
+		} else {
+			this._register({
+				dispose: () => {
+					if (this._dirtyListener) {
+						this._dirtyListener.dispose();
+					}
+				}
+			});
+		}
+		this._dirtyListener = disposable;
 	}
 
 	private async assignProviders(): Promise<void> {


### PR DESCRIPTION
Fix notebook dirty on open issue:
Before model is resolved we weren't getting dirty events.
Solution is to use backing text model until it's ready.
Must hook to the dirty event & notify to get the dot to appear

Also fixes related startup issues found during debugging:
- Do not create notebook model twice on start
- Do not cause disposed warnings due to markdown cell deserialization
