### PR TITLE
Fix casing on welcome page to be consistent

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -39,11 +39,11 @@ export default () => `
 				<div class="section help">
 					<h2 class="caption">${escape(localize('welcomePage.help', "Help"))}</h2>
 					<ul>
-						<li><a href="https://aka.ms/get-started-azdata">${escape(localize('welcomePage.gettingStarted', "Getting Started"))}</a></li>
+						<li><a href="https://aka.ms/get-started-azdata">${escape(localize('welcomePage.gettingStarted', "Getting started"))}</a></li>
 						<li><a href="https://aka.ms/azuredatastudio">${escape(localize('welcomePage.productDocumentation', "Documentation"))}</a></li>
 						<li><a href="https://github.com/Microsoft/azuredatastudio/issues/new/choose">${escape(localize('welcomePage.reportIssue', "Report issue or feature request"))}</a></li>
 						<li><a href="https://github.com/Microsoft/azuredatastudio">${escape(localize('welcomePage.gitHubRepository', "GitHub repository"))}</a></li>
-						<li><a href="https://aka.ms/azdata-releasenotes">${escape(localize('welcomePage.releaseNotes', "Release Notes"))}</a></li>
+						<li><a href="https://aka.ms/azdata-releasenotes">${escape(localize('welcomePage.releaseNotes', "Release notes"))}</a></li>
 					</ul>
 				</div>
 				<p class="showOnStartup"><input type="checkbox" id="showOnStartup" class="checkbox"> <label class="caption" for="showOnStartup">${escape(localize('welcomePage.showOnStartup', "Show welcome page on startup"))}</label></p>


### PR DESCRIPTION
Fix #5165.

Before:
![image](https://user-images.githubusercontent.com/40371649/56626149-593be080-65f5-11e9-8ade-fcb0afe35df9.png)

After:
![image](https://user-images.githubusercontent.com/40371649/56626133-45907a00-65f5-11e9-8ad7-50beb37c9136.png)
