### PR TITLE
Fixed #4947 and #3425 Increase the size of the notebook command icons and space…

### DIFF
--- a/src/sql/workbench/parts/notebook/notebook.css
+++ b/src/sql/workbench/parts/notebook/notebook.css
@@ -22,23 +22,25 @@
 }
 
 .notebookEditor .actionbar-container .monaco-action-bar > ul.actions-container {
-	padding-top: 0px;
+	padding-top: 4px;
+	padding-bottom: 4px;
 }
 
-.notebookEditor .notebook-button {
+.notebookEditor .actions-container .action-item .notebook-button {
 	display: inline-block;
 	width: 100%;
 	padding: 0px;
 	text-align: center;
 	cursor: pointer;
-	padding-left: 15px;
+	padding-left: 18px;
 	background-size: 13px;
-	margin-right: 0.3em;
-	font-size: 13px;
+	margin-right: 20px;
+	font-size: 11px;
 }
 
-.notebookEditor .monaco-select-box {
+.notebookEditor .labelOnLeftContainer {
 	min-width: 100px;
+	margin-right: 20px;
 }
 
 .notebookEditor .notebook-button.icon-add{


### PR DESCRIPTION
Fixed #4947 and #3425
- Increase the size of the notebook command icons
- Increase the space between icon and button
- Increase the top and bottom patting of toolbar
  After
![image](https://user-images.githubusercontent.com/43652751/56838434-c7b9b200-6832-11e9-9ba1-d39bc7eaf234.png)

  Before:
  ![image](https://user-images.githubusercontent.com/43652751/56838436-cd16fc80-6832-11e9-877e-a3a32115e958.png)
