### PR TITLE
Fixed #5463 missing mkdir call function

### DIFF
--- a/extensions/mssql/src/objectExplorerNodeProvider/hdfsCommands.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/hdfsCommands.ts
@@ -168,6 +168,7 @@ export class MkDirCommand extends ProgressCommand {
 	}
 
 	private async mkDir(fileName, folderNode: FolderNode, cancelToken: vscode.CancellationTokenSource): Promise<void> {
+		await folderNode.mkdir(fileName);
 	}
 }
 


### PR DESCRIPTION
Enable stricter compile options on extensions #5044 regressed this, which missed mkdir call.