### PR TITLE
Fix nullref exception in connection profile

### DIFF
--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -68,7 +68,7 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 
 	private nullCheckEqualsIgnoreCase(a: string, b: string) {
 		let bothNull: boolean = !a && !b;
-		return bothNull || equalsIgnoreCase(a, b);
+		return bothNull ? bothNull : equalsIgnoreCase(a, b);
 	}
 
 	public generateNewId() {

--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -58,12 +58,17 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 	public matches(other: interfaces.IConnectionProfile): boolean {
 		return other
 			&& this.providerName === other.providerName
-			&& equalsIgnoreCase(this.serverName, other.serverName)
-			&& equalsIgnoreCase(this.databaseName, other.databaseName)
-			&& equalsIgnoreCase(this.userName, other.userName)
-			&& equalsIgnoreCase(this.options['databaseDisplayName'], other.options['databaseDisplayName'])
+			&& this.nullCheckEqualsIgnoreCase(this.serverName, other.serverName)
+			&& this.nullCheckEqualsIgnoreCase(this.databaseName, other.databaseName)
+			&& this.nullCheckEqualsIgnoreCase(this.userName, other.userName)
+			&& this.nullCheckEqualsIgnoreCase(this.options['databaseDisplayName'], other.options['databaseDisplayName'])
 			&& this.authenticationType === other.authenticationType
 			&& this.groupId === other.groupId;
+	}
+
+	private nullCheckEqualsIgnoreCase(a: string, b: string) {
+		let bothNull: boolean = !a && !b;
+		return bothNull || equalsIgnoreCase(a, b);
 	}
 
 	public generateNewId() {


### PR DESCRIPTION
I hit the below exception and from code inspection it looks like VS Code's method doesn't work correctly if both string are null.  I'd prefer not to patch VS Code source so I'll fix at the point of the exception in this case.

```TypeScript
D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:2280 Unhandled Promise rejection: Cannot read property 'length' of undefined ; Zone: <root> ; Task: Promise.then ; Value: TypeError: Cannot read property 'length' of undefined
    at doEqualsIgnoreCase (file:///D:/xplat/azuredatastudio/out/vs/base/common/strings.js:338:50)
    at Object.equalsIgnoreCase (file:///D:/xplat/azuredatastudio/out/vs/base/common/strings.js:335:16)
    at ConnectionProfile.matches (file:///D:/xplat/azuredatastudio/out/sql/platform/connection/common/.js:39:30)
    at profiles.find.value (file:///D:/xplat/azuredatastudio/out/sql/platform/connection/common/connectionConfig.js:53:58)
    at Array.find (<anonymous>)
    at addGroupFromProfile.then.groupId (file:///D:/xplat/azuredatastudio/out/sql/platform/connection/common/connectionConfig.js:51:54)
    at ZoneDelegate.invoke (D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:388:26)
    at Zone.run (D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:138:43)
    at D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:872:34
    at ZoneDelegate.invokeTask (D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:421:31)
    at Zone.runTask (D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:188:47)
    at drainMicroTaskQueue (D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:595:35) TypeError: Cannot read property 'length' of undefined
    at doEqualsIgnoreCase (file:///D:/xplat/azuredatastudio/out/vs/base/common/strings.js:338:50)
    at Object.equalsIgnoreCase (file:///D:/xplat/azuredatastudio/out/vs/base/common/strings.js:335:16)
    at ConnectionProfile.matches (file:///D:/xplat/azuredatastudio/out/sql/platform/connection/common/connectionProfile.js:39:30)
    at profiles.find.value (file:///D:/xplat/azuredatastudio/out/sql/platform/connection/common/connectionConfig.js:53:58)
    at Array.find (<anonymous>)
    at addGroupFromProfile.then.groupId (file:///D:/xplat/azuredatastudio/out/sql/platform/connection/common/connectionConfig.js:51:54)
    at ZoneDelegate.invoke (D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:388:26)
    at Zone.run (D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:138:43)
    at D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:872:34
    at ZoneDelegate.invokeTask (D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:421:31)
    at Zone.runTask (D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:188:47)
    at drainMicroTaskQueue (D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:595:35)
console.(anonymous function) @ D:\xplat\azuredatastudio\node_modules\zone.js\dist\zone-node.js:2280
```