### PR TITLE
Typings reference failing in external extension

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -3705,7 +3705,7 @@ declare module 'azdata' {
 			| 'executionPlan';
 
 		export interface QueryEventListener {
-			onQueryEvent(type: QueryEvent, document: queryeditor.QueryDocument, args: any);
+			onQueryEvent(type: QueryEvent, document: queryeditor.QueryDocument, args: any): void;
 		}
 
 		// new extensibility interfaces


### PR DESCRIPTION
This fixes an issue where if you copy azdata.proposed.d.ts to
an extension project, it would fail to compile using default
tsconfig.json settings due to missing return type