### PR TITLE
Fix test cleanup to remove folders regardless if tests passed or failed

### DIFF
--- a/scripts/sql-test-integration.bat
+++ b/scripts/sql-test-integration.bat
@@ -18,10 +18,10 @@ if "%SKIP_PYTHON_INSTALL_TEST%" == "1" (
 
 call .\scripts\code.bat --extensionDevelopmentPath=%~dp0\..\extensions\integration-tests --extensionTestsPath=%~dp0\..\extensions\integration-tests\out --user-data-dir=%VSCODEUSERDATADIR% --extensions-dir=%VSCODEEXTENSIONSDIR% --remote-debugging-port=9222
 
-if %errorlevel% neq 0 exit /b %errorlevel%
-
 rmdir /s /q %VSCODEUSERDATADIR%
 rmdir /s /q %VSCODEEXTENSIONSDIR%
+
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 popd
 


### PR DESCRIPTION
There were a bunch of these folders on the build machine that caused it to run out of disk space - we should always delete these even if the test failed. 