### PR TITLE
changes to setEnvironmentVariables.js to not lanch code or new command

### DIFF
--- a/extensions/bat/test/colorize-results/test_bat.json
+++ b/extensions/bat/test/colorize-results/test_bat.json
@@ -3,10 +3,6 @@
 		"c": "@",
 		"t": "source.batchfile keyword.operator.at.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": "echo",
 		"t": "source.batchfile keyword.command.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": " ",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": "off",
 		"t": "source.batchfile keyword.other.special-method.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "setlocal",
 		"t": "source.batchfile keyword.command.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "title",
 		"t": "source.batchfile keyword.command.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": " VSCode Dev",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": "pushd",
 		"t": "source.batchfile keyword.command.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": " ",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": "%",
 		"t": "source.batchfile punctuation.definition.variable.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "~dp0",
 		"t": "source.batchfile variable.parameter.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "\\..",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": "::",
 		"t": "source.batchfile comment.line.colon.batchfile punctuation.definition.comment.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": " Node modules",
 		"t": "source.batchfile comment.line.colon.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "if",
 		"t": "source.batchfile keyword.control.conditional.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": " ",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "not",
 		"t": "source.batchfile keyword.operator.logical.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": " ",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "exist",
 		"t": "source.batchfile keyword.other.special-method.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": " node_modules ",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": "call",
 		"t": "source.batchfile keyword.control.statement.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": " .\\scripts\\npm.bat install",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "::",
 		"t": "source.batchfile comment.line.colon.batchfile punctuation.definition.comment.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": " Get electron",
 		"t": "source.batchfile comment.line.colon.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": "node .\\node_modules\\gulp\\bin\\gulp.js electron",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": "::",
 		"t": "source.batchfile comment.line.colon.batchfile punctuation.definition.comment.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": " Build",
 		"t": "source.batchfile comment.line.colon.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "if",
 		"t": "source.batchfile keyword.control.conditional.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": " ",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -322,10 +206,6 @@
 		"c": "not",
 		"t": "source.batchfile keyword.operator.logical.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -333,10 +213,6 @@
 		"c": " ",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -344,10 +220,6 @@
 		"c": "exist",
 		"t": "source.batchfile keyword.other.special-method.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -355,10 +227,6 @@
 		"c": " out node .\\node_modules\\gulp\\bin\\gulp.js compile",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -366,10 +234,6 @@
 		"c": "::",
 		"t": "source.batchfile comment.line.colon.batchfile punctuation.definition.comment.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -377,10 +241,6 @@
 		"c": " Configuration",
 		"t": "source.batchfile comment.line.colon.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -388,10 +248,6 @@
 		"c": "set",
 		"t": "source.batchfile keyword.command.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -399,10 +255,6 @@
 		"c": " ",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -410,10 +262,6 @@
 		"c": "NODE_ENV",
 		"t": "source.batchfile variable.other.readwrite.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -421,10 +269,6 @@
 		"c": "=",
 		"t": "source.batchfile keyword.operator.assignment.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -432,10 +276,6 @@
 		"c": "development",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -443,10 +283,6 @@
 		"c": "call",
 		"t": "source.batchfile keyword.control.statement.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -454,10 +290,6 @@
 		"c": " ",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -465,10 +297,6 @@
 		"c": "echo",
 		"t": "source.batchfile keyword.command.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -476,10 +304,6 @@
 		"c": " ",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -487,10 +311,6 @@
 		"c": "%%",
 		"t": "source.batchfile constant.character.escape.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.character: #569CD6"
 		}
 	},
@@ -498,10 +318,6 @@
 		"c": "LINE:rem +=",
 		"t": "source.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -509,10 +325,6 @@
 		"c": "%%",
 		"t": "source.batchfile constant.character.escape.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.character: #569CD6"
 		}
 	},
@@ -520,10 +332,6 @@
 		"c": "popd",
 		"t": "source.batchfile keyword.command.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -531,10 +339,6 @@
 		"c": "endlocal",
 		"t": "source.batchfile keyword.command.batchfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	}

--- a/extensions/docker/test/colorize-results/Dockerfile.json
+++ b/extensions/docker/test/colorize-results/Dockerfile.json
@@ -3,10 +3,6 @@
 		"c": "FROM",
 		"t": "source.dockerfile keyword.other.special-method.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": " ubuntu",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "MAINTAINER",
 		"t": "source.dockerfile keyword.other.special-method.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": " Kimbro Staken",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "RUN",
 		"t": "source.dockerfile keyword.other.special-method.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": " apt-get install -y software-properties-common python",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "RUN",
 		"t": "source.dockerfile keyword.other.special-method.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": " add-apt-repository ppa:chris-lea/node.js",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "RUN",
 		"t": "source.dockerfile keyword.other.special-method.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": " echo ",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "\"deb http://us.archive.ubuntu.com/ubuntu/ precise universe\"",
 		"t": "source.dockerfile string.quoted.double.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": " >> /etc/apt/sources.list",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": "RUN",
 		"t": "source.dockerfile keyword.other.special-method.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": " apt-get update",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "RUN",
 		"t": "source.dockerfile keyword.other.special-method.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": " apt-get install -y nodejs",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "#",
 		"t": "source.dockerfile comment.line.number-sign.dockerfile punctuation.definition.comment.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "RUN apt-get install -y nodejs=0.6.12~dfsg1-1ubuntu1",
 		"t": "source.dockerfile comment.line.number-sign.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "RUN",
 		"t": "source.dockerfile keyword.other.special-method.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": " mkdir /var/www",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": "ADD",
 		"t": "source.dockerfile keyword.other.special-method.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": " app.js /var/www/app.js",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "CMD",
 		"t": "source.dockerfile keyword.other.special-method.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": " [",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": "\"/usr/bin/node\"",
 		"t": "source.dockerfile string.quoted.double.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": ", ",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": "\"/var/www/app.js\"",
 		"t": "source.dockerfile string.quoted.double.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "] ",
 		"t": "source.dockerfile",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	}

--- a/extensions/git/test/colorize-results/COMMIT_EDITMSG.json
+++ b/extensions/git/test/colorize-results/COMMIT_EDITMSG.json
@@ -3,10 +3,6 @@
 		"c": "This is the summary line. It can't be too long.",
 		"t": "text.git-commit meta.scope.message.git-commit meta.scope.subject.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": "After I can write a much more detailed description without quite the same restrictions on length.",
 		"t": "text.git-commit meta.scope.message.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "#",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": " Please enter the commit message for your changes. Lines starting",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "#",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": " with '#' will be ignored, and an empty message aborts the commit.",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "#",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": " On branch master",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "#",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": " Your branch is up-to-date with 'origin/master'.",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "#",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "#",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": " Changes to be committed:",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "#",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "\t",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "deleted:    README.md",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit markup.deleted.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.deleted: #CE9178"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "#",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "\t",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "modified:   index.less",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit markup.changed.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.changed: #569CD6"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "#",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": "\t",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": "new file:   spec/COMMIT_EDITMSG",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit markup.inserted.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.inserted: #B5CEA8"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "#",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	}

--- a/extensions/git/test/colorize-results/example_diff.json
+++ b/extensions/git/test/colorize-results/example_diff.json
@@ -3,10 +3,6 @@
 		"c": "diff --git a/helloworld.txt b/helloworld.txt",
 		"t": "source.diff meta.diff.header.git",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "meta.diff.header: #000080"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": "index e4f37c4..557db03 100644",
 		"t": "source.diff meta.diff.index.git",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "---",
 		"t": "source.diff meta.diff.header.from-file punctuation.definition.from-file.diff",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "meta.diff.header: #000080"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": " a/helloworld.txt",
 		"t": "source.diff meta.diff.header.from-file",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "meta.diff.header: #000080"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "+++",
 		"t": "source.diff meta.diff.header.to-file punctuation.definition.to-file.diff",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "meta.diff.header: #000080"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": " b/helloworld.txt",
 		"t": "source.diff meta.diff.header.to-file",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "meta.diff.header: #000080"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "@@",
 		"t": "source.diff meta.diff.range.unified punctuation.definition.range.diff",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": " ",
 		"t": "source.diff meta.diff.range.unified",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "-1 +1",
 		"t": "source.diff meta.diff.range.unified meta.toc-list.line-number.diff",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": " ",
 		"t": "source.diff meta.diff.range.unified",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "@@",
 		"t": "source.diff meta.diff.range.unified punctuation.definition.range.diff",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "-",
 		"t": "source.diff markup.deleted.diff punctuation.definition.deleted.diff",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.deleted: #CE9178"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": "Hello world",
 		"t": "source.diff markup.deleted.diff",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.deleted: #CE9178"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "+",
 		"t": "source.diff markup.inserted.diff punctuation.definition.inserted.diff",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.inserted: #B5CEA8"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "Hello World",
 		"t": "source.diff markup.inserted.diff",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.inserted: #B5CEA8"
 		}
 	}

--- a/extensions/git/test/colorize-results/git-rebase-todo.json
+++ b/extensions/git/test/colorize-results/git-rebase-todo.json
@@ -3,10 +3,6 @@
 		"c": "pick",
 		"t": "text.git-rebase meta.commit-command.git-rebase support.function.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function.git-rebase: #D4D4D4"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": "    ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "1fc6c95",
 		"t": "text.git-rebase meta.commit-command.git-rebase constant.sha.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.sha.git-rebase: #B5CEA8"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": "  ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "Patch A",
 		"t": "text.git-rebase meta.commit-command.git-rebase meta.commit-message.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "squash",
 		"t": "text.git-rebase meta.commit-command.git-rebase support.function.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function.git-rebase: #D4D4D4"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "  ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": "fa39187",
 		"t": "text.git-rebase meta.commit-command.git-rebase constant.sha.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.sha.git-rebase: #B5CEA8"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "  ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": "Something to add to patch A",
 		"t": "text.git-rebase meta.commit-command.git-rebase meta.commit-message.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "pick",
 		"t": "text.git-rebase meta.commit-command.git-rebase support.function.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function.git-rebase: #D4D4D4"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "    ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": "7b36971",
 		"t": "text.git-rebase meta.commit-command.git-rebase constant.sha.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.sha.git-rebase: #B5CEA8"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "  ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "Something to move before patch B",
 		"t": "text.git-rebase meta.commit-command.git-rebase meta.commit-message.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "pick",
 		"t": "text.git-rebase meta.commit-command.git-rebase support.function.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function.git-rebase: #D4D4D4"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "    ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "6b2481b",
 		"t": "text.git-rebase meta.commit-command.git-rebase constant.sha.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.sha.git-rebase: #B5CEA8"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "  ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "Patch B",
 		"t": "text.git-rebase meta.commit-command.git-rebase meta.commit-message.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": "fixup",
 		"t": "text.git-rebase meta.commit-command.git-rebase support.function.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function.git-rebase: #D4D4D4"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": "   ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "c619268",
 		"t": "text.git-rebase meta.commit-command.git-rebase constant.sha.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.sha.git-rebase: #B5CEA8"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": "  ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": "A fix for Patch B",
 		"t": "text.git-rebase meta.commit-command.git-rebase meta.commit-message.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": "edit",
 		"t": "text.git-rebase meta.commit-command.git-rebase support.function.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function.git-rebase: #D4D4D4"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": "    ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "dd1475d",
 		"t": "text.git-rebase meta.commit-command.git-rebase constant.sha.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.sha.git-rebase: #B5CEA8"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": "  ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -322,10 +206,6 @@
 		"c": "Something I want to split",
 		"t": "text.git-rebase meta.commit-command.git-rebase meta.commit-message.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -333,10 +213,6 @@
 		"c": "reword",
 		"t": "text.git-rebase meta.commit-command.git-rebase support.function.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function.git-rebase: #D4D4D4"
 		}
 	},
@@ -344,10 +220,6 @@
 		"c": "  ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -355,10 +227,6 @@
 		"c": "4ca2acc",
 		"t": "text.git-rebase meta.commit-command.git-rebase constant.sha.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.sha.git-rebase: #B5CEA8"
 		}
 	},
@@ -366,10 +234,6 @@
 		"c": "  ",
 		"t": "text.git-rebase meta.commit-command.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -377,10 +241,6 @@
 		"c": "i cant' typ goods",
 		"t": "text.git-rebase meta.commit-command.git-rebase meta.commit-message.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -388,10 +248,6 @@
 		"c": "#",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase punctuation.definition.comment.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -399,10 +255,6 @@
 		"c": " Commands:",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -410,10 +262,6 @@
 		"c": "#",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase punctuation.definition.comment.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -421,10 +269,6 @@
 		"c": "  p, pick = use commit",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -432,10 +276,6 @@
 		"c": "#",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase punctuation.definition.comment.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -443,10 +283,6 @@
 		"c": "  r, reword = use commit, but edit the commit message",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -454,10 +290,6 @@
 		"c": "#",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase punctuation.definition.comment.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -465,10 +297,6 @@
 		"c": "  e, edit = use commit, but stop for amending",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -476,10 +304,6 @@
 		"c": "#",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase punctuation.definition.comment.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -487,10 +311,6 @@
 		"c": "  s, squash = use commit, but meld into previous commit",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -498,10 +318,6 @@
 		"c": "#",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase punctuation.definition.comment.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -509,10 +325,6 @@
 		"c": "  f, fixup = like \"squash\", but discard this commit's log message",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -520,10 +332,6 @@
 		"c": "#",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase punctuation.definition.comment.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -531,10 +339,6 @@
 		"c": "  x, exec = run command (the rest of the line) using shell",
 		"t": "text.git-rebase comment.line.number-sign.git-rebase",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	}

--- a/extensions/integration-tests/setEnvironmentVariables.js
+++ b/extensions/integration-tests/setEnvironmentVariables.js
@@ -58,7 +58,7 @@ if (process.argv.length === 3 && process.argv[2]) {
 			} else if (os.platform() === 'darwin') {
 				ENVVARS_OPTION = ENVVARS_BASH;
 			} else {
-				console.warn(`Launch terminal option is not implemented for your os: ${os.platform()}, vscode will be launched`);
+				console.warn(`Launch option: ENV is not implemented for your os: ${os.platform()}, vscode will be launched`);
 			}
 			LAUNCH_OPTION = LAUNCH_NONE
 			break;

--- a/extensions/json/test/colorize-results/test_json.json
+++ b/extensions/json/test/colorize-results/test_json.json
@@ -3,10 +3,6 @@
 		"c": "{",
 		"t": "source.json meta.structure.dictionary.json punctuation.definition.dictionary.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": "\t",
 		"t": "source.json meta.structure.dictionary.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "//",
 		"t": "source.json meta.structure.dictionary.json comment.line.double-slash.js punctuation.definition.comment.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": " a comment",
 		"t": "source.json meta.structure.dictionary.json comment.line.double-slash.js",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "\t",
 		"t": "source.json meta.structure.dictionary.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "options",
 		"t": "source.json meta.structure.dictionary.json string.json support.type.property-name.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": ":",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.key-value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "{",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json punctuation.definition.dictionary.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "\t\t",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "myBool",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": ":",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.key-value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "true",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json constant.language.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.language: #569CD6"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": ",",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.pair.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "\t\t",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": "myInteger",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": ":",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.key-value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": "1",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json constant.numeric.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": ",",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.pair.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "\t\t",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -322,10 +206,6 @@
 		"c": "myString",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -333,10 +213,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -344,10 +220,6 @@
 		"c": ":",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.key-value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -355,10 +227,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -366,10 +234,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json punctuation.definition.string.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -377,10 +241,6 @@
 		"c": "String",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -388,10 +248,6 @@
 		"c": "\\u0056",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json constant.character.escape.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.character: #569CD6"
 		}
 	},
@@ -399,10 +255,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json punctuation.definition.string.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -410,10 +262,6 @@
 		"c": ",",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.pair.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -421,10 +269,6 @@
 		"c": "\t\t",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -432,10 +276,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -443,10 +283,6 @@
 		"c": "myNumber",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -454,10 +290,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -465,10 +297,6 @@
 		"c": ":",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.key-value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -476,10 +304,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -487,10 +311,6 @@
 		"c": "1.24",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json constant.numeric.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -498,10 +318,6 @@
 		"c": ",",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.pair.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -509,10 +325,6 @@
 		"c": "\t\t",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -520,10 +332,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -531,10 +339,6 @@
 		"c": "myNull",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -542,10 +346,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -553,10 +353,6 @@
 		"c": ":",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.key-value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -564,10 +360,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -575,10 +367,6 @@
 		"c": "null",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json constant.language.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.language: #569CD6"
 		}
 	},
@@ -586,10 +374,6 @@
 		"c": ",",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.pair.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -597,10 +381,6 @@
 		"c": "\t\t",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -608,10 +388,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -619,10 +395,6 @@
 		"c": "myArray",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -630,10 +402,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -641,10 +409,6 @@
 		"c": ":",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.key-value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -652,10 +416,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -663,10 +423,6 @@
 		"c": "[",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json punctuation.definition.array.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -674,10 +430,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -685,10 +437,6 @@
 		"c": "1",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json constant.numeric.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -696,10 +444,6 @@
 		"c": ",",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json punctuation.separator.array.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -707,10 +451,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -718,10 +458,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json string.quoted.double.json punctuation.definition.string.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -729,10 +465,6 @@
 		"c": "Hello",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json string.quoted.double.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -740,10 +472,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json string.quoted.double.json punctuation.definition.string.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -751,10 +479,6 @@
 		"c": ",",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json punctuation.separator.array.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -762,10 +486,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -773,10 +493,6 @@
 		"c": "true",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json constant.language.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.language: #569CD6"
 		}
 	},
@@ -784,10 +500,6 @@
 		"c": ",",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json punctuation.separator.array.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -795,10 +507,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -806,10 +514,6 @@
 		"c": "null",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json constant.language.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.language: #569CD6"
 		}
 	},
@@ -817,10 +521,6 @@
 		"c": ",",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json punctuation.separator.array.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -828,10 +528,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -839,10 +535,6 @@
 		"c": "[",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.array.json punctuation.definition.array.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -850,10 +542,6 @@
 		"c": "]",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.array.json punctuation.definition.array.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -861,10 +549,6 @@
 		"c": ",",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json punctuation.separator.array.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -872,10 +556,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -883,10 +563,6 @@
 		"c": "{",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json punctuation.definition.dictionary.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -894,10 +570,6 @@
 		"c": "}",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json punctuation.definition.dictionary.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -905,10 +577,6 @@
 		"c": "]",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json punctuation.definition.array.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -916,10 +584,6 @@
 		"c": ",",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.pair.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -927,10 +591,6 @@
 		"c": "\t\t",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -938,10 +598,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -949,10 +605,6 @@
 		"c": "myObject",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -960,10 +612,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -971,10 +619,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -982,10 +626,6 @@
 		"c": ":",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.key-value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -993,10 +633,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1004,10 +640,6 @@
 		"c": "{",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json punctuation.definition.dictionary.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1015,10 +647,6 @@
 		"c": "\t\t\t",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1026,10 +654,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -1037,10 +661,6 @@
 		"c": "foo",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -1048,10 +668,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.json support.type.property-name.json punctuation.support.type.property-name.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type.property-name: #D4D4D4"
 		}
 	},
@@ -1059,10 +675,6 @@
 		"c": ":",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json punctuation.separator.dictionary.key-value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1070,10 +682,6 @@
 		"c": " ",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1081,10 +689,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json punctuation.definition.string.begin.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1092,10 +696,6 @@
 		"c": "bar",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1103,10 +703,6 @@
 		"c": "\"",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json punctuation.definition.string.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1114,10 +710,6 @@
 		"c": "\t\t",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1125,10 +717,6 @@
 		"c": "}",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json punctuation.definition.dictionary.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1136,10 +724,6 @@
 		"c": "\t",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1147,10 +731,6 @@
 		"c": "}",
 		"t": "source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json punctuation.definition.dictionary.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1158,10 +738,6 @@
 		"c": "}",
 		"t": "source.json meta.structure.dictionary.json punctuation.definition.dictionary.end.json",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	}

--- a/extensions/markdown-basics/test/colorize-results/test-33886_md.json
+++ b/extensions/markdown-basics/test/colorize-results/test-33886_md.json
@@ -3,10 +3,6 @@
 		"c": "#",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "h",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": "<pre><code>",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "#",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "a",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": "</code></pre>",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "#",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "h",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "<pre>",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": "#",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "a",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "a</pre>",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "#",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "h",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	}

--- a/extensions/markdown-basics/test/colorize-results/test_md.json
+++ b/extensions/markdown-basics/test/colorize-results/test_md.json
@@ -3,10 +3,6 @@
 		"c": "#",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "Header 1",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": " #",
 		"t": "text.html.markdown markup.heading.markdown heading.1.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "##",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "Header 2",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": " ##",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "###",
 		"t": "text.html.markdown markup.heading.markdown heading.3.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.3.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "Header 3 ###             (Hashes on right are optional)",
 		"t": "text.html.markdown markup.heading.markdown heading.3.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "##",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "Markdown plus h2 with a custom ID ##   {#id-goes-here}",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "[",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.string.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "Link back to H2",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown string.other.link.title.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "]",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.string.end.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "(",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.metadata.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "#id-goes-here",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown markup.underline.link.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": ")",
 		"t": "text.html.markdown meta.paragraph.markdown meta.link.inline.markdown punctuation.definition.metadata.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": "###",
 		"t": "text.html.markdown markup.heading.markdown heading.3.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.3.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "Alternate heading styles:",
 		"t": "text.html.markdown markup.heading.markdown heading.3.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": "Alternate Header 1",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": "==================",
 		"t": "text.html.markdown meta.paragraph.markdown markup.heading.setext.1.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": "Alternate Header 2",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": "------------------",
 		"t": "text.html.markdown meta.paragraph.markdown markup.heading.setext.2.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "<!--",
 		"t": "text.html.markdown comment.block.html punctuation.definition.comment.html",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": " html madness ",
 		"t": "text.html.markdown comment.block.html",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -322,10 +206,6 @@
 		"c": "-->",
 		"t": "text.html.markdown comment.block.html punctuation.definition.comment.html",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -333,10 +213,6 @@
 		"c": "<div class=\"custom-class\" markdown=\"1\">",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -344,10 +220,6 @@
 		"c": "  <div>",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -355,10 +227,6 @@
 		"c": "    nested div",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -366,10 +234,6 @@
 		"c": "  </div>",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -377,10 +241,6 @@
 		"c": "  <script type='text/x-koka'>",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -388,10 +248,6 @@
 		"c": "    function( x: int ) { return x*x; }",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -399,10 +255,6 @@
 		"c": "  </script>",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -410,10 +262,6 @@
 		"c": "  This is a div ",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -421,10 +269,6 @@
 		"c": "_",
 		"t": "text.html.markdown meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -432,10 +276,6 @@
 		"c": "with",
 		"t": "text.html.markdown meta.paragraph.markdown markup.italic.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -443,10 +283,6 @@
 		"c": "_",
 		"t": "text.html.markdown meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -454,10 +290,6 @@
 		"c": " underscores",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -465,10 +297,6 @@
 		"c": "  and a ",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -476,10 +304,6 @@
 		"c": "&",
 		"t": "text.html.markdown meta.paragraph.markdown meta.other.valid-ampersand.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -487,10 +311,6 @@
 		"c": " <b class=\"bold\">bold</b> element.",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -498,10 +318,6 @@
 		"c": "  <style>",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -509,10 +325,6 @@
 		"c": "    body { font: \"Consolas\" }",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -520,10 +332,6 @@
 		"c": "  </style>",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -531,10 +339,6 @@
 		"c": "</div>",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -542,10 +346,6 @@
 		"c": "*",
 		"t": "text.html.markdown markup.list.unnumbered.markdown punctuation.definition.list.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -553,10 +353,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.unnumbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -564,10 +360,6 @@
 		"c": "Bullet lists are easy too",
 		"t": "text.html.markdown markup.list.unnumbered.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -575,10 +367,6 @@
 		"c": "-",
 		"t": "text.html.markdown markup.list.unnumbered.markdown punctuation.definition.list.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -586,10 +374,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.unnumbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -597,10 +381,6 @@
 		"c": "Another one",
 		"t": "text.html.markdown markup.list.unnumbered.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -608,10 +388,6 @@
 		"c": "+",
 		"t": "text.html.markdown markup.list.unnumbered.markdown punctuation.definition.list.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -619,10 +395,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.unnumbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -630,10 +402,6 @@
 		"c": "Another one",
 		"t": "text.html.markdown markup.list.unnumbered.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -641,10 +409,6 @@
 		"c": "    ",
 		"t": "text.html.markdown markup.list.unnumbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -652,10 +416,6 @@
 		"c": "+",
 		"t": "text.html.markdown markup.list.unnumbered.markdown markup.list.unnumbered.markdown punctuation.definition.list.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -663,10 +423,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.unnumbered.markdown markup.list.unnumbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -674,10 +430,6 @@
 		"c": "nested list",
 		"t": "text.html.markdown markup.list.unnumbered.markdown markup.list.unnumbered.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -685,10 +437,6 @@
 		"c": "This is a paragraph, which is text surrounded by",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -696,10 +444,6 @@
 		"c": "whitespace. Paragraphs can be on one",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -707,10 +451,6 @@
 		"c": "line (or many), and can drone on for hours.",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -718,10 +458,6 @@
 		"c": "Now some inline markup like ",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -729,10 +465,6 @@
 		"c": "_",
 		"t": "text.html.markdown meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -740,10 +472,6 @@
 		"c": "italics",
 		"t": "text.html.markdown meta.paragraph.markdown markup.italic.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -751,10 +479,6 @@
 		"c": "_",
 		"t": "text.html.markdown meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -762,10 +486,6 @@
 		"c": ",  ",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -773,10 +493,6 @@
 		"c": "**",
 		"t": "text.html.markdown meta.paragraph.markdown markup.bold.markdown punctuation.definition.bold.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -784,10 +500,6 @@
 		"c": "bold",
 		"t": "text.html.markdown meta.paragraph.markdown markup.bold.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -795,10 +507,6 @@
 		"c": "**",
 		"t": "text.html.markdown meta.paragraph.markdown markup.bold.markdown punctuation.definition.bold.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -806,10 +514,6 @@
 		"c": ",",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -817,10 +521,6 @@
 		"c": "and ",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -828,10 +528,6 @@
 		"c": "`",
 		"t": "text.html.markdown meta.paragraph.markdown markup.inline.raw.string.markdown punctuation.definition.raw.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -839,10 +535,6 @@
 		"c": "code()",
 		"t": "text.html.markdown meta.paragraph.markdown markup.inline.raw.string.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -850,10 +542,6 @@
 		"c": "`",
 		"t": "text.html.markdown meta.paragraph.markdown markup.inline.raw.string.markdown punctuation.definition.raw.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -861,10 +549,6 @@
 		"c": ". Note that underscores",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -872,10 +556,6 @@
 		"c": "in_words_are ignored.",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -883,10 +563,6 @@
 		"c": "````",
 		"t": "text.html.markdown markup.fenced_code.block.markdown punctuation.definition.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -894,10 +570,6 @@
 		"c": "application/json",
 		"t": "text.html.markdown markup.fenced_code.block.markdown fenced_code.block.language",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -905,10 +577,6 @@
 		"c": "  { value: [\"or with a mime type\"] }",
 		"t": "text.html.markdown markup.fenced_code.block.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -916,10 +584,6 @@
 		"c": "````",
 		"t": "text.html.markdown markup.fenced_code.block.markdown punctuation.definition.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -927,10 +591,6 @@
 		"c": ">",
 		"t": "text.html.markdown markup.quote.markdown punctuation.definition.quote.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -938,10 +598,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.quote.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -949,10 +605,6 @@
 		"c": "Blockquotes are like quoted text in email replies",
 		"t": "text.html.markdown markup.quote.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -960,10 +612,6 @@
 		"c": ">",
 		"t": "text.html.markdown markup.quote.markdown punctuation.definition.quote.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -971,10 +619,6 @@
 		"c": ">",
 		"t": "text.html.markdown markup.quote.markdown markup.quote.markdown punctuation.definition.quote.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -982,10 +626,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.quote.markdown markup.quote.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -993,10 +633,6 @@
 		"c": "And, they can be nested",
 		"t": "text.html.markdown markup.quote.markdown markup.quote.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1004,10 +640,6 @@
 		"c": "1.",
 		"t": "text.html.markdown markup.list.numbered.markdown punctuation.definition.list.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1015,10 +647,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.numbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1026,10 +654,6 @@
 		"c": "A numbered list",
 		"t": "text.html.markdown markup.list.numbered.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1037,10 +661,6 @@
 		"c": "    ",
 		"t": "text.html.markdown markup.list.numbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1048,10 +668,6 @@
 		"c": ">",
 		"t": "text.html.markdown markup.list.numbered.markdown markup.quote.markdown punctuation.definition.quote.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1059,10 +675,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.numbered.markdown markup.quote.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1070,10 +682,6 @@
 		"c": "Block quotes in list",
 		"t": "text.html.markdown markup.list.numbered.markdown markup.quote.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1081,10 +689,6 @@
 		"c": "2.",
 		"t": "text.html.markdown markup.list.numbered.markdown punctuation.definition.list.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1092,10 +696,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.numbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1103,10 +703,6 @@
 		"c": "Which is numbered",
 		"t": "text.html.markdown markup.list.numbered.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1114,10 +710,6 @@
 		"c": "3.",
 		"t": "text.html.markdown markup.list.numbered.markdown punctuation.definition.list.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1125,10 +717,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.numbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1136,10 +724,6 @@
 		"c": "With periods and a space",
 		"t": "text.html.markdown markup.list.numbered.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1147,10 +731,6 @@
 		"c": "And now some code:",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1158,10 +738,6 @@
 		"c": "    // Code is just text indented a bit",
 		"t": "text.html.markdown markup.raw.block.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1169,10 +745,6 @@
 		"c": "    which(is_easy) to_remember();",
 		"t": "text.html.markdown markup.raw.block.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1180,10 +752,6 @@
 		"c": "And a block",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1191,10 +759,6 @@
 		"c": "~~~",
 		"t": "text.html.markdown markup.fenced_code.block.markdown punctuation.definition.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1202,10 +766,6 @@
 		"c": "// Markdown extra adds un-indented code blocks too",
 		"t": "text.html.markdown markup.fenced_code.block.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1213,10 +773,6 @@
 		"c": "if (this_is_more_code == true && !indented) {",
 		"t": "text.html.markdown markup.fenced_code.block.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1224,10 +780,6 @@
 		"c": "    // tild wrapped code blocks, also not indented",
 		"t": "text.html.markdown markup.fenced_code.block.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1235,10 +787,6 @@
 		"c": "}",
 		"t": "text.html.markdown markup.fenced_code.block.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1246,10 +794,6 @@
 		"c": "~~~",
 		"t": "text.html.markdown markup.fenced_code.block.markdown punctuation.definition.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1257,10 +801,6 @@
 		"c": "Text with",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1268,10 +808,6 @@
 		"c": "two trailing spaces",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1279,10 +815,6 @@
 		"c": "(on the right)",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1290,10 +822,6 @@
 		"c": "can be used",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1301,10 +829,6 @@
 		"c": "for things like poems",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1312,10 +836,6 @@
 		"c": "###",
 		"t": "text.html.markdown markup.heading.markdown heading.3.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -1323,10 +843,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.3.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -1334,10 +850,6 @@
 		"c": "Horizontal rules",
 		"t": "text.html.markdown markup.heading.markdown heading.3.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -1345,10 +857,6 @@
 		"c": "* * * *",
 		"t": "text.html.markdown meta.separator.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1356,10 +864,6 @@
 		"c": "****",
 		"t": "text.html.markdown meta.separator.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1367,10 +871,6 @@
 		"c": "--------------------------",
 		"t": "text.html.markdown meta.separator.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1378,10 +878,6 @@
 		"c": "![",
 		"t": "text.html.markdown meta.paragraph.markdown meta.image.inline.markdown punctuation.definition.string.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1389,10 +885,6 @@
 		"c": "picture alt",
 		"t": "text.html.markdown meta.paragraph.markdown meta.image.inline.markdown string.other.link.description.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1400,10 +892,6 @@
 		"c": "]",
 		"t": "text.html.markdown meta.paragraph.markdown meta.image.inline.markdown punctuation.definition.string.end.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1411,10 +899,6 @@
 		"c": "(",
 		"t": "text.html.markdown meta.paragraph.markdown meta.image.inline.markdown punctuation.definition.metadata.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1422,10 +906,6 @@
 		"c": "/images/photo.jpeg",
 		"t": "text.html.markdown meta.paragraph.markdown meta.image.inline.markdown markup.underline.link.image.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1433,10 +913,6 @@
 		"c": " ",
 		"t": "text.html.markdown meta.paragraph.markdown meta.image.inline.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1444,10 +920,6 @@
 		"c": "\"",
 		"t": "text.html.markdown meta.paragraph.markdown meta.image.inline.markdown string.other.link.description.title.markdown punctuation.definition.string.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1455,10 +927,6 @@
 		"c": "Title is optional",
 		"t": "text.html.markdown meta.paragraph.markdown meta.image.inline.markdown string.other.link.description.title.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1466,10 +934,6 @@
 		"c": "\"",
 		"t": "text.html.markdown meta.paragraph.markdown meta.image.inline.markdown string.other.link.description.title.markdown punctuation.definition.string.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1477,10 +941,6 @@
 		"c": ")",
 		"t": "text.html.markdown meta.paragraph.markdown meta.image.inline.markdown punctuation.definition.metadata.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1488,10 +948,6 @@
 		"c": "##",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -1499,10 +955,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -1510,10 +962,6 @@
 		"c": "Markdown plus tables",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -1521,10 +969,6 @@
 		"c": " ##",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -1532,10 +976,6 @@
 		"c": "| Header | Header | Right  |",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1543,10 +983,6 @@
 		"c": "| ------ | ------ | -----: |",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1554,10 +990,6 @@
 		"c": "|  Cell  |  Cell  |   $10  |",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1565,10 +997,6 @@
 		"c": "|  Cell  |  Cell  |   $20  |",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1576,10 +1004,6 @@
 		"c": "*",
 		"t": "text.html.markdown markup.list.unnumbered.markdown punctuation.definition.list.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1587,10 +1011,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.unnumbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1598,10 +1018,6 @@
 		"c": "Outer pipes on tables are optional",
 		"t": "text.html.markdown markup.list.unnumbered.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1609,10 +1025,6 @@
 		"c": "*",
 		"t": "text.html.markdown markup.list.unnumbered.markdown punctuation.definition.list.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1620,10 +1032,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.unnumbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1631,10 +1039,6 @@
 		"c": "Colon used for alignment (right versus left)",
 		"t": "text.html.markdown markup.list.unnumbered.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1642,10 +1046,6 @@
 		"c": "##",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -1653,10 +1053,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -1664,10 +1060,6 @@
 		"c": "Markdown plus definition lists",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown entity.name.section.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -1675,10 +1067,6 @@
 		"c": " ##",
 		"t": "text.html.markdown markup.heading.markdown heading.2.markdown punctuation.definition.heading.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "markup.heading: #6796E6"
 		}
 	},
@@ -1686,10 +1074,6 @@
 		"c": "Bottled water",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1697,10 +1081,6 @@
 		"c": ": $ 1.25",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1708,10 +1088,6 @@
 		"c": ": $ 1.55 (Large)",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1719,10 +1095,6 @@
 		"c": "Milk",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1730,10 +1102,6 @@
 		"c": "Pop",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1741,10 +1109,6 @@
 		"c": ": $ 1.75",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1752,10 +1116,6 @@
 		"c": "*",
 		"t": "text.html.markdown markup.list.unnumbered.markdown punctuation.definition.list.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1763,10 +1123,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.unnumbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1774,10 +1130,6 @@
 		"c": "Multiple definitions and terms are possible",
 		"t": "text.html.markdown markup.list.unnumbered.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1785,10 +1137,6 @@
 		"c": "*",
 		"t": "text.html.markdown markup.list.unnumbered.markdown punctuation.definition.list.begin.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1796,10 +1144,6 @@
 		"c": " ",
 		"t": "text.html.markdown markup.list.unnumbered.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1807,21 +1151,41 @@
 		"c": "Definitions can include multiple paragraphs too",
 		"t": "text.html.markdown markup.list.unnumbered.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
 	{
-		"c": "*[ABBR]: Markdown plus abbreviations (produces an <abbr> tag)",
+		"c": "*",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "[",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.reference.markdown punctuation.definition.string.begin.markdown",
+		"r": {
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "ABBR",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.reference.markdown string.other.link.title.markdown",
+		"r": {
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "]",
+		"t": "text.html.markdown meta.paragraph.markdown meta.link.reference.markdown punctuation.definition.string.end.markdown",
+		"r": {
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": ": Markdown plus abbreviations (produces an <abbr> tag)",
+		"t": "text.html.markdown meta.paragraph.markdown",
+		"r": {
 			"hc_black": "default: #FFFFFF"
 		}
 	}

--- a/extensions/powershell/test/colorize-results/test-freeze-56476_ps1.json
+++ b/extensions/powershell/test/colorize-results/test-freeze-56476_ps1.json
@@ -3,10 +3,6 @@
 		"c": "<#",
 		"t": "source.powershell comment.block.powershell punctuation.definition.comment.block.begin.powershell",
 		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": "                        .",
 		"t": "source.powershell comment.block.powershell",
 		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "#>",
 		"t": "source.powershell comment.block.powershell punctuation.definition.comment.block.end.powershell",
 		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
 			"hc_black": "comment: #7CA668"
 		}
 	}

--- a/extensions/powershell/test/colorize-results/test_ps1.json
+++ b/extensions/powershell/test/colorize-results/test_ps1.json
@@ -3,10 +3,6 @@
 		"c": "#",
 		"t": "source.powershell comment.line.powershell punctuation.definition.comment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": " Copyright Microsoft Corporation",
 		"t": "source.powershell comment.line.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "function",
 		"t": "source.powershell meta.function.powershell storage.type.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": " ",
 		"t": "source.powershell meta.function.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "Test-IsAdmin",
 		"t": "source.powershell meta.function.powershell entity.name.function.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "(",
 		"t": "source.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": ")",
 		"t": "source.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "{",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.braces.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": "    ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "try",
 		"t": "source.powershell meta.scriptblock.powershell keyword.control.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": "{",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.braces.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "        ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "identity",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "=",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "[",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.bracket.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": "Security.Principal.WindowsIdentity",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell storage.type.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": "]",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.bracket.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "::GetCurrent",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": "(",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": ")",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": "        ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "principal",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -322,10 +206,6 @@
 		"c": "=",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -333,10 +213,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -344,10 +220,6 @@
 		"c": "New-Object",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell support.function.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -355,10 +227,6 @@
 		"c": " Security.Principal.WindowsPrincipal ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -366,10 +234,6 @@
 		"c": "-",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -377,10 +241,6 @@
 		"c": "ArgumentList ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -388,10 +248,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -399,10 +255,6 @@
 		"c": "identity",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -410,10 +262,6 @@
 		"c": "        ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -421,10 +269,6 @@
 		"c": "return",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.control.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -432,10 +276,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -443,10 +283,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -454,10 +290,6 @@
 		"c": "principal",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -465,10 +297,6 @@
 		"c": ".IsInRole",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell entity.name.function.invocation.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
@@ -476,10 +304,6 @@
 		"c": "(",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -487,10 +311,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -498,10 +318,6 @@
 		"c": "[",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell punctuation.section.bracket.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -509,10 +325,6 @@
 		"c": "Security.Principal.WindowsBuiltInRole",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell storage.type.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -520,10 +332,6 @@
 		"c": "]",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell punctuation.section.bracket.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -531,10 +339,6 @@
 		"c": "::Administrator ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -542,10 +346,6 @@
 		"c": ")",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -553,10 +353,6 @@
 		"c": "    ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -564,10 +360,6 @@
 		"c": "}",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.braces.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -575,10 +367,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -586,10 +374,6 @@
 		"c": "catch",
 		"t": "source.powershell meta.scriptblock.powershell keyword.control.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -597,10 +381,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -608,10 +388,6 @@
 		"c": "{",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.braces.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -619,10 +395,6 @@
 		"c": "        ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -630,10 +402,6 @@
 		"c": "throw",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.control.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -641,10 +409,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -652,10 +416,6 @@
 		"c": "\"Failed to determine if the current user has elevated privileges. The error was: '{0}'.\"",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell string.quoted.double.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -663,10 +423,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -674,10 +430,6 @@
 		"c": "-f",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.operator.string-format.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -685,10 +437,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -696,10 +444,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -707,10 +451,6 @@
 		"c": "_",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell support.constant.automatic.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -718,10 +458,6 @@
 		"c": "    ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -729,10 +465,6 @@
 		"c": "}",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.braces.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -740,10 +472,6 @@
 		"c": "}",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.braces.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -751,10 +479,6 @@
 		"c": "function",
 		"t": "source.powershell meta.function.powershell storage.type.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -762,10 +486,6 @@
 		"c": " ",
 		"t": "source.powershell meta.function.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -773,10 +493,6 @@
 		"c": "Invoke-Environment",
 		"t": "source.powershell meta.function.powershell entity.name.function.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
@@ -784,10 +500,6 @@
 		"c": "(",
 		"t": "source.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -795,10 +507,6 @@
 		"c": ")",
 		"t": "source.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -806,10 +514,6 @@
 		"c": "{",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.braces.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -817,10 +521,6 @@
 		"c": "    ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -828,10 +528,6 @@
 		"c": "param",
 		"t": "source.powershell meta.scriptblock.powershell keyword.control.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -839,10 +535,6 @@
 		"c": "    ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -850,10 +542,6 @@
 		"c": "(",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -861,10 +549,6 @@
 		"c": "        ",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -872,10 +556,6 @@
 		"c": "[",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell meta.attribute.powershell punctuation.section.bracket.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -883,10 +563,6 @@
 		"c": "Parameter",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell meta.attribute.powershell support.function.attribute.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -894,10 +570,6 @@
 		"c": "(",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell meta.attribute.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -905,10 +577,6 @@
 		"c": "Mandatory",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell meta.attribute.powershell variable.parameter.attribute.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -916,10 +584,6 @@
 		"c": "=",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell meta.attribute.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -927,10 +591,6 @@
 		"c": "1",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell meta.attribute.powershell constant.numeric.integer.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -938,10 +598,6 @@
 		"c": ")",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell meta.attribute.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -949,10 +605,6 @@
 		"c": "]",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell meta.attribute.powershell punctuation.section.bracket.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -960,10 +612,6 @@
 		"c": "[",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell punctuation.section.bracket.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -971,10 +619,6 @@
 		"c": "string",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell storage.type.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -982,10 +626,6 @@
 		"c": "]",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell punctuation.section.bracket.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -993,10 +633,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -1004,10 +640,6 @@
 		"c": "Command",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -1015,10 +647,6 @@
 		"c": "    ",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1026,10 +654,6 @@
 		"c": ")",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1037,10 +661,6 @@
 		"c": "    ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1048,10 +668,6 @@
 		"c": "foreach",
 		"t": "source.powershell meta.scriptblock.powershell keyword.control.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -1059,10 +675,6 @@
 		"c": "(",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1070,10 +682,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -1081,10 +689,6 @@
 		"c": "_",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell support.constant.automatic.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1092,10 +696,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1103,10 +703,6 @@
 		"c": "in",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell keyword.control.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -1114,10 +710,6 @@
 		"c": " cmd ",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1125,10 +717,6 @@
 		"c": "/",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1136,10 +724,6 @@
 		"c": "c ",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1147,10 +731,6 @@
 		"c": "\"",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell string.quoted.double.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1158,10 +738,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell string.quoted.double.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -1169,10 +745,6 @@
 		"c": "Command",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell string.quoted.double.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -1180,10 +752,6 @@
 		"c": "  2>&1 & set\"",
 		"t": "source.powershell meta.scriptblock.powershell interpolated.simple.source.powershell string.quoted.double.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1191,10 +759,6 @@
 		"c": ")",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1202,10 +766,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1213,10 +773,6 @@
 		"c": "{",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.braces.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1224,10 +780,6 @@
 		"c": "        ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1235,10 +787,6 @@
 		"c": "if",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell keyword.control.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -1246,10 +794,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1257,10 +801,6 @@
 		"c": "(",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1268,10 +808,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -1279,10 +815,6 @@
 		"c": "_",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell support.constant.automatic.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1290,10 +822,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1301,10 +829,6 @@
 		"c": "-match",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell keyword.operator.comparison.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1312,10 +836,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1323,10 +843,6 @@
 		"c": "'^([^=]+)=(.*)'",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell string.quoted.single.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1334,10 +850,6 @@
 		"c": ")",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1345,10 +857,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1356,10 +864,6 @@
 		"c": "{",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.braces.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1367,10 +871,6 @@
 		"c": "            ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1378,10 +878,6 @@
 		"c": "[",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.bracket.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1389,10 +885,6 @@
 		"c": "System.Environment",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell storage.type.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -1400,10 +892,6 @@
 		"c": "]",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.bracket.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1411,10 +899,6 @@
 		"c": "::SetEnvironmentVariable",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1422,10 +906,6 @@
 		"c": "(",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1433,10 +913,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -1444,10 +920,6 @@
 		"c": "matches",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell support.constant.automatic.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1455,10 +927,6 @@
 		"c": "[",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell punctuation.section.bracket.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1466,10 +934,6 @@
 		"c": "1",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell constant.numeric.integer.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1477,10 +941,6 @@
 		"c": "]",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell punctuation.section.bracket.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1488,10 +948,6 @@
 		"c": ",",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell keyword.operator.other.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1499,10 +955,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1510,10 +962,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -1521,10 +969,6 @@
 		"c": "matches",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell support.constant.automatic.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1532,10 +976,6 @@
 		"c": "[",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell punctuation.section.bracket.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1543,10 +983,6 @@
 		"c": "2",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell constant.numeric.integer.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1554,10 +990,6 @@
 		"c": "]",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell interpolated.simple.source.powershell punctuation.section.bracket.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1565,10 +997,6 @@
 		"c": ")",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1576,10 +1004,6 @@
 		"c": "        ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1587,10 +1011,6 @@
 		"c": "}",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.braces.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1598,10 +1018,6 @@
 		"c": "    ",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1609,10 +1025,6 @@
 		"c": "}",
 		"t": "source.powershell meta.scriptblock.powershell meta.scriptblock.powershell punctuation.section.braces.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1620,10 +1032,6 @@
 		"c": "}",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.braces.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1631,10 +1039,6 @@
 		"c": "Write-Host",
 		"t": "source.powershell support.function.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -1642,10 +1046,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1653,10 +1053,6 @@
 		"c": "-",
 		"t": "source.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1664,10 +1060,6 @@
 		"c": "Object ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1675,10 +1067,6 @@
 		"c": "'Initializing Azure PowerShell environment...'",
 		"t": "source.powershell string.quoted.single.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1686,10 +1074,6 @@
 		"c": ";",
 		"t": "source.powershell keyword.other.statement-separator.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -1697,10 +1081,6 @@
 		"c": "#",
 		"t": "source.powershell comment.line.powershell punctuation.definition.comment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -1708,10 +1088,6 @@
 		"c": " PowerShell commands need elevation for dependencies installation and running tests",
 		"t": "source.powershell comment.line.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -1719,10 +1095,6 @@
 		"c": "if",
 		"t": "source.powershell keyword.control.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -1730,10 +1102,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1741,10 +1109,6 @@
 		"c": "(",
 		"t": "source.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1752,10 +1116,6 @@
 		"c": "!",
 		"t": "source.powershell interpolated.simple.source.powershell keyword.operator.unary.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1763,10 +1123,6 @@
 		"c": "(",
 		"t": "source.powershell interpolated.simple.source.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1774,10 +1130,6 @@
 		"c": "Test-IsAdmin",
 		"t": "source.powershell interpolated.simple.source.powershell interpolated.simple.source.powershell support.function.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -1785,10 +1137,6 @@
 		"c": ")",
 		"t": "source.powershell interpolated.simple.source.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1796,10 +1144,6 @@
 		"c": ")",
 		"t": "source.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1807,10 +1151,6 @@
 		"c": "{",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.braces.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1818,10 +1158,6 @@
 		"c": "    ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1829,10 +1165,6 @@
 		"c": "Write-Host",
 		"t": "source.powershell meta.scriptblock.powershell support.function.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -1840,10 +1172,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1851,10 +1179,6 @@
 		"c": "-",
 		"t": "source.powershell meta.scriptblock.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1862,10 +1186,6 @@
 		"c": "Object ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1873,10 +1193,6 @@
 		"c": "'Please launch command under administrator account. It is needed for environment setting up and unit test.'",
 		"t": "source.powershell meta.scriptblock.powershell string.quoted.single.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1884,10 +1200,6 @@
 		"c": " ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1895,10 +1207,6 @@
 		"c": "-",
 		"t": "source.powershell meta.scriptblock.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1906,10 +1214,6 @@
 		"c": "ForegroundColor Red",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1917,10 +1221,6 @@
 		"c": ";",
 		"t": "source.powershell meta.scriptblock.powershell keyword.other.statement-separator.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -1928,10 +1228,6 @@
 		"c": "}",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.braces.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1939,10 +1235,6 @@
 		"c": "$",
 		"t": "source.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -1950,10 +1242,6 @@
 		"c": "env:",
 		"t": "source.powershell support.variable.drive.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.variable: #9CDCFE"
 		}
 	},
@@ -1961,10 +1249,6 @@
 		"c": "AzurePSRoot",
 		"t": "source.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -1972,10 +1256,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1983,10 +1263,6 @@
 		"c": "=",
 		"t": "source.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1994,10 +1270,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2005,10 +1277,6 @@
 		"c": "Split-Path",
 		"t": "source.powershell support.function.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -2016,10 +1284,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2027,10 +1291,6 @@
 		"c": "-",
 		"t": "source.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2038,10 +1298,6 @@
 		"c": "Parent ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2049,10 +1305,6 @@
 		"c": "-",
 		"t": "source.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2060,10 +1312,6 @@
 		"c": "Path ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2071,10 +1319,6 @@
 		"c": "$",
 		"t": "source.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -2082,10 +1326,6 @@
 		"c": "env:",
 		"t": "source.powershell support.variable.drive.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.variable: #9CDCFE"
 		}
 	},
@@ -2093,10 +1333,6 @@
 		"c": "AzurePSRoot",
 		"t": "source.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2104,10 +1340,6 @@
 		"c": ";",
 		"t": "source.powershell keyword.other.statement-separator.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -2115,10 +1347,6 @@
 		"c": "if",
 		"t": "source.powershell keyword.control.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -2126,10 +1354,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2137,10 +1361,6 @@
 		"c": "(",
 		"t": "source.powershell punctuation.section.group.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2148,10 +1368,6 @@
 		"c": "Test-Path",
 		"t": "source.powershell interpolated.simple.source.powershell support.function.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -2159,10 +1375,6 @@
 		"c": " ",
 		"t": "source.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2170,10 +1382,6 @@
 		"c": "-",
 		"t": "source.powershell interpolated.simple.source.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2181,10 +1389,6 @@
 		"c": "Path ",
 		"t": "source.powershell interpolated.simple.source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2192,10 +1396,6 @@
 		"c": "\"",
 		"t": "source.powershell interpolated.simple.source.powershell string.quoted.double.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2203,10 +1403,6 @@
 		"c": "$",
 		"t": "source.powershell interpolated.simple.source.powershell string.quoted.double.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -2214,10 +1410,6 @@
 		"c": "env:",
 		"t": "source.powershell interpolated.simple.source.powershell string.quoted.double.powershell support.variable.drive.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.variable: #9CDCFE"
 		}
 	},
@@ -2225,10 +1417,6 @@
 		"c": "ADXSDKProgramFiles",
 		"t": "source.powershell interpolated.simple.source.powershell string.quoted.double.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2236,10 +1424,6 @@
 		"c": "\\Microsoft Visual Studio 12.0\"",
 		"t": "source.powershell interpolated.simple.source.powershell string.quoted.double.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2247,10 +1431,6 @@
 		"c": ")",
 		"t": "source.powershell punctuation.section.group.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2258,10 +1438,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2269,10 +1445,6 @@
 		"c": "{",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.braces.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2280,10 +1452,6 @@
 		"c": "    ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2291,10 +1459,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -2302,10 +1466,6 @@
 		"c": "vsVersion",
 		"t": "source.powershell meta.scriptblock.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2313,10 +1473,6 @@
 		"c": "=",
 		"t": "source.powershell meta.scriptblock.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2324,10 +1480,6 @@
 		"c": "\"12.0\"",
 		"t": "source.powershell meta.scriptblock.powershell string.quoted.double.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2335,10 +1487,6 @@
 		"c": "}",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.braces.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2346,10 +1494,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2357,10 +1501,6 @@
 		"c": "else",
 		"t": "source.powershell keyword.control.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -2368,10 +1508,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2379,10 +1515,6 @@
 		"c": "{",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.braces.begin.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2390,10 +1522,6 @@
 		"c": "    ",
 		"t": "source.powershell meta.scriptblock.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2401,10 +1529,6 @@
 		"c": "$",
 		"t": "source.powershell meta.scriptblock.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -2412,10 +1536,6 @@
 		"c": "vsVersion",
 		"t": "source.powershell meta.scriptblock.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2423,10 +1543,6 @@
 		"c": "=",
 		"t": "source.powershell meta.scriptblock.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2434,10 +1550,6 @@
 		"c": "\"11.0\"",
 		"t": "source.powershell meta.scriptblock.powershell string.quoted.double.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2445,10 +1557,6 @@
 		"c": "}",
 		"t": "source.powershell meta.scriptblock.powershell punctuation.section.braces.end.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2456,10 +1564,6 @@
 		"c": "$",
 		"t": "source.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -2467,10 +1571,6 @@
 		"c": "setVSEnv",
 		"t": "source.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2478,10 +1578,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2489,10 +1585,6 @@
 		"c": "=",
 		"t": "source.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2500,10 +1592,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2511,10 +1599,6 @@
 		"c": "'\"{0}\\Microsoft Visual Studio {1}\\VC\\vcvarsall.bat\" x64'",
 		"t": "source.powershell string.quoted.single.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2522,10 +1606,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2533,10 +1613,6 @@
 		"c": "-f",
 		"t": "source.powershell keyword.operator.string-format.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2544,10 +1620,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2555,10 +1627,6 @@
 		"c": "$",
 		"t": "source.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -2566,10 +1634,6 @@
 		"c": "env:",
 		"t": "source.powershell support.variable.drive.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.variable: #9CDCFE"
 		}
 	},
@@ -2577,10 +1641,6 @@
 		"c": "ADXSDKProgramFiles",
 		"t": "source.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2588,10 +1648,6 @@
 		"c": ",",
 		"t": "source.powershell keyword.operator.other.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2599,10 +1655,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2610,10 +1662,6 @@
 		"c": "$",
 		"t": "source.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -2621,10 +1669,6 @@
 		"c": "vsVersion",
 		"t": "source.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2632,10 +1676,6 @@
 		"c": ";",
 		"t": "source.powershell keyword.other.statement-separator.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -2643,10 +1683,6 @@
 		"c": "Invoke-Environment",
 		"t": "source.powershell support.function.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -2654,10 +1690,6 @@
 		"c": " ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2665,10 +1697,6 @@
 		"c": "-",
 		"t": "source.powershell keyword.operator.assignment.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2676,10 +1704,6 @@
 		"c": "Command ",
 		"t": "source.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2687,10 +1711,6 @@
 		"c": "$",
 		"t": "source.powershell keyword.other.variable.definition.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -2698,10 +1718,6 @@
 		"c": "setVSEnv",
 		"t": "source.powershell variable.other.readwrite.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2709,10 +1725,6 @@
 		"c": ";",
 		"t": "source.powershell keyword.other.statement-separator.powershell",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	}

--- a/extensions/python/test/colorize-results/test-freeze-56377_py.json
+++ b/extensions/python/test/colorize-results/test-freeze-56377_py.json
@@ -3,10 +3,6 @@
 		"c": "record ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": "keyword.operator: #D4D4D4",
-			"light_plus": "keyword.operator: #000000",
-			"dark_vs": "keyword.operator: #D4D4D4",
-			"light_vs": "keyword.operator: #000000",
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": "{",
 		"t": "source.python punctuation.definition.dict.begin.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "headers",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.dict.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "{",
 		"t": "source.python punctuation.definition.dict.begin.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "k",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.dict.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "str",
 		"t": "source.python meta.function-call.python support.type.python",
 		"r": {
-			"dark_plus": "support.type: #4EC9B0",
-			"light_plus": "support.type: #267F99",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "support.type: #4EC9B0"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "v",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "for",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": "keyword.control: #C586C0",
-			"light_plus": "keyword.control: #AF00DB",
-			"dark_vs": "keyword.control: #569CD6",
-			"light_vs": "keyword.control: #0000FF",
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": " k",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": ",",
 		"t": "source.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": " v ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": "in",
 		"t": "source.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": "keyword.operator.logical.python: #569CD6",
-			"light_plus": "keyword.operator.logical.python: #0000FF",
-			"dark_vs": "keyword.operator.logical.python: #569CD6",
-			"light_vs": "keyword.operator.logical.python: #0000FF",
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": "self",
 		"t": "source.python variable.language.special.self.python",
 		"r": {
-			"dark_plus": "variable.language: #569CD6",
-			"light_plus": "variable.language: #0000FF",
-			"dark_vs": "variable.language: #569CD6",
-			"light_vs": "variable.language: #0000FF",
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "request",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -322,10 +206,6 @@
 		"c": "META",
 		"t": "source.python constant.other.caps.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -333,10 +213,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -344,10 +220,6 @@
 		"c": "items",
 		"t": "source.python meta.function-call.python meta.function-call.generic.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -355,10 +227,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -366,10 +234,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -377,10 +241,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -388,10 +248,6 @@
 		"c": "if",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": "keyword.control: #C586C0",
-			"light_plus": "keyword.control: #AF00DB",
-			"dark_vs": "keyword.control: #569CD6",
-			"light_vs": "keyword.control: #0000FF",
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -399,10 +255,6 @@
 		"c": " k",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -410,10 +262,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -421,10 +269,6 @@
 		"c": "startswith",
 		"t": "source.python meta.function-call.python meta.function-call.generic.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -432,10 +276,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -443,10 +283,6 @@
 		"c": "'",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -454,10 +290,6 @@
 		"c": "HTTP_",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.quoted.single.python",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -465,10 +297,6 @@
 		"c": "'",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -476,10 +304,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -487,10 +311,6 @@
 		"c": "}",
 		"t": "source.python punctuation.definition.dict.end.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -498,10 +318,6 @@
 		"c": "}",
 		"t": "source.python punctuation.definition.dict.end.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -509,10 +325,6 @@
 		"c": "cmd ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -520,10 +332,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": "keyword.operator: #D4D4D4",
-			"light_plus": "keyword.operator: #000000",
-			"dark_vs": "keyword.operator: #D4D4D4",
-			"light_vs": "keyword.operator: #000000",
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -531,10 +339,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -542,10 +346,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -553,10 +353,6 @@
 		"c": "git-clang-format --style=",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -564,32 +360,20 @@
 		"c": "\\\"",
 		"t": "source.python string.quoted.single.python constant.character.escape.python",
 		"r": {
-			"dark_plus": "constant.character.escape: #D7BA7D",
-			"light_plus": "constant.character.escape: #FF0000",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
 			"hc_black": "constant.character: #569CD6"
 		}
 	},
 	{
 		"c": "{{",
-		"t": "source.python string.quoted.single.python meta.format.brace.python constant.character.format.placeholder.other.python",
+		"t": "source.python string.quoted.single.python meta.format.brace.python",
 		"r": {
-			"dark_plus": "constant.character: #569CD6",
-			"light_plus": "constant.character: #0000FF",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "constant.character: #569CD6"
+			"hc_black": "string: #CE9178"
 		}
 	},
 	{
 		"c": "BasedOnStyle: Google, ColumnLimit: 100, IndentWidth: 2, ",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -597,10 +381,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -608,10 +388,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -619,10 +395,6 @@
 		"c": "\\",
 		"t": "source.python punctuation.separator.continuation.line.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -630,10 +402,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -641,10 +409,6 @@
 		"c": "\"AlignConsecutiveAssignments: true}}\\\" {COMMIT_SHA} -- ./**/*.proto > {OUTPUT}\".format(",
 		"t": "source.python invalid.illegal.line.continuation.python",
 		"r": {
-			"dark_plus": "invalid: #F44747",
-			"light_plus": "invalid: #CD3131",
-			"dark_vs": "invalid: #F44747",
-			"light_vs": "invalid: #CD3131",
 			"hc_black": "invalid: #F44747"
 		}
 	}

--- a/extensions/python/test/colorize-results/test_py.json
+++ b/extensions/python/test/colorize-results/test_py.json
@@ -3,10 +3,6 @@
 		"c": "from",
 		"t": "source.python keyword.control.import.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": " banana ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "import",
 		"t": "source.python keyword.control.import.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "*",
 		"t": "source.python keyword.operator.arithmetic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "class",
 		"t": "source.python meta.class.python storage.type.class.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": " ",
 		"t": "source.python meta.class.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": "Monkey",
 		"t": "source.python meta.class.python entity.name.type.class.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.type: #4EC9B0"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": ":",
 		"t": "source.python meta.class.python punctuation.section.class.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": "\t",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "#",
 		"t": "source.python comment.line.number-sign.python punctuation.definition.comment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": " Bananas the monkey can eat.",
 		"t": "source.python comment.line.number-sign.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": "\tcapacity ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "10",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "\t",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "def",
 		"t": "source.python meta.function.python storage.type.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "eat",
 		"t": "source.python meta.function.python entity.name.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": "(",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": "self",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python variable.parameter.function.language.special.self.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": ",",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.separator.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": "N",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": ")",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": ":",
 		"t": "source.python meta.function.python punctuation.section.function.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "\t\t",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": "'''",
 		"t": "source.python string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -322,10 +206,6 @@
 		"c": "Make the monkey eat N bananas!",
 		"t": "source.python string.quoted.docstring.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -333,10 +213,6 @@
 		"c": "'''",
 		"t": "source.python string.quoted.docstring.multi.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -344,10 +220,6 @@
 		"c": "\t\tcapacity ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -355,10 +227,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -366,10 +234,6 @@
 		"c": " capacity ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -377,10 +241,6 @@
 		"c": "-",
 		"t": "source.python keyword.operator.arithmetic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -388,10 +248,6 @@
 		"c": " N",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -399,10 +255,6 @@
 		"c": "*",
 		"t": "source.python keyword.operator.arithmetic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -410,10 +262,6 @@
 		"c": "banana",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -421,10 +269,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -432,10 +276,6 @@
 		"c": "size",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -443,10 +283,6 @@
 		"c": "\t",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -454,10 +290,6 @@
 		"c": "def",
 		"t": "source.python meta.function.python storage.type.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -465,10 +297,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -476,10 +304,6 @@
 		"c": "feeding_frenzy",
 		"t": "source.python meta.function.python entity.name.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
@@ -487,10 +311,6 @@
 		"c": "(",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -498,10 +318,6 @@
 		"c": "self",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python variable.parameter.function.language.special.self.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -509,10 +325,6 @@
 		"c": ")",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -520,10 +332,6 @@
 		"c": ":",
 		"t": "source.python meta.function.python punctuation.section.function.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -531,10 +339,6 @@
 		"c": "\t\t",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -542,10 +346,6 @@
 		"c": "eat",
 		"t": "source.python meta.function-call.python meta.function-call.generic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -553,10 +353,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -564,10 +360,6 @@
 		"c": "9.25",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python constant.numeric.float.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -575,10 +367,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -586,10 +374,6 @@
 		"c": "\t\t",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -597,10 +381,6 @@
 		"c": "return",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -608,10 +388,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -619,10 +395,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -630,10 +402,6 @@
 		"c": "Yum yum",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -641,10 +409,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -652,10 +416,6 @@
 		"c": "\t",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -663,10 +423,6 @@
 		"c": "def",
 		"t": "source.python meta.function.python storage.type.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -674,10 +430,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -685,10 +437,6 @@
 		"c": "some_func",
 		"t": "source.python meta.function.python entity.name.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
@@ -696,10 +444,6 @@
 		"c": "(",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -707,10 +451,6 @@
 		"c": "a",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -718,10 +458,6 @@
 		"c": ":",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.separator.annotation.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -729,10 +465,6 @@
 		"c": "\t\t\t\t\t",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -740,10 +472,6 @@
 		"c": "lambda",
 		"t": "source.python meta.function.python meta.function.parameters.python meta.lambda-function.python storage.type.function.lambda.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -751,10 +479,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python meta.function.parameters.python meta.lambda-function.python meta.function.lambda.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -762,10 +486,6 @@
 		"c": "x",
 		"t": "source.python meta.function.python meta.function.parameters.python meta.lambda-function.python meta.function.lambda.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -773,10 +493,6 @@
 		"c": "=",
 		"t": "source.python meta.function.python meta.function.parameters.python meta.lambda-function.python meta.function.lambda.parameters.python keyword.operator.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -784,10 +500,6 @@
 		"c": "None",
 		"t": "source.python meta.function.python meta.function.parameters.python meta.lambda-function.python meta.function.lambda.parameters.python constant.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.language: #569CD6"
 		}
 	},
@@ -795,10 +507,6 @@
 		"c": ":",
 		"t": "source.python meta.function.python meta.function.parameters.python meta.lambda-function.python punctuation.section.function.lambda.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -806,10 +514,6 @@
 		"c": "\t\t\t\t\t",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -817,10 +521,6 @@
 		"c": "{",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.dict.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -828,10 +528,6 @@
 		"c": "key",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -839,10 +535,6 @@
 		"c": ":",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.separator.dict.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -850,10 +542,6 @@
 		"c": " val",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -861,10 +549,6 @@
 		"c": "\t\t\t\t\t\t",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -872,10 +556,6 @@
 		"c": "for",
 		"t": "source.python meta.function.python meta.function.parameters.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -883,10 +563,6 @@
 		"c": " key",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -894,10 +570,6 @@
 		"c": ",",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -905,10 +577,6 @@
 		"c": " val ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -916,10 +584,6 @@
 		"c": "in",
 		"t": "source.python meta.function.python meta.function.parameters.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -927,10 +591,6 @@
 		"c": "\t\t\t\t\t\t\t",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -938,10 +598,6 @@
 		"c": "(",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.parenthesis.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -949,10 +605,6 @@
 		"c": "x ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -960,10 +612,6 @@
 		"c": "if",
 		"t": "source.python meta.function.python meta.function.parameters.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -971,10 +619,6 @@
 		"c": " x ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -982,10 +626,6 @@
 		"c": "is",
 		"t": "source.python meta.function.python meta.function.parameters.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -993,10 +633,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1004,10 +640,6 @@
 		"c": "not",
 		"t": "source.python meta.function.python meta.function.parameters.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -1015,10 +647,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1026,10 +654,6 @@
 		"c": "None",
 		"t": "source.python meta.function.python meta.function.parameters.python constant.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.language: #569CD6"
 		}
 	},
@@ -1037,10 +661,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1048,10 +668,6 @@
 		"c": "else",
 		"t": "source.python meta.function.python meta.function.parameters.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -1059,10 +675,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1070,10 +682,6 @@
 		"c": "[",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.list.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1081,10 +689,6 @@
 		"c": "]",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.list.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1092,10 +696,6 @@
 		"c": ")",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.parenthesis.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1103,10 +703,6 @@
 		"c": "\t\t\t\t\t",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1114,10 +710,6 @@
 		"c": "}",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.dict.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1125,10 +717,6 @@
 		"c": "=",
 		"t": "source.python meta.function.python meta.function.parameters.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1136,10 +724,6 @@
 		"c": "42",
 		"t": "source.python meta.function.python meta.function.parameters.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1147,10 +731,6 @@
 		"c": ")",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1158,10 +738,6 @@
 		"c": ":",
 		"t": "source.python meta.function.python punctuation.section.function.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1169,10 +745,6 @@
 		"c": "\t\t",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1180,10 +752,6 @@
 		"c": "pass",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -1191,10 +759,6 @@
 		"c": "if",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -1202,10 +766,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1213,10 +773,6 @@
 		"c": "1900",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1224,10 +780,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1235,10 +787,6 @@
 		"c": "<",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1246,10 +794,6 @@
 		"c": " year ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1257,10 +801,6 @@
 		"c": "<",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1268,10 +808,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1279,10 +815,6 @@
 		"c": "2100",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1290,10 +822,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1301,10 +829,6 @@
 		"c": "and",
 		"t": "source.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -1312,10 +836,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1323,10 +843,6 @@
 		"c": "1",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1334,10 +850,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1345,10 +857,6 @@
 		"c": "<=",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1356,10 +864,6 @@
 		"c": " month ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1367,10 +871,6 @@
 		"c": "<=",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1378,10 +878,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1389,10 +885,6 @@
 		"c": "12",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1400,10 +892,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1411,10 +899,6 @@
 		"c": "\\",
 		"t": "source.python punctuation.separator.continuation.line.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1422,10 +906,6 @@
 		"c": "   ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1433,10 +913,6 @@
 		"c": "and",
 		"t": "source.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -1444,10 +920,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1455,10 +927,6 @@
 		"c": "1",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1466,10 +934,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1477,10 +941,6 @@
 		"c": "<=",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1488,10 +948,6 @@
 		"c": " day ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1499,10 +955,6 @@
 		"c": "<=",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1510,10 +962,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1521,10 +969,6 @@
 		"c": "31",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1532,10 +976,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1543,10 +983,6 @@
 		"c": "and",
 		"t": "source.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -1554,10 +990,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1565,10 +997,6 @@
 		"c": "0",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1576,10 +1004,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1587,10 +1011,6 @@
 		"c": "<=",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1598,10 +1018,6 @@
 		"c": " hour ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1609,10 +1025,6 @@
 		"c": "<",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1620,10 +1032,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1631,10 +1039,6 @@
 		"c": "24",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1642,10 +1046,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1653,10 +1053,6 @@
 		"c": "\\",
 		"t": "source.python punctuation.separator.continuation.line.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1664,10 +1060,6 @@
 		"c": "   ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1675,10 +1067,6 @@
 		"c": "and",
 		"t": "source.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -1686,10 +1074,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1697,10 +1081,6 @@
 		"c": "0",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1708,10 +1088,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1719,10 +1095,6 @@
 		"c": "<=",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1730,10 +1102,6 @@
 		"c": " minute ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1741,10 +1109,6 @@
 		"c": "<",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1752,10 +1116,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1763,10 +1123,6 @@
 		"c": "60",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1774,10 +1130,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1785,10 +1137,6 @@
 		"c": "and",
 		"t": "source.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -1796,10 +1144,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1807,10 +1151,6 @@
 		"c": "0",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1818,10 +1158,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1829,10 +1165,6 @@
 		"c": "<=",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1840,10 +1172,6 @@
 		"c": " second ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1851,10 +1179,6 @@
 		"c": "<",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -1862,10 +1186,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1873,10 +1193,6 @@
 		"c": "60",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1884,10 +1200,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.colon.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1895,10 +1207,6 @@
 		"c": "   ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1906,10 +1214,6 @@
 		"c": "#",
 		"t": "source.python comment.line.number-sign.python punctuation.definition.comment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -1917,10 +1221,6 @@
 		"c": " Looks like a valid date",
 		"t": "source.python comment.line.number-sign.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -1928,10 +1228,6 @@
 		"c": "        ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1939,10 +1235,6 @@
 		"c": "return",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -1950,10 +1242,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1961,10 +1249,6 @@
 		"c": "1",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -1972,10 +1256,6 @@
 		"c": "def",
 		"t": "source.python meta.function.python storage.type.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -1983,10 +1263,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1994,10 +1270,6 @@
 		"c": "firstn",
 		"t": "source.python meta.function.python entity.name.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
@@ -2005,10 +1277,6 @@
 		"c": "(",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2016,10 +1284,6 @@
 		"c": "g",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2027,10 +1291,6 @@
 		"c": ",",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.separator.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2038,10 +1298,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2049,10 +1305,6 @@
 		"c": "n",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2060,10 +1312,6 @@
 		"c": ")",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2071,10 +1319,6 @@
 		"c": ":",
 		"t": "source.python meta.function.python punctuation.section.function.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2082,10 +1326,6 @@
 		"c": "\t",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2093,10 +1333,6 @@
 		"c": "for",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -2104,10 +1340,6 @@
 		"c": " i ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2115,10 +1347,6 @@
 		"c": "in",
 		"t": "source.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -2126,10 +1354,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2137,10 +1361,6 @@
 		"c": "range",
 		"t": "source.python meta.function-call.python support.function.builtin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -2148,10 +1368,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2159,10 +1375,6 @@
 		"c": "n",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2170,10 +1382,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2181,10 +1389,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.colon.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2192,10 +1396,6 @@
 		"c": "\t\t",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2203,10 +1403,6 @@
 		"c": "yield",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -2214,10 +1410,6 @@
 		"c": " g",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2225,10 +1417,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2236,10 +1424,6 @@
 		"c": "next",
 		"t": "source.python meta.function-call.python meta.function-call.generic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2247,10 +1431,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2258,10 +1438,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2269,10 +1445,6 @@
 		"c": "reduce",
 		"t": "source.python meta.function-call.python variable.legacy.builtin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2280,10 +1452,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2291,10 +1459,6 @@
 		"c": "lambda",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python meta.lambda-function.python storage.type.function.lambda.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -2302,10 +1466,6 @@
 		"c": " ",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python meta.lambda-function.python meta.function.lambda.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2313,10 +1473,6 @@
 		"c": "x",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python meta.lambda-function.python meta.function.lambda.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2324,10 +1480,6 @@
 		"c": ",",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python meta.lambda-function.python meta.function.lambda.parameters.python punctuation.separator.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2335,10 +1487,6 @@
 		"c": "y",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python meta.lambda-function.python meta.function.lambda.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -2346,10 +1494,6 @@
 		"c": ":",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python meta.lambda-function.python punctuation.section.function.lambda.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2357,10 +1501,6 @@
 		"c": " x",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2368,10 +1508,6 @@
 		"c": "+",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python keyword.operator.arithmetic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2379,10 +1515,6 @@
 		"c": "y",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2390,10 +1522,6 @@
 		"c": ",",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python punctuation.separator.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2401,10 +1529,6 @@
 		"c": " ",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2412,10 +1536,6 @@
 		"c": "[",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python punctuation.definition.list.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2423,10 +1543,6 @@
 		"c": "47",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -2434,10 +1550,6 @@
 		"c": ",",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2445,10 +1557,6 @@
 		"c": "11",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -2456,10 +1564,6 @@
 		"c": ",",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2467,10 +1571,6 @@
 		"c": "42",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -2478,10 +1578,6 @@
 		"c": ",",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2489,10 +1585,6 @@
 		"c": "13",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -2500,10 +1592,6 @@
 		"c": "]",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python punctuation.definition.list.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2511,10 +1599,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2522,10 +1606,6 @@
 		"c": "woerter ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2533,10 +1613,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2544,10 +1620,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2555,10 +1627,6 @@
 		"c": "{",
 		"t": "source.python punctuation.definition.dict.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2566,10 +1634,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2577,10 +1641,6 @@
 		"c": "house",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2588,10 +1648,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2599,10 +1655,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2610,10 +1662,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.dict.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2621,10 +1669,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2632,10 +1676,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2643,10 +1683,6 @@
 		"c": "Haus",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2654,10 +1690,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2665,10 +1697,6 @@
 		"c": ",",
 		"t": "source.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2676,10 +1704,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2687,10 +1711,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2698,10 +1718,6 @@
 		"c": "cat",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2709,10 +1725,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2720,10 +1732,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.dict.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2731,10 +1739,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2742,10 +1746,6 @@
 		"c": "Katze",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2753,10 +1753,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2764,10 +1760,6 @@
 		"c": ",",
 		"t": "source.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2775,10 +1767,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2786,10 +1774,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2797,10 +1781,6 @@
 		"c": "black",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2808,10 +1788,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2819,10 +1795,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.dict.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2830,10 +1802,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2841,10 +1809,6 @@
 		"c": "schwarz",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2852,10 +1816,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2863,10 +1823,6 @@
 		"c": "}",
 		"t": "source.python punctuation.definition.dict.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2874,10 +1830,6 @@
 		"c": "mydictionary ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2885,10 +1837,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -2896,10 +1844,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2907,10 +1851,6 @@
 		"c": "{",
 		"t": "source.python punctuation.definition.dict.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2918,10 +1858,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2929,10 +1865,6 @@
 		"c": "'",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2940,10 +1872,6 @@
 		"c": "foo",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2951,10 +1879,6 @@
 		"c": "'",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -2962,10 +1886,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.dict.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2973,10 +1893,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -2984,10 +1900,6 @@
 		"c": "23",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -2995,10 +1907,6 @@
 		"c": ",",
 		"t": "source.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3006,10 +1914,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3017,10 +1921,6 @@
 		"c": "#",
 		"t": "source.python comment.line.number-sign.python punctuation.definition.comment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -3028,10 +1928,6 @@
 		"c": "comment",
 		"t": "source.python comment.line.number-sign.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -3039,10 +1935,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3050,10 +1942,6 @@
 		"c": "'",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -3061,10 +1949,6 @@
 		"c": "bar",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -3072,10 +1956,6 @@
 		"c": "'",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -3083,10 +1963,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.dict.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3094,10 +1970,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3105,10 +1977,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -3116,10 +1984,6 @@
 		"c": "hello",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -3127,10 +1991,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -3138,10 +1998,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3149,10 +2005,6 @@
 		"c": "#",
 		"t": "source.python comment.line.number-sign.python punctuation.definition.comment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -3160,10 +2012,6 @@
 		"c": "sqadsad",
 		"t": "source.python comment.line.number-sign.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -3171,10 +2019,6 @@
 		"c": "}",
 		"t": "source.python punctuation.definition.dict.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3182,10 +2026,6 @@
 		"c": "def",
 		"t": "source.python meta.function.python storage.type.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -3193,10 +2033,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3204,10 +2040,6 @@
 		"c": "steuern",
 		"t": "source.python meta.function.python entity.name.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
@@ -3215,10 +2047,6 @@
 		"c": "(",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3226,10 +2054,6 @@
 		"c": "einkommen",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -3237,10 +2061,6 @@
 		"c": ")",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3248,10 +2068,6 @@
 		"c": ":",
 		"t": "source.python meta.function.python punctuation.section.function.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3259,10 +2075,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3270,10 +2082,6 @@
 		"c": "\"\"\"",
 		"t": "source.python string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -3281,10 +2089,6 @@
 		"c": "Berechnung der zu zahlenden Steuern fuer ein zu versteuerndes Einkommen von x",
 		"t": "source.python string.quoted.docstring.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -3292,10 +2096,6 @@
 		"c": "\"\"\"",
 		"t": "source.python string.quoted.docstring.multi.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -3303,10 +2103,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3314,10 +2110,6 @@
 		"c": "if",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -3325,10 +2117,6 @@
 		"c": " einkommen ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3336,10 +2124,6 @@
 		"c": "<=",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3347,10 +2131,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3358,10 +2138,6 @@
 		"c": "8004",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -3369,10 +2145,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.colon.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3380,10 +2152,6 @@
 		"c": "        steuer ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3391,10 +2159,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3402,10 +2166,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3413,10 +2173,6 @@
 		"c": "0",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -3424,10 +2180,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3435,10 +2187,6 @@
 		"c": "elif",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -3446,10 +2194,6 @@
 		"c": " einkommen ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3457,10 +2201,6 @@
 		"c": "<=",
 		"t": "source.python keyword.operator.comparison.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3468,10 +2208,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3479,10 +2215,6 @@
 		"c": "13469",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -3490,10 +2222,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.colon.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3501,10 +2229,6 @@
 		"c": "        y ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3512,10 +2236,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3523,10 +2243,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3534,10 +2250,6 @@
 		"c": "(",
 		"t": "source.python punctuation.parenthesis.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3545,10 +2257,6 @@
 		"c": "einkommen ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3556,10 +2264,6 @@
 		"c": "-",
 		"t": "source.python keyword.operator.arithmetic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3567,10 +2271,6 @@
 		"c": "8004.0",
 		"t": "source.python constant.numeric.float.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -3578,10 +2278,6 @@
 		"c": ")",
 		"t": "source.python punctuation.parenthesis.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3589,10 +2285,6 @@
 		"c": "/",
 		"t": "source.python keyword.operator.arithmetic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3600,10 +2292,6 @@
 		"c": "10000.0",
 		"t": "source.python constant.numeric.float.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -3611,10 +2299,6 @@
 		"c": "        steuer ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3622,10 +2306,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3633,10 +2313,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3644,10 +2320,6 @@
 		"c": "(",
 		"t": "source.python punctuation.parenthesis.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3655,10 +2327,6 @@
 		"c": "912.17",
 		"t": "source.python constant.numeric.float.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -3666,10 +2334,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3677,10 +2341,6 @@
 		"c": "*",
 		"t": "source.python keyword.operator.arithmetic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3688,10 +2348,6 @@
 		"c": " y ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3699,10 +2355,6 @@
 		"c": "+",
 		"t": "source.python keyword.operator.arithmetic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3710,10 +2362,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3721,10 +2369,6 @@
 		"c": "1400",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -3732,10 +2376,6 @@
 		"c": ")",
 		"t": "source.python punctuation.parenthesis.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3743,10 +2383,6 @@
 		"c": "*",
 		"t": "source.python keyword.operator.arithmetic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3754,10 +2390,6 @@
 		"c": "y",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3765,10 +2397,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3776,10 +2404,6 @@
 		"c": "else",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -3787,10 +2411,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.colon.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3798,10 +2418,6 @@
 		"c": "        steuer ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3809,10 +2425,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3820,10 +2432,6 @@
 		"c": " einkommen ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3831,10 +2439,6 @@
 		"c": "*",
 		"t": "source.python keyword.operator.arithmetic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3842,10 +2446,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3853,10 +2453,6 @@
 		"c": "0.44",
 		"t": "source.python constant.numeric.float.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -3864,10 +2460,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3875,10 +2467,6 @@
 		"c": "-",
 		"t": "source.python keyword.operator.arithmetic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -3886,10 +2474,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3897,10 +2481,6 @@
 		"c": "15694",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -3908,10 +2488,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3919,10 +2495,6 @@
 		"c": "return",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -3930,10 +2502,6 @@
 		"c": " steuer",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3941,10 +2509,6 @@
 		"c": "def",
 		"t": "source.python meta.function.python storage.type.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -3952,10 +2516,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3963,10 +2523,6 @@
 		"c": "beliebig",
 		"t": "source.python meta.function.python entity.name.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
@@ -3974,10 +2530,6 @@
 		"c": "(",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -3985,10 +2537,6 @@
 		"c": "x",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -3996,10 +2544,6 @@
 		"c": ",",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.separator.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4007,10 +2551,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4018,10 +2558,6 @@
 		"c": "y",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -4029,10 +2565,6 @@
 		"c": ",",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.separator.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4040,10 +2572,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4051,10 +2579,6 @@
 		"c": "*",
 		"t": "source.python meta.function.python meta.function.parameters.python keyword.operator.unpacking.parameter.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -4062,10 +2586,6 @@
 		"c": "mehr",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -4073,10 +2593,6 @@
 		"c": ")",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4084,10 +2600,6 @@
 		"c": ":",
 		"t": "source.python meta.function.python punctuation.section.function.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4095,10 +2607,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4106,10 +2614,6 @@
 		"c": "print",
 		"t": "source.python support.function.builtin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -4117,10 +2621,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4128,10 +2628,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -4139,10 +2635,6 @@
 		"c": "x=",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -4150,10 +2642,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -4161,10 +2649,6 @@
 		"c": ",",
 		"t": "source.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4172,10 +2656,6 @@
 		"c": " x",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4183,10 +2663,6 @@
 		"c": ",",
 		"t": "source.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4194,10 +2670,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4205,10 +2677,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -4216,10 +2684,6 @@
 		"c": ", x=",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -4227,10 +2691,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -4238,10 +2698,6 @@
 		"c": ",",
 		"t": "source.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4249,10 +2705,6 @@
 		"c": " y",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4260,10 +2712,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4271,10 +2719,6 @@
 		"c": "print",
 		"t": "source.python support.function.builtin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -4282,10 +2726,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4293,10 +2733,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -4304,10 +2740,6 @@
 		"c": "mehr: ",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -4315,10 +2747,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -4326,10 +2754,6 @@
 		"c": ",",
 		"t": "source.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4337,10 +2761,6 @@
 		"c": " mehr",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4348,10 +2768,6 @@
 		"c": "class",
 		"t": "source.python meta.class.python storage.type.class.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -4359,10 +2775,6 @@
 		"c": " ",
 		"t": "source.python meta.class.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4370,10 +2782,6 @@
 		"c": "Memoize",
 		"t": "source.python meta.class.python entity.name.type.class.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.type: #4EC9B0"
 		}
 	},
@@ -4381,10 +2789,6 @@
 		"c": ":",
 		"t": "source.python meta.class.python punctuation.section.class.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4392,10 +2796,6 @@
 		"c": "    ",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4403,10 +2803,6 @@
 		"c": "def",
 		"t": "source.python meta.function.python storage.type.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -4414,10 +2810,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4425,10 +2817,6 @@
 		"c": "__init__",
 		"t": "source.python meta.function.python support.function.magic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -4436,10 +2824,6 @@
 		"c": "(",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4447,10 +2831,6 @@
 		"c": "self",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python variable.parameter.function.language.special.self.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -4458,10 +2838,6 @@
 		"c": ",",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.separator.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4469,10 +2845,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4480,10 +2852,6 @@
 		"c": "fn",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -4491,10 +2859,6 @@
 		"c": ")",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4502,10 +2866,6 @@
 		"c": ":",
 		"t": "source.python meta.function.python punctuation.section.function.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4513,10 +2873,6 @@
 		"c": "        ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4524,10 +2880,6 @@
 		"c": "self",
 		"t": "source.python variable.language.special.self.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -4535,10 +2887,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4546,10 +2894,6 @@
 		"c": "fn ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4557,10 +2901,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -4568,10 +2908,6 @@
 		"c": " fn",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4579,10 +2915,6 @@
 		"c": "        ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4590,10 +2922,6 @@
 		"c": "self",
 		"t": "source.python variable.language.special.self.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -4601,10 +2929,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4612,10 +2936,6 @@
 		"c": "memo ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4623,10 +2943,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -4634,10 +2950,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4645,10 +2957,6 @@
 		"c": "{",
 		"t": "source.python punctuation.definition.dict.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4656,10 +2964,6 @@
 		"c": "}",
 		"t": "source.python punctuation.definition.dict.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4667,10 +2971,6 @@
 		"c": "    ",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4678,10 +2978,6 @@
 		"c": "def",
 		"t": "source.python meta.function.python storage.type.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -4689,10 +2985,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4700,10 +2992,6 @@
 		"c": "__call__",
 		"t": "source.python meta.function.python support.function.magic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -4711,10 +2999,6 @@
 		"c": "(",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4722,10 +3006,6 @@
 		"c": "self",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python variable.parameter.function.language.special.self.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -4733,10 +3013,6 @@
 		"c": ",",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.separator.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4744,10 +3020,6 @@
 		"c": " ",
 		"t": "source.python meta.function.python meta.function.parameters.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4755,10 +3027,6 @@
 		"c": "*",
 		"t": "source.python meta.function.python meta.function.parameters.python keyword.operator.unpacking.parameter.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -4766,10 +3034,6 @@
 		"c": "args",
 		"t": "source.python meta.function.python meta.function.parameters.python variable.parameter.function.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -4777,10 +3041,6 @@
 		"c": ")",
 		"t": "source.python meta.function.python meta.function.parameters.python punctuation.definition.parameters.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4788,10 +3048,6 @@
 		"c": ":",
 		"t": "source.python meta.function.python punctuation.section.function.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4799,10 +3055,6 @@
 		"c": "        ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4810,10 +3062,6 @@
 		"c": "if",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -4821,10 +3069,6 @@
 		"c": " args ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4832,10 +3076,6 @@
 		"c": "not",
 		"t": "source.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -4843,10 +3083,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4854,10 +3090,6 @@
 		"c": "in",
 		"t": "source.python keyword.operator.logical.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator.logical.python: #569CD6"
 		}
 	},
@@ -4865,10 +3097,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4876,10 +3104,6 @@
 		"c": "self",
 		"t": "source.python variable.language.special.self.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -4887,10 +3111,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4898,10 +3118,6 @@
 		"c": "memo",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4909,10 +3125,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.colon.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4920,10 +3132,6 @@
 		"c": "                ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4931,10 +3139,6 @@
 		"c": "self",
 		"t": "source.python variable.language.special.self.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -4942,10 +3146,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4953,10 +3153,6 @@
 		"c": "memo",
 		"t": "source.python meta.item-access.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4964,10 +3160,6 @@
 		"c": "[",
 		"t": "source.python meta.item-access.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4975,10 +3167,6 @@
 		"c": "args",
 		"t": "source.python meta.item-access.python meta.item-access.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4986,10 +3174,6 @@
 		"c": "]",
 		"t": "source.python meta.item-access.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -4997,10 +3181,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5008,10 +3188,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -5019,10 +3195,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5030,10 +3202,6 @@
 		"c": "self",
 		"t": "source.python variable.language.special.self.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -5041,10 +3209,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5052,10 +3216,6 @@
 		"c": "fn",
 		"t": "source.python meta.function-call.python meta.function-call.generic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5063,10 +3223,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5074,10 +3230,6 @@
 		"c": "*",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python keyword.operator.unpacking.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -5085,10 +3237,6 @@
 		"c": "args",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5096,10 +3244,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5107,10 +3251,6 @@
 		"c": "        ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5118,10 +3258,6 @@
 		"c": "return",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -5129,10 +3265,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5140,10 +3272,6 @@
 		"c": "self",
 		"t": "source.python variable.language.special.self.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -5151,10 +3279,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5162,10 +3286,6 @@
 		"c": "memo",
 		"t": "source.python meta.item-access.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5173,10 +3293,6 @@
 		"c": "[",
 		"t": "source.python meta.item-access.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5184,10 +3300,6 @@
 		"c": "args",
 		"t": "source.python meta.item-access.python meta.item-access.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5195,10 +3307,6 @@
 		"c": "]",
 		"t": "source.python meta.item-access.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5206,10 +3314,6 @@
 		"c": "res ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5217,10 +3321,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -5228,10 +3328,6 @@
 		"c": " re",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5239,10 +3335,6 @@
 		"c": ".",
 		"t": "source.python punctuation.separator.period.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5250,10 +3342,6 @@
 		"c": "search",
 		"t": "source.python meta.function-call.python meta.function-call.generic.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5261,10 +3349,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5272,10 +3356,6 @@
 		"c": "r",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python storage.type.string.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -5283,10 +3363,6 @@
 		"c": "\"",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5294,10 +3370,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python support.other.parenthesis.regexp punctuation.parenthesis.begin.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5305,10 +3377,6 @@
 		"c": "[",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python meta.character.set.regexp punctuation.character.set.begin.regexp constant.other.set.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5316,10 +3384,6 @@
 		"c": "0-9-",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python meta.character.set.regexp constant.character.set.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.character: #569CD6"
 		}
 	},
@@ -5327,10 +3391,6 @@
 		"c": "]",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python meta.character.set.regexp punctuation.character.set.end.regexp constant.other.set.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5338,10 +3398,6 @@
 		"c": "*",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python keyword.operator.quantifier.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -5349,10 +3405,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python support.other.parenthesis.regexp punctuation.parenthesis.end.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5360,10 +3412,6 @@
 		"c": "\\s",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python support.other.escape.special.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5371,10 +3419,6 @@
 		"c": "*",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python keyword.operator.quantifier.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -5382,10 +3426,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python support.other.parenthesis.regexp punctuation.parenthesis.begin.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5393,10 +3433,6 @@
 		"c": "[",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python meta.character.set.regexp punctuation.character.set.begin.regexp constant.other.set.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5404,10 +3440,6 @@
 		"c": "A-Za-z",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python meta.character.set.regexp constant.character.set.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.character: #569CD6"
 		}
 	},
@@ -5415,10 +3447,6 @@
 		"c": "]",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python meta.character.set.regexp punctuation.character.set.end.regexp constant.other.set.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5426,10 +3454,6 @@
 		"c": "+",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python keyword.operator.quantifier.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -5437,10 +3461,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python support.other.parenthesis.regexp punctuation.parenthesis.end.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5448,10 +3468,6 @@
 		"c": ",",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5459,10 +3475,6 @@
 		"c": "\\s",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python support.other.escape.special.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5470,10 +3482,6 @@
 		"c": "+",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python keyword.operator.quantifier.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -5481,10 +3489,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python support.other.parenthesis.regexp punctuation.parenthesis.begin.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5492,10 +3496,6 @@
 		"c": ".",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python support.other.match.any.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5503,10 +3503,6 @@
 		"c": "*",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python keyword.operator.quantifier.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -5514,10 +3510,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python support.other.parenthesis.regexp punctuation.parenthesis.end.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5525,10 +3517,6 @@
 		"c": "\"",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.regexp.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -5536,10 +3524,6 @@
 		"c": ",",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python punctuation.separator.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5547,10 +3531,6 @@
 		"c": " i",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5558,10 +3538,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5569,10 +3545,6 @@
 		"c": "while",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -5580,10 +3552,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5591,10 +3559,6 @@
 		"c": "True",
 		"t": "source.python constant.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.language: #569CD6"
 		}
 	},
@@ -5602,10 +3566,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.colon.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5613,10 +3573,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5624,10 +3580,6 @@
 		"c": "try",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -5635,10 +3587,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.colon.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5646,10 +3594,6 @@
 		"c": "        n ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5657,10 +3601,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -5668,10 +3608,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5679,10 +3615,6 @@
 		"c": "raw_input",
 		"t": "source.python meta.function-call.python variable.legacy.builtin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -5690,10 +3622,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5701,10 +3629,6 @@
 		"c": "\"",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -5712,10 +3636,6 @@
 		"c": "Number: ",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -5723,10 +3643,6 @@
 		"c": "\"",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -5734,10 +3650,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5745,10 +3657,6 @@
 		"c": "        n ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5756,10 +3664,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -5767,10 +3671,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5778,10 +3678,6 @@
 		"c": "int",
 		"t": "source.python meta.function-call.python support.type.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type: #4EC9B0"
 		}
 	},
@@ -5789,10 +3685,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5800,10 +3692,6 @@
 		"c": "n",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5811,10 +3699,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5822,10 +3706,6 @@
 		"c": "        ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5833,10 +3713,6 @@
 		"c": "break",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -5844,10 +3720,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5855,10 +3727,6 @@
 		"c": "except",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -5866,10 +3734,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5877,10 +3741,6 @@
 		"c": "ValueError",
 		"t": "source.python support.type.exception.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.type: #4EC9B0"
 		}
 	},
@@ -5888,10 +3748,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.colon.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5899,10 +3755,6 @@
 		"c": "        ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5910,10 +3762,6 @@
 		"c": "print",
 		"t": "source.python meta.function-call.python support.function.builtin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -5921,10 +3769,6 @@
 		"c": "(",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5932,10 +3776,6 @@
 		"c": "\"",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -5943,10 +3783,6 @@
 		"c": "Not a number",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -5954,10 +3790,6 @@
 		"c": "\"",
 		"t": "source.python meta.function-call.python meta.function-call.arguments.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -5965,10 +3797,6 @@
 		"c": ")",
 		"t": "source.python meta.function-call.python punctuation.definition.arguments.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5976,10 +3804,6 @@
 		"c": "async",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -5987,10 +3811,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -5998,10 +3818,6 @@
 		"c": "with",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -6009,10 +3825,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6020,10 +3832,6 @@
 		"c": "EXPR",
 		"t": "source.python constant.other.caps.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6031,10 +3839,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6042,10 +3846,6 @@
 		"c": "as",
 		"t": "source.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -6053,10 +3853,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6064,10 +3860,6 @@
 		"c": "VAR",
 		"t": "source.python constant.other.caps.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6075,10 +3867,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.colon.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6086,10 +3874,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6097,10 +3881,6 @@
 		"c": "BLOCK",
 		"t": "source.python constant.other.caps.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6108,10 +3888,6 @@
 		"c": "#",
 		"t": "source.python comment.line.number-sign.python punctuation.definition.comment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -6119,10 +3895,6 @@
 		"c": " Comments in dictionary items should be colorized accordingly",
 		"t": "source.python comment.line.number-sign.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -6130,10 +3902,6 @@
 		"c": "my_dictionary ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6141,10 +3909,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -6152,10 +3916,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6163,10 +3923,6 @@
 		"c": "{",
 		"t": "source.python punctuation.definition.dict.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6174,10 +3930,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6185,10 +3937,6 @@
 		"c": "'",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6196,10 +3944,6 @@
 		"c": "foo",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6207,10 +3951,6 @@
 		"c": "'",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6218,10 +3958,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.dict.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6229,10 +3965,6 @@
 		"c": "23",
 		"t": "source.python constant.numeric.dec.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -6240,10 +3972,6 @@
 		"c": ",",
 		"t": "source.python punctuation.separator.element.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6251,10 +3979,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6262,10 +3986,6 @@
 		"c": "#",
 		"t": "source.python comment.line.number-sign.python punctuation.definition.comment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -6273,10 +3993,6 @@
 		"c": " this should be colorized as comment",
 		"t": "source.python comment.line.number-sign.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -6284,10 +4000,6 @@
 		"c": "    ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6295,10 +4007,6 @@
 		"c": "'",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6306,10 +4014,6 @@
 		"c": "bar",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6317,10 +4021,6 @@
 		"c": "'",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6328,10 +4028,6 @@
 		"c": ":",
 		"t": "source.python punctuation.separator.dict.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6339,10 +4035,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6350,10 +4042,6 @@
 		"c": "foobar",
 		"t": "source.python string.quoted.single.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6361,10 +4049,6 @@
 		"c": "\"",
 		"t": "source.python string.quoted.single.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6372,10 +4056,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6383,10 +4063,6 @@
 		"c": "#",
 		"t": "source.python comment.line.number-sign.python punctuation.definition.comment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -6394,10 +4070,6 @@
 		"c": "this should be colorized as comment",
 		"t": "source.python comment.line.number-sign.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -6405,10 +4077,6 @@
 		"c": "}",
 		"t": "source.python punctuation.definition.dict.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6416,10 +4084,6 @@
 		"c": "#",
 		"t": "source.python comment.line.number-sign.python punctuation.definition.comment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -6427,10 +4091,6 @@
 		"c": " test raw strings",
 		"t": "source.python comment.line.number-sign.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -6438,10 +4098,6 @@
 		"c": "text ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6449,10 +4105,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -6460,10 +4112,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6471,10 +4119,6 @@
 		"c": "r",
 		"t": "source.python string.regexp.quoted.multi.python storage.type.string.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -6482,10 +4126,6 @@
 		"c": "\"\"\"",
 		"t": "source.python string.regexp.quoted.multi.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -6493,10 +4133,6 @@
 		"c": "interval ``",
 		"t": "source.python string.regexp.quoted.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -6504,10 +4140,6 @@
 		"c": "[",
 		"t": "source.python string.regexp.quoted.multi.python meta.character.set.regexp punctuation.character.set.begin.regexp constant.other.set.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -6515,10 +4147,6 @@
 		"c": "1,2)`` leads to",
 		"t": "source.python string.regexp.quoted.multi.python meta.character.set.regexp constant.character.set.regexp",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.character: #569CD6"
 		}
 	},
@@ -6526,10 +4154,6 @@
 		"c": "\"\"\"",
 		"t": "source.python string.regexp.quoted.multi.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string.regexp: #D16969"
 		}
 	},
@@ -6537,10 +4161,6 @@
 		"c": "highlight_error ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6548,10 +4168,6 @@
 		"c": "=",
 		"t": "source.python keyword.operator.assignment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -6559,10 +4175,6 @@
 		"c": " ",
 		"t": "source.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -6570,10 +4182,6 @@
 		"c": "True",
 		"t": "source.python constant.language.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.language: #569CD6"
 		}
 	},
@@ -6581,10 +4189,6 @@
 		"c": "#",
 		"t": "source.python comment.line.number-sign.python punctuation.definition.comment.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -6592,10 +4196,6 @@
 		"c": " highlight doctests",
 		"t": "source.python comment.line.number-sign.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -6603,10 +4203,6 @@
 		"c": "r",
 		"t": "source.python string.quoted.docstring.raw.multi.python storage.type.string.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "storage.type: #569CD6"
 		}
 	},
@@ -6614,10 +4210,6 @@
 		"c": "'''",
 		"t": "source.python string.quoted.docstring.raw.multi.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6625,10 +4217,6 @@
 		"c": "Module docstring",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6636,10 +4224,6 @@
 		"c": "    Some text followed by code sample:",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6647,10 +4231,6 @@
 		"c": "    ",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6658,10 +4238,6 @@
 		"c": ">>> ",
 		"t": "source.python string.quoted.docstring.raw.multi.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -6669,10 +4245,6 @@
 		"c": "for a in foo(2, b=1,",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6680,10 +4252,6 @@
 		"c": "    ",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6691,10 +4259,6 @@
 		"c": "... ",
 		"t": "source.python string.quoted.docstring.raw.multi.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -6702,10 +4266,6 @@
 		"c": "                c=3):",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6713,10 +4273,6 @@
 		"c": "    ",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6724,10 +4280,6 @@
 		"c": "... ",
 		"t": "source.python string.quoted.docstring.raw.multi.python keyword.control.flow.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -6735,10 +4287,6 @@
 		"c": "  print(a)",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6746,10 +4294,6 @@
 		"c": "    0",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6757,10 +4301,6 @@
 		"c": "    1",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -6768,10 +4308,6 @@
 		"c": "'''",
 		"t": "source.python string.quoted.docstring.raw.multi.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	}

--- a/extensions/r/test/colorize-results/test_r.json
+++ b/extensions/r/test/colorize-results/test_r.json
@@ -3,10 +3,6 @@
 		"c": "#",
 		"t": "source.r comment.line.number-sign.r punctuation.definition.comment.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": " © Microsoft. All rights reserved.",
 		"t": "source.r comment.line.number-sign.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "#'",
 		"t": "source.r comment.line.roxygen.r punctuation.definition.comment.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": " Add together two numbers.",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "#'",
 		"t": "source.r comment.line.roxygen.r punctuation.definition.comment.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "#'",
 		"t": "source.r comment.line.roxygen.r punctuation.definition.comment.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": " ",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": "@param",
 		"t": "source.r comment.line.roxygen.r keyword.other.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": " ",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": "x",
 		"t": "source.r comment.line.roxygen.r variable.parameter.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": " A number.",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "#'",
 		"t": "source.r comment.line.roxygen.r punctuation.definition.comment.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": " ",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "@param",
 		"t": "source.r comment.line.roxygen.r keyword.other.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": " ",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "y",
 		"t": "source.r comment.line.roxygen.r variable.parameter.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": " A number.",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "#'",
 		"t": "source.r comment.line.roxygen.r punctuation.definition.comment.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": " ",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "@return",
 		"t": "source.r comment.line.roxygen.r keyword.other.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": " The sum of \\code{x} and \\code{y}.",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": "#'",
 		"t": "source.r comment.line.roxygen.r punctuation.definition.comment.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": " ",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": "@examples",
 		"t": "source.r comment.line.roxygen.r keyword.other.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": "#'",
 		"t": "source.r comment.line.roxygen.r punctuation.definition.comment.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": " add(1, 1)",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": "#'",
 		"t": "source.r comment.line.roxygen.r punctuation.definition.comment.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": " add(10, 1)",
 		"t": "source.r comment.line.roxygen.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": "add",
 		"t": "source.r meta.function.r entity.name.function.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
@@ -322,10 +206,6 @@
 		"c": " ",
 		"t": "source.r meta.function.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -333,10 +213,6 @@
 		"c": "<-",
 		"t": "source.r meta.function.r keyword.operator.assignment.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -344,10 +220,6 @@
 		"c": " ",
 		"t": "source.r meta.function.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -355,10 +227,6 @@
 		"c": "function",
 		"t": "source.r meta.function.r meta.function.r keyword.control.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -366,10 +234,6 @@
 		"c": "(",
 		"t": "source.r meta.function.r meta.function.r punctuation.section.parens.begin.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -377,10 +241,6 @@
 		"c": "x",
 		"t": "source.r meta.function.r meta.function.r meta.function.parameters.r variable.parameter.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -388,10 +248,6 @@
 		"c": ",",
 		"t": "source.r meta.function.r meta.function.r meta.function.parameters.r punctuation.separator.parameters.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -399,10 +255,6 @@
 		"c": " ",
 		"t": "source.r meta.function.r meta.function.r meta.function.parameters.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -410,10 +262,6 @@
 		"c": "y",
 		"t": "source.r meta.function.r meta.function.r meta.function.parameters.r variable.parameter.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -421,10 +269,6 @@
 		"c": ")",
 		"t": "source.r meta.function.r meta.function.r punctuation.section.parens.end.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -432,10 +276,6 @@
 		"c": " ",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -443,10 +283,6 @@
 		"c": "{",
 		"t": "source.r punctuation.section.braces.begin.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -454,10 +290,6 @@
 		"c": "  ",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -465,10 +297,6 @@
 		"c": "x",
 		"t": "source.r variable.other.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -476,10 +304,6 @@
 		"c": " ",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -487,10 +311,6 @@
 		"c": "+",
 		"t": "source.r keyword.operator.arithmetic.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -498,10 +318,6 @@
 		"c": " ",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -509,10 +325,6 @@
 		"c": "y",
 		"t": "source.r variable.other.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -520,10 +332,6 @@
 		"c": "}",
 		"t": "source.r punctuation.section.braces.end.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -531,10 +339,6 @@
 		"c": "add",
 		"t": "source.r meta.function-call.r variable.function.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -542,10 +346,6 @@
 		"c": "(",
 		"t": "source.r meta.function-call.r punctuation.section.parens.begin.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -553,10 +353,6 @@
 		"c": "1",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r constant.numeric.float.decimal.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -564,10 +360,6 @@
 		"c": ",",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r punctuation.separator.parameters.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -575,10 +367,6 @@
 		"c": " ",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -586,10 +374,6 @@
 		"c": "-",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r keyword.operator.arithmetic.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -597,10 +381,6 @@
 		"c": "2",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r constant.numeric.float.decimal.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -608,10 +388,6 @@
 		"c": ",",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r punctuation.separator.parameters.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -619,10 +395,6 @@
 		"c": " ",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -630,10 +402,6 @@
 		"c": "2.0",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r constant.numeric.float.decimal.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -641,10 +409,6 @@
 		"c": ")",
 		"t": "source.r meta.function-call.r punctuation.definition.parameters.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -652,10 +416,6 @@
 		"c": "add",
 		"t": "source.r meta.function-call.r variable.function.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -663,10 +423,6 @@
 		"c": "(",
 		"t": "source.r meta.function-call.r punctuation.section.parens.begin.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -674,10 +430,6 @@
 		"c": "1.0e10",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r constant.numeric.float.decimal.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -685,10 +437,6 @@
 		"c": ",",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r punctuation.separator.parameters.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -696,10 +444,6 @@
 		"c": " ",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -707,10 +451,6 @@
 		"c": "2.0e10",
 		"t": "source.r meta.function-call.r meta.function-call.arguments.r constant.numeric.float.decimal.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -718,10 +458,6 @@
 		"c": ")",
 		"t": "source.r meta.function-call.r punctuation.definition.parameters.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -729,10 +465,6 @@
 		"c": "paste",
 		"t": "source.r support.function.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -740,10 +472,6 @@
 		"c": "(",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -751,10 +479,6 @@
 		"c": "\"",
 		"t": "source.r string.quoted.double.r punctuation.definition.string.begin.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -762,10 +486,6 @@
 		"c": "one",
 		"t": "source.r string.quoted.double.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -773,10 +493,6 @@
 		"c": "\"",
 		"t": "source.r string.quoted.double.r punctuation.definition.string.end.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -784,10 +500,6 @@
 		"c": ", ",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -795,10 +507,6 @@
 		"c": "NULL",
 		"t": "source.r constant.language.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.language: #569CD6"
 		}
 	},
@@ -806,10 +514,6 @@
 		"c": ")",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -817,10 +521,6 @@
 		"c": "paste",
 		"t": "source.r support.function.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -828,10 +528,6 @@
 		"c": "(",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -839,10 +535,6 @@
 		"c": "NA",
 		"t": "source.r constant.language.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.language: #569CD6"
 		}
 	},
@@ -850,10 +542,6 @@
 		"c": ", ",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -861,10 +549,6 @@
 		"c": "'",
 		"t": "source.r string.quoted.single.r punctuation.definition.string.begin.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -872,10 +556,6 @@
 		"c": "two",
 		"t": "source.r string.quoted.single.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -883,10 +563,6 @@
 		"c": "'",
 		"t": "source.r string.quoted.single.r punctuation.definition.string.end.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -894,10 +570,6 @@
 		"c": ")",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -905,10 +577,6 @@
 		"c": "paste",
 		"t": "source.r support.function.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -916,10 +584,6 @@
 		"c": "(",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -927,10 +591,6 @@
 		"c": "\"",
 		"t": "source.r string.quoted.double.r punctuation.definition.string.begin.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -938,10 +598,6 @@
 		"c": "multi-",
 		"t": "source.r string.quoted.double.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -949,10 +605,6 @@
 		"c": "      line",
 		"t": "source.r string.quoted.double.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -960,10 +612,6 @@
 		"c": "\"",
 		"t": "source.r string.quoted.double.r punctuation.definition.string.end.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -971,10 +619,6 @@
 		"c": ",",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -982,10 +626,6 @@
 		"c": "      ",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -993,10 +633,6 @@
 		"c": "'",
 		"t": "source.r string.quoted.single.r punctuation.definition.string.begin.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1004,10 +640,6 @@
 		"c": "multi-",
 		"t": "source.r string.quoted.single.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1015,10 +647,6 @@
 		"c": "      line",
 		"t": "source.r string.quoted.single.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1026,10 +654,6 @@
 		"c": "'",
 		"t": "source.r string.quoted.single.r punctuation.definition.string.end.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1037,10 +661,6 @@
 		"c": ")",
 		"t": "source.r",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	}

--- a/extensions/sql/test/colorize-results/test_sql.json
+++ b/extensions/sql/test/colorize-results/test_sql.json
@@ -3,10 +3,6 @@
 		"c": "CREATE",
 		"t": "source.sql keyword.other.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": " VIEW METRIC_STATS (ID, ",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "MONTH",
 		"t": "source.sql support.function.datetime.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": ", TEMP_C, RAIN_C) ",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "AS",
 		"t": "source.sql keyword.other.alias.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "SELECT",
 		"t": "source.sql keyword.other.DML.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": " ID,",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": "MONTH",
 		"t": "source.sql support.function.datetime.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "support.function: #DCDCAA"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": ",",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": "(TEMP_F ",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "-",
 		"t": "source.sql keyword.operator.math.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": " ",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": "32",
 		"t": "source.sql constant.numeric.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": ") ",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "*",
 		"t": "source.sql keyword.operator.star.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": " ",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "5",
 		"t": "source.sql constant.numeric.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": " ",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "/",
 		"t": "source.sql keyword.operator.math.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "9",
 		"t": "source.sql constant.numeric.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": ",",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": "RAIN_I ",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "*",
 		"t": "source.sql keyword.operator.star.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.operator: #D4D4D4"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": " ",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": "0",
 		"t": "source.sql constant.numeric.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": ".",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": "3937",
 		"t": "source.sql constant.numeric.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "FROM",
 		"t": "source.sql keyword.other.DML.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword: #569CD6"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": " STATS;",
 		"t": "source.sql",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	}

--- a/extensions/xml/test/colorize-results/test-7115_xml.json
+++ b/extensions/xml/test/colorize-results/test-7115_xml.json
@@ -3,10 +3,6 @@
 		"c": "<?",
 		"t": "text.xml meta.tag.preprocessor.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": "xml",
 		"t": "text.xml meta.tag.preprocessor.xml entity.name.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": " version",
 		"t": "text.xml meta.tag.preprocessor.xml entity.other.attribute-name.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.preprocessor.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.preprocessor.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "1.0",
 		"t": "text.xml meta.tag.preprocessor.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.preprocessor.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": " encoding",
 		"t": "text.xml meta.tag.preprocessor.xml entity.other.attribute-name.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.preprocessor.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.preprocessor.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "utf-8",
 		"t": "text.xml meta.tag.preprocessor.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.preprocessor.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": " standalone",
 		"t": "text.xml meta.tag.preprocessor.xml entity.other.attribute-name.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.preprocessor.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.preprocessor.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "no",
 		"t": "text.xml meta.tag.preprocessor.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.preprocessor.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.preprocessor.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "?>",
 		"t": "text.xml meta.tag.preprocessor.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": "WorkFine",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "  ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": "NoColorWithNonLatinCharacters_АБВ",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": "NextTagnotWork",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -322,10 +206,6 @@
 		"c": "something",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -333,10 +213,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -344,10 +220,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -355,10 +227,6 @@
 		"c": "Поле",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -366,10 +234,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -377,10 +241,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -388,10 +248,6 @@
 		"c": "tagnotwork",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -399,10 +255,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -410,10 +262,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -421,10 +269,6 @@
 		"c": "     ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -432,10 +276,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -443,10 +283,6 @@
 		"c": "WorkFine",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -454,10 +290,6 @@
 		"c": "/>",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -465,10 +297,6 @@
 		"c": "     ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -476,10 +304,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -487,10 +311,6 @@
 		"c": "Error_АБВГД",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -498,10 +318,6 @@
 		"c": "/>",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -509,10 +325,6 @@
 		"c": "  ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -520,10 +332,6 @@
 		"c": "</",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -531,10 +339,6 @@
 		"c": "NoColorWithNonLatinCharacters_АБВ",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -542,10 +346,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -553,10 +353,6 @@
 		"c": "</",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -564,10 +360,6 @@
 		"c": "WorkFine",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -575,10 +367,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	}

--- a/extensions/xml/test/colorize-results/test_xml.json
+++ b/extensions/xml/test/colorize-results/test_xml.json
@@ -3,10 +3,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": "project",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": "    ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "target",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": "name",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "jar",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "        ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "mkdir",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "dir",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": "build/jar",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "/>",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": "        ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": "jar",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "destfile",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -322,10 +206,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -333,10 +213,6 @@
 		"c": "build/jar/HelloWorld.jar",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -344,10 +220,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -355,10 +227,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -366,10 +234,6 @@
 		"c": "basedir",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -377,10 +241,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -388,10 +248,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -399,10 +255,6 @@
 		"c": "build/classes",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -410,10 +262,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -421,10 +269,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -432,10 +276,6 @@
 		"c": "            ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -443,10 +283,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -454,10 +290,6 @@
 		"c": "manifest",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -465,10 +297,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -476,10 +304,6 @@
 		"c": "                ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -487,10 +311,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -498,10 +318,6 @@
 		"c": "attribute",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -509,10 +325,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -520,10 +332,6 @@
 		"c": "name",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -531,10 +339,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -542,10 +346,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -553,10 +353,6 @@
 		"c": "Main-Class",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -564,10 +360,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -575,10 +367,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -586,10 +374,6 @@
 		"c": "value",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -597,10 +381,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -608,10 +388,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -619,10 +395,6 @@
 		"c": "oata.HelloWorld",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -630,10 +402,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -641,10 +409,6 @@
 		"c": "/>",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -652,10 +416,6 @@
 		"c": "            ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -663,10 +423,6 @@
 		"c": "</",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -674,10 +430,6 @@
 		"c": "manifest",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -685,10 +437,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -696,10 +444,6 @@
 		"c": "        ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -707,10 +451,6 @@
 		"c": "</",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -718,10 +458,6 @@
 		"c": "jar",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -729,10 +465,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -740,10 +472,6 @@
 		"c": "    ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -751,10 +479,6 @@
 		"c": "</",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -762,10 +486,6 @@
 		"c": "target",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -773,10 +493,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -784,10 +500,6 @@
 		"c": "    ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -795,10 +507,6 @@
 		"c": "<!--",
 		"t": "text.xml comment.block.xml punctuation.definition.comment.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -806,10 +514,6 @@
 		"c": " The stuff below was added for extra tokenizer testing ",
 		"t": "text.xml comment.block.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -817,10 +521,6 @@
 		"c": "-->",
 		"t": "text.xml comment.block.xml punctuation.definition.comment.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -828,10 +528,6 @@
 		"c": "   ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -839,10 +535,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -850,10 +542,6 @@
 		"c": "character",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -861,10 +549,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -872,10 +556,6 @@
 		"c": "id",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -883,10 +563,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -894,10 +570,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -905,10 +577,6 @@
 		"c": "Lucy",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -916,10 +584,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -927,10 +591,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -938,10 +598,6 @@
 		"c": "        ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -949,10 +605,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -960,10 +612,6 @@
 		"c": "hr",
 		"t": "text.xml meta.tag.xml entity.name.tag.namespace.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -971,10 +619,6 @@
 		"c": ":",
 		"t": "text.xml meta.tag.xml entity.name.tag.xml punctuation.separator.namespace.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -982,10 +626,6 @@
 		"c": "name",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -993,10 +633,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1004,10 +640,6 @@
 		"c": "Lucy",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1015,10 +647,6 @@
 		"c": "</",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1026,10 +654,6 @@
 		"c": "hr",
 		"t": "text.xml meta.tag.xml entity.name.tag.namespace.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1037,10 +661,6 @@
 		"c": ":",
 		"t": "text.xml meta.tag.xml entity.name.tag.xml punctuation.separator.namespace.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1048,10 +668,6 @@
 		"c": "name",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1059,10 +675,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1070,10 +682,6 @@
 		"c": "        ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1081,10 +689,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1092,10 +696,6 @@
 		"c": "hr",
 		"t": "text.xml meta.tag.xml entity.name.tag.namespace.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1103,10 +703,6 @@
 		"c": ":",
 		"t": "text.xml meta.tag.xml entity.name.tag.xml punctuation.separator.namespace.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1114,10 +710,6 @@
 		"c": "born",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1125,10 +717,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1136,10 +724,6 @@
 		"c": "1952-03-03",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1147,10 +731,6 @@
 		"c": "</",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1158,10 +738,6 @@
 		"c": "hr",
 		"t": "text.xml meta.tag.xml entity.name.tag.namespace.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1169,10 +745,6 @@
 		"c": ":",
 		"t": "text.xml meta.tag.xml entity.name.tag.xml punctuation.separator.namespace.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1180,10 +752,6 @@
 		"c": "born",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1191,10 +759,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1202,10 +766,6 @@
 		"c": "        ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1213,10 +773,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1224,10 +780,6 @@
 		"c": "qualification",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1235,10 +787,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1246,10 +794,6 @@
 		"c": "bossy, crabby and selfish",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1257,10 +801,6 @@
 		"c": "</",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1268,10 +808,6 @@
 		"c": "qualification",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1279,10 +815,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1290,10 +822,6 @@
 		"c": "   ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1301,10 +829,6 @@
 		"c": "</",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1312,10 +836,6 @@
 		"c": "character",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1323,10 +843,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1334,10 +850,6 @@
 		"c": "    ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1345,10 +857,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1356,10 +864,6 @@
 		"c": "VisualState.Setters",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1367,10 +871,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1378,10 +878,6 @@
 		"c": "        ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1389,10 +885,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1400,10 +892,6 @@
 		"c": "Setter",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1411,10 +899,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1422,10 +906,6 @@
 		"c": "Target",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -1433,10 +913,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1444,10 +920,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1455,10 +927,6 @@
 		"c": "inputPanel.Orientation",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1466,10 +934,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1477,10 +941,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1488,10 +948,6 @@
 		"c": "Value",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -1499,10 +955,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1510,10 +962,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1521,10 +969,6 @@
 		"c": "Vertical",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1532,10 +976,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1543,10 +983,6 @@
 		"c": "/>",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1554,10 +990,6 @@
 		"c": "        ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1565,10 +997,6 @@
 		"c": "<",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1576,10 +1004,6 @@
 		"c": "Setter",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1587,10 +1011,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1598,10 +1018,6 @@
 		"c": "Target",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -1609,10 +1025,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1620,10 +1032,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1631,10 +1039,6 @@
 		"c": "inputButton.Margin",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1642,10 +1046,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1653,10 +1053,6 @@
 		"c": " ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1664,10 +1060,6 @@
 		"c": "Value",
 		"t": "text.xml meta.tag.xml entity.other.attribute-name.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.other.attribute-name: #9CDCFE"
 		}
 	},
@@ -1675,10 +1067,6 @@
 		"c": "=",
 		"t": "text.xml meta.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1686,10 +1074,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.begin.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1697,10 +1081,6 @@
 		"c": "0,4,0,0",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1708,10 +1088,6 @@
 		"c": "\"",
 		"t": "text.xml meta.tag.xml string.quoted.double.xml punctuation.definition.string.end.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1719,10 +1095,6 @@
 		"c": "/>",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1730,10 +1102,6 @@
 		"c": "    ",
 		"t": "text.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1741,10 +1109,6 @@
 		"c": "</",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1752,10 +1116,6 @@
 		"c": "VisualState.Setters",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1763,10 +1123,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1774,10 +1130,6 @@
 		"c": "</",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	},
@@ -1785,10 +1137,6 @@
 		"c": "project",
 		"t": "text.xml meta.tag.xml entity.name.tag.localname.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1796,10 +1144,6 @@
 		"c": ">",
 		"t": "text.xml meta.tag.xml punctuation.definition.tag.xml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "punctuation.definition.tag: #808080"
 		}
 	}

--- a/extensions/yaml/test/colorize-results/issue-1550_yaml.json
+++ b/extensions/yaml/test/colorize-results/issue-1550_yaml.json
@@ -3,10 +3,6 @@
 		"c": "test1",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": "  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "dsd",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "test2",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": "abc-def",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "test-3",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "abcdef",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "test-4",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "abc-def",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	}

--- a/extensions/yaml/test/colorize-results/issue-4008_yaml.json
+++ b/extensions/yaml/test/colorize-results/issue-4008_yaml.json
@@ -3,10 +3,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "blue",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "a=\"brown,not_brown\"",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "not_blue",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "foo",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "blue",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "foo=\"}\"",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": "not_blue",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": "1",
 		"t": "source.yaml constant.numeric.integer.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	}

--- a/extensions/yaml/test/colorize-results/issue-6303_yaml.json
+++ b/extensions/yaml/test/colorize-results/issue-6303_yaml.json
@@ -3,10 +3,6 @@
 		"c": "swagger",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": "'",
 		"t": "source.yaml string.quoted.single.yaml punctuation.definition.string.begin.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": "2.0",
 		"t": "source.yaml string.quoted.single.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "'",
 		"t": "source.yaml string.quoted.single.yaml punctuation.definition.string.end.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": "info",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": "description",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": "'",
 		"t": "source.yaml string.quoted.single.yaml punctuation.definition.string.begin.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "The API Management Service API defines an updated and refined version",
 		"t": "source.yaml string.quoted.single.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "    of the concepts currently known as Developer, APP, and API Product in Edge. Of",
 		"t": "source.yaml string.quoted.single.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": "    note is the introduction of the API concept, missing previously from Edge",
 		"t": "source.yaml string.quoted.single.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "    ",
 		"t": "source.yaml string.quoted.single.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "'",
 		"t": "source.yaml string.quoted.single.yaml punctuation.definition.string.end.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "title",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "API Management Service API",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": "  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": "version",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "initial",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	}

--- a/extensions/yaml/test/colorize-results/test_yaml.json
+++ b/extensions/yaml/test/colorize-results/test_yaml.json
@@ -3,10 +3,6 @@
 		"c": "#",
 		"t": "source.yaml comment.line.number-sign.yaml punctuation.definition.comment.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -14,10 +10,6 @@
 		"c": " sequencer protocols for Laser eye surgery",
 		"t": "source.yaml comment.line.number-sign.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -25,10 +17,6 @@
 		"c": "---",
 		"t": "source.yaml entity.other.document.begin.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -36,10 +24,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -47,10 +31,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -58,10 +38,6 @@
 		"c": "step",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -69,10 +45,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -80,10 +52,6 @@
 		"c": "  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -91,10 +59,6 @@
 		"c": "&",
 		"t": "source.yaml meta.property.yaml keyword.control.property.anchor.yaml punctuation.definition.anchor.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -102,10 +66,6 @@
 		"c": "id001",
 		"t": "source.yaml meta.property.yaml entity.name.type.anchor.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.type: #4EC9B0"
 		}
 	},
@@ -113,10 +73,6 @@
 		"c": "                  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -124,10 +80,6 @@
 		"c": "#",
 		"t": "source.yaml comment.line.number-sign.yaml punctuation.definition.comment.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -135,10 +87,6 @@
 		"c": " defines anchor label &id001",
 		"t": "source.yaml comment.line.number-sign.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -146,10 +94,6 @@
 		"c": "    ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -157,10 +101,6 @@
 		"c": "instrument",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -168,10 +108,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -179,10 +115,6 @@
 		"c": "      ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -190,10 +122,6 @@
 		"c": "Lasik 2000",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -201,10 +129,6 @@
 		"c": "    ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -212,10 +136,6 @@
 		"c": "pulseEnergy",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -223,10 +143,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -234,10 +150,6 @@
 		"c": "     ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -245,10 +157,6 @@
 		"c": "5.4",
 		"t": "source.yaml constant.numeric.float.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -256,10 +164,6 @@
 		"c": "    ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -267,10 +171,6 @@
 		"c": "spotSize",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -278,10 +178,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -289,10 +185,6 @@
 		"c": "        ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -300,10 +192,6 @@
 		"c": "1mm",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -311,10 +199,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -322,10 +206,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -333,10 +213,6 @@
 		"c": "step",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -344,10 +220,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -355,10 +227,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -366,10 +234,6 @@
 		"c": "*",
 		"t": "source.yaml keyword.control.flow.alias.yaml punctuation.definition.alias.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -377,10 +241,6 @@
 		"c": "id001",
 		"t": "source.yaml variable.other.alias.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -388,10 +248,6 @@
 		"c": "                   ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -399,10 +255,6 @@
 		"c": "#",
 		"t": "source.yaml comment.line.number-sign.yaml punctuation.definition.comment.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -410,10 +262,6 @@
 		"c": " refers to the first step (with anchor &id001)",
 		"t": "source.yaml comment.line.number-sign.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "comment: #7CA668"
 		}
 	},
@@ -421,10 +269,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -432,10 +276,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -443,10 +283,6 @@
 		"c": "step",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -454,10 +290,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -465,10 +297,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -476,10 +304,6 @@
 		"c": "*",
 		"t": "source.yaml keyword.control.flow.alias.yaml punctuation.definition.alias.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -487,10 +311,6 @@
 		"c": "id001",
 		"t": "source.yaml variable.other.alias.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -498,10 +318,6 @@
 		"c": "    ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -509,10 +325,6 @@
 		"c": "spotSize",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -520,10 +332,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -531,10 +339,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -542,10 +346,6 @@
 		"c": "2mm",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -553,10 +353,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -564,10 +360,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -575,10 +367,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -586,10 +374,6 @@
 		"c": "step",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -597,10 +381,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -608,10 +388,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -619,10 +395,6 @@
 		"c": "*",
 		"t": "source.yaml keyword.control.flow.alias.yaml punctuation.definition.alias.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "keyword.control: #C586C0"
 		}
 	},
@@ -630,10 +402,6 @@
 		"c": "id002",
 		"t": "source.yaml variable.other.alias.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -641,10 +409,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -652,10 +416,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -663,10 +423,6 @@
 		"c": "{",
 		"t": "source.yaml meta.flow-mapping.yaml punctuation.definition.mapping.begin.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -674,10 +430,6 @@
 		"c": "name",
 		"t": "source.yaml meta.flow-mapping.yaml meta.flow-pair.key.yaml string.unquoted.plain.in.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -685,10 +437,6 @@
 		"c": ":",
 		"t": "source.yaml meta.flow-mapping.yaml meta.flow-pair.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -696,10 +444,6 @@
 		"c": " ",
 		"t": "source.yaml meta.flow-mapping.yaml meta.flow-pair.yaml meta.flow-pair.value.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -707,10 +451,6 @@
 		"c": "John Smith",
 		"t": "source.yaml meta.flow-mapping.yaml meta.flow-pair.yaml meta.flow-pair.value.yaml string.unquoted.plain.in.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -718,10 +458,6 @@
 		"c": ",",
 		"t": "source.yaml meta.flow-mapping.yaml punctuation.separator.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -729,10 +465,6 @@
 		"c": " ",
 		"t": "source.yaml meta.flow-mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -740,10 +472,6 @@
 		"c": "age",
 		"t": "source.yaml meta.flow-mapping.yaml meta.flow-pair.key.yaml string.unquoted.plain.in.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -751,10 +479,6 @@
 		"c": ":",
 		"t": "source.yaml meta.flow-mapping.yaml meta.flow-pair.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -762,10 +486,6 @@
 		"c": " ",
 		"t": "source.yaml meta.flow-mapping.yaml meta.flow-pair.yaml meta.flow-pair.value.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -773,10 +493,6 @@
 		"c": "33",
 		"t": "source.yaml meta.flow-mapping.yaml meta.flow-pair.yaml meta.flow-pair.value.yaml constant.numeric.integer.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -784,10 +500,6 @@
 		"c": "}",
 		"t": "source.yaml meta.flow-mapping.yaml punctuation.definition.mapping.end.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -795,10 +507,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -806,10 +514,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -817,10 +521,6 @@
 		"c": "name",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -828,10 +528,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -839,10 +535,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -850,10 +542,6 @@
 		"c": "Mary Smith",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -861,10 +549,6 @@
 		"c": "  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -872,10 +556,6 @@
 		"c": "age",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -883,10 +563,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -894,10 +570,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -905,10 +577,6 @@
 		"c": "27",
 		"t": "source.yaml constant.numeric.integer.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "constant.numeric: #B5CEA8"
 		}
 	},
@@ -916,10 +584,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -927,10 +591,6 @@
 		"c": "men",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -938,10 +598,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -949,10 +605,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -960,10 +612,6 @@
 		"c": "[",
 		"t": "source.yaml meta.flow-sequence.yaml punctuation.definition.sequence.begin.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -971,10 +619,6 @@
 		"c": "John Smith",
 		"t": "source.yaml meta.flow-sequence.yaml string.unquoted.plain.in.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -982,10 +626,6 @@
 		"c": ",",
 		"t": "source.yaml meta.flow-sequence.yaml punctuation.separator.sequence.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -993,10 +633,6 @@
 		"c": " ",
 		"t": "source.yaml meta.flow-sequence.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1004,10 +640,6 @@
 		"c": "Bill Jones",
 		"t": "source.yaml meta.flow-sequence.yaml string.unquoted.plain.in.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1015,10 +647,6 @@
 		"c": "]",
 		"t": "source.yaml meta.flow-sequence.yaml punctuation.definition.sequence.end.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1026,10 +654,6 @@
 		"c": "women",
 		"t": "source.yaml string.unquoted.plain.out.yaml entity.name.tag.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "entity.name.tag: #569CD6"
 		}
 	},
@@ -1037,10 +661,6 @@
 		"c": ":",
 		"t": "source.yaml punctuation.separator.key-value.mapping.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1048,10 +668,6 @@
 		"c": "  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1059,10 +675,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1070,10 +682,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1081,10 +689,6 @@
 		"c": "Mary Smith",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	},
@@ -1092,10 +696,6 @@
 		"c": "  ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1103,10 +703,6 @@
 		"c": "-",
 		"t": "source.yaml punctuation.definition.block.sequence.item.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1114,10 +710,6 @@
 		"c": " ",
 		"t": "source.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "default: #FFFFFF"
 		}
 	},
@@ -1125,10 +717,6 @@
 		"c": "Susan Williams",
 		"t": "source.yaml string.unquoted.plain.out.yaml",
 		"r": {
-			"dark_plus": null,
-			"light_plus": null,
-			"dark_vs": null,
-			"light_vs": null,
 			"hc_black": "string: #CE9178"
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "native-watchdog": "1.0.0",
     "ng2-charts": "^1.6.0",
     "node-pty": "0.8.1",
-    "npm": "^6.9.0",
     "pretty-data": "^0.40.0",
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.4.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "native-watchdog": "1.0.0",
     "ng2-charts": "^1.6.0",
     "node-pty": "0.8.1",
+    "npm": "^6.9.0",
     "pretty-data": "^0.40.0",
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.4.0",

--- a/scripts/test-integration.bat
+++ b/scripts/test-integration.bat
@@ -11,11 +11,11 @@ set VSCODEUSERDATADIR=%TMP%\vscodeuserfolder-%RANDOM%-%TIME:~6,5%
 :: if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Tests in the extension host
-call .\scripts\code.bat %~dp0\..\extensions\vscode-api-tests\testWorkspace --extensionDevelopmentPath=%~dp0\..\extensions\vscode-api-tests --extensionTestsPath=%~dp0\..\extensions\vscode-api-tests\out\singlefolder-tests --disable-extensions --user-data-dir=%VSCODEUSERDATADIR%
-if %errorlevel% neq 0 exit /b %errorlevel%
+REM call .\scripts\code.bat %~dp0\..\extensions\vscode-api-tests\testWorkspace --extensionDevelopmentPath=%~dp0\..\extensions\vscode-api-tests --extensionTestsPath=%~dp0\..\extensions\vscode-api-tests\out\singlefolder-tests --disable-extensions --user-data-dir=%VSCODEUSERDATADIR%
+REM if %errorlevel% neq 0 exit /b %errorlevel%
 
-call .\scripts\code.bat %~dp0\..\extensions\vscode-api-tests\testworkspace.code-workspace --extensionDevelopmentPath=%~dp0\..\extensions\vscode-api-tests --extensionTestsPath=%~dp0\..\extensions\vscode-api-tests\out\workspace-tests --disable-extensions --user-data-dir=%VSCODEUSERDATADIR%
-if %errorlevel% neq 0 exit /b %errorlevel%
+REM call .\scripts\code.bat %~dp0\..\extensions\vscode-api-tests\testworkspace.code-workspace --extensionDevelopmentPath=%~dp0\..\extensions\vscode-api-tests --extensionTestsPath=%~dp0\..\extensions\vscode-api-tests\out\workspace-tests --disable-extensions --user-data-dir=%VSCODEUSERDATADIR%
+REM if %errorlevel% neq 0 exit /b %errorlevel%
 
 call .\scripts\code.bat %~dp0\..\extensions\vscode-colorize-tests\test --extensionDevelopmentPath=%~dp0\..\extensions\vscode-colorize-tests --extensionTestsPath=%~dp0\..\extensions\vscode-colorize-tests\out --disable-extensions --user-data-dir=%VSCODEUSERDATADIR%
 call .\scripts\code.bat %~dp0\..\extensions\markdown-language-features\test-fixtures --extensionDevelopmentPath=%~dp0\..\extensions\markdown-language-features --extensionTestsPath=%~dp0\..\extensions\markdown-language-features\out\test --disableExtensions --user-data-dir=%VSCODEUSERDATADIR%

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,7 +322,15 @@
     "@webassemblyjs/wast-parser" "1.5.13"
     long "^3.2.0"
 
-abbrev@1:
+JSONStream@^1.3.4, JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
+
+abbrev@1, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
@@ -386,12 +394,19 @@ agent-base@4, agent-base@^4.1.0:
   dependencies:
     es6-promisify "^5.0.0"
 
-agent-base@~4.2.0:
+agent-base@~4.2.0, agent-base@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
   integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
   dependencies:
     es6-promisify "^5.0.0"
+
+agentkeepalive@^3.4.1:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-3.5.2.tgz#a113924dd3fa24a0bc3b78108c450c2abee00f67"
+  integrity sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==
+  dependencies:
+    humanize-ms "^1.2.1"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
@@ -478,6 +493,13 @@ angular2-grid@2.0.6:
 "angular2-slickgrid@github:Microsoft/angular2-slickgrid#1.4.6":
   version "1.4.6"
   resolved "https://codeload.github.com/Microsoft/angular2-slickgrid/tar.gz/09579fdc90b1ec469578ec1040d1515585ce2a11"
+
+ansi-align@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
+  integrity sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=
+  dependencies:
+    string-width "^2.0.0"
 
 ansi-colors@^1.0.1:
   version "1.1.0"
@@ -571,6 +593,16 @@ ansi_up@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi_up/-/ansi_up-3.0.0.tgz#27f45d8f457d9ceff59e4ea03c8e6f13c1a303e8"
   integrity sha1-J/Rdj0V9nO/1nk6gPI5vE8GjA+g=
 
+ansicolors@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz#665597de86a9ffe3aa9bfbe6cae5c6ea426b4979"
+  integrity sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=
+
+ansistyles@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ansistyles/-/ansistyles-0.1.3.tgz#5de60415bda071bb37127854c864f41b23254539"
+  integrity sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -595,12 +627,17 @@ applicationinsights@1.0.8:
     diagnostic-channel-publishers "0.2.1"
     zone.js "0.7.6"
 
-aproba@^1.0.3, aproba@^1.1.1:
+aproba@^1.0.3, aproba@^1.1.1, aproba@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
-archy@^1.0.0:
+"aproba@^1.1.2 || 2", aproba@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
+  integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
+
+archy@^1.0.0, archy@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
@@ -754,6 +791,11 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+
+asap@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
 asar@^0.14.0:
   version "0.14.0"
@@ -977,6 +1019,17 @@ big.js@^3.1.3:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
   integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
 
+bin-links@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/bin-links/-/bin-links-1.1.2.tgz#fb74bd54bae6b7befc6c6221f25322ac830d9757"
+  integrity sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==
+  dependencies:
+    bluebird "^3.5.0"
+    cmd-shim "^2.0.2"
+    gentle-fs "^2.0.0"
+    graceful-fs "^4.1.11"
+    write-file-atomic "^2.3.0"
+
 binary-extensions@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
@@ -1012,6 +1065,18 @@ bl@^1.0.0:
   dependencies:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
+
+block-stream@*:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
+  dependencies:
+    inherits "~2.0.0"
+
+bluebird@^3.5.0, bluebird@^3.5.3:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
+  integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
 
 bluebird@^3.5.1:
   version "3.5.1"
@@ -1064,6 +1129,19 @@ boom@5.x.x:
   integrity sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==
   dependencies:
     hoek "4.x.x"
+
+boxen@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
+  integrity sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==
+  dependencies:
+    ansi-align "^2.0.0"
+    camelcase "^4.0.0"
+    chalk "^2.0.1"
+    cli-boxes "^1.0.0"
+    string-width "^2.0.0"
+    term-size "^1.2.0"
+    widest-line "^2.0.0"
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.8"
@@ -1242,6 +1320,21 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
+  integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+
+byline@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
+  integrity sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=
+
+byte-size@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-5.0.1.tgz#4b651039a5ecd96767e71a3d7ed380e48bed4191"
+  integrity sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -1266,6 +1359,26 @@ cacache@^10.0.4:
     unique-filename "^1.1.0"
     y18n "^4.0.0"
 
+cacache@^11.0.1, cacache@^11.3.2:
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.2.tgz#2d81e308e3d258ca38125b676b98b2ac9ce69bfa"
+  integrity sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==
+  dependencies:
+    bluebird "^3.5.3"
+    chownr "^1.1.1"
+    figgy-pudding "^3.5.1"
+    glob "^7.1.3"
+    graceful-fs "^4.1.15"
+    lru-cache "^5.1.1"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.2"
+    ssri "^6.0.1"
+    unique-filename "^1.1.1"
+    y18n "^4.0.0"
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -1280,6 +1393,11 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+call-limit@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/call-limit/-/call-limit-1.1.0.tgz#6fd61b03f3da42a2cd0ec2b60f02bd0e71991fea"
+  integrity sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -1321,7 +1439,7 @@ camelcase@^3.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
 
-camelcase@^4.1.0:
+camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
@@ -1340,6 +1458,11 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000760"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000760.tgz#3ea29473eb78a6ccb09f2eb73ac9e1debfec528d"
   integrity sha1-PqKUc+t4psywny63Osnh3r/sUo0=
+
+capture-stack-trace@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
+  integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -1395,7 +1518,7 @@ chalk@^2.0.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.1.0, chalk@^2.4.2:
+chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1507,6 +1630,11 @@ chownr@^1.0.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
   integrity sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=
 
+chownr@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
+  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
+
 chrome-remote-interface@0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.26.1.tgz#6c7d4479742b6d236752d716a9bc2d322d7d8ad2"
@@ -1531,6 +1659,23 @@ ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
   integrity sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==
+
+ci-info@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+cidr-regex@^2.0.10:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/cidr-regex/-/cidr-regex-2.0.10.tgz#af13878bd4ad704de77d6dc800799358b3afa70d"
+  integrity sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==
+  dependencies:
+    ip-regex "^2.1.0"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -1570,6 +1715,19 @@ clean-css@3.4.6:
     commander "2.8.x"
     source-map "0.4.x"
 
+cli-boxes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
+  integrity sha1-T6kXw+WclKAEzWH47lCdplFocUM=
+
+cli-columns@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/cli-columns/-/cli-columns-3.1.2.tgz#6732d972979efc2ae444a1f08e08fa139c96a18e"
+  integrity sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=
+  dependencies:
+    string-width "^2.0.0"
+    strip-ansi "^3.0.1"
+
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -1583,6 +1741,16 @@ cli-cursor@^2.1.0:
   integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   dependencies:
     restore-cursor "^2.0.0"
+
+cli-table3@^0.5.0, cli-table3@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
+  integrity sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==
+  dependencies:
+    object-assign "^4.1.0"
+    string-width "^2.1.1"
+  optionalDependencies:
+    colors "^1.1.2"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -1649,6 +1817,14 @@ cloneable-readable@^1.0.0:
     inherits "^2.0.1"
     process-nextick-args "^1.0.6"
     through2 "^2.0.1"
+
+cmd-shim@^2.0.2, cmd-shim@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-2.0.2.tgz#6fcbda99483a8fd15d7d30a196ca69d688a2efdb"
+  integrity sha1-b8vamUg6j9FdfTChlspp1oii79s=
+  dependencies:
+    graceful-fs "^4.1.2"
+    mkdirp "~0.5.0"
 
 co@^4.6.0:
   version "4.6.0"
@@ -1745,6 +1921,14 @@ colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
   integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
+
+columnify@~1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
+  integrity sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=
+  dependencies:
+    strip-ansi "^3.0.0"
+    wcwidth "^1.0.0"
 
 combined-stream@1.0.6:
   version "1.0.6"
@@ -1858,6 +2042,18 @@ config-chain@^1.1.12:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
+configstore@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f"
+  integrity sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==
+  dependencies:
+    dot-prop "^4.1.0"
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    unique-string "^1.0.0"
+    write-file-atomic "^2.0.0"
+    xdg-basedir "^3.0.0"
+
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
@@ -1865,7 +2061,7 @@ console-browserify@^1.1.0:
   dependencies:
     date-now "^0.1.4"
 
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
+console-control-strings@^1.0.0, console-control-strings@^1.1.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
@@ -1970,6 +2166,13 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
+create-error-class@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
+  dependencies:
+    capture-stack-trace "^1.0.0"
+
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
@@ -2048,6 +2251,11 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+  integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
 cson-parser@^1.3.3:
   version "1.3.5"
@@ -2203,6 +2411,11 @@ debug@^4.0.1:
   dependencies:
     ms "^2.1.1"
 
+debuglog@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
+  integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
+
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -2266,6 +2479,13 @@ default-resolution@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/default-resolution/-/default-resolution-2.0.0.tgz#bcb82baa72ad79b426a76732f1a81ad6df26d684"
   integrity sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=
+
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
+  dependencies:
+    clone "^1.0.2"
 
 define-properties@^1.1.2:
   version "1.1.3"
@@ -2357,7 +2577,7 @@ detect-file@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
-detect-indent@^5.0.0:
+detect-indent@^5.0.0, detect-indent@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
@@ -2366,6 +2586,19 @@ detect-libc@^1.0.2, detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
+
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
+
+dezalgo@^1.0.0, dezalgo@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
+  integrity sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=
+  dependencies:
+    asap "^2.0.0"
+    wrappy "1"
 
 diagnostic-channel-publishers@0.2.1:
   version "0.2.1"
@@ -2484,6 +2717,23 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
+dot-prop@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
+  integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
+  dependencies:
+    is-obj "^1.0.0"
+
+dotenv@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
+  integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
+
+duplexer3@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
+  integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
+
 duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
@@ -2536,6 +2786,11 @@ editions@^1.1.1, editions@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.4.tgz#3662cb592347c3168eb8e498a0ff73271d67f50b"
   integrity sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==
+
+editor@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
+  integrity sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=
 
 editorconfig@^0.15.0:
   version "0.15.0"
@@ -2617,6 +2872,13 @@ encodeurl@~1.0.1:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
   integrity sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.0.tgz#7a90d833efda6cfa6eac0f4949dbb0fad3a63206"
@@ -2642,6 +2904,11 @@ env-paths@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
   integrity sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=
+
+err-code@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
+  integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -3234,6 +3501,11 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
+figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
+  integrity sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -3312,6 +3584,11 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
+
+find-npm-prefix@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz#8d8ce2c78b3b4b9e66c8acc6a37c231eb841cfdf"
+  integrity sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==
 
 find-parent-dir@^0.3.0:
   version "0.3.0"
@@ -3474,6 +3751,14 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+from2@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-1.3.0.tgz#88413baaa5f9a597cfde9221d86986cd3c061dfd"
+  integrity sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=
+  dependencies:
+    inherits "~2.0.1"
+    readable-stream "~1.1.10"
+
 from2@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
@@ -3535,7 +3820,16 @@ fs-mkdirp-stream@^1.0.0:
     graceful-fs "^4.1.11"
     through2 "^2.0.3"
 
-fs-write-stream-atomic@^1.0.8:
+fs-vacuum@^1.2.10, fs-vacuum@~1.2.10:
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/fs-vacuum/-/fs-vacuum-1.2.10.tgz#b7629bec07a4031a2548fdf99f5ecf1cc8b31e36"
+  integrity sha1-t2Kb7AekAxolSP35n17PHMizHjY=
+  dependencies:
+    graceful-fs "^4.1.2"
+    path-is-inside "^1.0.1"
+    rimraf "^2.5.2"
+
+fs-write-stream-atomic@^1.0.8, fs-write-stream-atomic@~1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
   integrity sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=
@@ -3565,6 +3859,16 @@ fsevents@^1.2.7:
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
+
+fstream@^1.0.0, fstream@^1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
+  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
 
 function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
@@ -3607,6 +3911,25 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
+genfun@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
+  integrity sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==
+
+gentle-fs@^2.0.0, gentle-fs@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/gentle-fs/-/gentle-fs-2.0.1.tgz#585cfd612bfc5cd52471fdb42537f016a5ce3687"
+  integrity sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==
+  dependencies:
+    aproba "^1.1.2"
+    fs-vacuum "^1.2.10"
+    graceful-fs "^4.1.11"
+    iferr "^0.1.5"
+    mkdirp "^0.5.1"
+    path-is-inside "^1.0.2"
+    read-cmd-shim "^1.0.1"
+    slide "^1.1.6"
+
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
@@ -3621,6 +3944,13 @@ get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
+get-stream@^4.0.0, get-stream@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -3776,6 +4106,13 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-dirs@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
+  integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
+  dependencies:
+    ini "^1.3.4"
+
 global-modules-path@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/global-modules-path/-/global-modules-path-2.3.0.tgz#b0e2bac6beac39745f7db5c59d26a36a0b94f7dc"
@@ -3842,10 +4179,32 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
+got@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  integrity sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=
+  dependencies:
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
+    url-parse-lax "^1.0.0"
+
 graceful-fs@4.1.11, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
+
+graceful-fs@^4.1.15:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -4193,7 +4552,7 @@ has-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
   integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
 
-has-unicode@^2.0.0:
+has-unicode@^2.0.0, has-unicode@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
@@ -4303,6 +4662,11 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
   integrity sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==
 
+hosted-git-info@^2.6.0, hosted-git-info@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
+  integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
+
 html-comment-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
@@ -4335,6 +4699,11 @@ htmlparser2@^3.10.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+http-cache-semantics@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
+  integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
 
 http-errors@1.6.2, http-errors@~1.6.2:
   version "1.6.2"
@@ -4385,6 +4754,13 @@ https-proxy-agent@2.2.1, https-proxy-agent@^2.2.1:
     agent-base "^4.1.0"
     debug "^3.1.0"
 
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+  dependencies:
+    ms "^2.0.0"
+
 husky@^0.13.1:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/husky/-/husky-0.13.4.tgz#48785c5028de3452a51c48c12c4f94b2124a1407"
@@ -4407,7 +4783,7 @@ iconv-lite@0.4.23, iconv-lite@^0.4.22, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.24:
+iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4423,6 +4799,11 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
+
+iferr@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/iferr/-/iferr-1.0.2.tgz#e9fde49a9da06dc4a4194c6c9ed6d08305037a6d"
+  integrity sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==
 
 ignore-walk@^3.0.1:
   version "3.0.1"
@@ -4454,6 +4835,11 @@ import-fresh@^3.0.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-lazy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
+  integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
+
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -4484,7 +4870,7 @@ indexof@0.0.1:
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
   integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
-inflight@^1.0.4:
+inflight@^1.0.4, inflight@~1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
   integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
@@ -4506,6 +4892,25 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
   integrity sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=
+
+ini@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+init-package-json@^1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/init-package-json/-/init-package-json-1.10.3.tgz#45ffe2f610a8ca134f2bd1db5637b235070f6cbe"
+  integrity sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==
+  dependencies:
+    glob "^7.1.1"
+    npm-package-arg "^4.0.0 || ^5.0.0 || ^6.0.0"
+    promzard "^0.3.0"
+    read "~1.0.1"
+    read-package-json "1 || 2"
+    semver "2.x || 3.x || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+    validate-npm-package-name "^3.0.0"
 
 innosetup-compiler@^5.5.60:
   version "5.5.62"
@@ -4589,6 +4994,11 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
+ip-regex@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+
 ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -4663,12 +5073,26 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-ci@^1.0.10:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
+  dependencies:
+    ci-info "^1.5.0"
+
 is-ci@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
   integrity sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=
   dependencies:
     ci-info "^1.0.0"
+
+is-cidr@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-cidr/-/is-cidr-3.0.0.tgz#1acf35c9e881063cd5f696d48959b30fed3eed56"
+  integrity sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==
+  dependencies:
+    cidr-regex "^2.0.10"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -4776,6 +5200,14 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-installed-globally@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
+  integrity sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=
+  dependencies:
+    global-dirs "^0.1.0"
+    is-path-inside "^1.0.0"
+
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz#5a846777e2c2620d1e69104e5d3a03b1f6088f11"
@@ -4790,6 +5222,11 @@ is-negated-glob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-negated-glob/-/is-negated-glob-1.0.0.tgz#6910bca5da8c95e784b5751b976cf5a10fee36d2"
   integrity sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=
+
+is-npm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
+  integrity sha1-8vtjpl5JBbQGyGBydloaTceTufQ=
 
 is-number@^2.0.2, is-number@^2.1.0:
   version "2.1.0"
@@ -4809,6 +5246,11 @@ is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
   integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
+
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -4861,6 +5303,11 @@ is-property@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
   integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
+
 is-relative@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-0.2.1.tgz#d27f4c7d516d175fb610db84bbeef23c3bc97aa5"
@@ -4882,7 +5329,12 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-retry-allowed@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
+  integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
+
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -5136,7 +5588,7 @@ json-edm-parser@0.1.2:
   dependencies:
     jsonparse "~1.2.0"
 
-json-parse-better-errors@^1.0.2:
+json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
@@ -5196,6 +5648,11 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
+
+jsonparse@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
+  integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
 jsonparse@~1.2.0:
   version "1.2.0"
@@ -5281,10 +5738,22 @@ last-run@^1.1.0:
     default-resolution "^2.0.0"
     es6-weak-map "^2.0.1"
 
+latest-version@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
+  integrity sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=
+  dependencies:
+    package-json "^4.0.0"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
   integrity sha1-odePw6UEdMuAhF07O24dpJpEbo4=
+
+lazy-property@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lazy-property/-/lazy-property-1.0.0.tgz#84ddc4b370679ba8bd4cdcfa4c06b43d57111147"
+  integrity sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=
 
 lazy.js@^0.4.2:
   version "0.4.3"
@@ -5332,6 +5801,140 @@ levn@~0.2.5:
   dependencies:
     prelude-ls "~1.1.0"
     type-check "~0.3.1"
+
+libcipm@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/libcipm/-/libcipm-3.0.3.tgz#2e764effe0b90d458790dab3165794c804075ed3"
+  integrity sha512-71V5CpTI+zFydTc5IjJ/tx8JHbXEJvmYF2zaSVW1V3X1rRnRjXqh44iuiyry1xgi3ProUQ1vX1uwFiWs00+2og==
+  dependencies:
+    bin-links "^1.1.2"
+    bluebird "^3.5.1"
+    figgy-pudding "^3.5.1"
+    find-npm-prefix "^1.0.2"
+    graceful-fs "^4.1.11"
+    ini "^1.3.5"
+    lock-verify "^2.0.2"
+    mkdirp "^0.5.1"
+    npm-lifecycle "^2.0.3"
+    npm-logical-tree "^1.2.1"
+    npm-package-arg "^6.1.0"
+    pacote "^9.1.0"
+    read-package-json "^2.0.13"
+    rimraf "^2.6.2"
+    worker-farm "^1.6.0"
+
+libnpm@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/libnpm/-/libnpm-2.0.1.tgz#a48fcdee3c25e13c77eb7c60a0efe561d7fb0d8f"
+  integrity sha512-qTKoxyJvpBxHZQB6k0AhSLajyXq9ZE/lUsZzuHAplr2Bpv9G+k4YuYlExYdUCeVRRGqcJt8hvkPh4tBwKoV98w==
+  dependencies:
+    bin-links "^1.1.2"
+    bluebird "^3.5.3"
+    find-npm-prefix "^1.0.2"
+    libnpmaccess "^3.0.1"
+    libnpmconfig "^1.2.1"
+    libnpmhook "^5.0.2"
+    libnpmorg "^1.0.0"
+    libnpmpublish "^1.1.0"
+    libnpmsearch "^2.0.0"
+    libnpmteam "^1.0.1"
+    lock-verify "^2.0.2"
+    npm-lifecycle "^2.1.0"
+    npm-logical-tree "^1.2.1"
+    npm-package-arg "^6.1.0"
+    npm-profile "^4.0.1"
+    npm-registry-fetch "^3.8.0"
+    npmlog "^4.1.2"
+    pacote "^9.2.3"
+    read-package-json "^2.0.13"
+    stringify-package "^1.0.0"
+
+libnpmaccess@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-3.0.1.tgz#5b3a9de621f293d425191aa2e779102f84167fa8"
+  integrity sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==
+  dependencies:
+    aproba "^2.0.0"
+    get-stream "^4.0.0"
+    npm-package-arg "^6.1.0"
+    npm-registry-fetch "^3.8.0"
+
+libnpmconfig@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/libnpmconfig/-/libnpmconfig-1.2.1.tgz#c0c2f793a74e67d4825e5039e7a02a0044dfcbc0"
+  integrity sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==
+  dependencies:
+    figgy-pudding "^3.5.1"
+    find-up "^3.0.0"
+    ini "^1.3.5"
+
+libnpmhook@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/libnpmhook/-/libnpmhook-5.0.2.tgz#d12817b0fb893f36f1d5be20017f2aea25825d94"
+  integrity sha512-vLenmdFWhRfnnZiNFPNMog6CK7Ujofy2TWiM2CrpZUjBRIhHkJeDaAbJdYCT6W4lcHtyrJR8yXW8KFyq6UAp1g==
+  dependencies:
+    aproba "^2.0.0"
+    figgy-pudding "^3.4.1"
+    get-stream "^4.0.0"
+    npm-registry-fetch "^3.8.0"
+
+libnpmorg@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/libnpmorg/-/libnpmorg-1.0.0.tgz#979b868c48ba28c5820e3bb9d9e73c883c16a232"
+  integrity sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==
+  dependencies:
+    aproba "^2.0.0"
+    figgy-pudding "^3.4.1"
+    get-stream "^4.0.0"
+    npm-registry-fetch "^3.8.0"
+
+libnpmpublish@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/libnpmpublish/-/libnpmpublish-1.1.1.tgz#ff0c6bb0b4ad2bda2ad1f5fba6760a4af37125f0"
+  integrity sha512-nefbvJd/wY38zdt+b9SHL6171vqBrMtZ56Gsgfd0duEKb/pB8rDT4/ObUQLrHz1tOfht1flt2zM+UGaemzAG5g==
+  dependencies:
+    aproba "^2.0.0"
+    figgy-pudding "^3.5.1"
+    get-stream "^4.0.0"
+    lodash.clonedeep "^4.5.0"
+    normalize-package-data "^2.4.0"
+    npm-package-arg "^6.1.0"
+    npm-registry-fetch "^3.8.0"
+    semver "^5.5.1"
+    ssri "^6.0.1"
+
+libnpmsearch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/libnpmsearch/-/libnpmsearch-2.0.0.tgz#de05af47ada81554a5f64276a69599070d4a5685"
+  integrity sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==
+  dependencies:
+    figgy-pudding "^3.5.1"
+    get-stream "^4.0.0"
+    npm-registry-fetch "^3.8.0"
+
+libnpmteam@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/libnpmteam/-/libnpmteam-1.0.1.tgz#ff704b1b6c06ea674b3b1101ac3e305f5114f213"
+  integrity sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==
+  dependencies:
+    aproba "^2.0.0"
+    figgy-pudding "^3.4.1"
+    get-stream "^4.0.0"
+    npm-registry-fetch "^3.8.0"
+
+libnpx@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/libnpx/-/libnpx-10.2.0.tgz#1bf4a1c9f36081f64935eb014041da10855e3102"
+  integrity sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==
+  dependencies:
+    dotenv "^5.0.1"
+    npm-package-arg "^6.0.0"
+    rimraf "^2.6.2"
+    safe-buffer "^5.1.0"
+    update-notifier "^2.3.0"
+    which "^1.3.0"
+    y18n "^4.0.0"
+    yargs "^11.0.0"
 
 liftoff@^2.5.0:
   version "2.5.0"
@@ -5395,17 +5998,50 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lock-verify@^2.0.2, lock-verify@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/lock-verify/-/lock-verify-2.1.0.tgz#fff4c918b8db9497af0c5fa7f6d71555de3ceb47"
+  integrity sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==
+  dependencies:
+    npm-package-arg "^6.1.0"
+    semver "^5.4.1"
+
+lockfile@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"
+  integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
+  dependencies:
+    signal-exit "^3.0.2"
+
+lodash._baseuniq@~4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
+  integrity sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=
+  dependencies:
+    lodash._createset "~4.0.0"
+    lodash._root "~3.0.0"
+
+lodash._createset@~4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
+  integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
+
+lodash._root@~3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
+  integrity sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=
 
 lodash.clone@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
 
-lodash.clonedeep@^4.5.0:
+lodash.clonedeep@^4.5.0, lodash.clonedeep@~4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
@@ -5475,10 +6111,20 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash.uniq@^4.5.0:
+lodash.union@~4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
+  integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
+
+lodash.uniq@^4.5.0, lodash.uniq@~4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+
+lodash.without@~4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
+  integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
 lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.3.0:
   version "4.17.4"
@@ -5528,6 +6174,11 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lowercase-keys@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
+  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
+
 lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
@@ -5549,13 +6200,20 @@ lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lru-cache@^4.1.3:
+lru-cache@^4.1.2, lru-cache@^4.1.3, lru-cache@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
 
 macaddress@^0.2.8:
   version "0.2.8"
@@ -5580,6 +6238,23 @@ make-error@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.0.tgz#52ad3a339ccf10ce62b4040b708fe707244b8b96"
   integrity sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=
+
+make-fetch-happen@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz#141497cb878f243ba93136c83d8aba12c216c083"
+  integrity sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==
+  dependencies:
+    agentkeepalive "^3.4.1"
+    cacache "^11.0.1"
+    http-cache-semantics "^3.8.1"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
+    lru-cache "^4.1.2"
+    mississippi "^3.0.0"
+    node-fetch-npm "^2.0.2"
+    promise-retry "^1.1.1"
+    socks-proxy-agent "^4.0.0"
+    ssri "^6.0.0"
 
 make-iterator@^1.0.0:
   version "1.0.1"
@@ -5667,6 +6342,11 @@ mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
+
+meant@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.1.tgz#66044fea2f23230ec806fb515efea29c44d2115d"
+  integrity sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -5873,10 +6553,25 @@ minipass@^2.2.1, minipass@^2.3.3:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^2.3.4, minipass@^2.3.5:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minizlib@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
   integrity sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==
+  dependencies:
+    minipass "^2.2.1"
+
+minizlib@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
 
@@ -5892,6 +6587,22 @@ mississippi@^2.0.0:
     from2 "^2.1.0"
     parallel-transform "^1.1.0"
     pump "^2.0.1"
+    pumpify "^1.3.3"
+    stream-each "^1.1.0"
+    through2 "^2.0.0"
+
+mississippi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
+  integrity sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==
+  dependencies:
+    concat-stream "^1.5.0"
+    duplexify "^3.4.2"
+    end-of-stream "^1.1.0"
+    flush-write-stream "^1.0.0"
+    from2 "^2.1.0"
+    parallel-transform "^1.1.0"
+    pump "^3.0.0"
     pumpify "^1.3.3"
     stream-each "^1.1.0"
     through2 "^2.0.0"
@@ -5916,7 +6627,7 @@ mkdirp@0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -5991,7 +6702,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.1.1:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
@@ -6126,6 +6837,33 @@ node-addon-api@1.6.2:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.6.2.tgz#d8aad9781a5cfc4132cc2fecdbdd982534265217"
   integrity sha512-479Bjw9nTE5DdBSZZWprFryHGjUaQC31y1wHo19We/k0BZlrmhqQitWoUL0cD8+scljCbIUL+E58oRDEakdGGA==
 
+node-fetch-npm@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz#7258c9046182dca345b4208eda918daf33697ff7"
+  integrity sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==
+  dependencies:
+    encoding "^0.1.11"
+    json-parse-better-errors "^1.0.0"
+    safe-buffer "^5.1.1"
+
+node-gyp@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
+  integrity sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==
+  dependencies:
+    fstream "^1.0.0"
+    glob "^7.0.3"
+    graceful-fs "^4.1.2"
+    mkdirp "^0.5.0"
+    nopt "2 || 3"
+    npmlog "0 || 1 || 2 || 3 || 4"
+    osenv "0"
+    request "^2.87.0"
+    rimraf "2"
+    semver "~5.3.0"
+    tar "^2.0.0"
+    which "1"
+
 node-libs-browser@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
@@ -6190,7 +6928,7 @@ noop-logger@^0.1.1:
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
   integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
 
-nopt@3.x, nopt@^3.0.1:
+"nopt@2 || 3", nopt@3.x, nopt@^3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
@@ -6211,6 +6949,16 @@ nopt@~1.0.10:
   integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
   dependencies:
     abbrev "1"
+
+normalize-package-data@^2.0.0, normalize-package-data@^2.4.0, normalize-package-data@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+  dependencies:
+    hosted-git-info "^2.1.4"
+    resolve "^1.10.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
@@ -6266,10 +7014,67 @@ now-and-later@^2.0.0:
   dependencies:
     once "^1.3.2"
 
+npm-audit-report@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/npm-audit-report/-/npm-audit-report-1.3.2.tgz#303bc78cd9e4c226415076a4f7e528c89fc77018"
+  integrity sha512-abeqS5ONyXNaZJPGAf6TOUMNdSe1Y6cpc9MLBRn+CuUoYbfdca6AxOyXVlfIv9OgKX+cacblbG5w7A6ccwoTPw==
+  dependencies:
+    cli-table3 "^0.5.0"
+    console-control-strings "^1.1.0"
+
 npm-bundled@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
   integrity sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==
+
+npm-cache-filename@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz#ded306c5b0bfc870a9e9faf823bc5f283e05ae11"
+  integrity sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=
+
+npm-install-checks@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/npm-install-checks/-/npm-install-checks-3.0.0.tgz#d4aecdfd51a53e3723b7b2f93b2ee28e307bc0d7"
+  integrity sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=
+  dependencies:
+    semver "^2.3.0 || 3.x || 4 || 5"
+
+npm-lifecycle@^2.0.3, npm-lifecycle@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/npm-lifecycle/-/npm-lifecycle-2.1.0.tgz#1eda2eedb82db929e3a0c50341ab0aad140ed569"
+  integrity sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==
+  dependencies:
+    byline "^5.0.0"
+    graceful-fs "^4.1.11"
+    node-gyp "^3.8.0"
+    resolve-from "^4.0.0"
+    slide "^1.1.6"
+    uid-number "0.0.6"
+    umask "^1.1.0"
+    which "^1.3.1"
+
+npm-logical-tree@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz#44610141ca24664cad35d1e607176193fd8f5b88"
+  integrity sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==
+
+"npm-package-arg@^4.0.0 || ^5.0.0 || ^6.0.0", npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-6.1.0.tgz#15ae1e2758a5027efb4c250554b85a737db7fcc1"
+  integrity sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==
+  dependencies:
+    hosted-git-info "^2.6.0"
+    osenv "^0.1.5"
+    semver "^5.5.0"
+    validate-npm-package-name "^3.0.0"
+
+npm-packlist@^1.1.12, npm-packlist@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
+  integrity sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
 
 npm-packlist@^1.1.6:
   version "1.1.11"
@@ -6279,6 +7084,36 @@ npm-packlist@^1.1.6:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
 
+npm-pick-manifest@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz#32111d2a9562638bb2c8f2bf27f7f3092c8fae40"
+  integrity sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==
+  dependencies:
+    figgy-pudding "^3.5.1"
+    npm-package-arg "^6.0.0"
+    semver "^5.4.1"
+
+npm-profile@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-profile/-/npm-profile-4.0.1.tgz#d350f7a5e6b60691c7168fbb8392c3603583f5aa"
+  integrity sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==
+  dependencies:
+    aproba "^1.1.2 || 2"
+    figgy-pudding "^3.4.1"
+    npm-registry-fetch "^3.8.0"
+
+npm-registry-fetch@^3.8.0, npm-registry-fetch@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-3.9.0.tgz#44d841780e2833f06accb34488f8c7450d1a6856"
+  integrity sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==
+  dependencies:
+    JSONStream "^1.3.4"
+    bluebird "^3.5.1"
+    figgy-pudding "^3.4.1"
+    lru-cache "^4.1.3"
+    make-fetch-happen "^4.0.1"
+    npm-package-arg "^6.1.0"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -6286,7 +7121,126 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.1, npmlog@^4.0.2:
+npm-user-validate@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.0.tgz#8ceca0f5cea04d4e93519ef72d0557a75122e951"
+  integrity sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=
+
+npm@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/npm/-/npm-6.9.0.tgz#5296720486814a64a7fb082de00c4b5cfd11211f"
+  integrity sha512-91V+zB5hDxO+Jyp2sUKS7juHlIM95dGQxTeQtmZI1nAI/7kjWXFipPrtwwKjhyKmV4GsS2LzJhrxRjGWsU9z/w==
+  dependencies:
+    JSONStream "^1.3.5"
+    abbrev "~1.1.1"
+    ansicolors "~0.3.2"
+    ansistyles "~0.1.3"
+    aproba "^2.0.0"
+    archy "~1.0.0"
+    bin-links "^1.1.2"
+    bluebird "^3.5.3"
+    byte-size "^5.0.1"
+    cacache "^11.3.2"
+    call-limit "~1.1.0"
+    chownr "^1.1.1"
+    ci-info "^2.0.0"
+    cli-columns "^3.1.2"
+    cli-table3 "^0.5.1"
+    cmd-shim "~2.0.2"
+    columnify "~1.5.4"
+    config-chain "^1.1.12"
+    detect-indent "~5.0.0"
+    detect-newline "^2.1.0"
+    dezalgo "~1.0.3"
+    editor "~1.0.0"
+    figgy-pudding "^3.5.1"
+    find-npm-prefix "^1.0.2"
+    fs-vacuum "~1.2.10"
+    fs-write-stream-atomic "~1.0.10"
+    gentle-fs "^2.0.1"
+    glob "^7.1.3"
+    graceful-fs "^4.1.15"
+    has-unicode "~2.0.1"
+    hosted-git-info "^2.7.1"
+    iferr "^1.0.2"
+    inflight "~1.0.6"
+    inherits "~2.0.3"
+    ini "^1.3.5"
+    init-package-json "^1.10.3"
+    is-cidr "^3.0.0"
+    json-parse-better-errors "^1.0.2"
+    lazy-property "~1.0.0"
+    libcipm "^3.0.3"
+    libnpm "^2.0.1"
+    libnpmhook "^5.0.2"
+    libnpx "^10.2.0"
+    lock-verify "^2.1.0"
+    lockfile "^1.0.4"
+    lodash._baseuniq "~4.6.0"
+    lodash.clonedeep "~4.5.0"
+    lodash.union "~4.6.0"
+    lodash.uniq "~4.5.0"
+    lodash.without "~4.4.0"
+    lru-cache "^4.1.5"
+    meant "~1.0.1"
+    mississippi "^3.0.0"
+    mkdirp "~0.5.1"
+    move-concurrently "^1.0.1"
+    node-gyp "^3.8.0"
+    nopt "~4.0.1"
+    normalize-package-data "^2.5.0"
+    npm-audit-report "^1.3.2"
+    npm-cache-filename "~1.0.2"
+    npm-install-checks "~3.0.0"
+    npm-lifecycle "^2.1.0"
+    npm-package-arg "^6.1.0"
+    npm-packlist "^1.4.1"
+    npm-pick-manifest "^2.2.3"
+    npm-registry-fetch "^3.9.0"
+    npm-user-validate "~1.0.0"
+    npmlog "~4.1.2"
+    once "~1.4.0"
+    opener "^1.5.1"
+    osenv "^0.1.5"
+    pacote "^9.5.0"
+    path-is-inside "~1.0.2"
+    promise-inflight "~1.0.1"
+    qrcode-terminal "^0.12.0"
+    query-string "^6.2.0"
+    qw "~1.0.1"
+    read "~1.0.7"
+    read-cmd-shim "~1.0.1"
+    read-installed "~4.0.3"
+    read-package-json "^2.0.13"
+    read-package-tree "^5.2.2"
+    readable-stream "^3.1.1"
+    request "^2.88.0"
+    retry "^0.12.0"
+    rimraf "^2.6.3"
+    safe-buffer "^5.1.2"
+    semver "^5.6.0"
+    sha "~2.0.1"
+    slide "~1.1.6"
+    sorted-object "~2.0.1"
+    sorted-union-stream "~2.1.3"
+    ssri "^6.0.1"
+    stringify-package "^1.0.0"
+    tar "^4.4.8"
+    text-table "~0.2.0"
+    tiny-relative-date "^1.3.0"
+    uid-number "0.0.6"
+    umask "~1.1.0"
+    unique-filename "^1.1.1"
+    unpipe "~1.0.0"
+    update-notifier "^2.5.0"
+    uuid "^3.3.2"
+    validate-npm-package-license "^3.0.4"
+    validate-npm-package-name "~3.0.0"
+    which "^1.3.1"
+    worker-farm "^1.6.0"
+    write-file-atomic "^2.4.2"
+
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2, npmlog@~4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -6430,7 +7384,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@1.x, once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0:
+once@1.x, once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0, once@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -6455,6 +7409,11 @@ oniguruma@^7.0.0:
   integrity sha512-zCsdNxTrrB4yVPMxhcIODGv1p4NVBu9WvsWnIGhMpu5djO4MQWXrC7YKjtza+OyoRqqgy27CqYWa1h5e2DDbig==
   dependencies:
     nan "^2.10.0"
+
+opener@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
+  integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
 optimist@0.3.5:
   version "0.3.5"
@@ -6541,18 +7500,18 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
-  integrity sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=
+osenv@0, osenv@^0.1.4, osenv@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
+  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-osenv@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
-  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
+osenv@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
+  integrity sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
@@ -6618,6 +7577,49 @@ p-try@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
   integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
+
+package-json@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
+  integrity sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=
+  dependencies:
+    got "^6.7.1"
+    registry-auth-token "^3.0.1"
+    registry-url "^3.0.3"
+    semver "^5.1.0"
+
+pacote@^9.1.0, pacote@^9.2.3, pacote@^9.5.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/pacote/-/pacote-9.5.0.tgz#85f3013a3f6dd51c108b0ccabd3de8102ddfaeda"
+  integrity sha512-aUplXozRbzhaJO48FaaeClmN+2Mwt741MC6M3bevIGZwdCaP7frXzbUOfOWa91FPHoLITzG0hYaKY363lxO3bg==
+  dependencies:
+    bluebird "^3.5.3"
+    cacache "^11.3.2"
+    figgy-pudding "^3.5.1"
+    get-stream "^4.1.0"
+    glob "^7.1.3"
+    lru-cache "^5.1.1"
+    make-fetch-happen "^4.0.1"
+    minimatch "^3.0.4"
+    minipass "^2.3.5"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    normalize-package-data "^2.4.0"
+    npm-package-arg "^6.1.0"
+    npm-packlist "^1.1.12"
+    npm-pick-manifest "^2.2.3"
+    npm-registry-fetch "^3.8.0"
+    osenv "^0.1.5"
+    promise-inflight "^1.0.1"
+    promise-retry "^1.1.1"
+    protoduck "^5.0.1"
+    rimraf "^2.6.2"
+    safe-buffer "^5.1.2"
+    semver "^5.6.0"
+    ssri "^6.0.1"
+    tar "^4.4.8"
+    unique-filename "^1.1.1"
+    which "^1.3.1"
 
 pako@~1.0.5:
   version "1.0.6"
@@ -6743,7 +7745,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2, path-is-inside@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -7168,7 +8170,7 @@ prelude-ls@~1.1.0, prelude-ls@~1.1.1, prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prepend-http@^1.0.0:
+prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
@@ -7242,15 +8244,37 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-promise-inflight@^1.0.1:
+promise-inflight@^1.0.1, promise-inflight@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-retry@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-1.1.1.tgz#6739e968e3051da20ce6497fb2b50f6911df3d6d"
+  integrity sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=
+  dependencies:
+    err-code "^1.0.0"
+    retry "^0.10.0"
+
+promzard@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/promzard/-/promzard-0.3.0.tgz#26a5d6ee8c7dee4cb12208305acfb93ba382a9ee"
+  integrity sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=
+  dependencies:
+    read "1"
 
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
+protoduck@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/protoduck/-/protoduck-5.0.1.tgz#03c3659ca18007b69a50fd82a7ebcc516261151f"
+  integrity sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==
+  dependencies:
+    genfun "^5.0.0"
 
 proxy-addr@~2.0.2:
   version "2.0.2"
@@ -7310,6 +8334,14 @@ pump@^2.0.0, pump@^2.0.1:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 pumpify@^1.3.3, pumpify@^1.3.5:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
@@ -7339,6 +8371,11 @@ q@^1.0.1, q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+qrcode-terminal@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz#bb5b699ef7f9f0505092a3748be4464fe71b5819"
+  integrity sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==
+
 qs@6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
@@ -7361,6 +8398,15 @@ query-string@^4.1.0:
   dependencies:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
+
+query-string@^6.2.0:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.4.2.tgz#8be1dbd105306aebf86022144f575a29d516b713"
+  integrity sha512-DfJqAen17LfLA3rQ+H5S4uXphrF+ANU1lT2ijds4V/Tj4gZxA3gx5/tg1bz7kYCmwna7LyJNCYqO7jNRzo3aLw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -7392,6 +8438,11 @@ queue@^4.2.1:
   integrity sha512-DwxpAnqJuoQa+wyDgQuwkSshkhlqIlWEvwvdAY27fDPunZ2cVJzXU4JyjY+5l7zs7oGLaYAQm4MbLOVFAHFBzA==
   dependencies:
     inherits "~2.0.0"
+
+qw@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
+  integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
 
 randomatic@^1.1.3:
   version "1.1.5"
@@ -7431,7 +8482,7 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
-rc@1.2.8, rc@^1.1.2, rc@^1.1.6, rc@^1.2.7:
+rc@1.2.8, rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -7451,6 +8502,50 @@ rcedit@^1.1.0:
   resolved "https://registry.yarnpkg.com/rcedit/-/rcedit-1.1.0.tgz#ae21c28d4efdd78e95fcab7309a5dd084920b16a"
   integrity sha512-JkXJ0IrUcdupLoIx6gE4YcFaMVSGtu7kQf4NJoDJUnfBZGuATmJ2Yal2v55KTltp+WV8dGr7A0RtOzx6jmtM6Q==
 
+read-cmd-shim@^1.0.1, read-cmd-shim@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz#2d5d157786a37c055d22077c32c53f8329e91c7b"
+  integrity sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=
+  dependencies:
+    graceful-fs "^4.1.2"
+
+read-installed@~4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/read-installed/-/read-installed-4.0.3.tgz#ff9b8b67f187d1e4c29b9feb31f6b223acd19067"
+  integrity sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=
+  dependencies:
+    debuglog "^1.0.1"
+    read-package-json "^2.0.0"
+    readdir-scoped-modules "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    slide "~1.1.3"
+    util-extend "^1.0.1"
+  optionalDependencies:
+    graceful-fs "^4.1.2"
+
+"read-package-json@1 || 2", read-package-json@^2.0.0, read-package-json@^2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-2.0.13.tgz#2e82ebd9f613baa6d2ebe3aa72cefe3f68e41f4a"
+  integrity sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==
+  dependencies:
+    glob "^7.1.1"
+    json-parse-better-errors "^1.0.1"
+    normalize-package-data "^2.0.0"
+    slash "^1.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.2"
+
+read-package-tree@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/read-package-tree/-/read-package-tree-5.2.2.tgz#4b6a0ef2d943c1ea36a578214c9a7f6b7424f7a8"
+  integrity sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==
+  dependencies:
+    debuglog "^1.0.1"
+    dezalgo "^1.0.0"
+    once "^1.3.0"
+    read-package-json "^2.0.0"
+    readdir-scoped-modules "^1.0.0"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -7468,7 +8563,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-read@^1.0.7:
+read@1, read@^1.0.7, read@~1.0.1, read@~1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
   integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
@@ -7507,7 +8602,7 @@ read@^1.0.7:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^1.1.8, readable-stream@~1.1.9:
+readable-stream@^1.1.8, readable-stream@~1.1.10, readable-stream@~1.1.9:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
@@ -7550,6 +8645,16 @@ readable-stream@~2.0.0:
     process-nextick-args "~1.0.6"
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
+
+readdir-scoped-modules@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
+  integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
+  dependencies:
+    debuglog "^1.0.1"
+    dezalgo "^1.0.0"
+    graceful-fs "^4.1.2"
+    once "^1.3.0"
 
 readdirp@^2.0.0:
   version "2.1.0"
@@ -7635,6 +8740,21 @@ regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
+registry-auth-token@^3.0.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.4.0.tgz#d7446815433f5d5ed6431cd5dca21048f66b397e"
+  integrity sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
+
+registry-url@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+  integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
+  dependencies:
+    rc "^1.0.1"
 
 remap-istanbul@^0.13.0:
   version "0.13.0"
@@ -7773,7 +8893,7 @@ request@2.79.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@^2.86.0, request@^2.88.0:
+request@^2.86.0, request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -7871,7 +8991,7 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.4.0:
+resolve@^1.10.0, resolve@^1.4.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
@@ -7899,12 +9019,29 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+retry@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
+  integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
   integrity sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
   dependencies:
     align-text "^0.1.1"
+
+rimraf@2, rimraf@^2.5.2, rimraf@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@^2.2.8:
   version "2.6.1"
@@ -8051,6 +9188,13 @@ semaphore@1.0.5:
   resolved "https://registry.yarnpkg.com/semaphore/-/semaphore-1.0.5.tgz#b492576e66af193db95d65e25ec53f5f19798d60"
   integrity sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA=
 
+semver-diff@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
+  integrity sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=
+  dependencies:
+    semver "^5.0.3"
+
 semver-greatest-satisfied-range@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz#13e8c2658ab9691cb0cd71093240280d36f77a5b"
@@ -8062,6 +9206,11 @@ semver-greatest-satisfied-range@^1.1.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
   integrity sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==
+
+"semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 semver@^4.3.4:
   version "4.3.6"
@@ -8077,6 +9226,11 @@ semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
 send@0.16.1:
   version "0.16.1"
@@ -8164,6 +9318,14 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+sha@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/sha/-/sha-2.0.1.tgz#6030822fbd2c9823949f8f72ed6411ee5cf25aae"
+  integrity sha1-YDCCL70smCOUn49y7WQR7lzyWq4=
+  dependencies:
+    graceful-fs "^4.1.2"
+    readable-stream "^2.0.2"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -8297,6 +9459,16 @@ slice-ansi@^2.0.0:
     jquery ">=1.8.0"
     jquery-ui ">=1.8.0"
 
+slide@^1.1.6, slide@~1.1.3, slide@~1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+  integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
+
+smart-buffer@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.0.2.tgz#5207858c3815cc69110703c6b94e46c15634395d"
+  integrity sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==
+
 smart-buffer@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.0.1.tgz#07ea1ca8d4db24eb4cac86537d7d18995221ace3"
@@ -8354,6 +9526,14 @@ socks-proxy-agent@4.0.1:
     agent-base "~4.2.0"
     socks "~2.2.0"
 
+socks-proxy-agent@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz#3c8991f3145b2799e70e11bd5fbc8b1963116386"
+  integrity sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==
+  dependencies:
+    agent-base "~4.2.1"
+    socks "~2.3.2"
+
 socks@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/socks/-/socks-2.2.1.tgz#68ad678b3642fbc5d99c64c165bc561eab0215f9"
@@ -8362,12 +9542,33 @@ socks@~2.2.0:
     ip "^1.1.5"
     smart-buffer "^4.0.1"
 
+socks@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.3.2.tgz#ade388e9e6d87fdb11649c15746c578922a5883e"
+  integrity sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "4.0.2"
+
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
   integrity sha1-RBttTTRnmPG05J6JIK37oOVD+a0=
   dependencies:
     is-plain-obj "^1.0.0"
+
+sorted-object@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/sorted-object/-/sorted-object-2.0.1.tgz#7d631f4bd3a798a24af1dffcfbfe83337a5df5fc"
+  integrity sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=
+
+sorted-union-stream@~2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz#c7794c7e077880052ff71a8d4a2dbb4a9a638ac7"
+  integrity sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=
+  dependencies:
+    from2 "^1.3.0"
+    stream-iterate "^1.1.0"
 
 source-list-map@^2.0.0:
   version "2.0.0"
@@ -8428,12 +9629,33 @@ spdlog@0.8.1:
     mkdirp "^0.5.1"
     nan "^2.8.0"
 
+spdx-correct@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
+  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
   integrity sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=
   dependencies:
     spdx-license-ids "^1.0.2"
+
+spdx-exceptions@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
+  integrity sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
 
 spdx-expression-parse@~1.0.0:
   version "1.0.4"
@@ -8445,10 +9667,20 @@ spdx-license-ids@^1.0.2:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
   integrity sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=
 
+spdx-license-ids@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz#75ecd1a88de8c184ef015eafb51b5b48bfd11bb1"
+  integrity sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==
+
 speedometer@~0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-0.1.4.tgz#9876dbd2a169d3115402d48e6ea6329c8816a50d"
   integrity sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=
+
+split-on-first@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.0.0.tgz#648af4ce9a28fbcaadd43274455f298b55025fc6"
+  integrity sha512-mjA57TQtdWztVZ9THAjGNpgbuIrNfsNrGa5IyK94NoPaT4N14M+GI4jD7t4arLjFkYRQWdETC5RxFzLWouoB3A==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -8498,6 +9730,13 @@ ssri@^5.2.4:
   integrity sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==
   dependencies:
     safe-buffer "^5.1.1"
+
+ssri@^6.0.0, ssri@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
+  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
+  dependencies:
+    figgy-pudding "^3.5.1"
 
 stack-trace@0.0.10:
   version "0.0.10"
@@ -8561,6 +9800,14 @@ stream-http@^2.7.2:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
+stream-iterate@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/stream-iterate/-/stream-iterate-1.2.0.tgz#2bd7c77296c1702a46488b8ad41f79865eecd4e1"
+  integrity sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=
+  dependencies:
+    readable-stream "^2.1.5"
+    stream-shift "^1.0.0"
+
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
@@ -8582,6 +9829,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
@@ -8625,6 +9877,11 @@ string_decoder@~1.0.3:
   integrity sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-package@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.0.tgz#e02828089333d7d45cd8c287c30aa9a13375081b"
+  integrity sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==
 
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
@@ -8822,6 +10079,15 @@ tar-stream@^1.1.2:
     to-buffer "^1.1.0"
     xtend "^4.0.0"
 
+tar@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
+  integrity sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=
+  dependencies:
+    block-stream "*"
+    fstream "^1.0.2"
+    inherits "2"
+
 tar@^4:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
@@ -8831,6 +10097,19 @@ tar@^4:
     fs-minipass "^1.2.5"
     minipass "^2.3.3"
     minizlib "^1.1.0"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
+
+tar@^4.4.8:
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
+  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.4"
+    minizlib "^1.1.1"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
@@ -8859,6 +10138,13 @@ temp@^0.8.3:
   dependencies:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
+
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
+  integrity sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
+  dependencies:
+    execa "^0.7.0"
 
 text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
@@ -8923,7 +10209,7 @@ through2@~0.4.0:
     readable-stream "~1.0.17"
     xtend "~2.1.1"
 
-through@2, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.8:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -8933,12 +10219,22 @@ time-stamp@^1.0.0:
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
   integrity sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
 
+timed-out@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+  integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
+
 timers-browserify@^2.0.4:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
   integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-relative-date@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz#fa08aad501ed730f31cc043181d995c39a935e07"
+  integrity sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==
 
 tmp@0.0.28:
   version "0.0.28"
@@ -9273,10 +10569,20 @@ uglifyjs-webpack-plugin@^1.2.4:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
+uid-number@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+  integrity sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=
+
 ultron@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
   integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
+
+umask@^1.1.0, umask@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
+  integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
 
 unc-path-regex@^0.1.0, unc-path-regex@^0.1.2:
   version "0.1.2"
@@ -9347,6 +10653,13 @@ unique-filename@^1.1.0:
   dependencies:
     unique-slug "^2.0.0"
 
+unique-filename@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
+  integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
+  dependencies:
+    unique-slug "^2.0.0"
+
 unique-slug@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.0.tgz#db6676e7c7cc0629878ff196097c78855ae9f4ab"
@@ -9361,6 +10674,13 @@ unique-stream@^2.0.2:
   dependencies:
     json-stable-stringify "^1.0.0"
     through2-filter "^2.0.0"
+
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
+  dependencies:
+    crypto-random-string "^1.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -9380,10 +10700,31 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+unzip-response@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+  integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
+
 upath@^1.0.5, upath@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
   integrity sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==
+
+update-notifier@^2.3.0, update-notifier@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
+  integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==
+  dependencies:
+    boxen "^1.2.1"
+    chalk "^2.0.1"
+    configstore "^3.0.0"
+    import-lazy "^2.1.0"
+    is-ci "^1.0.10"
+    is-installed-globally "^0.1.0"
+    is-npm "^1.0.0"
+    latest-version "^3.0.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 uri-js@^4.2.1, uri-js@^4.2.2:
   version "4.2.2"
@@ -9401,6 +10742,13 @@ url-join@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
   integrity sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=
+
+url-parse-lax@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
+  integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
+  dependencies:
+    prepend-http "^1.0.1"
 
 url@^0.11.0:
   version "0.11.0"
@@ -9426,6 +10774,11 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+util-extend@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f"
+  integrity sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=
 
 util@0.10.3, "util@>=0.10.3 <1":
   version "0.10.3"
@@ -9487,6 +10840,21 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
+
+validate-npm-package-license@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
+
+validate-npm-package-name@^3.0.0, validate-npm-package-name@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
+  integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
+  dependencies:
+    builtins "^1.0.3"
 
 validator@~9.4.1:
   version "9.4.1"
@@ -9821,6 +11189,13 @@ watchpack@^1.5.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
+wcwidth@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
+  dependencies:
+    defaults "^1.0.3"
+
 webpack-cli@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.1.0.tgz#d71a83687dcfeb758fdceeb0fe042f96bcf62994"
@@ -9912,17 +11287,17 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
+which@1, which@^1.2.14, which@^1.3.0, which@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
 which@^1.1.1, which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   integrity sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==
-  dependencies:
-    isexe "^2.0.0"
-
-which@^1.2.14:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
@@ -9932,6 +11307,13 @@ wide-align@^1.1.0:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
+
+widest-line@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc"
+  integrity sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==
+  dependencies:
+    string-width "^2.1.1"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -9973,7 +11355,7 @@ wordwrap@~0.0.2:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
   integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
 
-worker-farm@^1.5.2:
+worker-farm@^1.5.2, worker-farm@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0"
   integrity sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==
@@ -9993,6 +11375,15 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
+write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
+  integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
 write@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
@@ -10008,6 +11399,11 @@ ws@^3.3.3:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
+
+xdg-basedir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
+  integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
 
 xml-name-validator@^1.0.0:
   version "1.0.0"
@@ -10112,6 +11508,13 @@ yargs-parser@^8.1.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@^10.1.1:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
@@ -10129,6 +11532,24 @@ yargs@^10.1.1:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
+
+yargs@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^12.0.1:
   version "12.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,15 +322,7 @@
     "@webassemblyjs/wast-parser" "1.5.13"
     long "^3.2.0"
 
-JSONStream@^1.3.4, JSONStream@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
-  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
-
-abbrev@1, abbrev@~1.1.1:
+abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
@@ -394,19 +386,12 @@ agent-base@4, agent-base@^4.1.0:
   dependencies:
     es6-promisify "^5.0.0"
 
-agent-base@~4.2.0, agent-base@~4.2.1:
+agent-base@~4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
   integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
   dependencies:
     es6-promisify "^5.0.0"
-
-agentkeepalive@^3.4.1:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-3.5.2.tgz#a113924dd3fa24a0bc3b78108c450c2abee00f67"
-  integrity sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==
-  dependencies:
-    humanize-ms "^1.2.1"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
@@ -493,13 +478,6 @@ angular2-grid@2.0.6:
 "angular2-slickgrid@github:Microsoft/angular2-slickgrid#1.4.6":
   version "1.4.6"
   resolved "https://codeload.github.com/Microsoft/angular2-slickgrid/tar.gz/09579fdc90b1ec469578ec1040d1515585ce2a11"
-
-ansi-align@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
-  integrity sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=
-  dependencies:
-    string-width "^2.0.0"
 
 ansi-colors@^1.0.1:
   version "1.1.0"
@@ -593,16 +571,6 @@ ansi_up@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi_up/-/ansi_up-3.0.0.tgz#27f45d8f457d9ceff59e4ea03c8e6f13c1a303e8"
   integrity sha1-J/Rdj0V9nO/1nk6gPI5vE8GjA+g=
 
-ansicolors@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz#665597de86a9ffe3aa9bfbe6cae5c6ea426b4979"
-  integrity sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=
-
-ansistyles@~0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/ansistyles/-/ansistyles-0.1.3.tgz#5de60415bda071bb37127854c864f41b23254539"
-  integrity sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=
-
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -627,17 +595,12 @@ applicationinsights@1.0.8:
     diagnostic-channel-publishers "0.2.1"
     zone.js "0.7.6"
 
-aproba@^1.0.3, aproba@^1.1.1, aproba@^1.1.2:
+aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
-"aproba@^1.1.2 || 2", aproba@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
-  integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
-
-archy@^1.0.0, archy@~1.0.0:
+archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
@@ -791,11 +754,6 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
-
-asap@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
 asar@^0.14.0:
   version "0.14.0"
@@ -1019,17 +977,6 @@ big.js@^3.1.3:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
   integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
 
-bin-links@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/bin-links/-/bin-links-1.1.2.tgz#fb74bd54bae6b7befc6c6221f25322ac830d9757"
-  integrity sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==
-  dependencies:
-    bluebird "^3.5.0"
-    cmd-shim "^2.0.2"
-    gentle-fs "^2.0.0"
-    graceful-fs "^4.1.11"
-    write-file-atomic "^2.3.0"
-
 binary-extensions@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
@@ -1065,18 +1012,6 @@ bl@^1.0.0:
   dependencies:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
-
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
-  dependencies:
-    inherits "~2.0.0"
-
-bluebird@^3.5.0, bluebird@^3.5.3:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
-  integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
 
 bluebird@^3.5.1:
   version "3.5.1"
@@ -1129,19 +1064,6 @@ boom@5.x.x:
   integrity sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==
   dependencies:
     hoek "4.x.x"
-
-boxen@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
-  integrity sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==
-  dependencies:
-    ansi-align "^2.0.0"
-    camelcase "^4.0.0"
-    chalk "^2.0.1"
-    cli-boxes "^1.0.0"
-    string-width "^2.0.0"
-    term-size "^1.2.0"
-    widest-line "^2.0.0"
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.8"
@@ -1320,21 +1242,6 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-builtins@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
-  integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
-
-byline@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
-  integrity sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=
-
-byte-size@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-5.0.1.tgz#4b651039a5ecd96767e71a3d7ed380e48bed4191"
-  integrity sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==
-
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -1359,26 +1266,6 @@ cacache@^10.0.4:
     unique-filename "^1.1.0"
     y18n "^4.0.0"
 
-cacache@^11.0.1, cacache@^11.3.2:
-  version "11.3.2"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.2.tgz#2d81e308e3d258ca38125b676b98b2ac9ce69bfa"
-  integrity sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==
-  dependencies:
-    bluebird "^3.5.3"
-    chownr "^1.1.1"
-    figgy-pudding "^3.5.1"
-    glob "^7.1.3"
-    graceful-fs "^4.1.15"
-    lru-cache "^5.1.1"
-    mississippi "^3.0.0"
-    mkdirp "^0.5.1"
-    move-concurrently "^1.0.1"
-    promise-inflight "^1.0.1"
-    rimraf "^2.6.2"
-    ssri "^6.0.1"
-    unique-filename "^1.1.1"
-    y18n "^4.0.0"
-
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -1393,11 +1280,6 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
-
-call-limit@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/call-limit/-/call-limit-1.1.0.tgz#6fd61b03f3da42a2cd0ec2b60f02bd0e71991fea"
-  integrity sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -1439,7 +1321,7 @@ camelcase@^3.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
 
-camelcase@^4.0.0, camelcase@^4.1.0:
+camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
@@ -1458,11 +1340,6 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000760"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000760.tgz#3ea29473eb78a6ccb09f2eb73ac9e1debfec528d"
   integrity sha1-PqKUc+t4psywny63Osnh3r/sUo0=
-
-capture-stack-trace@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
-  integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -1518,7 +1395,7 @@ chalk@^2.0.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
+chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1630,11 +1507,6 @@ chownr@^1.0.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
   integrity sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=
 
-chownr@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
-  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
-
 chrome-remote-interface@0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.26.1.tgz#6c7d4479742b6d236752d716a9bc2d322d7d8ad2"
@@ -1659,23 +1531,6 @@ ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
   integrity sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==
-
-ci-info@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
-  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
-
-ci-info@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
-  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
-
-cidr-regex@^2.0.10:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/cidr-regex/-/cidr-regex-2.0.10.tgz#af13878bd4ad704de77d6dc800799358b3afa70d"
-  integrity sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==
-  dependencies:
-    ip-regex "^2.1.0"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -1715,19 +1570,6 @@ clean-css@3.4.6:
     commander "2.8.x"
     source-map "0.4.x"
 
-cli-boxes@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
-  integrity sha1-T6kXw+WclKAEzWH47lCdplFocUM=
-
-cli-columns@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/cli-columns/-/cli-columns-3.1.2.tgz#6732d972979efc2ae444a1f08e08fa139c96a18e"
-  integrity sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=
-  dependencies:
-    string-width "^2.0.0"
-    strip-ansi "^3.0.1"
-
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -1741,16 +1583,6 @@ cli-cursor@^2.1.0:
   integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   dependencies:
     restore-cursor "^2.0.0"
-
-cli-table3@^0.5.0, cli-table3@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
-  integrity sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==
-  dependencies:
-    object-assign "^4.1.0"
-    string-width "^2.1.1"
-  optionalDependencies:
-    colors "^1.1.2"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -1817,14 +1649,6 @@ cloneable-readable@^1.0.0:
     inherits "^2.0.1"
     process-nextick-args "^1.0.6"
     through2 "^2.0.1"
-
-cmd-shim@^2.0.2, cmd-shim@~2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-2.0.2.tgz#6fcbda99483a8fd15d7d30a196ca69d688a2efdb"
-  integrity sha1-b8vamUg6j9FdfTChlspp1oii79s=
-  dependencies:
-    graceful-fs "^4.1.2"
-    mkdirp "~0.5.0"
 
 co@^4.6.0:
   version "4.6.0"
@@ -1921,14 +1745,6 @@ colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
   integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
-
-columnify@~1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
-  integrity sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=
-  dependencies:
-    strip-ansi "^3.0.0"
-    wcwidth "^1.0.0"
 
 combined-stream@1.0.6:
   version "1.0.6"
@@ -2042,18 +1858,6 @@ config-chain@^1.1.12:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
-configstore@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f"
-  integrity sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==
-  dependencies:
-    dot-prop "^4.1.0"
-    graceful-fs "^4.1.2"
-    make-dir "^1.0.0"
-    unique-string "^1.0.0"
-    write-file-atomic "^2.0.0"
-    xdg-basedir "^3.0.0"
-
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
@@ -2061,7 +1865,7 @@ console-browserify@^1.1.0:
   dependencies:
     date-now "^0.1.4"
 
-console-control-strings@^1.0.0, console-control-strings@^1.1.0, console-control-strings@~1.1.0:
+console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
@@ -2166,13 +1970,6 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
-create-error-class@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
-  integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
-  dependencies:
-    capture-stack-trace "^1.0.0"
-
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
@@ -2251,11 +2048,6 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
-
-crypto-random-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
-  integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
 cson-parser@^1.3.3:
   version "1.3.5"
@@ -2411,11 +2203,6 @@ debug@^4.0.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
-  integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
-
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -2479,13 +2266,6 @@ default-resolution@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/default-resolution/-/default-resolution-2.0.0.tgz#bcb82baa72ad79b426a76732f1a81ad6df26d684"
   integrity sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=
-
-defaults@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
-  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
-  dependencies:
-    clone "^1.0.2"
 
 define-properties@^1.1.2:
   version "1.1.3"
@@ -2577,7 +2357,7 @@ detect-file@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
-detect-indent@^5.0.0, detect-indent@~5.0.0:
+detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
@@ -2586,19 +2366,6 @@ detect-libc@^1.0.2, detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
-
-detect-newline@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
-  integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
-
-dezalgo@^1.0.0, dezalgo@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
-  integrity sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=
-  dependencies:
-    asap "^2.0.0"
-    wrappy "1"
 
 diagnostic-channel-publishers@0.2.1:
   version "0.2.1"
@@ -2717,23 +2484,6 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-dot-prop@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
-  integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
-  dependencies:
-    is-obj "^1.0.0"
-
-dotenv@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
-  integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
-
-duplexer3@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
-  integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
-
 duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
@@ -2786,11 +2536,6 @@ editions@^1.1.1, editions@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.4.tgz#3662cb592347c3168eb8e498a0ff73271d67f50b"
   integrity sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==
-
-editor@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
-  integrity sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=
 
 editorconfig@^0.15.0:
   version "0.15.0"
@@ -2872,13 +2617,6 @@ encodeurl@~1.0.1:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
   integrity sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
-
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.0.tgz#7a90d833efda6cfa6eac0f4949dbb0fad3a63206"
@@ -2904,11 +2642,6 @@ env-paths@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
   integrity sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=
-
-err-code@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
-  integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -3501,11 +3234,6 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
-figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
-  integrity sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
-
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -3584,11 +3312,6 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
-
-find-npm-prefix@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz#8d8ce2c78b3b4b9e66c8acc6a37c231eb841cfdf"
-  integrity sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==
 
 find-parent-dir@^0.3.0:
   version "0.3.0"
@@ -3751,14 +3474,6 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-from2@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/from2/-/from2-1.3.0.tgz#88413baaa5f9a597cfde9221d86986cd3c061dfd"
-  integrity sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=
-  dependencies:
-    inherits "~2.0.1"
-    readable-stream "~1.1.10"
-
 from2@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
@@ -3820,16 +3535,7 @@ fs-mkdirp-stream@^1.0.0:
     graceful-fs "^4.1.11"
     through2 "^2.0.3"
 
-fs-vacuum@^1.2.10, fs-vacuum@~1.2.10:
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/fs-vacuum/-/fs-vacuum-1.2.10.tgz#b7629bec07a4031a2548fdf99f5ecf1cc8b31e36"
-  integrity sha1-t2Kb7AekAxolSP35n17PHMizHjY=
-  dependencies:
-    graceful-fs "^4.1.2"
-    path-is-inside "^1.0.1"
-    rimraf "^2.5.2"
-
-fs-write-stream-atomic@^1.0.8, fs-write-stream-atomic@~1.0.10:
+fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
   integrity sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=
@@ -3859,16 +3565,6 @@ fsevents@^1.2.7:
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
-
-fstream@^1.0.0, fstream@^1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
-  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
-  dependencies:
-    graceful-fs "^4.1.2"
-    inherits "~2.0.0"
-    mkdirp ">=0.5 0"
-    rimraf "2"
 
 function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
@@ -3911,25 +3607,6 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
-genfun@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
-  integrity sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==
-
-gentle-fs@^2.0.0, gentle-fs@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/gentle-fs/-/gentle-fs-2.0.1.tgz#585cfd612bfc5cd52471fdb42537f016a5ce3687"
-  integrity sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==
-  dependencies:
-    aproba "^1.1.2"
-    fs-vacuum "^1.2.10"
-    graceful-fs "^4.1.11"
-    iferr "^0.1.5"
-    mkdirp "^0.5.1"
-    path-is-inside "^1.0.2"
-    read-cmd-shim "^1.0.1"
-    slide "^1.1.6"
-
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
@@ -3944,13 +3621,6 @@ get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
-
-get-stream@^4.0.0, get-stream@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
-  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
-  dependencies:
-    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -4106,13 +3776,6 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global-dirs@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
-  integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
-  dependencies:
-    ini "^1.3.4"
-
 global-modules-path@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/global-modules-path/-/global-modules-path-2.3.0.tgz#b0e2bac6beac39745f7db5c59d26a36a0b94f7dc"
@@ -4179,32 +3842,10 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-got@^6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
-  integrity sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=
-  dependencies:
-    create-error-class "^3.0.0"
-    duplexer3 "^0.1.4"
-    get-stream "^3.0.0"
-    is-redirect "^1.0.0"
-    is-retry-allowed "^1.0.0"
-    is-stream "^1.0.0"
-    lowercase-keys "^1.0.0"
-    safe-buffer "^5.0.1"
-    timed-out "^4.0.0"
-    unzip-response "^2.0.1"
-    url-parse-lax "^1.0.0"
-
 graceful-fs@4.1.11, graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
-
-graceful-fs@^4.1.15:
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -4552,7 +4193,7 @@ has-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
   integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
 
-has-unicode@^2.0.0, has-unicode@~2.0.1:
+has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
@@ -4662,11 +4303,6 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
   integrity sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==
 
-hosted-git-info@^2.6.0, hosted-git-info@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
-  integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
-
 html-comment-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
@@ -4699,11 +4335,6 @@ htmlparser2@^3.10.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
-
-http-cache-semantics@^3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
-  integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
 
 http-errors@1.6.2, http-errors@~1.6.2:
   version "1.6.2"
@@ -4754,13 +4385,6 @@ https-proxy-agent@2.2.1, https-proxy-agent@^2.2.1:
     agent-base "^4.1.0"
     debug "^3.1.0"
 
-humanize-ms@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
-  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
-  dependencies:
-    ms "^2.0.0"
-
 husky@^0.13.1:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/husky/-/husky-0.13.4.tgz#48785c5028de3452a51c48c12c4f94b2124a1407"
@@ -4783,7 +4407,7 @@ iconv-lite@0.4.23, iconv-lite@^0.4.22, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4799,11 +4423,6 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
-
-iferr@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/iferr/-/iferr-1.0.2.tgz#e9fde49a9da06dc4a4194c6c9ed6d08305037a6d"
-  integrity sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==
 
 ignore-walk@^3.0.1:
   version "3.0.1"
@@ -4835,11 +4454,6 @@ import-fresh@^3.0.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-lazy@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
-  integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
-
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -4870,7 +4484,7 @@ indexof@0.0.1:
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
   integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
-inflight@^1.0.4, inflight@~1.0.6:
+inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
   integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
@@ -4892,25 +4506,6 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
   integrity sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=
-
-ini@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-
-init-package-json@^1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/init-package-json/-/init-package-json-1.10.3.tgz#45ffe2f610a8ca134f2bd1db5637b235070f6cbe"
-  integrity sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==
-  dependencies:
-    glob "^7.1.1"
-    npm-package-arg "^4.0.0 || ^5.0.0 || ^6.0.0"
-    promzard "^0.3.0"
-    read "~1.0.1"
-    read-package-json "1 || 2"
-    semver "2.x || 3.x || 4 || 5"
-    validate-npm-package-license "^3.0.1"
-    validate-npm-package-name "^3.0.0"
 
 innosetup-compiler@^5.5.60:
   version "5.5.62"
@@ -4994,11 +4589,6 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
-ip-regex@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
-  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
-
 ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -5073,26 +4663,12 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-ci@^1.0.10:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
-  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
-  dependencies:
-    ci-info "^1.5.0"
-
 is-ci@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
   integrity sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=
   dependencies:
     ci-info "^1.0.0"
-
-is-cidr@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-cidr/-/is-cidr-3.0.0.tgz#1acf35c9e881063cd5f696d48959b30fed3eed56"
-  integrity sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==
-  dependencies:
-    cidr-regex "^2.0.10"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -5200,14 +4776,6 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
-is-installed-globally@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
-  integrity sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=
-  dependencies:
-    global-dirs "^0.1.0"
-    is-path-inside "^1.0.0"
-
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz#5a846777e2c2620d1e69104e5d3a03b1f6088f11"
@@ -5222,11 +4790,6 @@ is-negated-glob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-negated-glob/-/is-negated-glob-1.0.0.tgz#6910bca5da8c95e784b5751b976cf5a10fee36d2"
   integrity sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=
-
-is-npm@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
-  integrity sha1-8vtjpl5JBbQGyGBydloaTceTufQ=
 
 is-number@^2.0.2, is-number@^2.1.0:
   version "2.1.0"
@@ -5246,11 +4809,6 @@ is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
   integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
-
-is-obj@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
-  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -5303,11 +4861,6 @@ is-property@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
   integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
-is-redirect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
-  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
-
 is-relative@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-0.2.1.tgz#d27f4c7d516d175fb610db84bbeef23c3bc97aa5"
@@ -5329,12 +4882,7 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-retry-allowed@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
-  integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
-
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -5588,7 +5136,7 @@ json-edm-parser@0.1.2:
   dependencies:
     jsonparse "~1.2.0"
 
-json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
+json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
@@ -5648,11 +5196,6 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
-
-jsonparse@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
-  integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
 jsonparse@~1.2.0:
   version "1.2.0"
@@ -5738,22 +5281,10 @@ last-run@^1.1.0:
     default-resolution "^2.0.0"
     es6-weak-map "^2.0.1"
 
-latest-version@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
-  integrity sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=
-  dependencies:
-    package-json "^4.0.0"
-
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
   integrity sha1-odePw6UEdMuAhF07O24dpJpEbo4=
-
-lazy-property@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lazy-property/-/lazy-property-1.0.0.tgz#84ddc4b370679ba8bd4cdcfa4c06b43d57111147"
-  integrity sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=
 
 lazy.js@^0.4.2:
   version "0.4.3"
@@ -5801,140 +5332,6 @@ levn@~0.2.5:
   dependencies:
     prelude-ls "~1.1.0"
     type-check "~0.3.1"
-
-libcipm@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/libcipm/-/libcipm-3.0.3.tgz#2e764effe0b90d458790dab3165794c804075ed3"
-  integrity sha512-71V5CpTI+zFydTc5IjJ/tx8JHbXEJvmYF2zaSVW1V3X1rRnRjXqh44iuiyry1xgi3ProUQ1vX1uwFiWs00+2og==
-  dependencies:
-    bin-links "^1.1.2"
-    bluebird "^3.5.1"
-    figgy-pudding "^3.5.1"
-    find-npm-prefix "^1.0.2"
-    graceful-fs "^4.1.11"
-    ini "^1.3.5"
-    lock-verify "^2.0.2"
-    mkdirp "^0.5.1"
-    npm-lifecycle "^2.0.3"
-    npm-logical-tree "^1.2.1"
-    npm-package-arg "^6.1.0"
-    pacote "^9.1.0"
-    read-package-json "^2.0.13"
-    rimraf "^2.6.2"
-    worker-farm "^1.6.0"
-
-libnpm@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/libnpm/-/libnpm-2.0.1.tgz#a48fcdee3c25e13c77eb7c60a0efe561d7fb0d8f"
-  integrity sha512-qTKoxyJvpBxHZQB6k0AhSLajyXq9ZE/lUsZzuHAplr2Bpv9G+k4YuYlExYdUCeVRRGqcJt8hvkPh4tBwKoV98w==
-  dependencies:
-    bin-links "^1.1.2"
-    bluebird "^3.5.3"
-    find-npm-prefix "^1.0.2"
-    libnpmaccess "^3.0.1"
-    libnpmconfig "^1.2.1"
-    libnpmhook "^5.0.2"
-    libnpmorg "^1.0.0"
-    libnpmpublish "^1.1.0"
-    libnpmsearch "^2.0.0"
-    libnpmteam "^1.0.1"
-    lock-verify "^2.0.2"
-    npm-lifecycle "^2.1.0"
-    npm-logical-tree "^1.2.1"
-    npm-package-arg "^6.1.0"
-    npm-profile "^4.0.1"
-    npm-registry-fetch "^3.8.0"
-    npmlog "^4.1.2"
-    pacote "^9.2.3"
-    read-package-json "^2.0.13"
-    stringify-package "^1.0.0"
-
-libnpmaccess@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-3.0.1.tgz#5b3a9de621f293d425191aa2e779102f84167fa8"
-  integrity sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==
-  dependencies:
-    aproba "^2.0.0"
-    get-stream "^4.0.0"
-    npm-package-arg "^6.1.0"
-    npm-registry-fetch "^3.8.0"
-
-libnpmconfig@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/libnpmconfig/-/libnpmconfig-1.2.1.tgz#c0c2f793a74e67d4825e5039e7a02a0044dfcbc0"
-  integrity sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==
-  dependencies:
-    figgy-pudding "^3.5.1"
-    find-up "^3.0.0"
-    ini "^1.3.5"
-
-libnpmhook@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/libnpmhook/-/libnpmhook-5.0.2.tgz#d12817b0fb893f36f1d5be20017f2aea25825d94"
-  integrity sha512-vLenmdFWhRfnnZiNFPNMog6CK7Ujofy2TWiM2CrpZUjBRIhHkJeDaAbJdYCT6W4lcHtyrJR8yXW8KFyq6UAp1g==
-  dependencies:
-    aproba "^2.0.0"
-    figgy-pudding "^3.4.1"
-    get-stream "^4.0.0"
-    npm-registry-fetch "^3.8.0"
-
-libnpmorg@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/libnpmorg/-/libnpmorg-1.0.0.tgz#979b868c48ba28c5820e3bb9d9e73c883c16a232"
-  integrity sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==
-  dependencies:
-    aproba "^2.0.0"
-    figgy-pudding "^3.4.1"
-    get-stream "^4.0.0"
-    npm-registry-fetch "^3.8.0"
-
-libnpmpublish@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/libnpmpublish/-/libnpmpublish-1.1.1.tgz#ff0c6bb0b4ad2bda2ad1f5fba6760a4af37125f0"
-  integrity sha512-nefbvJd/wY38zdt+b9SHL6171vqBrMtZ56Gsgfd0duEKb/pB8rDT4/ObUQLrHz1tOfht1flt2zM+UGaemzAG5g==
-  dependencies:
-    aproba "^2.0.0"
-    figgy-pudding "^3.5.1"
-    get-stream "^4.0.0"
-    lodash.clonedeep "^4.5.0"
-    normalize-package-data "^2.4.0"
-    npm-package-arg "^6.1.0"
-    npm-registry-fetch "^3.8.0"
-    semver "^5.5.1"
-    ssri "^6.0.1"
-
-libnpmsearch@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/libnpmsearch/-/libnpmsearch-2.0.0.tgz#de05af47ada81554a5f64276a69599070d4a5685"
-  integrity sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==
-  dependencies:
-    figgy-pudding "^3.5.1"
-    get-stream "^4.0.0"
-    npm-registry-fetch "^3.8.0"
-
-libnpmteam@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/libnpmteam/-/libnpmteam-1.0.1.tgz#ff704b1b6c06ea674b3b1101ac3e305f5114f213"
-  integrity sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==
-  dependencies:
-    aproba "^2.0.0"
-    figgy-pudding "^3.4.1"
-    get-stream "^4.0.0"
-    npm-registry-fetch "^3.8.0"
-
-libnpx@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/libnpx/-/libnpx-10.2.0.tgz#1bf4a1c9f36081f64935eb014041da10855e3102"
-  integrity sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==
-  dependencies:
-    dotenv "^5.0.1"
-    npm-package-arg "^6.0.0"
-    rimraf "^2.6.2"
-    safe-buffer "^5.1.0"
-    update-notifier "^2.3.0"
-    which "^1.3.0"
-    y18n "^4.0.0"
-    yargs "^11.0.0"
 
 liftoff@^2.5.0:
   version "2.5.0"
@@ -5998,50 +5395,17 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lock-verify@^2.0.2, lock-verify@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/lock-verify/-/lock-verify-2.1.0.tgz#fff4c918b8db9497af0c5fa7f6d71555de3ceb47"
-  integrity sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==
-  dependencies:
-    npm-package-arg "^6.1.0"
-    semver "^5.4.1"
-
-lockfile@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"
-  integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
-  dependencies:
-    signal-exit "^3.0.2"
-
-lodash._baseuniq@~4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
-  integrity sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=
-  dependencies:
-    lodash._createset "~4.0.0"
-    lodash._root "~3.0.0"
-
-lodash._createset@~4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
-  integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
-
-lodash._root@~3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
-  integrity sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=
 
 lodash.clone@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
 
-lodash.clonedeep@^4.5.0, lodash.clonedeep@~4.5.0:
+lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
@@ -6111,20 +5475,10 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash.union@~4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
-  integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
-
-lodash.uniq@^4.5.0, lodash.uniq@~4.5.0:
+lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
-
-lodash.without@~4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
-  integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
 lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.3.0:
   version "4.17.4"
@@ -6174,11 +5528,6 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lowercase-keys@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
-  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
-
 lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
@@ -6200,20 +5549,13 @@ lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lru-cache@^4.1.2, lru-cache@^4.1.3, lru-cache@^4.1.5:
+lru-cache@^4.1.3:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
-
-lru-cache@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
-  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
-  dependencies:
-    yallist "^3.0.2"
 
 macaddress@^0.2.8:
   version "0.2.8"
@@ -6238,23 +5580,6 @@ make-error@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.0.tgz#52ad3a339ccf10ce62b4040b708fe707244b8b96"
   integrity sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=
-
-make-fetch-happen@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz#141497cb878f243ba93136c83d8aba12c216c083"
-  integrity sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==
-  dependencies:
-    agentkeepalive "^3.4.1"
-    cacache "^11.0.1"
-    http-cache-semantics "^3.8.1"
-    http-proxy-agent "^2.1.0"
-    https-proxy-agent "^2.2.1"
-    lru-cache "^4.1.2"
-    mississippi "^3.0.0"
-    node-fetch-npm "^2.0.2"
-    promise-retry "^1.1.1"
-    socks-proxy-agent "^4.0.0"
-    ssri "^6.0.0"
 
 make-iterator@^1.0.0:
   version "1.0.1"
@@ -6342,11 +5667,6 @@ mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
-
-meant@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.1.tgz#66044fea2f23230ec806fb515efea29c44d2115d"
-  integrity sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -6553,25 +5873,10 @@ minipass@^2.2.1, minipass@^2.3.3:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minipass@^2.3.4, minipass@^2.3.5:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
-  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minizlib@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
   integrity sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==
-  dependencies:
-    minipass "^2.2.1"
-
-minizlib@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
-  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
 
@@ -6587,22 +5892,6 @@ mississippi@^2.0.0:
     from2 "^2.1.0"
     parallel-transform "^1.1.0"
     pump "^2.0.1"
-    pumpify "^1.3.3"
-    stream-each "^1.1.0"
-    through2 "^2.0.0"
-
-mississippi@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
-  integrity sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==
-  dependencies:
-    concat-stream "^1.5.0"
-    duplexify "^3.4.2"
-    end-of-stream "^1.1.0"
-    flush-write-stream "^1.0.0"
-    from2 "^2.1.0"
-    parallel-transform "^1.1.0"
-    pump "^3.0.0"
     pumpify "^1.3.3"
     stream-each "^1.1.0"
     through2 "^2.0.0"
@@ -6627,7 +5916,7 @@ mkdirp@0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -6702,7 +5991,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.0.0, ms@^2.1.1:
+ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
@@ -6837,33 +6126,6 @@ node-addon-api@1.6.2:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.6.2.tgz#d8aad9781a5cfc4132cc2fecdbdd982534265217"
   integrity sha512-479Bjw9nTE5DdBSZZWprFryHGjUaQC31y1wHo19We/k0BZlrmhqQitWoUL0cD8+scljCbIUL+E58oRDEakdGGA==
 
-node-fetch-npm@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz#7258c9046182dca345b4208eda918daf33697ff7"
-  integrity sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==
-  dependencies:
-    encoding "^0.1.11"
-    json-parse-better-errors "^1.0.0"
-    safe-buffer "^5.1.1"
-
-node-gyp@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
-  integrity sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==
-  dependencies:
-    fstream "^1.0.0"
-    glob "^7.0.3"
-    graceful-fs "^4.1.2"
-    mkdirp "^0.5.0"
-    nopt "2 || 3"
-    npmlog "0 || 1 || 2 || 3 || 4"
-    osenv "0"
-    request "^2.87.0"
-    rimraf "2"
-    semver "~5.3.0"
-    tar "^2.0.0"
-    which "1"
-
 node-libs-browser@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
@@ -6928,7 +6190,7 @@ noop-logger@^0.1.1:
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
   integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
 
-"nopt@2 || 3", nopt@3.x, nopt@^3.0.1:
+nopt@3.x, nopt@^3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
@@ -6949,16 +6211,6 @@ nopt@~1.0.10:
   integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
   dependencies:
     abbrev "1"
-
-normalize-package-data@^2.0.0, normalize-package-data@^2.4.0, normalize-package-data@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
-  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
-  dependencies:
-    hosted-git-info "^2.1.4"
-    resolve "^1.10.0"
-    semver "2 || 3 || 4 || 5"
-    validate-npm-package-license "^3.0.1"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
@@ -7014,67 +6266,10 @@ now-and-later@^2.0.0:
   dependencies:
     once "^1.3.2"
 
-npm-audit-report@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/npm-audit-report/-/npm-audit-report-1.3.2.tgz#303bc78cd9e4c226415076a4f7e528c89fc77018"
-  integrity sha512-abeqS5ONyXNaZJPGAf6TOUMNdSe1Y6cpc9MLBRn+CuUoYbfdca6AxOyXVlfIv9OgKX+cacblbG5w7A6ccwoTPw==
-  dependencies:
-    cli-table3 "^0.5.0"
-    console-control-strings "^1.1.0"
-
 npm-bundled@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
   integrity sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==
-
-npm-cache-filename@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz#ded306c5b0bfc870a9e9faf823bc5f283e05ae11"
-  integrity sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=
-
-npm-install-checks@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/npm-install-checks/-/npm-install-checks-3.0.0.tgz#d4aecdfd51a53e3723b7b2f93b2ee28e307bc0d7"
-  integrity sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=
-  dependencies:
-    semver "^2.3.0 || 3.x || 4 || 5"
-
-npm-lifecycle@^2.0.3, npm-lifecycle@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/npm-lifecycle/-/npm-lifecycle-2.1.0.tgz#1eda2eedb82db929e3a0c50341ab0aad140ed569"
-  integrity sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==
-  dependencies:
-    byline "^5.0.0"
-    graceful-fs "^4.1.11"
-    node-gyp "^3.8.0"
-    resolve-from "^4.0.0"
-    slide "^1.1.6"
-    uid-number "0.0.6"
-    umask "^1.1.0"
-    which "^1.3.1"
-
-npm-logical-tree@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz#44610141ca24664cad35d1e607176193fd8f5b88"
-  integrity sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==
-
-"npm-package-arg@^4.0.0 || ^5.0.0 || ^6.0.0", npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-6.1.0.tgz#15ae1e2758a5027efb4c250554b85a737db7fcc1"
-  integrity sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==
-  dependencies:
-    hosted-git-info "^2.6.0"
-    osenv "^0.1.5"
-    semver "^5.5.0"
-    validate-npm-package-name "^3.0.0"
-
-npm-packlist@^1.1.12, npm-packlist@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
-  integrity sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
 
 npm-packlist@^1.1.6:
   version "1.1.11"
@@ -7084,36 +6279,6 @@ npm-packlist@^1.1.6:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
 
-npm-pick-manifest@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz#32111d2a9562638bb2c8f2bf27f7f3092c8fae40"
-  integrity sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==
-  dependencies:
-    figgy-pudding "^3.5.1"
-    npm-package-arg "^6.0.0"
-    semver "^5.4.1"
-
-npm-profile@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/npm-profile/-/npm-profile-4.0.1.tgz#d350f7a5e6b60691c7168fbb8392c3603583f5aa"
-  integrity sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==
-  dependencies:
-    aproba "^1.1.2 || 2"
-    figgy-pudding "^3.4.1"
-    npm-registry-fetch "^3.8.0"
-
-npm-registry-fetch@^3.8.0, npm-registry-fetch@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-3.9.0.tgz#44d841780e2833f06accb34488f8c7450d1a6856"
-  integrity sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==
-  dependencies:
-    JSONStream "^1.3.4"
-    bluebird "^3.5.1"
-    figgy-pudding "^3.4.1"
-    lru-cache "^4.1.3"
-    make-fetch-happen "^4.0.1"
-    npm-package-arg "^6.1.0"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -7121,126 +6286,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npm-user-validate@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.0.tgz#8ceca0f5cea04d4e93519ef72d0557a75122e951"
-  integrity sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=
-
-npm@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/npm/-/npm-6.9.0.tgz#5296720486814a64a7fb082de00c4b5cfd11211f"
-  integrity sha512-91V+zB5hDxO+Jyp2sUKS7juHlIM95dGQxTeQtmZI1nAI/7kjWXFipPrtwwKjhyKmV4GsS2LzJhrxRjGWsU9z/w==
-  dependencies:
-    JSONStream "^1.3.5"
-    abbrev "~1.1.1"
-    ansicolors "~0.3.2"
-    ansistyles "~0.1.3"
-    aproba "^2.0.0"
-    archy "~1.0.0"
-    bin-links "^1.1.2"
-    bluebird "^3.5.3"
-    byte-size "^5.0.1"
-    cacache "^11.3.2"
-    call-limit "~1.1.0"
-    chownr "^1.1.1"
-    ci-info "^2.0.0"
-    cli-columns "^3.1.2"
-    cli-table3 "^0.5.1"
-    cmd-shim "~2.0.2"
-    columnify "~1.5.4"
-    config-chain "^1.1.12"
-    detect-indent "~5.0.0"
-    detect-newline "^2.1.0"
-    dezalgo "~1.0.3"
-    editor "~1.0.0"
-    figgy-pudding "^3.5.1"
-    find-npm-prefix "^1.0.2"
-    fs-vacuum "~1.2.10"
-    fs-write-stream-atomic "~1.0.10"
-    gentle-fs "^2.0.1"
-    glob "^7.1.3"
-    graceful-fs "^4.1.15"
-    has-unicode "~2.0.1"
-    hosted-git-info "^2.7.1"
-    iferr "^1.0.2"
-    inflight "~1.0.6"
-    inherits "~2.0.3"
-    ini "^1.3.5"
-    init-package-json "^1.10.3"
-    is-cidr "^3.0.0"
-    json-parse-better-errors "^1.0.2"
-    lazy-property "~1.0.0"
-    libcipm "^3.0.3"
-    libnpm "^2.0.1"
-    libnpmhook "^5.0.2"
-    libnpx "^10.2.0"
-    lock-verify "^2.1.0"
-    lockfile "^1.0.4"
-    lodash._baseuniq "~4.6.0"
-    lodash.clonedeep "~4.5.0"
-    lodash.union "~4.6.0"
-    lodash.uniq "~4.5.0"
-    lodash.without "~4.4.0"
-    lru-cache "^4.1.5"
-    meant "~1.0.1"
-    mississippi "^3.0.0"
-    mkdirp "~0.5.1"
-    move-concurrently "^1.0.1"
-    node-gyp "^3.8.0"
-    nopt "~4.0.1"
-    normalize-package-data "^2.5.0"
-    npm-audit-report "^1.3.2"
-    npm-cache-filename "~1.0.2"
-    npm-install-checks "~3.0.0"
-    npm-lifecycle "^2.1.0"
-    npm-package-arg "^6.1.0"
-    npm-packlist "^1.4.1"
-    npm-pick-manifest "^2.2.3"
-    npm-registry-fetch "^3.9.0"
-    npm-user-validate "~1.0.0"
-    npmlog "~4.1.2"
-    once "~1.4.0"
-    opener "^1.5.1"
-    osenv "^0.1.5"
-    pacote "^9.5.0"
-    path-is-inside "~1.0.2"
-    promise-inflight "~1.0.1"
-    qrcode-terminal "^0.12.0"
-    query-string "^6.2.0"
-    qw "~1.0.1"
-    read "~1.0.7"
-    read-cmd-shim "~1.0.1"
-    read-installed "~4.0.3"
-    read-package-json "^2.0.13"
-    read-package-tree "^5.2.2"
-    readable-stream "^3.1.1"
-    request "^2.88.0"
-    retry "^0.12.0"
-    rimraf "^2.6.3"
-    safe-buffer "^5.1.2"
-    semver "^5.6.0"
-    sha "~2.0.1"
-    slide "~1.1.6"
-    sorted-object "~2.0.1"
-    sorted-union-stream "~2.1.3"
-    ssri "^6.0.1"
-    stringify-package "^1.0.0"
-    tar "^4.4.8"
-    text-table "~0.2.0"
-    tiny-relative-date "^1.3.0"
-    uid-number "0.0.6"
-    umask "~1.1.0"
-    unique-filename "^1.1.1"
-    unpipe "~1.0.0"
-    update-notifier "^2.5.0"
-    uuid "^3.3.2"
-    validate-npm-package-license "^3.0.4"
-    validate-npm-package-name "~3.0.0"
-    which "^1.3.1"
-    worker-farm "^1.6.0"
-    write-file-atomic "^2.4.2"
-
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2, npmlog@~4.1.2:
+npmlog@^4.0.1, npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -7384,7 +6430,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@1.x, once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0, once@~1.4.0:
+once@1.x, once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -7409,11 +6455,6 @@ oniguruma@^7.0.0:
   integrity sha512-zCsdNxTrrB4yVPMxhcIODGv1p4NVBu9WvsWnIGhMpu5djO4MQWXrC7YKjtza+OyoRqqgy27CqYWa1h5e2DDbig==
   dependencies:
     nan "^2.10.0"
-
-opener@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
-  integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
 optimist@0.3.5:
   version "0.3.5"
@@ -7500,18 +6541,18 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0, osenv@^0.1.4, osenv@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
-  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.0"
-
 osenv@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
   integrity sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.0"
+
+osenv@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
+  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
@@ -7577,49 +6618,6 @@ p-try@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
   integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
-
-package-json@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
-  integrity sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=
-  dependencies:
-    got "^6.7.1"
-    registry-auth-token "^3.0.1"
-    registry-url "^3.0.3"
-    semver "^5.1.0"
-
-pacote@^9.1.0, pacote@^9.2.3, pacote@^9.5.0:
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/pacote/-/pacote-9.5.0.tgz#85f3013a3f6dd51c108b0ccabd3de8102ddfaeda"
-  integrity sha512-aUplXozRbzhaJO48FaaeClmN+2Mwt741MC6M3bevIGZwdCaP7frXzbUOfOWa91FPHoLITzG0hYaKY363lxO3bg==
-  dependencies:
-    bluebird "^3.5.3"
-    cacache "^11.3.2"
-    figgy-pudding "^3.5.1"
-    get-stream "^4.1.0"
-    glob "^7.1.3"
-    lru-cache "^5.1.1"
-    make-fetch-happen "^4.0.1"
-    minimatch "^3.0.4"
-    minipass "^2.3.5"
-    mississippi "^3.0.0"
-    mkdirp "^0.5.1"
-    normalize-package-data "^2.4.0"
-    npm-package-arg "^6.1.0"
-    npm-packlist "^1.1.12"
-    npm-pick-manifest "^2.2.3"
-    npm-registry-fetch "^3.8.0"
-    osenv "^0.1.5"
-    promise-inflight "^1.0.1"
-    promise-retry "^1.1.1"
-    protoduck "^5.0.1"
-    rimraf "^2.6.2"
-    safe-buffer "^5.1.2"
-    semver "^5.6.0"
-    ssri "^6.0.1"
-    tar "^4.4.8"
-    unique-filename "^1.1.1"
-    which "^1.3.1"
 
 pako@~1.0.5:
   version "1.0.6"
@@ -7745,7 +6743,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2, path-is-inside@~1.0.2:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -8170,7 +7168,7 @@ prelude-ls@~1.1.0, prelude-ls@~1.1.1, prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prepend-http@^1.0.0, prepend-http@^1.0.1:
+prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
@@ -8244,37 +7242,15 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-promise-inflight@^1.0.1, promise-inflight@~1.0.1:
+promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
-
-promise-retry@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-1.1.1.tgz#6739e968e3051da20ce6497fb2b50f6911df3d6d"
-  integrity sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=
-  dependencies:
-    err-code "^1.0.0"
-    retry "^0.10.0"
-
-promzard@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/promzard/-/promzard-0.3.0.tgz#26a5d6ee8c7dee4cb12208305acfb93ba382a9ee"
-  integrity sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=
-  dependencies:
-    read "1"
 
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
-
-protoduck@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/protoduck/-/protoduck-5.0.1.tgz#03c3659ca18007b69a50fd82a7ebcc516261151f"
-  integrity sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==
-  dependencies:
-    genfun "^5.0.0"
 
 proxy-addr@~2.0.2:
   version "2.0.2"
@@ -8334,14 +7310,6 @@ pump@^2.0.0, pump@^2.0.1:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-pump@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
-  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
-
 pumpify@^1.3.3, pumpify@^1.3.5:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
@@ -8371,11 +7339,6 @@ q@^1.0.1, q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qrcode-terminal@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz#bb5b699ef7f9f0505092a3748be4464fe71b5819"
-  integrity sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==
-
 qs@6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
@@ -8398,15 +7361,6 @@ query-string@^4.1.0:
   dependencies:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
-
-query-string@^6.2.0:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.4.2.tgz#8be1dbd105306aebf86022144f575a29d516b713"
-  integrity sha512-DfJqAen17LfLA3rQ+H5S4uXphrF+ANU1lT2ijds4V/Tj4gZxA3gx5/tg1bz7kYCmwna7LyJNCYqO7jNRzo3aLw==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -8438,11 +7392,6 @@ queue@^4.2.1:
   integrity sha512-DwxpAnqJuoQa+wyDgQuwkSshkhlqIlWEvwvdAY27fDPunZ2cVJzXU4JyjY+5l7zs7oGLaYAQm4MbLOVFAHFBzA==
   dependencies:
     inherits "~2.0.0"
-
-qw@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
-  integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
 
 randomatic@^1.1.3:
   version "1.1.5"
@@ -8482,7 +7431,7 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
-rc@1.2.8, rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.2.7:
+rc@1.2.8, rc@^1.1.2, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -8502,50 +7451,6 @@ rcedit@^1.1.0:
   resolved "https://registry.yarnpkg.com/rcedit/-/rcedit-1.1.0.tgz#ae21c28d4efdd78e95fcab7309a5dd084920b16a"
   integrity sha512-JkXJ0IrUcdupLoIx6gE4YcFaMVSGtu7kQf4NJoDJUnfBZGuATmJ2Yal2v55KTltp+WV8dGr7A0RtOzx6jmtM6Q==
 
-read-cmd-shim@^1.0.1, read-cmd-shim@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz#2d5d157786a37c055d22077c32c53f8329e91c7b"
-  integrity sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=
-  dependencies:
-    graceful-fs "^4.1.2"
-
-read-installed@~4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/read-installed/-/read-installed-4.0.3.tgz#ff9b8b67f187d1e4c29b9feb31f6b223acd19067"
-  integrity sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=
-  dependencies:
-    debuglog "^1.0.1"
-    read-package-json "^2.0.0"
-    readdir-scoped-modules "^1.0.0"
-    semver "2 || 3 || 4 || 5"
-    slide "~1.1.3"
-    util-extend "^1.0.1"
-  optionalDependencies:
-    graceful-fs "^4.1.2"
-
-"read-package-json@1 || 2", read-package-json@^2.0.0, read-package-json@^2.0.13:
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-2.0.13.tgz#2e82ebd9f613baa6d2ebe3aa72cefe3f68e41f4a"
-  integrity sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==
-  dependencies:
-    glob "^7.1.1"
-    json-parse-better-errors "^1.0.1"
-    normalize-package-data "^2.0.0"
-    slash "^1.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.2"
-
-read-package-tree@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/read-package-tree/-/read-package-tree-5.2.2.tgz#4b6a0ef2d943c1ea36a578214c9a7f6b7424f7a8"
-  integrity sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==
-  dependencies:
-    debuglog "^1.0.1"
-    dezalgo "^1.0.0"
-    once "^1.3.0"
-    read-package-json "^2.0.0"
-    readdir-scoped-modules "^1.0.0"
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -8563,7 +7468,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-read@1, read@^1.0.7, read@~1.0.1, read@~1.0.7:
+read@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
   integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
@@ -8602,7 +7507,7 @@ read@1, read@^1.0.7, read@~1.0.1, read@~1.0.7:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^1.1.8, readable-stream@~1.1.10, readable-stream@~1.1.9:
+readable-stream@^1.1.8, readable-stream@~1.1.9:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
@@ -8645,16 +7550,6 @@ readable-stream@~2.0.0:
     process-nextick-args "~1.0.6"
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
-
-readdir-scoped-modules@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
-  integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
-  dependencies:
-    debuglog "^1.0.1"
-    dezalgo "^1.0.0"
-    graceful-fs "^4.1.2"
-    once "^1.3.0"
 
 readdirp@^2.0.0:
   version "2.1.0"
@@ -8740,21 +7635,6 @@ regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
-
-registry-auth-token@^3.0.1:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.4.0.tgz#d7446815433f5d5ed6431cd5dca21048f66b397e"
-  integrity sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==
-  dependencies:
-    rc "^1.1.6"
-    safe-buffer "^5.0.1"
-
-registry-url@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
-  integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
-  dependencies:
-    rc "^1.0.1"
 
 remap-istanbul@^0.13.0:
   version "0.13.0"
@@ -8893,7 +7773,7 @@ request@2.79.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@^2.86.0, request@^2.87.0, request@^2.88.0:
+request@^2.86.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -8991,7 +7871,7 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.10.0, resolve@^1.4.0:
+resolve@^1.4.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
@@ -9019,29 +7899,12 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-retry@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
-  integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
-
-retry@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
-  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
-
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
   integrity sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
   dependencies:
     align-text "^0.1.1"
-
-rimraf@2, rimraf@^2.5.2, rimraf@^2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
 
 rimraf@^2.2.8:
   version "2.6.1"
@@ -9188,13 +8051,6 @@ semaphore@1.0.5:
   resolved "https://registry.yarnpkg.com/semaphore/-/semaphore-1.0.5.tgz#b492576e66af193db95d65e25ec53f5f19798d60"
   integrity sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA=
 
-semver-diff@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
-  integrity sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=
-  dependencies:
-    semver "^5.0.3"
-
 semver-greatest-satisfied-range@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz#13e8c2658ab9691cb0cd71093240280d36f77a5b"
@@ -9206,11 +8062,6 @@ semver-greatest-satisfied-range@^1.1.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
   integrity sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==
-
-"semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
-  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 semver@^4.3.4:
   version "4.3.6"
@@ -9226,11 +8077,6 @@ semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
-
-semver@~5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
 send@0.16.1:
   version "0.16.1"
@@ -9318,14 +8164,6 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
-
-sha@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/sha/-/sha-2.0.1.tgz#6030822fbd2c9823949f8f72ed6411ee5cf25aae"
-  integrity sha1-YDCCL70smCOUn49y7WQR7lzyWq4=
-  dependencies:
-    graceful-fs "^4.1.2"
-    readable-stream "^2.0.2"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -9459,16 +8297,6 @@ slice-ansi@^2.0.0:
     jquery ">=1.8.0"
     jquery-ui ">=1.8.0"
 
-slide@^1.1.6, slide@~1.1.3, slide@~1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
-  integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
-
-smart-buffer@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.0.2.tgz#5207858c3815cc69110703c6b94e46c15634395d"
-  integrity sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==
-
 smart-buffer@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.0.1.tgz#07ea1ca8d4db24eb4cac86537d7d18995221ace3"
@@ -9526,14 +8354,6 @@ socks-proxy-agent@4.0.1:
     agent-base "~4.2.0"
     socks "~2.2.0"
 
-socks-proxy-agent@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz#3c8991f3145b2799e70e11bd5fbc8b1963116386"
-  integrity sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==
-  dependencies:
-    agent-base "~4.2.1"
-    socks "~2.3.2"
-
 socks@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/socks/-/socks-2.2.1.tgz#68ad678b3642fbc5d99c64c165bc561eab0215f9"
@@ -9542,33 +8362,12 @@ socks@~2.2.0:
     ip "^1.1.5"
     smart-buffer "^4.0.1"
 
-socks@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.3.2.tgz#ade388e9e6d87fdb11649c15746c578922a5883e"
-  integrity sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==
-  dependencies:
-    ip "^1.1.5"
-    smart-buffer "4.0.2"
-
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
   integrity sha1-RBttTTRnmPG05J6JIK37oOVD+a0=
   dependencies:
     is-plain-obj "^1.0.0"
-
-sorted-object@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/sorted-object/-/sorted-object-2.0.1.tgz#7d631f4bd3a798a24af1dffcfbfe83337a5df5fc"
-  integrity sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=
-
-sorted-union-stream@~2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz#c7794c7e077880052ff71a8d4a2dbb4a9a638ac7"
-  integrity sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=
-  dependencies:
-    from2 "^1.3.0"
-    stream-iterate "^1.1.0"
 
 source-list-map@^2.0.0:
   version "2.0.0"
@@ -9629,33 +8428,12 @@ spdlog@0.8.1:
     mkdirp "^0.5.1"
     nan "^2.8.0"
 
-spdx-correct@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
-  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
-  dependencies:
-    spdx-expression-parse "^3.0.0"
-    spdx-license-ids "^3.0.0"
-
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
   integrity sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=
   dependencies:
     spdx-license-ids "^1.0.2"
-
-spdx-exceptions@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
-  integrity sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
-
-spdx-expression-parse@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
-  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
 
 spdx-expression-parse@~1.0.0:
   version "1.0.4"
@@ -9667,20 +8445,10 @@ spdx-license-ids@^1.0.2:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
   integrity sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=
 
-spdx-license-ids@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz#75ecd1a88de8c184ef015eafb51b5b48bfd11bb1"
-  integrity sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==
-
 speedometer@~0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-0.1.4.tgz#9876dbd2a169d3115402d48e6ea6329c8816a50d"
   integrity sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=
-
-split-on-first@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.0.0.tgz#648af4ce9a28fbcaadd43274455f298b55025fc6"
-  integrity sha512-mjA57TQtdWztVZ9THAjGNpgbuIrNfsNrGa5IyK94NoPaT4N14M+GI4jD7t4arLjFkYRQWdETC5RxFzLWouoB3A==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -9730,13 +8498,6 @@ ssri@^5.2.4:
   integrity sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==
   dependencies:
     safe-buffer "^5.1.1"
-
-ssri@^6.0.0, ssri@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
-  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
-  dependencies:
-    figgy-pudding "^3.5.1"
 
 stack-trace@0.0.10:
   version "0.0.10"
@@ -9800,14 +8561,6 @@ stream-http@^2.7.2:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
-stream-iterate@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/stream-iterate/-/stream-iterate-1.2.0.tgz#2bd7c77296c1702a46488b8ad41f79865eecd4e1"
-  integrity sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=
-  dependencies:
-    readable-stream "^2.1.5"
-    stream-shift "^1.0.0"
-
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
@@ -9829,11 +8582,6 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
@@ -9877,11 +8625,6 @@ string_decoder@~1.0.3:
   integrity sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==
   dependencies:
     safe-buffer "~5.1.0"
-
-stringify-package@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.0.tgz#e02828089333d7d45cd8c287c30aa9a13375081b"
-  integrity sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==
 
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
@@ -10079,15 +8822,6 @@ tar-stream@^1.1.2:
     to-buffer "^1.1.0"
     xtend "^4.0.0"
 
-tar@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
-  integrity sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=
-  dependencies:
-    block-stream "*"
-    fstream "^1.0.2"
-    inherits "2"
-
 tar@^4:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
@@ -10097,19 +8831,6 @@ tar@^4:
     fs-minipass "^1.2.5"
     minipass "^2.3.3"
     minizlib "^1.1.0"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.2"
-
-tar@^4.4.8:
-  version "4.4.8"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
-  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.3.4"
-    minizlib "^1.1.1"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
@@ -10138,13 +8859,6 @@ temp@^0.8.3:
   dependencies:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
-
-term-size@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
-  integrity sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
-  dependencies:
-    execa "^0.7.0"
 
 text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
@@ -10209,7 +8923,7 @@ through2@~0.4.0:
     readable-stream "~1.0.17"
     xtend "~2.1.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.8:
+through@2, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -10219,22 +8933,12 @@ time-stamp@^1.0.0:
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
   integrity sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
 
-timed-out@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
-  integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
-
 timers-browserify@^2.0.4:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
   integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
-
-tiny-relative-date@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz#fa08aad501ed730f31cc043181d995c39a935e07"
-  integrity sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==
 
 tmp@0.0.28:
   version "0.0.28"
@@ -10569,20 +9273,10 @@ uglifyjs-webpack-plugin@^1.2.4:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
-uid-number@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
-  integrity sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=
-
 ultron@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
   integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
-
-umask@^1.1.0, umask@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
-  integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
 
 unc-path-regex@^0.1.0, unc-path-regex@^0.1.2:
   version "0.1.2"
@@ -10653,13 +9347,6 @@ unique-filename@^1.1.0:
   dependencies:
     unique-slug "^2.0.0"
 
-unique-filename@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
-  integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
-  dependencies:
-    unique-slug "^2.0.0"
-
 unique-slug@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.0.tgz#db6676e7c7cc0629878ff196097c78855ae9f4ab"
@@ -10674,13 +9361,6 @@ unique-stream@^2.0.2:
   dependencies:
     json-stable-stringify "^1.0.0"
     through2-filter "^2.0.0"
-
-unique-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
-  integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
-  dependencies:
-    crypto-random-string "^1.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -10700,31 +9380,10 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-unzip-response@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
-  integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
-
 upath@^1.0.5, upath@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
   integrity sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==
-
-update-notifier@^2.3.0, update-notifier@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
-  integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==
-  dependencies:
-    boxen "^1.2.1"
-    chalk "^2.0.1"
-    configstore "^3.0.0"
-    import-lazy "^2.1.0"
-    is-ci "^1.0.10"
-    is-installed-globally "^0.1.0"
-    is-npm "^1.0.0"
-    latest-version "^3.0.0"
-    semver-diff "^2.0.0"
-    xdg-basedir "^3.0.0"
 
 uri-js@^4.2.1, uri-js@^4.2.2:
   version "4.2.2"
@@ -10742,13 +9401,6 @@ url-join@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
   integrity sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=
-
-url-parse-lax@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
-  integrity sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=
-  dependencies:
-    prepend-http "^1.0.1"
 
 url@^0.11.0:
   version "0.11.0"
@@ -10774,11 +9426,6 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-
-util-extend@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f"
-  integrity sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=
 
 util@0.10.3, "util@>=0.10.3 <1":
   version "0.10.3"
@@ -10840,21 +9487,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
-
-validate-npm-package-license@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
-  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
-  dependencies:
-    spdx-correct "^3.0.0"
-    spdx-expression-parse "^3.0.0"
-
-validate-npm-package-name@^3.0.0, validate-npm-package-name@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
-  integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
-  dependencies:
-    builtins "^1.0.3"
 
 validator@~9.4.1:
   version "9.4.1"
@@ -11189,13 +9821,6 @@ watchpack@^1.5.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
-wcwidth@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
-  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
-  dependencies:
-    defaults "^1.0.3"
-
 webpack-cli@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.1.0.tgz#d71a83687dcfeb758fdceeb0fe042f96bcf62994"
@@ -11287,17 +9912,17 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@1, which@^1.2.14, which@^1.3.0, which@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
-  dependencies:
-    isexe "^2.0.0"
-
 which@^1.1.1, which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   integrity sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.2.14:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
@@ -11307,13 +9932,6 @@ wide-align@^1.1.0:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
-
-widest-line@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc"
-  integrity sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==
-  dependencies:
-    string-width "^2.1.1"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -11355,7 +9973,7 @@ wordwrap@~0.0.2:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
   integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
 
-worker-farm@^1.5.2, worker-farm@^1.6.0:
+worker-farm@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0"
   integrity sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==
@@ -11375,15 +9993,6 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
-  integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
-  dependencies:
-    graceful-fs "^4.1.11"
-    imurmurhash "^0.1.4"
-    signal-exit "^3.0.2"
-
 write@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
@@ -11399,11 +10008,6 @@ ws@^3.3.3:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
-
-xdg-basedir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
-  integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
 
 xml-name-validator@^1.0.0:
   version "1.0.0"
@@ -11508,13 +10112,6 @@ yargs-parser@^8.1.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
-  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
-  dependencies:
-    camelcase "^4.1.0"
-
 yargs@^10.1.1:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
@@ -11532,24 +10129,6 @@ yargs@^10.1.1:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
-
-yargs@^11.0.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
-  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
 
 yargs@^12.0.1:
   version "12.0.1"


### PR DESCRIPTION
changes to setEnvironmentVariables.js to print environment variables that need to be set without invoking lanch vscode or a new command-shell. 

These change adds a new command line option ENV that when provided to setEnvironmentVariables.js skips launching VSCode or a new command shell.