### PR TITLE
Corrected Keyboard Shortcut Execution Issue

### DIFF
--- a/src/sql/platform/query/common/queryManagement.ts
+++ b/src/sql/platform/query/common/queryManagement.ts
@@ -210,6 +210,7 @@ export class QueryManagementService implements IQueryManagementService {
 		});
 	}
 	public runQueryString(ownerUri: string, queryString: string): Thenable<void> {
+		this.addTelemetry(TelemetryKeys.RunQueryString, ownerUri);
 		return this._runAction(ownerUri, (runner) => {
 			return runner.runQueryString(ownerUri, queryString);
 		});

--- a/src/sql/platform/query/common/queryRunner.ts
+++ b/src/sql/platform/query/common/queryRunner.ts
@@ -197,6 +197,8 @@ export default class QueryRunner extends Disposable {
 			this._isExecuting = true;
 			this._totalElapsedMilliseconds = 0;
 
+			this._onQueryStart.fire();
+
 			return this._queryManagementService.runQueryString(this.uri, input).then(() => this.handleSuccessRunQueryResult(), e => this.handleFailureRunQueryResult(e));
 		} else {
 			return Promise.reject('Unknown input');

--- a/src/sql/platform/telemetry/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/telemetryKeys.ts
@@ -20,6 +20,7 @@ export const ChartCreated = 'ChartCreated';
 export const ObjectExplorerExpand = 'ObjectExplorerExpand';
 export const RunQuery = 'RunQuery';
 export const RunQueryStatement = 'RunQueryStatement';
+export const RunQueryString = 'RunQueryString';
 export const CancelQuery = 'CancelQuery';
 export const NewQuery = 'NewQuery';
 export const FirewallRuleRequested = 'FirewallRuleCreated';


### PR DESCRIPTION
Keyboard shortcuts now fire the same events the standard query execution events are firing which corrects an issue with the results panel.

This fix will allow keyboard shortcuts to execute procedures or SQL statements without the results pane cluttering up with incomplete meta data. The previous executed results headers would not clear, the new data would fill into those columns, and the new headers would appear below the completed set.

Should fix #4704 .