### PR TITLE
Fix connections from editor not saving to MRU

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -241,7 +241,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		}
 		let options: IConnectionCompletionOptions = {
 			params: params,
-			saveTheConnection: !fromEditor,
+			saveTheConnection: true,
 			showDashboard: params && params.showDashboard !== undefined ? params.showDashboard : !fromEditor,
 			showConnectionDialogOnError: false,
 			showFirewallRuleOnError: true


### PR DESCRIPTION
Fix #5325 - the recent change to reduce MRU connections resulted in query editor connections not being saved. The fix here means that the connection will be saved to the connection store as well - but I've verified that it doesn't show up in OE or *Saved Connections*, it just adds it to the MRU.

This also doesn't impact changing the database in the dropdown - that still correctly doesn't add the connection to the MRU or saved connections. 
