### PR TITLE
Fixed agent filter in dark theme

### DIFF
--- a/src/sql/base/browser/ui/table/media/table.css
+++ b/src/sql/base/browser/ui/table/media/table.css
@@ -156,3 +156,7 @@ label {
 .hc-black .slick-header-menu > input.input {
     color: #000000;
 }
+
+.vs-dark .slick-header-menu {
+    color: #FFFFFF;
+}

--- a/src/sql/base/browser/ui/table/media/table.css
+++ b/src/sql/base/browser/ui/table/media/table.css
@@ -157,6 +157,7 @@ label {
     color: #000000;
 }
 
-.vs-dark .slick-header-menu {
+.vs-dark .slick-header-menu,
+.hc-black .slick-header-menu {
     color: #FFFFFF;
 }


### PR DESCRIPTION
There was a regression where the text on header filters weren't themed right for text.

Before -

![before](https://user-images.githubusercontent.com/6411451/56235626-a12e9680-603c-11e9-8d91-df349839aa81.JPG)

After -

![afterchange](https://user-images.githubusercontent.com/6411451/56235634-a55ab400-603c-11e9-975d-0cfe1297229e.JPG)
