### PR TITLE
Fixed bug: CheckboxTreeNode label overflows, and node icon disappears

### DIFF
--- a/src/sql/parts/modelComponents/tree/treeComponent.css
+++ b/src/sql/parts/modelComponents/tree/treeComponent.css
@@ -2,7 +2,12 @@
 	display: flex;
 }
 
-.tree-component-node-tile .model-view-tree-node-item-icon{
-	width: 15px;
+.tree-component-node-tile .model-view-tree-node-item-icon {
+	width: 17px;
 	height: 15px;
+	flex-shrink: 0;
+}
+
+.tree-component-node-tile .model-view-tree-node-item-label {
+	overflow: hidden;
 }

--- a/src/sql/parts/modelComponents/tree/treeComponent.css
+++ b/src/sql/parts/modelComponents/tree/treeComponent.css
@@ -4,10 +4,11 @@
 
 .tree-component-node-tile .model-view-tree-node-item-icon {
 	width: 17px;
-	height: 15px;
+	height: 17px;
 	flex-shrink: 0;
 }
 
 .tree-component-node-tile .model-view-tree-node-item-label {
 	overflow: hidden;
+	text-overflow: ellipsis;
 }

--- a/src/sql/parts/modelComponents/tree/treeComponentRenderer.ts
+++ b/src/sql/parts/modelComponents/tree/treeComponentRenderer.ts
@@ -147,6 +147,7 @@ export class TreeComponentRenderer extends Disposable implements IRenderer {
 		const icon = this.themeService.getTheme().type === LIGHT ? element.icon : element.iconDark;
 		const iconUri = icon ? URI.revive(icon) : null;
 		templateData.icon.style.backgroundImage = iconUri ? `url('${iconUri.toString(true)}')` : '';
+		templateData.icon.style.backgroundRepeat = 'no-repeat';
 		dom.toggleClass(templateData.icon, 'model-view-tree-node-item-icon', !!icon);
 		if (element) {
 			element.onCheckedChanged = (checked: boolean) => {

--- a/src/sql/parts/modelComponents/tree/treeComponentRenderer.ts
+++ b/src/sql/parts/modelComponents/tree/treeComponentRenderer.ts
@@ -148,6 +148,7 @@ export class TreeComponentRenderer extends Disposable implements IRenderer {
 		const iconUri = icon ? URI.revive(icon) : null;
 		templateData.icon.style.backgroundImage = iconUri ? `url('${iconUri.toString(true)}')` : '';
 		templateData.icon.style.backgroundRepeat = 'no-repeat';
+		templateData.icon.style.backgroundPosition = 'center';
 		dom.toggleClass(templateData.icon, 'model-view-tree-node-item-icon', !!icon);
 		if (element) {
 			element.onCheckedChanged = (checked: boolean) => {


### PR DESCRIPTION
This is fix for the bug: https://github.com/Microsoft/azuredatastudio/issues/5021
The string value of `DIV` element with  `model-view-tree-node-item-label` class overflows if its container size is smaller than the string length, and this makes the tree node icon disappears.
This PR fixes the issue.

After fix: 
![image](https://user-images.githubusercontent.com/19577035/56070594-72af7380-5d3d-11e9-9250-6913fc571879.png)

