### PR TITLE
SsmsMin integration clean-up and improvements

### DIFF
--- a/extensions/admin-tool-ext-win/src/test/utils.test.ts
+++ b/extensions/admin-tool-ext-win/src/test/utils.test.ts
@@ -19,7 +19,6 @@ describe('buildSsmsMinCommandArgs Method Tests', () => {
 			server: 'myServer',
 			database: 'myDatabase',
 			user: 'user',
-			password: 'password',
 			useAad: false,
 			urn: 'Server\\Database\\Table'
 		};
@@ -33,7 +32,6 @@ describe('buildSsmsMinCommandArgs Method Tests', () => {
 			server: 'myServer',
 			database: 'myDatabase',
 			user: 'user',
-			password: 'password',
 			useAad: true,
 			urn: 'Server\\Database\\Table'
 		};
@@ -48,7 +46,6 @@ describe('buildSsmsMinCommandArgs Method Tests', () => {
 			server: 'myServer\'"/\\[]tricky',
 			database: 'myDatabase\'"/\\[]tricky',
 			user: 'user\'"/\\[]tricky',
-			password: 'password',
 			useAad: true,
 			urn: 'Server\\Database[\'myDatabase\'\'"/\\[]tricky\']\\Table["myTable\'""/\\[]tricky"]'
 		};


### PR DESCRIPTION
- Display more errors to users to make it clear when the dialog is unable to be launched
- Add fetching of passwords to pass to SsmsMin for SQL Login connections
- Disallow launching from disconnected or Azure nodes (gap in API and dialog support)