### PR TITLE
Update dropdown.ts

### DIFF
--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -242,13 +242,6 @@ export class Dropdown extends Disposable {
 							this._treeContainer.remove();
 						}
 					};
-				},
-				onDOMEvent: e => {
-					if (!DOM.isAncestor((<HTMLElement>e.target), this._el) && !DOM.isAncestor((<HTMLElement>e.target), this._treeContainer)) {
-						this._input.validate();
-						this._onBlur.fire();
-						this.contextViewService.hideContextView();
-					}
 				}
 			});
 		}
@@ -280,6 +273,7 @@ export class Dropdown extends Disposable {
 			this._treeContainer.style.width = DOM.getContentWidth(this._inputContainer) - 2 + 'px';
 			this._tree.layout(parseInt(this._treeContainer.style.height));
 			this._tree.setInput(new DropdownModel());
+			this._input.validate();
 		}
 	}
 

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -219,6 +219,7 @@ export class Dropdown extends Disposable {
 
 		this.onBlur(() => {
 			this.contextViewService.hideContextView();
+			this._input.validate();
 		});
 
 		this._register(this._tree);
@@ -241,6 +242,13 @@ export class Dropdown extends Disposable {
 							this._treeContainer.remove();
 						}
 					};
+				},
+				onDOMEvent: e => {
+					if (!DOM.isAncestor((<HTMLElement>e.target), this._el) && !DOM.isAncestor((<HTMLElement>e.target), this._treeContainer)) {
+						this._input.validate();
+						this._onBlur.fire();
+						this.contextViewService.hideContextView();
+					}
 				}
 			});
 		}
@@ -272,7 +280,6 @@ export class Dropdown extends Disposable {
 			this._treeContainer.style.width = DOM.getContentWidth(this._inputContainer) - 2 + 'px';
 			this._tree.layout(parseInt(this._treeContainer.style.height));
 			this._tree.setInput(new DropdownModel());
-			this._input.validate();
 		}
 	}
 
@@ -301,7 +308,7 @@ export class Dropdown extends Disposable {
 	}
 
 	private _inputValidator(value: string): IMessage | null {
-		if (this._dataSource.options && !this._dataSource.options.find(i => i.value === value)) {
+		if (!this._input.hasFocus() && !this._tree.isDOMFocused() &&  this._dataSource.options && !this._dataSource.options.find(i => i.value === value)) {
 			if (this._options.strictSelection && this._options.errorMessage) {
 				return {
 					content: this._options.errorMessage,

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -308,7 +308,7 @@ export class Dropdown extends Disposable {
 	}
 
 	private _inputValidator(value: string): IMessage | null {
-		if (!this._input.hasFocus() && !this._tree.isDOMFocused() &&  this._dataSource.options && !this._dataSource.options.find(i => i.value === value)) {
+		if (!this._input.hasFocus() && !this._tree.isDOMFocused() && this._dataSource.options && !this._dataSource.options.find(i => i.value === value)) {
 			if (this._options.strictSelection && this._options.errorMessage) {
 				return {
 					content: this._options.errorMessage,


### PR DESCRIPTION
fix the issue that the filtering feature is not working, with current design there is no way to make this experience perfect, with my fix, we can address the regression introduced in previous release. and we can work on the right solution after the may release. #5245 

root cause:
1. with the change made in contextview.ts by vscode, the event passed to the onDomEvent handler had changed, which caused the srcElement to be null, as a result, the context view will be hidden for any event. the fix is to use the right element: e.target

2. with the recent layering changes, both the inputbox's error message window and the dropdown's list view are using the same context view element, for now we have to compromise by only showing the dropdown, and the textbox will get the red border indicating its in error state, i think it is ok since user was not able to see it anyways (previously covered by the dropdown's view)