### PR TITLE
Fix #5314: schema compare doesn't always open with correct default connection

### DIFF
--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -45,9 +45,9 @@ if (context.RunTest) {
 			let expectedActions;
 
 			if (process.platform === 'win32') {
-				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Launch Profiler', 'Properties'];
+				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Data-tier Application wizard', 'Launch Profiler', 'Properties'];
 			} else {
-				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Launch Profiler'];
+				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Data-tier Application wizard', 'Launch Profiler'];
 			}
 
 			const expectedString = expectedActions.join(',');

--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -45,9 +45,9 @@ if (context.RunTest) {
 			let expectedActions;
 
 			if (process.platform === 'win32') {
-				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Data-tier Application wizard', 'Launch Profiler', 'Properties'];
+				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Launch Profiler', 'Properties'];
 			} else {
-				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Data-tier Application wizard', 'Launch Profiler'];
+				expectedActions = ['Manage', 'New Query', 'Disconnect', 'Delete Connection', 'Refresh', 'New Notebook', 'Launch Profiler'];
 			}
 
 			const expectedString = expectedActions.join(',');

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -54,8 +54,8 @@ export class SchemaCompareDialog {
 		this.dialog.content = [this.schemaCompareTab];
 	}
 
-	public async openDialog(p: any, dialogName?: string): Promise<void> {
-		let profile = p ? <azdata.IConnectionProfile>p.connectionProfile : undefined;
+	public async openDialog(context: azdata.ObjectExplorerContext, dialogName?: string): Promise<void> {
+		let profile = context ? context.connectionProfile : undefined;
 		if (profile) {
 			this.database = profile.databaseName;
 			this.connectionId = profile.id;

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -24,6 +24,7 @@ const SchemaCompareLabel: string = localize('schemaCompare.dialogTitle', 'Schema
 
 export class SchemaCompareDialog {
 	public dialog: azdata.window.Dialog;
+	public dialogName: string;
 	private schemaCompareTab: azdata.window.DialogTab;
 	private sourceDacpacComponent: azdata.FormComponent;
 	private sourceTextBox: azdata.InputBoxComponent;
@@ -45,8 +46,7 @@ export class SchemaCompareDialog {
 	private sourceIsDacpac: boolean;
 	private targetIsDacpac: boolean;
 	private database: string;
-	public dialogName: string;
-	private connection: azdata.connection.ConnectionProfile;
+	private connectionId: string;
 
 	protected initializeDialog(): void {
 		this.schemaCompareTab = azdata.window.createTab(SchemaCompareLabel);
@@ -58,8 +58,13 @@ export class SchemaCompareDialog {
 		let profile = p ? <azdata.IConnectionProfile>p.connectionProfile : undefined;
 		if (profile) {
 			this.database = profile.databaseName;
+			this.connectionId = profile.id;
+		} else {
+			let connection = await azdata.connection.getCurrentConnection();
+			if (connection) {
+				this.connectionId = connection.connectionId;
+			}
 		}
-		this.connection = await azdata.connection.getCurrentConnection();
 
 		let event = dialogName ? dialogName : null;
 		this.dialog = azdata.window.createModelViewDialog(SchemaCompareLabel, event);
@@ -382,10 +387,9 @@ export class SchemaCompareDialog {
 		let idx = -1;
 		let values = cons.map(c => {
 			count++;
-			if (idx === -1) {
-				if (this.connection && c.connectionId === this.connection.connectionId) {
-					idx = count;
-				}
+
+			if (c.connectionId === this.connectionId) {
+				idx = count;
 			}
 
 			let db = c.options.databaseDisplayName;

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -54,8 +54,8 @@ export class SchemaCompareDialog {
 		this.dialog.content = [this.schemaCompareTab];
 	}
 
-	public async openDialog(context: azdata.ObjectExplorerContext, dialogName?: string): Promise<void> {
-		let profile = context ? context.connectionProfile : undefined;
+	public async openDialog(context: any, dialogName?: string): Promise<void> {
+		let profile = context ? <azdata.IConnectionProfile>context.connectionProfile : undefined;
 		if (profile) {
 			this.database = profile.databaseName;
 			this.connectionId = profile.id;
@@ -63,6 +63,7 @@ export class SchemaCompareDialog {
 			let connection = await azdata.connection.getCurrentConnection();
 			if (connection) {
 				this.connectionId = connection.connectionId;
+				this.database = undefined;
 			}
 		}
 
@@ -408,7 +409,8 @@ export class SchemaCompareDialog {
 			};
 		});
 
-		if (idx >= 0) {
+		// move server of current connection to the top of the list so it is the default
+		if (idx >= 1) {
 			let tmp = values[0];
 			values[0] = values[idx];
 			values[idx] = tmp;


### PR DESCRIPTION
This fixes #5314 the schema compare dialog not always opening with the correct default connection if there are multiple connections.

Previously, the server dropdown in the dialog would have the first server be the default value. This fixes that by setting the server dropdown value to the current connection's server if there is a connection.
