### PR TITLE
Fix "Open File Location" for CSV Export

### DIFF
--- a/src/sql/workbench/common/workspaceActions.ts
+++ b/src/sql/workbench/common/workspaceActions.ts
@@ -14,7 +14,7 @@ export class ShowFileInFolderAction extends Action {
 	}
 
 	run(): Promise<void> {
-		return this.windowsService.showItemInFolder(URI.parse(this.path));
+		return this.windowsService.showItemInFolder(URI.file(this.path));
 	}
 }
 


### PR DESCRIPTION
Fix #5177 - File path wasn't being parsed correctly, URI.file should be used for full file paths. 