### PR TITLE
Notebook Port Test Fix

### DIFF
--- a/extensions/notebook/src/test/common/port.test.ts
+++ b/extensions/notebook/src/test/common/port.test.ts
@@ -26,8 +26,8 @@ describe('Ports', () => {
 
 				// once listening, find another free port and assert that the port is different from the opened one
 				ports.findFreePort(7000, 50, 300000).then(freePort => {
-					assert.ok(freePort >= 7000 && freePort !== initialPort);
 					server.close();
+					assert.ok(freePort >= 7000 && freePort !== initialPort);
 
 					done();
 				}, err => done(err));
@@ -51,11 +51,10 @@ describe('Ports', () => {
 				// once listening, find another free port and assert that the port is different from the opened one
 				options.minPort = initialPort;
 				options.maxRetriesPerStartPort = 1;
-				options.totalRetryLoops = 50;
+				options.totalRetryLoops = 10;
 				ports.strictFindFreePort(options).then(freePort => {
-					assert(freePort !== initialPort, `Expected freePort !== initialPort, Actual: ${freePort}`);
 					server.close();
-
+					assert(freePort !== initialPort, `Expected freePort !== initialPort, Actual: ${freePort}`);
 					done();
 				}, err => done(err));
 			});

--- a/extensions/notebook/src/test/common/port.test.ts
+++ b/extensions/notebook/src/test/common/port.test.ts
@@ -53,7 +53,7 @@ describe('Ports', () => {
 				options.maxRetriesPerStartPort = 1;
 				options.totalRetryLoops = 50;
 				ports.strictFindFreePort(options).then(freePort => {
-					assert.ok(freePort >= 7100 && freePort !== initialPort);
+					assert(freePort !== initialPort, `Expected freePort !== initialPort, Actual: ${freePort}`);
 					server.close();
 
 					done();


### PR DESCRIPTION
There was recently a change in how we calculate valid notebook ports, and instead of relying on a hardcoded starting value (which causes tons of issues in rare cases when Jupyter server doesn't shutdown correctly), we instead choose a random port in a range. This test was flakey because sometimes, with the new behavior, we would choose a port that's < 7100 some small % of the time, causing the assert to fail. Just running the test enough times on my machine I was able to eventually repro the issue.

This should unblock the insider build, we will look at timeouts separately, as I'm unsure why setting timeouts isn't working as we expect.