### PR TITLE
fix profiler formatter issue

### DIFF
--- a/src/sql/workbench/parts/profiler/browser/profilerTableEditor.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerTableEditor.ts
@@ -141,7 +141,11 @@ export class ProfilerTableEditor extends BaseEditor implements IProfilerControll
 		this._findCountChangeListener = input.data.onFindCountChange(() => this._updateFinderMatchState());
 
 		this._profilerTable.setData(input.data);
-		this._profilerTable.columns = input.columns;
+		this._profilerTable.columns = input.columns.map(c => {
+			c.formatter = textFormatter;
+			return c;
+		});
+
 		this._profilerTable.autosizeColumns();
 		this._input.data.currentFindPosition.then(val => {
 			this._profilerTable.setActiveCell(val.row, val.col);


### PR DESCRIPTION
#5350 
for some reason, the formatter for the columns got lost during tab switch when multiple profiler windows are opened, I haven't investigated into how the regression was introduced. The changes in this PR will enforce the columns get the correct formatter.