### PR TITLE
Improvements to notebook editor code auto height

### DIFF
--- a/src/sql/workbench/electron-browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/queryTextEditor.ts
@@ -132,8 +132,8 @@ export class QueryTextEditor extends BaseTextEditor {
 
 	public setHeightToScrollHeight(configChanged?: boolean): void {
 		let editorWidget = this.getControl() as ICodeEditor;
-		if (!this._config) {
-			this._config = new Configuration(true, undefined, editorWidget.getDomNode(), this.accessibilityService);
+		this._config = new Configuration(true, undefined, editorWidget.getDomNode(), this.accessibilityService);
+		if (!this._scrollbarHeight) {
 			this._scrollbarHeight = this._config.editor.viewInfo.scrollbar.horizontalScrollbarSize;
 		}
 		let editorWidgetModel = editorWidget.getModel();
@@ -157,7 +157,8 @@ export class QueryTextEditor extends BaseTextEditor {
 			for (let line = 1; line <= lineCount; line++) {
 				// 4 columns is equivalent to the viewport column width and the edge of the editor
 				if (editorWidgetModel.getLineMaxColumn(line) >= this._config.editor.layoutInfo.viewportColumn + 4) {
-					numberWrappedLines += Math.ceil(editorWidgetModel.getLineMaxColumn(line) / this._config.editor.layoutInfo.viewportColumn);
+					// Subtract 1 because the first line should not count as a wrapped line
+					numberWrappedLines += Math.ceil(editorWidgetModel.getLineMaxColumn(line) / this._config.editor.layoutInfo.viewportColumn) - 1;
 				}
 			}
 		} else {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/40371649/57007976-82ceac00-6ba1-11e9-84ee-7fe27a44d52e.png)

After:
![image](https://user-images.githubusercontent.com/40371649/57007952-4ac76900-6ba1-11e9-8476-7b2fc78055cf.png)

Fixes #4263.
