### PR TITLE
Bug fix Backup dialog list box to allow selecting file

### DIFF
--- a/src/sql/base/browser/ui/listBox/listBox.ts
+++ b/src/sql/base/browser/ui/listBox/listBox.ts
@@ -52,7 +52,7 @@ export class ListBox extends SelectBox {
 	public readonly onKeyDown = this._onKeyDown.event;
 
 	constructor(
-		options: ISelectOptionItem[],
+		private options: ISelectOptionItem[],
 		contextViewProvider: IContextViewProvider) {
 
 		super(options, 0, contextViewProvider);
@@ -66,6 +66,15 @@ export class ListBox extends SelectBox {
 		this.selectElement.style['min-width'] = '100%';
 
 		this._register(dom.addStandardDisposableListener(this.selectElement, dom.EventType.KEY_DOWN, (e: StandardKeyboardEvent) => this._onKeyDown.fire(e)));
+
+		this._register(dom.addDisposableListener(this.selectElement, dom.EventType.CLICK, (e) => {
+			this.contextViewProvider.hideContextView();
+			let index = (<any>e.target).index;
+			if (index !== null && index !== undefined) {
+				this.select(index);
+			}
+			this.selectElement.focus();
+		}));
 
 		this.enabledSelectBackground = this.selectBackground;
 		this.enabledSelectForeground = this.selectForeground;
@@ -140,11 +149,23 @@ export class ListBox extends SelectBox {
 
 		for (let i = 0; i < indexes.length; i++) {
 			this.selectElement.remove(indexes[i]);
+			this.options.splice(indexes[i], 1);
 		}
+		super.setOptions(this.options);
 	}
 
 	public add(option: string): void {
-		this.selectElement.add(this.createOption(option));
+		let optionObj = this.createOption(option);
+		this.selectElement.add(optionObj);
+
+		// make sure that base options are updated since that is used in selection not selectElement
+		this.options.push(optionObj);
+		super.setOptions(this.options);
+	}
+
+	public setOptions(options: ISelectOptionItem[], selected?: number): void {
+		this.options = options;
+		super.setOptions(options, selected);
 	}
 
 	public enable(): void {

--- a/src/sql/base/browser/ui/listBox/listBox.ts
+++ b/src/sql/base/browser/ui/listBox/listBox.ts
@@ -5,6 +5,7 @@
 
 import { SelectBox, ISelectBoxStyles, ISelectOptionItem } from 'vs/base/browser/ui/selectBox/selectBox';
 import { Color } from 'vs/base/common/color';
+import { isUndefinedOrNull } from 'vs/base/common/types';
 import { IMessage, MessageType, defaultOpts } from 'vs/base/browser/ui/inputbox/inputBox';
 import * as dom from 'vs/base/browser/dom';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
@@ -70,7 +71,7 @@ export class ListBox extends SelectBox {
 		this._register(dom.addDisposableListener(this.selectElement, dom.EventType.CLICK, (e) => {
 			this.contextViewProvider.hideContextView();
 			let index = (<any>e.target).index;
-			if (index !== null && index !== undefined) {
+			if (!isUndefinedOrNull(index)) {
 				this.select(index);
 			}
 			this.selectElement.focus();


### PR DESCRIPTION
Fixing list box in backup dialog to allow selection of file and and not show dropdown at click. This PR fixes bug- #1777 

![backupfilelistbox](https://user-images.githubusercontent.com/46980425/57663593-771fb400-75a9-11e9-803f-f8d05c8e5f73.gif)

We might also need overall refracting for list box component but doesn't seem to be in scope for this bug.