### PR TITLE
Maddy/newline overrides edit data

### DIFF
--- a/src/sql/workbench/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/workbench/parts/grid/views/editData/editData.component.ts
@@ -177,9 +177,9 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 		this.overrideCellFn = (rowNumber, columnId, value?, data?): string => {
 			let returnVal = '';
 			if (Services.DBCellValue.isDBCellValue(value)) {
-				returnVal = value.displayValue;
+				returnVal = value.displayValue.replace(/(\r\n|\n|\r)/g, '');
 			} else if (typeof value === 'string') {
-				returnVal = value;
+				returnVal = value.replace(/(\r\n|\n|\r)/g, '');
 			}
 			return returnVal;
 		};

--- a/src/sql/workbench/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/workbench/parts/grid/views/editData/editData.component.ts
@@ -177,9 +177,9 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 		this.overrideCellFn = (rowNumber, columnId, value?, data?): string => {
 			let returnVal = '';
 			if (Services.DBCellValue.isDBCellValue(value)) {
-				returnVal = value.displayValue.replace(/(\r\n|\n|\r)/g, '');
+				returnVal = value.displayValue.replace(/(\r\n|\n|\r)/g, ' ');
 			} else if (typeof value === 'string') {
-				returnVal = value.replace(/(\r\n|\n|\r)/g, '');
+				returnVal = value.replace(/(\r\n|\n|\r)/g, ' ');
 			}
 			return returnVal;
 		};

--- a/src/sql/workbench/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/workbench/parts/grid/views/editData/editData.component.ts
@@ -176,10 +176,12 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 
 		this.overrideCellFn = (rowNumber, columnId, value?, data?): string => {
 			let returnVal = '';
+			// replace the line breaks with space since the edit text control cannot
+			// render line breaks and strips them, updating the value.
 			if (Services.DBCellValue.isDBCellValue(value)) {
-				returnVal = value.displayValue.replace(/(\r\n|\n|\r)/g, ' ');
+				returnVal = this.spacefyLinebreaks(value.displayValue);
 			} else if (typeof value === 'string') {
-				returnVal = value.replace(/(\r\n|\n|\r)/g, ' ');
+				returnVal = this.spacefyLinebreaks(value);
 			}
 			return returnVal;
 		};
@@ -403,6 +405,13 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 	 */
 	onScroll(scrollTop): void {
 		this.refreshGrid();
+	}
+
+	/**
+	 * Replace the line breaks with space.
+	 */
+	private spacefyLinebreaks(inputStr: string): string {
+		return inputStr.replace(/(\r\n|\n|\r)/g, ' ');
 	}
 
 	private refreshGrid(): Thenable<void> {


### PR DESCRIPTION
overrideCellFn is called and the value returned is set as defaultValue of the input text box and it returns value with /r/n. This default value is serialized which strips off the /r/n and shows the string value on UI. And when users just tabs out, the hasChanged event checks the defaultValue and the value inside the input text box and causes the update to trigger. 

Updated the overrideCellFn to replace /r/n with space and this stops the update call when the text isn't changed.
