### PR TITLE
Load MSSQL extension first during eager load phase

### DIFF
--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -409,7 +409,20 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 	// -- eager activation
 
 	// Handle "eager" activation extensions
-	private _handleEagerExtensions(): Promise<void> {
+	private async _handleEagerExtensions(): Promise<void> {
+		// {{SQL CARBON EDIT}} - load MSSQL extension first so it doesn't get delayed by other extensions
+		try {
+			await this._activateById(new ExtensionIdentifier('microsoft.mssql'), new ExtensionActivatedByEvent(true, `Load MSSQL extension first on startup`));
+		} catch (err) {
+			console.error(err);
+		}
+
+		return this._defaultHandleEagerExtensions();
+	}
+
+
+	// Handle "eager" activation extensions
+	private _defaultHandleEagerExtensions(): Promise<void> {
 		this._activateByEvent('*', true).then(undefined, (err) => {
 			console.error(err);
 		});


### PR DESCRIPTION
This PR forces MSSQL extension to load first during eager load phase to prevent other extensions from causing delays during startup.  It still seems like there is a some delay between `activate` and when the SQL Tools Services launches, but I think that optimization will need to be in the Service Loader component.  While this doesn't seem to make a huge difference I don't see a downside to the change other than further special-casing MSSQL.