### PR TITLE
Add pipeline task to push coverage results to coveralls

### DIFF
--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -32,6 +32,10 @@ steps:
     .\scripts\test.bat --reporter mocha-junit-reporter --coverage
   displayName: 'Test'
 
+- script: |
+    cat .\.build\coverage\lcov.info | node .\node_modules\coveralls\bin\coveralls.js
+  displayName: 'Upload coverage to Coveralls'
+
 - task: PublishTestResults@2
   inputs:
     testResultsFiles: 'test-results.xml'

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "chromium-pickle-js": "^0.2.0",
     "clean-css": "3.4.6",
     "copy-webpack-plugin": "^4.5.2",
-    "coveralls": "^2.11.11",
+    "coveralls": "^3.0.3",
     "cson-parser": "^1.3.3",
     "debounce": "^1.0.0",
     "documentdb": "^1.5.1",


### PR DESCRIPTION
This is just for the core tests right now (no extensions)

https://coveralls.io/github/microsoft/azuredatastudio