### PR TITLE
Notebooks: Don't scroll when running code cell if in view

### DIFF
--- a/src/sql/workbench/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/code.component.ts
@@ -306,7 +306,7 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 	private setFocusAndScroll(): void {
 		if (this.cellModel.id === this._activeCellId) {
 			this._editor.focus();
-			this._editor.getContainer().scrollIntoView();
+			this._editor.getContainer().scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 		}
 	}
 

--- a/src/sql/workbench/parts/notebook/cellViews/textCell.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/textCell.component.ts
@@ -287,7 +287,7 @@ export class TextCellComponent extends CellView implements OnInit, AfterContentI
 		this.toggleEditMode(this.isActive());
 
 		if (this.output && this.output.nativeElement) {
-			(<HTMLElement>this.output.nativeElement).scrollTo();
+			(<HTMLElement>this.output.nativeElement).scrollTo({ behavior: 'smooth' });
 		}
 	}
 


### PR DESCRIPTION
This is a demo blocker. Stop scrolling to the very top of a code cell when clicking the run button. Ruins demo flows if the notebook is constantly jumping all over the place.

For the run all cells scenario, we still scroll with this change.