### PR TITLE
Show correct release notes for command

### DIFF
--- a/src/vs/workbench/contrib/update/electron-browser/update.ts
+++ b/src/vs/workbench/contrib/update/electron-browser/update.ts
@@ -73,11 +73,14 @@ export abstract class AbstractShowReleaseNotesAction extends Action {
 
 		this.enabled = false;
 
-		return showReleaseNotes(this.instantiationService, this.version)
-			.then(undefined, () => {
-				const action = this.instantiationService.createInstance(OpenLatestReleaseNotesInBrowserAction);
-				return action.run().then(() => false);
-			});
+		// {{SQL CARBON EDIT}}
+		// return showReleaseNotes(this.instantiationService, this.version)
+		// .then(undefined, () => {
+		// 	const action = this.instantiationService.createInstance(OpenLatestReleaseNotesInBrowserAction);
+		// 	return action.run().then(() => false);
+		// });
+		const action = this.instantiationService.createInstance(OpenLatestReleaseNotesInBrowserAction);
+		return action.run().then(() => true);
 	}
 }
 


### PR DESCRIPTION
Fix #5105 #2386 Show Release Notes command was using the VS Code showReleaseNotes code for displaying the notes in a new window - but this is currently hardcoded to always show VS Code release notes. Until we can update that code to download our release notes and show those instead changing the command action to just open the release notes in the browser (which uses the correct URL specified in our config).

Note that while I would have preferred to change the contribution to use the OpenLatestReleaseNotesInBrowserAction instead that action doesn't have the correct constructor to directly replace the ShowCurrentReleaseNotesAction and so to minimize changes I instead changed that action to just run the OpenLatestReleaseNotesInBrowserAction.