### PR TITLE
Update notebooks to use new message event

### DIFF
--- a/src/sql/platform/query/common/queryRunner.ts
+++ b/src/sql/platform/query/common/queryRunner.ts
@@ -32,8 +32,8 @@ export interface IEditSessionReadyEvent {
 	message: string;
 }
 
-export interface IGridMessage extends azdata.IResultMessage {
-	selection: azdata.ISelectionData;
+export interface IQueryMessage extends azdata.IResultMessage {
+	selection?: azdata.ISelectionData;
 }
 
 /*
@@ -47,7 +47,7 @@ export default class QueryRunner extends Disposable {
 	private _isExecuting: boolean = false;
 	private _hasCompleted: boolean = false;
 	private _batchSets: azdata.BatchSummary[] = [];
-	private _messages: azdata.IResultMessage[] = [];
+	private _messages: IQueryMessage[] = [];
 	private registered = false;
 
 	private _isQueryPlan: boolean;
@@ -55,8 +55,8 @@ export default class QueryRunner extends Disposable {
 	private _planXml = new Deferred<string>();
 	public get planXml(): Thenable<string> { return this._planXml.promise; }
 
-	private _onMessage = this._register(new Emitter<azdata.IResultMessage>());
-	public get onMessage(): Event<azdata.IResultMessage> { return this._onMessage.event; } // this is the only way typemoq can moq this... needs investigation @todo anthonydresser 5/2/2019
+	private _onMessage = this._register(new Emitter<IQueryMessage>());
+	public get onMessage(): Event<IQueryMessage> { return this._onMessage.event; } // this is the only way typemoq can moq this... needs investigation @todo anthonydresser 5/2/2019
 
 	private _onResultSet = this._register(new Emitter<azdata.ResultSetSummary>());
 	public readonly onResultSet = this._onResultSet.event;
@@ -122,7 +122,7 @@ export default class QueryRunner extends Disposable {
 	/**
 	 * For public use only, for private use, directly access the member
 	 */
-	public get messages(): azdata.IResultMessage[] {
+	public get messages(): IQueryMessage[] {
 		return this._messages.slice(0);
 	}
 
@@ -641,7 +641,7 @@ export default class QueryRunner extends Disposable {
 		// get config copyRemoveNewLine option from vscode config
 		let showBatchTime: boolean = WorkbenchUtils.getSqlConfigValue<boolean>(this._configurationService, Constants.configShowBatchTime);
 		if (showBatchTime) {
-			let message: azdata.IResultMessage = {
+			let message: IQueryMessage = {
 				batchId: batchId,
 				message: nls.localize('elapsedBatchTime', 'Batch execution time: {0}', executionTime),
 				time: undefined,

--- a/src/sql/workbench/parts/query/browser/messagePanel.ts
+++ b/src/sql/workbench/parts/query/browser/messagePanel.ts
@@ -5,11 +5,11 @@
 
 import 'vs/css!./media/messagePanel';
 import { IMessagesActionContext, CopyMessagesAction, CopyAllMessagesAction } from './actions';
-import QueryRunner from 'sql/platform/query/common/queryRunner';
+import QueryRunner, { IQueryMessage } from 'sql/platform/query/common/queryRunner';
 import { QueryInput } from 'sql/workbench/parts/query/common/queryInput';
 import { IExpandableTree } from 'sql/workbench/parts/objectExplorer/browser/treeUpdateUtils';
 
-import { IResultMessage, ISelectionData } from 'azdata';
+import { ISelectionData } from 'azdata';
 
 import { ViewletPanel, IViewletPanelOptions } from 'vs/workbench/browser/parts/views/panelViewlet';
 import { IDataSource, ITree, IRenderer, ContextMenuEvent } from 'vs/base/parts/tree/browser/tree';
@@ -31,7 +31,7 @@ import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { $ } from 'vs/base/browser/dom';
 
-export interface IResultMessageIntern extends IResultMessage {
+export interface IResultMessageIntern extends IQueryMessage {
 	id?: string;
 }
 
@@ -77,7 +77,7 @@ export class MessagePanelState {
 }
 
 export class MessagePanel extends ViewletPanel {
-	private messageLineCountMap = new Map<IResultMessage, number>();
+	private messageLineCountMap = new Map<IQueryMessage, number>();
 	private ds = new MessageDataSource();
 	private renderer = new MessageRenderer(this.messageLineCountMap);
 	private model = new Model();
@@ -203,7 +203,7 @@ export class MessagePanel extends ViewletPanel {
 		this.onMessage(runner.messages);
 	}
 
-	private onMessage(message: IResultMessage | IResultMessage[]) {
+	private onMessage(message: IQueryMessage | IQueryMessage[]) {
 		let hasError = false;
 		let lines: number;
 		if (isArray(message)) {
@@ -237,7 +237,7 @@ export class MessagePanel extends ViewletPanel {
 		}
 	}
 
-	private countMessageLines(resultMessage: IResultMessage): number {
+	private countMessageLines(resultMessage: IQueryMessage): number {
 		let lines = resultMessage.message.split('\n').length;
 		this.messageLineCountMap.set(resultMessage, lines);
 		return lines;
@@ -307,10 +307,10 @@ class MessageDataSource implements IDataSource {
 }
 
 class MessageRenderer implements IRenderer {
-	constructor(private messageLineCountMap: Map<IResultMessage, number>) {
+	constructor(private messageLineCountMap: Map<IQueryMessage, number>) {
 	}
 
-	getHeight(tree: ITree, element: any): number {
+	getHeight(tree: ITree, element: IQueryMessage): number {
 		const lineHeight = 22;
 		if (this.messageLineCountMap.has(element)) {
 			return lineHeight * this.messageLineCountMap.get(element);
@@ -318,7 +318,7 @@ class MessageRenderer implements IRenderer {
 		return lineHeight;
 	}
 
-	getTemplateId(tree: ITree, element: any): string {
+	getTemplateId(tree: ITree, element: IQueryMessage): string {
 		if (element instanceof Model) {
 			return TemplateIds.MODEL;
 		} else if (element.selection) {
@@ -355,7 +355,7 @@ class MessageRenderer implements IRenderer {
 		}
 	}
 
-	renderElement(tree: ITree, element: IResultMessage, templateId: string, templateData: IMessageTemplate | IBatchTemplate): void {
+	renderElement(tree: ITree, element: IQueryMessage, templateId: string, templateData: IMessageTemplate | IBatchTemplate): void {
 		if (templateId === TemplateIds.MESSAGE || templateId === TemplateIds.ERROR) {
 			let data: IMessageTemplate = templateData;
 			data.message.innerText = element.message;

--- a/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/sql/sqlSessionManager.ts
@@ -23,6 +23,7 @@ import * as notebookUtils from 'sql/workbench/parts/notebook/notebookUtils';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { ILogService } from 'vs/platform/log/common/log';
+import { isUndefinedOrNull } from 'vs/base/common/types';
 
 export const sqlKernelError: string = localize("sqlKernelError", "SQL kernel error");
 export const MAX_ROWS = 5000;
@@ -311,7 +312,7 @@ class SqlKernel extends Disposable implements nb.IKernel {
 		}));
 		this._register(queryRunner.onMessage(message => {
 			// TODO handle showing a messages output (should be updated with all messages, only changing 1 output in total)
-			if (this._future) {
+			if (this._future && isUndefinedOrNull(message.selection)) {
 				this._future.handleMessage(message);
 			}
 		}));
@@ -441,7 +442,6 @@ export class SQLFuture extends Disposable implements FutureInternal {
 
 	public handleBatchEnd(batch: BatchSummary): void {
 		if (this.ioHandler) {
-			this.handleMessage(strings.format(elapsedTimeLabel, batch.executionElapsed));
 			this._outputAddedPromises.push(this.processResultSets(batch));
 		}
 	}


### PR DESCRIPTION
Fixes the messages output of notebooks to be what it was before.

![image](https://user-images.githubusercontent.com/4324725/57267441-04f12180-7035-11e9-9de2-85bf64231060.png)
