### PR TITLE
Notebooks: Improve table markdown css

### DIFF
--- a/src/sql/workbench/parts/notebook/cellViews/textCell.css
+++ b/src/sql/workbench/parts/notebook/cellViews/textCell.css
@@ -16,3 +16,35 @@ text-cell-component .notebook-preview {
 .notebook-preview.actionselect {
 	user-select: text;
 }
+
+text-cell-component table {
+	border-collapse: collapse;
+	border-spacing: 0;
+	border: none;
+	font-size: 12px;
+	table-layout: auto;
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 1em;
+	display: table-row;
+ }
+
+ text-cell-component thead {
+	vertical-align: bottom;
+ }
+
+ text-cell-component td,
+ text-cell-component th,
+ text-cell-component tr {
+	text-align: left;
+	vertical-align: middle;
+	padding: 0.5em 0.5em;
+	line-height: normal;
+	white-space: normal;
+	max-width: none;
+	border: none;
+ }
+
+ text-cell-component th {
+	font-weight: bold;
+ }

--- a/src/sql/workbench/parts/notebook/notebookStyles.ts
+++ b/src/sql/workbench/parts/notebook/notebookStyles.ts
@@ -6,7 +6,7 @@ import 'vs/css!./notebook';
 
 import { registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
 import { SIDE_BAR_BACKGROUND, SIDE_BAR_SECTION_HEADER_BACKGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND } from 'vs/workbench/common/theme';
-import { activeContrastBorder, contrastBorder, buttonBackground, textLinkForeground, editorBackground } from 'vs/platform/theme/common/colorRegistry';
+import { activeContrastBorder, contrastBorder, buttonBackground, textLinkForeground } from 'vs/platform/theme/common/colorRegistry';
 import { IDisposable } from 'vscode-xterm';
 import { editorLineHighlight, editorLineHighlightBorder } from 'vs/editor/common/view/editorColorRegistry';
 
@@ -182,6 +182,16 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean): IDi
 				text-decoration: none;
 				font-weight: bold;
 				color: ${linkForeground};
+			}
+			`);
+		}
+
+		// Styling for tables in notebooks
+		const borderColor = theme.getColor(SIDE_BAR_BACKGROUND);
+		if (borderColor) {
+			collector.addRule(`
+			.notebookEditor text-cell-component tbody tr:nth-child(odd) {
+				background: ${borderColor};
 			}
 			`);
 		}


### PR DESCRIPTION
Fixes #4906.

Before:
![image](https://user-images.githubusercontent.com/40371649/56330126-90b11580-613b-11e9-89f0-7f7501310df4.png)


After:
<img width="1308" alt="image" src="https://user-images.githubusercontent.com/40371649/56330115-8727ad80-613b-11e9-876c-76c84037e060.png">
