### PR TITLE
Show an Install Skipped message when Python already exists at the specified install location.

### DIFF
--- a/extensions/notebook/src/common/apiWrapper.ts
+++ b/extensions/notebook/src/common/apiWrapper.ts
@@ -44,6 +44,10 @@ export class ApiWrapper {
 		return vscode.window.showErrorMessage(message, ...items);
 	}
 
+	public showInfoMessage(message: string, ...items: string[]): Thenable<string | undefined> {
+		return vscode.window.showInformationMessage(message, ...items);
+	}
+
 	public showOpenDialog(options: vscode.OpenDialogOptions): Thenable<vscode.Uri[] | undefined> {
 		return vscode.window.showOpenDialog(options);
 	}

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -33,6 +33,7 @@ const msgInstallPkgStart = localize('msgInstallPkgStart', "Installing Notebook d
 const msgInstallPkgFinish = localize('msgInstallPkgFinish', "Notebook dependencies installation is complete");
 const msgPythonRunningError = localize('msgPythonRunningError', "Cannot overwrite existing Python installation while python is running.");
 const msgPendingInstallError = localize('msgPendingInstallError', "Another Python installation is currently in progress.");
+const msgSkipPythonInstall = localize('msgSkipPythonInstall', "Python already exists at the specific location. Skipping install.");
 function msgDependenciesInstallationFailed(errorMessage: string): string { return localize('msgDependenciesInstallationFailed', "Installing Notebook dependencies failed with error: {0}", errorMessage); }
 function msgDownloadPython(platform: string, pythonDownloadUrl: string): string { return localize('msgDownloadPython', "Downloading local python for platform: {0} to {1}", platform, pythonDownloadUrl); }
 
@@ -298,6 +299,8 @@ export default class JupyterServerInstallation {
 			// so update it here
 			await updateConfig();
 			installReady.resolve();
+			this._installInProgress = false;
+			this.apiWrapper.showInfoMessage(msgSkipPythonInstall);
 		}
 		return installReady.promise;
 	}


### PR DESCRIPTION
Also fixed a bug where future installs would get blocked after doing an install that gets skipped.