### PR TITLE
Disable page scrolling in slickgrid

### DIFF
--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -24,7 +24,8 @@ import { range } from 'vs/base/common/arrays';
 function getDefaultOptions<T>(): Slick.GridOptions<T> {
 	return <Slick.GridOptions<T>>{
 		syncColumnCellResize: true,
-		enableColumnReorder: false
+		enableColumnReorder: false,
+		emulatePagingWhenScrolling: false
 	};
 }
 

--- a/src/typings/globals/slickgrid/index.d.ts
+++ b/src/typings/globals/slickgrid/index.d.ts
@@ -663,6 +663,11 @@ declare namespace Slick {
 		*
 		**/
 		topPanelHeight?: number;
+
+		/**
+		 * Page grid when navigating
+		 */
+		emulatePagingWhenScrolling?: boolean;
 	}
 
 	export interface DataProvider<T extends SlickData> {


### PR DESCRIPTION
This should fix this in schema compare as well assuming they are using the default options.

fixes #5332