### PR TITLE
produce the vsix files during windows build

### DIFF
--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -40,9 +40,11 @@ function packageBuiltInExtensions() {
         .filter(({ name }) => excludedExtensions.indexOf(name) === -1)
         .filter(({ name }) => builtInExtensions.every(b => b.name !== name))
         .filter(({ name }) => sqlBuiltInExtensions.indexOf(name) >= 0);
+    const visxDirectory = path.join(path.dirname(root), 'vsix');
+    fs.mkdirSync(visxDirectory);
     sqlBuiltInLocalExtensionDescriptions.forEach(element => {
         let pkgJson = JSON.parse(fs.readFileSync(path.join(element.path, 'package.json'), { encoding: 'utf8' }));
-        const packagePath = path.join(root, `${pkgJson.name}-${pkgJson.version}.vsix`);
+        const packagePath = path.join(visxDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
         console.info('Creating vsix for ' + element.path + ' result:' + packagePath);
         vsce.createVSIX({
             cwd: element.path,

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -41,7 +41,8 @@ function packageBuiltInExtensions() {
         .filter(({ name }) => builtInExtensions.every(b => b.name !== name))
         .filter(({ name }) => sqlBuiltInExtensions.indexOf(name) >= 0);
     sqlBuiltInLocalExtensionDescriptions.forEach(element => {
-        const packagePath = path.join(path.dirname(root), element.name + '.vsix');
+        let pkgJson = JSON.parse(fs.readFileSync(path.join(element.path, 'package.json'), { encoding: 'utf8' }));
+        const packagePath = path.join(root, `${pkgJson.name}-${pkgJson.version}.vsix`);
         console.info('Creating vsix for ' + element.path + ' result:' + packagePath);
         vsce.createVSIX({
             cwd: element.path,

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -43,9 +43,11 @@ export function packageBuiltInExtensions() {
 		.filter(({ name }) => excludedExtensions.indexOf(name) === -1)
 		.filter(({ name }) => builtInExtensions.every(b => b.name !== name))
 		.filter(({ name }) => sqlBuiltInExtensions.indexOf(name) >= 0);
+	const visxDirectory = path.join(path.dirname(root), 'vsix');
+	fs.mkdirSync(visxDirectory);
 	sqlBuiltInLocalExtensionDescriptions.forEach(element => {
 		let pkgJson = JSON.parse(fs.readFileSync(path.join(element.path, 'package.json'), { encoding: 'utf8' }));
-		const packagePath = path.join(root, `${pkgJson.name}-${pkgJson.version}.vsix`);
+		const packagePath = path.join(visxDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
 		console.info('Creating vsix for ' + element.path + ' result:' + packagePath);
 		vsce.createVSIX({
 			cwd: element.path,

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -44,7 +44,8 @@ export function packageBuiltInExtensions() {
 		.filter(({ name }) => builtInExtensions.every(b => b.name !== name))
 		.filter(({ name }) => sqlBuiltInExtensions.indexOf(name) >= 0);
 	sqlBuiltInLocalExtensionDescriptions.forEach(element => {
-		const packagePath = path.join(path.dirname(root), element.name + '.vsix');
+		let pkgJson = JSON.parse(fs.readFileSync(path.join(element.path, 'package.json'), { encoding: 'utf8' }));
+		const packagePath = path.join(root, `${pkgJson.name}-${pkgJson.version}.vsix`);
 		console.info('Creating vsix for ' + element.path + ' result:' + packagePath);
 		vsce.createVSIX({
 			cwd: element.path,
@@ -365,9 +366,9 @@ export function packageExtensionsStream(optsIn?: IPackageExtensionsOptions): Nod
 	];
 
 	const localExtensionDependencies = () => gulp.src(extensionDepsSrc, { base: '.', dot: true })
-			.pipe(filter(['**', '!**/package-lock.json']))
-			.pipe(util2.cleanNodeModule('account-provider-azure', ['node_modules/date-utils/doc/**', 'node_modules/adal_node/node_modules/**'], undefined))
-			.pipe(util2.cleanNodeModule('typescript', ['**/**'], undefined));
+		.pipe(filter(['**', '!**/package-lock.json']))
+		.pipe(util2.cleanNodeModule('account-provider-azure', ['node_modules/date-utils/doc/**', 'node_modules/adal_node/node_modules/**'], undefined))
+		.pipe(util2.cleanNodeModule('typescript', ['**/**'], undefined));
 
 	// Original code commented out here
 	// const localExtensionDependencies = () => gulp.src('extensions/node_modules/**', { base: '.' });


### PR DESCRIPTION
This is part of the effort to make the pipeline produce the extension installers. in this PR I am trying to address the issue that the current visx file naming doesn't include the version information. I've also made changes to a clone of pipeline definition to copy the vsix files to the drop folder, once this PR is merged, I will update the windows pipeline definition and vsix files can be found here:
![image](https://user-images.githubusercontent.com/13777222/57504051-c0b98780-72a7-11e9-9ed0-8560edfb995b.png)
