### PR TITLE
Delete nb manager from adapter

### DIFF
--- a/src/sql/workbench/api/node/extHostNotebook.ts
+++ b/src/sql/workbench/api/node/extHostNotebook.ts
@@ -51,7 +51,7 @@ export class ExtHostNotebook implements ExtHostNotebookShape {
 		let manager = this.findManagerForUri(uriString);
 		if (manager) {
 			manager.provider.handleNotebookClosed(uri);
-			// Note: deliberately not removing handle.
+			this._adapters.delete(manager.handle);
 		}
 	}
 

--- a/src/sql/workbench/parts/notebook/models/notebookModel.ts
+++ b/src/sql/workbench/parts/notebook/models/notebookModel.ts
@@ -789,7 +789,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			catch (err) {
 				this.notifyError(localize('shutdownClientSessionError', "A client session error occurred when closing the notebook: {0}", err));
 			}
-			await this._activeClientSession.shutdown();
+			//await this._activeClientSession.shutdown();
 			this.clearClientSessionListeners();
 			this._activeClientSession = undefined;
 		}


### PR DESCRIPTION
This is a proposed partial fix of #3477. This fixes untitled notebook save/unsave by clicking close in Notebook.

Save notebook from File menu doesn't go through the same code path. We have to think how to hook up the jupyter shutdown.

The problem is tricky.  check file \azuredatastudio\src\sql\workbench\api\node\extHostNotebook.ts
The first python notebook can shutdown Jupyter server correctly in handleNotebookClosed() manager.dispose().

After the first notebook is closed, if create the second untitled notebook, the notebookUri will be the same as the first one. So it wouldn't 
createManager() in  $getNotebookManager() since the uri is reused and the previous adapter is not deleted.

                let adapter = this.findManagerForUri(uriString);
		if (!adapter) {
			adapter = await this._withProvider(providerHandle, (provider) => {
				return this.createManager(provider, uri);
			});
		}

The code has comment: "// Note: deliberately not removing handle" in $handleNotebookClosed(). There is no further explanation for the purpose to keep handle.  So I tried to remove it and see what could fail. 

I can see if delete the manager handle from adapters, shutdownActiveSession() in notebookModel will run into issue since manager doesn't exist anymore. Not sure if that is reason not delete the handle before. 

By looking into the code, the sessions are shutdown in JupyterSessionManager.shutdownAll. So I removed activeSession.shutdown in NotebookModel.dispose.

I did do some manual tests and didn't see other side effects so far. Though the change may be stupid, I would like to send this PR to collect more info to get more insights. At the same time to share my findings.


