### PR TITLE
Fixed bug: wrong handle usage in updateWizardPageInfo() in extHostModelViewDialog

### DIFF
--- a/src/sql/workbench/api/node/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/node/extHostModelViewDialog.ts
@@ -479,7 +479,7 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 	public $updateWizardPageInfo(handle: number, pageHandles: number[], currentPageIndex: number): void {
 		let callback = this._pageInfoChangedCallbacks.get(handle);
 		if (callback) {
-			let pages = pageHandles.map(pageHandle => this._objectsByHandle.get(handle) as azdata.window.WizardPage);
+			let pages = pageHandles.map(pageHandle => this._objectsByHandle.get(pageHandle) as azdata.window.WizardPage);
 			callback({
 				eventType: WizardPageInfoEventType.PageAddedOrRemoved,
 				pageChangeInfo: {


### PR DESCRIPTION
`UpdateWizardPageInfo()` in `extHostModelViewDialog` has been using `Wizard` handle where `WizardPage` handle is supposed to be used.