### PR TITLE
Adjust estimated scrollbar height to avoid unneeded scrollbar

### DIFF
--- a/src/sql/workbench/parts/query/electron-browser/gridPanel.ts
+++ b/src/sql/workbench/parts/query/electron-browser/gridPanel.ts
@@ -47,7 +47,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 const ROW_HEIGHT = 29;
 const HEADER_HEIGHT = 26;
 const MIN_GRID_HEIGHT_ROWS = 8;
-const ESTIMATED_SCROLL_BAR_HEIGHT = 10;
+const ESTIMATED_SCROLL_BAR_HEIGHT = 15;
 const BOTTOM_PADDING = 15;
 const ACTIONBAR_WIDTH = 36;
 


### PR DESCRIPTION
Avoid unnecessary scrollbar by adjust some height calculations.  For example, below there is no need for vertical scrollbar since there is a ton of extra vertical space, but the messages can't be made smaller.

![image](https://user-images.githubusercontent.com/599935/57495303-66f29680-7282-11e9-84d4-73e82d30ce51.png)
