### PR TITLE
Fix failing OE Tests caused by changes in connection API defaults

### DIFF
--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -45,7 +45,7 @@ if (context.RunTest) {
 			let expectedActions;
 
 			if (process.platform === 'win32') {
-				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Properties', 'Launch Profiler'];
+				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Launch Profiler', 'Properties'];
 			} else {
 				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Launch Profiler'];
 			}
@@ -56,7 +56,7 @@ if (context.RunTest) {
 		});
 	});
 }
-async function VerifyOeNode(server: TestServerProfile, timeout: number, expectedNodeLable: string[]) {
+async function VerifyOeNode(server: TestServerProfile, timeout: number, expectedNodeLabel: string[]) {
 	await connectToServer(server, timeout);
 	let nodes = <azdata.objectexplorer.ObjectExplorerNode[]>await azdata.objectexplorer.getActiveConnectionNodes();
 	assert(nodes.length > 0, `Expecting at least one active connection, actual: ${nodes.length}`);
@@ -65,9 +65,9 @@ async function VerifyOeNode(server: TestServerProfile, timeout: number, expected
 	assert(index !== -1, `Failed to find server: "${server.serverName}" in OE tree`);
 	let actualNodeLable = [];
 	let childeren = await nodes[index].getChildren();
-	assert(childeren.length === expectedNodeLable.length, `Expecting node count: ${expectedNodeLable.length}, Actual: ${childeren.length}`);
+	assert(childeren.length === expectedNodeLabel.length, `Expecting node count: ${expectedNodeLabel.length}, Actual: ${childeren.length}`);
 
 	childeren.forEach(c => actualNodeLable.push(c.label));
-	assert(expectedNodeLable.toLocaleString() === actualNodeLable.toLocaleString(), `Expected node label: "${expectedNodeLable}", Actual: "${actualNodeLable}"`);
+	assert(expectedNodeLabel.toLocaleString() === actualNodeLable.toLocaleString(), `Expected node label: "${expectedNodeLabel}", Actual: "${actualNodeLable}"`);
 }
 

--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -63,11 +63,11 @@ async function VerifyOeNode(server: TestServerProfile, timeout: number, expected
 
 	let index = nodes.findIndex(node => node.nodePath.includes(server.serverName));
 	assert(index !== -1, `Failed to find server: "${server.serverName}" in OE tree`);
-	let actualNodeLable = [];
-	let childeren = await nodes[index].getChildren();
-	assert(childeren.length === expectedNodeLabel.length, `Expecting node count: ${expectedNodeLabel.length}, Actual: ${childeren.length}`);
+	let actualNodeLabel = [];
+	let children = await nodes[index].getChildren();
+	assert(children.length === expectedNodeLabel.length, `Expecting node count: ${expectedNodeLabel.length}, Actual: ${children.length}`);
 
-	childeren.forEach(c => actualNodeLable.push(c.label));
-	assert(expectedNodeLabel.toLocaleString() === actualNodeLable.toLocaleString(), `Expected node label: "${expectedNodeLabel}", Actual: "${actualNodeLable}"`);
+	children.forEach(c => actualNodeLabel.push(c.label));
+	assert(expectedNodeLabel.toLocaleString() === actualNodeLabel.toLocaleString(), `Expected node label: "${expectedNodeLabel}", Actual: "${actualNodeLabel}"`);
 }
 

--- a/src/sql/workbench/api/node/extHostConnectionManagement.ts
+++ b/src/sql/workbench/api/node/extHostConnectionManagement.ts
@@ -61,7 +61,7 @@ export class ExtHostConnectionManagement extends ExtHostConnectionManagementShap
 		return this._proxy.$getUriForConnection(connectionId);
 	}
 
-	public $connect(connectionProfile: azdata.IConnectionProfile, saveConnection: boolean = false, showDashboard: boolean = false): Thenable<azdata.ConnectionResult> {
+	public $connect(connectionProfile: azdata.IConnectionProfile, saveConnection: boolean = true, showDashboard: boolean = true): Thenable<azdata.ConnectionResult> {
 		return this._proxy.$connect(connectionProfile, saveConnection, showDashboard);
 	}
 }

--- a/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
@@ -111,7 +111,7 @@ export class MainThreadConnectionManagement implements MainThreadConnectionManag
 		return connection;
 	}
 
-	public $connect(connectionProfile: IConnectionProfile, saveConnection: boolean = false, showDashboard: boolean = false): Thenable<azdata.ConnectionResult> {
+	public $connect(connectionProfile: IConnectionProfile, saveConnection: boolean = true, showDashboard: boolean = true): Thenable<azdata.ConnectionResult> {
 		let profile = new ConnectionProfile(this._capabilitiesService, connectionProfile);
 		profile.id = generateUuid();
 		return this._connectionManagementService.connectAndSaveProfile(profile, undefined, {


### PR DESCRIPTION
#4908 changed the default behavior for connect - previously it would save the connection by default but after the change the default was not to save the connection. Reverting back to having the connection saved by default since that should be the normal case. 

Also fixed ordering of context menu items which have changed with latest SSMS Integration extension changes