### PR TITLE
Fix broken CMS commands

### DIFF
--- a/extensions/cms/package.json
+++ b/extensions/cms/package.json
@@ -548,16 +548,16 @@
 				}
 			},
 			{
-				"command": "cms.resource.registerCMSServer",
-				"title": "%cms.resource.registerCMSServer.title%",
+				"command": "cms.resource.registerCmsServer",
+				"title": "%cms.resource.registerCmsServer.title%",
 				"icon": {
 					"light": "resources/light/add.svg",
 					"dark": "resources/dark/add_inverse.svg"
 				}
 			},
 			{
-				"command": "cms.resource.deleteCMSServer",
-				"title": "%cms.resource.deleteCMSServer.title%"
+				"command": "cms.resource.deleteCmsServer",
+				"title": "%cms.resource.deleteCmsServer.title%"
 			}
 		],
 		"dataExplorer": {
@@ -571,7 +571,7 @@
 		"menus": {
 			"view/title": [
 				{
-					"command": "cms.resource.registerCMSServer",
+					"command": "cms.resource.registerCmsServer",
 					"when": "view == cmsResourceExplorer",
 					"group": "navigation"
 				}
@@ -618,7 +618,7 @@
 					"group": "navigation@10"
 				},
 				{
-					"command": "cms.resource.deleteCMSServer",
+					"command": "cms.resource.deleteCmsServer",
 					"when": "viewItem == cms.resource.itemType.cmsNodeContainer",
 					"group": "navigation@10"
 				}

--- a/extensions/cms/package.nls.json
+++ b/extensions/cms/package.nls.json
@@ -10,8 +10,8 @@
 	"cms.resource.addRegisteredServer.title": "Add Registered Server",
 	"cms.resource.deleteServerGroup.title": "Delete Server Group",
 	"cms.resource.addServerGroup.title": "Add Server Group",
-	"cms.resource.registerCMSServer.title": "Add Central Management Server",
-	"cms.resource.deleteCMSServer.title": "Delete Central Management Server",
+	"cms.resource.registerCmsServer.title": "Add Central Management Server",
+	"cms.resource.deleteCmsServer.title": "Delete Central Management Server",
 
 	"cms.configuration.title": "MSSQL configuration",
 	"cms.query.displayBitAsNumber": "Should BIT columns be displayed as numbers (1 or 0)? If false, BIT columns will be displayed as 'true' or 'false'",

--- a/extensions/cms/src/apiWrapper.ts
+++ b/extensions/cms/src/apiWrapper.ts
@@ -273,7 +273,7 @@ export class ApiWrapper {
 			if (connection && connection.options) {
 				if (connection.options.server === parentServerName) {
 					// error out for same server registration
-					let errorText = localize('cms.errors.sameServerUnderCMS', 'You cannot add a shared registered server with the same name as the Configuration Server');
+					let errorText = localize('cms.errors.sameServerUnderCms', 'You cannot add a shared registered server with the same name as the Configuration Server');
 					this.showErrorMessage(errorText);
 					return;
 				} else {

--- a/extensions/cms/src/cmsResource/tree/cmsResourceEmptyTreeNode.ts
+++ b/extensions/cms/src/cmsResource/tree/cmsResourceEmptyTreeNode.ts
@@ -22,7 +22,7 @@ export class CmsResourceEmptyTreeNode extends TreeNode {
 		let item = new TreeItem(CmsResourceEmptyTreeNode.addCmsServerLabel, TreeItemCollapsibleState.None);
 		item.command = {
 			title: CmsResourceEmptyTreeNode.addCmsServerLabel,
-			command: 'cms.resource.registerCMSServer',
+			command: 'cms.resource.registerCmsServer',
 			arguments: [this]
 		};
 		item.contextValue = CmsResourceItemType.cmsEmptyNodeContainer;
@@ -47,5 +47,5 @@ export class CmsResourceEmptyTreeNode extends TreeNode {
 		return 'message_cmsTreeNode';
 	}
 
-	private static readonly addCmsServerLabel = localize('cms.resource.tree.CMSTreeNode.addCmsServerLabel', 'Add Central Management Server...');
+	private static readonly addCmsServerLabel = localize('cms.resource.tree.CmsTreeNode.addCmsServerLabel', 'Add Central Management Server...');
 }

--- a/extensions/cms/src/test/cmsResource/tree/cmsResourceEmptyTreeNode.test.ts
+++ b/extensions/cms/src/test/cmsResource/tree/cmsResourceEmptyTreeNode.test.ts
@@ -27,7 +27,7 @@ describe('CmsResourceEmptyTreeNode.info', function(): void {
 		should(treeItem.collapsibleState).equal(vscode.TreeItemCollapsibleState.None);
 		should(treeItem.command).not.undefined();
 		should(treeItem.command.title).equal(label);
-		should(treeItem.command.command).equal('cms.resource.registerCMSServer');
+		should(treeItem.command.command).equal('cms.resource.registerCmsServer');
 
 		const nodeInfo = treeNode.getNodeInfo();
 		should(nodeInfo.isLeaf).true();


### PR DESCRIPTION
Some commands were using CMS and some were using Cms - commands are case-sensitive so this was causing some functionality (such as clicking the + symbol on CMS tree) to not function. 

I've updated the commands and other labels as appropriate to all use Cms to be consistent across the extension.