### PR TITLE
Remove database name from schema compare source/target server field

### DIFF
--- a/extensions/dacpac/src/wizard/api/basePage.ts
+++ b/extensions/dacpac/src/wizard/api/basePage.ts
@@ -4,7 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
+import * as nls from 'vscode-nls';
 import { DacFxDataModel } from './models';
+
+const localize = nls.loadMessageBundle();
 
 export abstract class BasePage {
 
@@ -69,11 +72,11 @@ export abstract class BasePage {
 			let srv = c.options.server;
 
 			if (!db) {
-				db = '<default>';
+				usr = localize('basePage.defaultDb', '<default>');
 			}
 
 			if (!usr) {
-				usr = 'default';
+				usr = localize('basePage.defaultUser', 'default');
 			}
 
 			let finalName = `${srv}, ${db} (${usr})`;

--- a/extensions/dacpac/src/wizard/api/basePage.ts
+++ b/extensions/dacpac/src/wizard/api/basePage.ts
@@ -72,7 +72,7 @@ export abstract class BasePage {
 			let srv = c.options.server;
 
 			if (!db) {
-				usr = localize('basePage.defaultDb', '<default>');
+				db = localize('basePage.defaultDb', '<default>');
 			}
 
 			if (!usr) {

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -381,7 +381,7 @@ export class SchemaCompareDialog {
 			let srv = c.options.server;
 
 			if (!usr) {
-				usr = 'default';
+				usr = localize('schemaCompareDialog.defaultUser', 'default');
 			}
 
 			let finalName = `${srv} (${usr})`;

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -377,19 +377,14 @@ export class SchemaCompareDialog {
 		}
 
 		let values = cons.map(c => {
-			let db = c.options.databaseDisplayName;
 			let usr = c.options.user;
 			let srv = c.options.server;
-
-			if (!db) {
-				db = '<default>';
-			}
 
 			if (!usr) {
 				usr = 'default';
 			}
 
-			let finalName = `${srv}, ${db} (${usr})`;
+			let finalName = `${srv} (${usr})`;
 			return {
 				connection: c,
 				displayName: finalName,


### PR DESCRIPTION
This removes the database name from the source and target server field in the schema compare dialog

old:
![image](https://user-images.githubusercontent.com/31145923/57107793-d64a1280-6ce5-11e9-87be-b3f4b03d6dd0.png)

new:
![image](https://user-images.githubusercontent.com/31145923/57108029-79029100-6ce6-11e9-934f-5ed14b331250.png)
