### PR TITLE
Fix schema compare dialog font sizes

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -186,7 +186,8 @@ export class SchemaCompareDialog {
 							]
 						}
 					], {
-							horizontal: true
+							horizontal: true,
+							titleFontSize: 12
 						});
 			} else {
 				this.formBuilder = view.modelBuilder.formContainer()
@@ -205,7 +206,8 @@ export class SchemaCompareDialog {
 							]
 						}
 					], {
-							horizontal: true
+							horizontal: true,
+							titleFontSize: 12
 						});
 			}
 			let formModel = this.formBuilder.component();
@@ -276,17 +278,17 @@ export class SchemaCompareDialog {
 			this.formBuilder.removeFormItem(this.sourceNoActiveConnectionsText);
 			this.formBuilder.removeFormItem(this.sourceServerComponent);
 			this.formBuilder.removeFormItem(this.sourceDatabaseComponent);
-			this.formBuilder.insertFormItem(this.sourceDacpacComponent, 1, { horizontal: true });
+			this.formBuilder.insertFormItem(this.sourceDacpacComponent, 1, { horizontal: true, titleFontSize: 12 });
 		});
 
 		// show server and db dropdowns or 'No active connections' text
 		databaseRadioButton.onDidClick(() => {
 			this.sourceIsDacpac = false;
 			if ((this.sourceServerDropdown.value as ConnectionDropdownValue)) {
-				this.formBuilder.insertFormItem(this.sourceServerComponent, 1, { horizontal: true, componentWidth: 300 });
-				this.formBuilder.insertFormItem(this.sourceDatabaseComponent, 2, { horizontal: true, componentWidth: 300 });
+				this.formBuilder.insertFormItem(this.sourceServerComponent, 1, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
+				this.formBuilder.insertFormItem(this.sourceDatabaseComponent, 2, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
 			} else {
-				this.formBuilder.insertFormItem(this.sourceNoActiveConnectionsText, 1, { horizontal: true });
+				this.formBuilder.insertFormItem(this.sourceNoActiveConnectionsText, 1, { horizontal: true, titleFontSize: 12 });
 			}
 			this.formBuilder.removeFormItem(this.sourceDacpacComponent);
 		});
@@ -328,7 +330,7 @@ export class SchemaCompareDialog {
 			this.formBuilder.removeFormItem(this.targetNoActiveConnectionsText);
 			this.formBuilder.removeFormItem(this.targetServerComponent);
 			this.formBuilder.removeFormItem(this.targetDatabaseComponent);
-			this.formBuilder.addFormItem(this.targetDacpacComponent, { horizontal: true });
+			this.formBuilder.addFormItem(this.targetDacpacComponent, { horizontal: true, titleFontSize: 12 });
 		});
 
 		// show server and db dropdowns or 'No active connections' text
@@ -336,10 +338,10 @@ export class SchemaCompareDialog {
 			this.targetIsDacpac = false;
 			this.formBuilder.removeFormItem(this.targetDacpacComponent);
 			if ((this.targetServerDropdown.value as ConnectionDropdownValue)) {
-				this.formBuilder.addFormItem(this.targetServerComponent, { horizontal: true, componentWidth: 300 });
-				this.formBuilder.addFormItem(this.targetDatabaseComponent, { horizontal: true, componentWidth: 300 });
+				this.formBuilder.addFormItem(this.targetServerComponent, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
+				this.formBuilder.addFormItem(this.targetDatabaseComponent, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
 			} else {
-				this.formBuilder.addFormItem(this.targetNoActiveConnectionsText, { horizontal: true });
+				this.formBuilder.addFormItem(this.targetNoActiveConnectionsText, { horizontal: true, titleFontSize: 12 });
 			}
 		});
 

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -278,17 +278,17 @@ export class SchemaCompareDialog {
 			this.formBuilder.removeFormItem(this.sourceNoActiveConnectionsText);
 			this.formBuilder.removeFormItem(this.sourceServerComponent);
 			this.formBuilder.removeFormItem(this.sourceDatabaseComponent);
-			this.formBuilder.insertFormItem(this.sourceDacpacComponent, 1, { horizontal: true, titleFontSize: 12 });
+			this.formBuilder.insertFormItem(this.sourceDacpacComponent, 2, { horizontal: true, titleFontSize: 12 });
 		});
 
 		// show server and db dropdowns or 'No active connections' text
 		databaseRadioButton.onDidClick(() => {
 			this.sourceIsDacpac = false;
 			if ((this.sourceServerDropdown.value as ConnectionDropdownValue)) {
-				this.formBuilder.insertFormItem(this.sourceServerComponent, 1, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
-				this.formBuilder.insertFormItem(this.sourceDatabaseComponent, 2, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
+				this.formBuilder.insertFormItem(this.sourceServerComponent, 2, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
+				this.formBuilder.insertFormItem(this.sourceDatabaseComponent, 3, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
 			} else {
-				this.formBuilder.insertFormItem(this.sourceNoActiveConnectionsText, 1, { horizontal: true, titleFontSize: 12 });
+				this.formBuilder.insertFormItem(this.sourceNoActiveConnectionsText, 2, { horizontal: true, titleFontSize: 12 });
 			}
 			this.formBuilder.removeFormItem(this.sourceDacpacComponent);
 		});

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -187,7 +187,7 @@ export class SchemaCompareDialog {
 						}
 					], {
 							horizontal: true,
-							titleFontSize: 12
+							titleFontSize: 13
 						});
 			} else {
 				this.formBuilder = view.modelBuilder.formContainer()
@@ -207,7 +207,7 @@ export class SchemaCompareDialog {
 						}
 					], {
 							horizontal: true,
-							titleFontSize: 12
+							titleFontSize: 13
 						});
 			}
 			let formModel = this.formBuilder.component();
@@ -278,17 +278,17 @@ export class SchemaCompareDialog {
 			this.formBuilder.removeFormItem(this.sourceNoActiveConnectionsText);
 			this.formBuilder.removeFormItem(this.sourceServerComponent);
 			this.formBuilder.removeFormItem(this.sourceDatabaseComponent);
-			this.formBuilder.insertFormItem(this.sourceDacpacComponent, 2, { horizontal: true, titleFontSize: 12 });
+			this.formBuilder.insertFormItem(this.sourceDacpacComponent, 2, { horizontal: true, titleFontSize: 13 });
 		});
 
 		// show server and db dropdowns or 'No active connections' text
 		databaseRadioButton.onDidClick(() => {
 			this.sourceIsDacpac = false;
 			if ((this.sourceServerDropdown.value as ConnectionDropdownValue)) {
-				this.formBuilder.insertFormItem(this.sourceServerComponent, 2, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
-				this.formBuilder.insertFormItem(this.sourceDatabaseComponent, 3, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
+				this.formBuilder.insertFormItem(this.sourceServerComponent, 2, { horizontal: true, componentWidth: 300, titleFontSize: 13 });
+				this.formBuilder.insertFormItem(this.sourceDatabaseComponent, 3, { horizontal: true, componentWidth: 300, titleFontSize: 13 });
 			} else {
-				this.formBuilder.insertFormItem(this.sourceNoActiveConnectionsText, 2, { horizontal: true, titleFontSize: 12 });
+				this.formBuilder.insertFormItem(this.sourceNoActiveConnectionsText, 2, { horizontal: true, titleFontSize: 13 });
 			}
 			this.formBuilder.removeFormItem(this.sourceDacpacComponent);
 		});
@@ -330,7 +330,7 @@ export class SchemaCompareDialog {
 			this.formBuilder.removeFormItem(this.targetNoActiveConnectionsText);
 			this.formBuilder.removeFormItem(this.targetServerComponent);
 			this.formBuilder.removeFormItem(this.targetDatabaseComponent);
-			this.formBuilder.addFormItem(this.targetDacpacComponent, { horizontal: true, titleFontSize: 12 });
+			this.formBuilder.addFormItem(this.targetDacpacComponent, { horizontal: true, titleFontSize: 13 });
 		});
 
 		// show server and db dropdowns or 'No active connections' text
@@ -338,10 +338,10 @@ export class SchemaCompareDialog {
 			this.targetIsDacpac = false;
 			this.formBuilder.removeFormItem(this.targetDacpacComponent);
 			if ((this.targetServerDropdown.value as ConnectionDropdownValue)) {
-				this.formBuilder.addFormItem(this.targetServerComponent, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
-				this.formBuilder.addFormItem(this.targetDatabaseComponent, { horizontal: true, componentWidth: 300, titleFontSize: 12 });
+				this.formBuilder.addFormItem(this.targetServerComponent, { horizontal: true, componentWidth: 300, titleFontSize: 13 });
+				this.formBuilder.addFormItem(this.targetDatabaseComponent, { horizontal: true, componentWidth: 300, titleFontSize: 13 });
 			} else {
-				this.formBuilder.addFormItem(this.targetNoActiveConnectionsText, { horizontal: true, titleFontSize: 12 });
+				this.formBuilder.addFormItem(this.targetNoActiveConnectionsText, { horizontal: true, titleFontSize: 13 });
 			}
 		});
 

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -23,6 +23,7 @@ const ServerDropdownLabel: string = localize('schemaCompareDialog.serverDropdown
 const DatabaseDropdownLabel: string = localize('schemaCompareDialog.databaseDropdownTitle', 'Database');
 const NoActiveConnectionsLabel: string = localize('schemaCompare.noActiveConnectionsText', 'No active connections');
 const SchemaCompareLabel: string = localize('schemaCompare.dialogTitle', 'Schema Compare');
+const titleFontSize: number = 13;
 
 export class SchemaCompareDialog {
 	public dialog: azdata.window.Dialog;
@@ -187,7 +188,7 @@ export class SchemaCompareDialog {
 						}
 					], {
 							horizontal: true,
-							titleFontSize: 13
+							titleFontSize: titleFontSize
 						});
 			} else {
 				this.formBuilder = view.modelBuilder.formContainer()
@@ -207,7 +208,7 @@ export class SchemaCompareDialog {
 						}
 					], {
 							horizontal: true,
-							titleFontSize: 13
+							titleFontSize: titleFontSize
 						});
 			}
 			let formModel = this.formBuilder.component();
@@ -278,17 +279,17 @@ export class SchemaCompareDialog {
 			this.formBuilder.removeFormItem(this.sourceNoActiveConnectionsText);
 			this.formBuilder.removeFormItem(this.sourceServerComponent);
 			this.formBuilder.removeFormItem(this.sourceDatabaseComponent);
-			this.formBuilder.insertFormItem(this.sourceDacpacComponent, 2, { horizontal: true, titleFontSize: 13 });
+			this.formBuilder.insertFormItem(this.sourceDacpacComponent, 2, { horizontal: true, titleFontSize: titleFontSize });
 		});
 
 		// show server and db dropdowns or 'No active connections' text
 		databaseRadioButton.onDidClick(() => {
 			this.sourceIsDacpac = false;
 			if ((this.sourceServerDropdown.value as ConnectionDropdownValue)) {
-				this.formBuilder.insertFormItem(this.sourceServerComponent, 2, { horizontal: true, componentWidth: 300, titleFontSize: 13 });
-				this.formBuilder.insertFormItem(this.sourceDatabaseComponent, 3, { horizontal: true, componentWidth: 300, titleFontSize: 13 });
+				this.formBuilder.insertFormItem(this.sourceServerComponent, 2, { horizontal: true, componentWidth: 300, titleFontSize: titleFontSize });
+				this.formBuilder.insertFormItem(this.sourceDatabaseComponent, 3, { horizontal: true, componentWidth: 300, titleFontSize: titleFontSize });
 			} else {
-				this.formBuilder.insertFormItem(this.sourceNoActiveConnectionsText, 2, { horizontal: true, titleFontSize: 13 });
+				this.formBuilder.insertFormItem(this.sourceNoActiveConnectionsText, 2, { horizontal: true, titleFontSize: titleFontSize });
 			}
 			this.formBuilder.removeFormItem(this.sourceDacpacComponent);
 		});
@@ -330,7 +331,7 @@ export class SchemaCompareDialog {
 			this.formBuilder.removeFormItem(this.targetNoActiveConnectionsText);
 			this.formBuilder.removeFormItem(this.targetServerComponent);
 			this.formBuilder.removeFormItem(this.targetDatabaseComponent);
-			this.formBuilder.addFormItem(this.targetDacpacComponent, { horizontal: true, titleFontSize: 13 });
+			this.formBuilder.addFormItem(this.targetDacpacComponent, { horizontal: true, titleFontSize: titleFontSize });
 		});
 
 		// show server and db dropdowns or 'No active connections' text
@@ -338,10 +339,10 @@ export class SchemaCompareDialog {
 			this.targetIsDacpac = false;
 			this.formBuilder.removeFormItem(this.targetDacpacComponent);
 			if ((this.targetServerDropdown.value as ConnectionDropdownValue)) {
-				this.formBuilder.addFormItem(this.targetServerComponent, { horizontal: true, componentWidth: 300, titleFontSize: 13 });
-				this.formBuilder.addFormItem(this.targetDatabaseComponent, { horizontal: true, componentWidth: 300, titleFontSize: 13 });
+				this.formBuilder.addFormItem(this.targetServerComponent, { horizontal: true, componentWidth: 300, titleFontSize: titleFontSize });
+				this.formBuilder.addFormItem(this.targetDatabaseComponent, { horizontal: true, componentWidth: 300, titleFontSize: titleFontSize });
 			} else {
-				this.formBuilder.addFormItem(this.targetNoActiveConnectionsText, { horizontal: true, titleFontSize: 13 });
+				this.formBuilder.addFormItem(this.targetNoActiveConnectionsText, { horizontal: true, titleFontSize: titleFontSize });
 			}
 		});
 


### PR DESCRIPTION
This sets the font size of the title labels in the schema compare dialog to 13px to be consistent. Also fixing the ordering of the source dialog components since the indexes changed after formComponentGroups were added in this PR #5329


old:
![image](https://user-images.githubusercontent.com/31145923/57167704-89347200-6db3-11e9-9bab-1e88b88b77ab.png)

new:
![image](https://user-images.githubusercontent.com/31145923/57167682-7883fc00-6db3-11e9-9695-2622016dc238.png)
