### PR TITLE
Change default folder in dacpac and schema compare extensions

### DIFF
--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -147,10 +147,17 @@ export abstract class DacFxConfigPage extends BasePage {
 	}
 
 	protected generateFilePath(): string {
+		return path.join(this.getRootPath(), this.model.database + '-' + this.getDateTime() + this.fileExtension);
+	}
+
+	protected getDateTime(): string {
 		let now = new Date();
-		let datetime = now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + '-' + now.getHours() + '-' + now.getMinutes();
-		let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
-		return path.join(rootPath, this.model.database + '-' + datetime + this.fileExtension);
+		return now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + '-' + now.getHours() + '-' + now.getMinutes();
+	}
+
+	protected getRootPath(): string {
+		// return rootpath of opened folder in file explorer if one is open, otherwise default to user home directory
+		return vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
 	}
 }
 

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -102,7 +102,7 @@ export abstract class DacFxConfigPage extends BasePage {
 		// Handle database changes
 		this.databaseDropdown.onValueChanged(async () => {
 			this.model.database = (<azdata.CategoryValue>this.databaseDropdown.value).name;
-			this.fileTextBox.value = this.generateFilePath();
+			this.fileTextBox.value = this.generateFilePathFromDatabaseAndTimestamp();
 			this.model.filePath = this.fileTextBox.value;
 		});
 
@@ -125,7 +125,7 @@ export abstract class DacFxConfigPage extends BasePage {
 
 		let values = await this.getDatabaseValues();
 		this.model.database = values[0].name;
-		this.model.filePath = this.generateFilePath();
+		this.model.filePath = this.generateFilePathFromDatabaseAndTimestamp();
 		this.fileTextBox.value = this.model.filePath;
 
 		this.databaseDropdown.updateProperties({
@@ -146,7 +146,7 @@ export abstract class DacFxConfigPage extends BasePage {
 		}).component();
 	}
 
-	protected generateFilePath(): string {
+	protected generateFilePathFromDatabaseAndTimestamp(): string {
 		return path.join(this.getRootPath(), this.model.database + '-' + this.getDateTime() + this.fileExtension);
 	}
 

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -6,6 +6,7 @@
 
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
+import * as vscode from 'vscode';
 import * as os from 'os';
 import * as path from 'path';
 import { DataTierApplicationWizard } from '../dataTierApplicationWizard';
@@ -148,7 +149,8 @@ export abstract class DacFxConfigPage extends BasePage {
 	protected generateFilePath(): string {
 		let now = new Date();
 		let datetime = now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + '-' + now.getHours() + '-' + now.getMinutes();
-		return path.join(os.homedir(), this.model.database + '-' + datetime + this.fileExtension);
+		let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
+		return path.join(rootPath, this.model.database + '-' + datetime + this.fileExtension);
 	}
 }
 

--- a/extensions/dacpac/src/wizard/pages/deployActionPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployActionPage.ts
@@ -167,10 +167,7 @@ export class DeployActionPage extends DacFxConfigPage {
 	}
 
 	private setDefaultScriptFilePath(): void {
-		let now = new Date();
-		let datetime = now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + '-' + now.getHours() + '-' + now.getMinutes();
-		let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
-		this.fileTextBox.value = path.join(rootPath, this.model.database + '_UpgradeDACScript_' + datetime + '.sql');
+		this.fileTextBox.value = path.join(this.getRootPath(), this.model.database + '_UpgradeDACScript_' + this.getDateTime() + '.sql');
 		this.model.scriptFilePath = this.fileTextBox.value;
 	}
 

--- a/extensions/dacpac/src/wizard/pages/deployActionPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployActionPage.ts
@@ -169,7 +169,8 @@ export class DeployActionPage extends DacFxConfigPage {
 	private setDefaultScriptFilePath(): void {
 		let now = new Date();
 		let datetime = now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + '-' + now.getHours() + '-' + now.getMinutes();
-		this.fileTextBox.value = path.join(os.homedir(), this.model.database + '_UpgradeDACScript_' + datetime + '.sql');
+		let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
+		this.fileTextBox.value = path.join(rootPath, this.model.database + '_UpgradeDACScript_' + datetime + '.sql');
 		this.model.scriptFilePath = this.fileTextBox.value;
 	}
 

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -67,12 +67,13 @@ export class DeployConfigPage extends DacFxConfigPage {
 		this.createFileBrowserParts();
 
 		this.fileButton.onDidClick(async (click) => {
+			let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
 			let fileUris = await vscode.window.showOpenDialog(
 				{
 					canSelectFiles: true,
 					canSelectFolders: false,
 					canSelectMany: false,
-					defaultUri: vscode.Uri.file(os.homedir()),
+					defaultUri: vscode.Uri.file(rootPath),
 					openLabel: localize('dacFxDeploy.openFile', 'Open'),
 					filters: {
 						'dacpac Files': ['dacpac'],

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -67,13 +67,12 @@ export class DeployConfigPage extends DacFxConfigPage {
 		this.createFileBrowserParts();
 
 		this.fileButton.onDidClick(async (click) => {
-			let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
 			let fileUris = await vscode.window.showOpenDialog(
 				{
 					canSelectFiles: true,
 					canSelectFolders: false,
 					canSelectMany: false,
-					defaultUri: vscode.Uri.file(rootPath),
+					defaultUri: vscode.Uri.file(this.getRootPath()),
 					openLabel: localize('dacFxDeploy.openFile', 'Open'),
 					filters: {
 						'dacpac Files': ['dacpac'],

--- a/extensions/dacpac/src/wizard/pages/exportConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/exportConfigPage.ts
@@ -65,7 +65,7 @@ export class ExportConfigPage extends DacFxConfigPage {
 		this.createFileBrowserParts();
 
 		// default filepath
-		this.fileTextBox.value = this.generateFilePath();
+		this.fileTextBox.value = this.generateFilePathFromDatabaseAndTimestamp();
 		this.model.filePath = this.fileTextBox.value;
 
 		this.fileButton.onDidClick(async (click) => {

--- a/extensions/dacpac/src/wizard/pages/extractConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/extractConfigPage.ts
@@ -68,7 +68,7 @@ export class ExtractConfigPage extends DacFxConfigPage {
 		this.createFileBrowserParts();
 
 		// default filepath
-		this.fileTextBox.value = this.generateFilePath();
+		this.fileTextBox.value = this.generateFilePathFromDatabaseAndTimestamp();
 		this.model.filePath = this.fileTextBox.value;
 
 		this.fileButton.onDidClick(async (click) => {

--- a/extensions/dacpac/src/wizard/pages/importConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/importConfigPage.ts
@@ -57,13 +57,12 @@ export class ImportConfigPage extends DacFxConfigPage {
 		this.createFileBrowserParts();
 
 		this.fileButton.onDidClick(async (click) => {
-			let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
 			let fileUris = await vscode.window.showOpenDialog(
 				{
 					canSelectFiles: true,
 					canSelectFolders: false,
 					canSelectMany: false,
-					defaultUri: vscode.Uri.file(rootPath),
+					defaultUri: vscode.Uri.file(this.getRootPath()),
 					openLabel: localize('dacFxImport.openFile', 'Open'),
 					filters: {
 						'bacpac Files': ['bacpac'],

--- a/extensions/dacpac/src/wizard/pages/importConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/importConfigPage.ts
@@ -57,12 +57,13 @@ export class ImportConfigPage extends DacFxConfigPage {
 		this.createFileBrowserParts();
 
 		this.fileButton.onDidClick(async (click) => {
+			let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
 			let fileUris = await vscode.window.showOpenDialog(
 				{
 					canSelectFiles: true,
 					canSelectFolders: false,
 					canSelectMany: false,
-					defaultUri: vscode.Uri.file(os.homedir()),
+					defaultUri: vscode.Uri.file(rootPath),
 					openLabel: localize('dacFxImport.openFile', 'Open'),
 					filters: {
 						'bacpac Files': ['bacpac'],

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -208,12 +208,13 @@ export class SchemaCompareDialog {
 		let currentButton = isTarget ? this.targetFileButton : this.sourceFileButton;
 
 		currentButton.onDidClick(async (click) => {
+			let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
 			let fileUris = await vscode.window.showOpenDialog(
 				{
 					canSelectFiles: true,
 					canSelectFolders: false,
 					canSelectMany: false,
-					defaultUri: vscode.Uri.file(os.homedir()),
+					defaultUri: vscode.Uri.file(rootPath),
 					openLabel: localize('schemaCompare.openFile', 'Open'),
 					filters: {
 						'dacpac Files': ['dacpac'],

--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -291,7 +291,8 @@ export class SchemaCompareResult {
 			// get file path
 			let now = new Date();
 			let datetime = now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate() + '-' + now.getHours() + '-' + now.getMinutes() + '-' + now.getSeconds();
-			let defaultFilePath = path.join(os.homedir(), this.targetName + '_Update_' + datetime + '.sql');
+			let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
+			let defaultFilePath = path.join(rootPath, this.targetName + '_Update_' + datetime + '.sql');
 			let fileUri = await vscode.window.showSaveDialog(
 				{
 					defaultUri: vscode.Uri.file(defaultFilePath),


### PR DESCRIPTION
This changes the default folder in the dacpac and schema compare extensions to be the root path opened in the file explorer if a folder is open, otherwise the default is the user's home folder. 

Fixes  #4457