### PR TITLE
Notebooks: More Jupyter Server Hardening

### DIFF
--- a/extensions/notebook/src/common/ports.ts
+++ b/extensions/notebook/src/common/ports.ts
@@ -7,7 +7,7 @@
 import * as net from 'net';
 
 export class StrictPortFindOptions {
-	constructor(public startPort: number, public minPort: number, public maxport: number) {
+	constructor(public minPort: number, public maxport: number) {
 	}
 	public maxRetriesPerStartPort: number = 5;
 	public totalRetryLoops: number = 10;
@@ -21,7 +21,7 @@ export class StrictPortFindOptions {
  */
 export async function strictFindFreePort(options: StrictPortFindOptions): Promise<number> {
 	let totalRetries = options.totalRetryLoops;
-	let startPort = options.startPort;
+	let startPort = getRandomInt(options.minPort, options.maxport);
 	let port = await findFreePort(startPort, options.maxRetriesPerStartPort, options.timeout);
 	while (port === 0 && totalRetries > 0) {
 		startPort = getRandomInt(options.minPort, options.maxport);

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -80,16 +80,17 @@ export class ServerInstanceUtils {
 		if (!childProcess) {
 			return;
 		}
-		// Wait 5 seconds and then force kill. Jupyter stop is slow so this seems a reasonable time limit
+		// Wait 3 seconds and then force kill. Jupyter stop is slow so this seems a reasonable time limit
 		setTimeout(() => {
 			// Test if the process is still alive. Throws an exception if not
 			try {
 				process.kill(childProcess.pid, 'SIGKILL');
 			} catch (error) {
-				console.log(error);
-				// All is fine.
+				if (!error || !error.code || (typeof error.code === 'string' && error.code !== 'ESRCH')) {
+					console.log(error);
+				}
 			}
-		}, 5000);
+		}, 3000);
 	}
 }
 
@@ -230,8 +231,8 @@ export class PerNotebookServerInstance implements IServerInstance {
 			return;
 		}
 		let notebookDirectory = this.getNotebookDirectory();
-		// Find a port in a given range. If run into trouble, got up 100 in range and search inside a larger range
-		let port = await ports.strictFindFreePort(new ports.StrictPortFindOptions(defaultPort, defaultPort + 100, defaultPort + 1000));
+		// Find a port in a given range. If run into trouble, try another port inside the given range
+		let port = await ports.strictFindFreePort(new ports.StrictPortFindOptions(defaultPort, defaultPort + 1000));
 		let token = await notebookUtils.getRandomToken();
 		this._uri = vscode.Uri.parse(`http://localhost:${port}/?token=${token}`);
 		this._port = port.toString();

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -80,7 +80,7 @@ export class ServerInstanceUtils {
 		if (!childProcess) {
 			return;
 		}
-		// Wait 3 seconds and then force kill. Jupyter stop is slow so this seems a reasonable time limit
+		// Wait 5 seconds and then force kill. Jupyter stop is slow so this seems a reasonable time limit
 		setTimeout(() => {
 			// Test if the process is still alive. Throws an exception if not
 			try {
@@ -90,7 +90,7 @@ export class ServerInstanceUtils {
 					console.log(error);
 				}
 			}
-		}, 3000);
+		}, 5000);
 	}
 }
 

--- a/extensions/notebook/src/test/common/port.test.ts
+++ b/extensions/notebook/src/test/common/port.test.ts
@@ -39,7 +39,7 @@ describe('Ports', () => {
 		this.timeout(1000 * 10); // higher timeout for this test
 
 		// get an initial freeport >= 7000
-		let options = new ports.StrictPortFindOptions(7000, 7100, 7200);
+		let options = new ports.StrictPortFindOptions(7000, 7200);
 		options.timeout = 300000;
 		ports.strictFindFreePort(options).then(initialPort => {
 			assert.ok(initialPort >= 7000);
@@ -49,7 +49,7 @@ describe('Ports', () => {
 			server.listen(initialPort, undefined, undefined, () => {
 
 				// once listening, find another free port and assert that the port is different from the opened one
-				options.startPort = initialPort;
+				options.minPort = initialPort;
 				options.maxRetriesPerStartPort = 1;
 				options.totalRetryLoops = 50;
 				ports.strictFindFreePort(options).then(freePort => {

--- a/src/sql/workbench/api/node/extHostNotebook.ts
+++ b/src/sql/workbench/api/node/extHostNotebook.ts
@@ -117,6 +117,10 @@ export class ExtHostNotebook implements ExtHostNotebookShape {
 	}
 
 	$shutdownSession(managerHandle: number, sessionId: string): Thenable<void> {
+		// If manager handle has already been removed, don't try to access it again when shutting down
+		if (this._adapters.get(managerHandle) === undefined) {
+			return undefined;
+		}
 		return this._withSessionManager(managerHandle, async (sessionManager) => {
 			return sessionManager.shutdown(sessionId);
 		});


### PR DESCRIPTION
More hardening around Jupyter server:
- Do not always start at port 8888 (can cause 403 issues in rare cases [should be extremely rare now after last batch of fixes])
- Only log errors around killing the jupyter process when an exception isn't expected: http://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html [ESRCH]
No process or process group can be found corresponding to that specified by pid.

This means that #4822 should be extremely unlikely to happen, if the current understanding is correct.