### PR TITLE
Only show nb loading spinner when no cells shown

### DIFF
--- a/src/sql/workbench/parts/notebook/notebook.component.ts
+++ b/src/sql/workbench/parts/notebook/notebook.component.ts
@@ -222,7 +222,6 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		try {
 			await this.setNotebookManager();
 			await this.loadModel();
-			this.setLoading(false);
 			this._modelReadyDeferred.resolve(this._model);
 		} catch (error) {
 			this.setViewInErrorState(localize('displayFailed', 'Could not display contents: {0}', notebookUtils.getErrorMessage(error)));
@@ -260,6 +259,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		model.contentChanged((change) => this.handleContentChanged(change));
 		model.onProviderIdChange((provider) => this.handleProviderIdChanged(provider));
 		this._model = this._register(model);
+		this.setLoading(false);
 		this.updateToolbarComponents(this._model.trustedMode);
 		this._modelRegisteredDeferred.resolve(this._model);
 		await model.startSession(this.model.notebookManager, undefined, true);


### PR DESCRIPTION
Fixes #4969. Instead of waiting for the session to start, only show the loading spinner when the model isn't created with cell information.

This is in relation to feedback that we got around the loading spinner being redundant when the kernel/attach to dropdown showed "loading" and cells being rendered.