### PR TITLE
Fix Account deletion ignoring "No" confirmation

### DIFF
--- a/src/sql/platform/accounts/common/accountActions.ts
+++ b/src/sql/platform/accounts/common/accountActions.ts
@@ -87,7 +87,7 @@ export class RemoveAccountAction extends Action {
 		};
 
 		return this._dialogService.confirm(confirm).then(result => {
-			if (!result) {
+			if (!result || !result.confirmed) {
 				return Promise.resolve(false);
 			} else {
 				return Promise.resolve(this._accountManagementService.removeAccount(this._account.key)).catch(err => {


### PR DESCRIPTION
Fix #4553 - the check wasn't correctly checking returned result