### PR TITLE
Fix path to dark icon of schema compare options button

### DIFF
--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -417,7 +417,7 @@ export class SchemaCompareResult {
 			label: localize('schemaCompare.optionsButton', 'Options'),
 			iconPath: {
 				light: path.join(__dirname, 'media', 'options.svg'),
-				dark: path.join(__dirname, 'media', 'options_reverse.svg')
+				dark: path.join(__dirname, 'media', 'options-inverse.svg')
 			},
 			title: localize('schemaCompare.optionsButtonTitle', 'Options')
 		}).component();


### PR DESCRIPTION
The icon for options for dark theme wasn't showing because the path was incorrect:
![image](https://user-images.githubusercontent.com/31145923/56980694-dacdca00-6b31-11e9-9d86-146844ea65d0.png)

This is how the dark theme icon looks:
![image](https://user-images.githubusercontent.com/31145923/56980767-15376700-6b32-11e9-9e03-87c34cdd6b18.png)

