### PR TITLE
Fix schema compare diff script formatting

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.91",
+	"version": "1.5.0-alpha.93",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",


### PR DESCRIPTION
Fix #5419. This fixes the formatting problems below. Adding 'GO' after statements and blank lines at the beginning were fixed in SqlToolsService and are in version 1.5.0-alpha.93.

**Blank lines no longer showing as difference:**
old:
![image](https://user-images.githubusercontent.com/31145923/57340094-417e5500-70e9-11e9-8d22-9837849d4a45.png)
fixed:
![image](https://user-images.githubusercontent.com/31145923/57473413-a26e7000-7244-11e9-93ab-f2cbed44627b.png)

**No more blank lines at the beginning of some scripts:**
old:
![image](https://user-images.githubusercontent.com/31145923/57340142-6e326c80-70e9-11e9-9b6f-0670ad5d26fa.png)
fixed:
![image](https://user-images.githubusercontent.com/31145923/57473059-d09f8000-7243-11e9-8479-667b66d35f68.png)

**Each statement now starts on its own line:**
old:
![image](https://user-images.githubusercontent.com/31145923/57340168-8a360e00-70e9-11e9-867f-b60e357c71b3.png)
fixed:
![image](https://user-images.githubusercontent.com/31145923/57474749-ac45a280-7247-11e9-9173-200cc619e721.png)

