### PR TITLE
Fix wrong release notes being loaded

### DIFF
--- a/src/vs/workbench/contrib/update/electron-browser/update.ts
+++ b/src/vs/workbench/contrib/update/electron-browser/update.ts
@@ -491,7 +491,8 @@ export class UpdateContribution implements IGlobalActivity {
 			actions.push({
 				label: nls.localize('releaseNotes', "Release Notes"),
 				run: () => {
-					const action = this.instantiationService.createInstance(ShowReleaseNotesAction, update.productVersion);
+					// {{SQL CARBON EDIT}}
+					const action = this.instantiationService.createInstance(OpenLatestReleaseNotesInBrowserAction);
 					action.run();
 					action.dispose();
 				}


### PR DESCRIPTION

Fix #4835 The "Release Notes" button on the update dialog runs an action that downloads an MD file of the latest release notes - but this is currently hardcoded to VS Code. 

I chatted with Alan and while we have our release notes available in MD format some extra work is going to need to be done to get it showing in a tab in ADS which is scheduled for May. But this quick fix will at least let people easily see the notes instead of browsing to it themselves manually or relying on other links. 

So instead we'll just use the action to open the release notes in the browser which uses the releaseNotesUrl we define for our product so correctly goes to the ADS release notes URL. 