### PR TITLE
Add CSSStyles for text component

### DIFF
--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -95,11 +95,13 @@ export class SchemaCompareResult {
 			}]);
 
 			let sourceLabel = view.modelBuilder.text().withProperties({
-				value: localize('schemaCompare.sourceLabel', 'Source')
+				value: localize('schemaCompare.sourceLabel', 'Source'),
+				CSSStyles: { 'margin-bottom': '0px' }
 			}).component();
 
 			let targetLabel = view.modelBuilder.text().withProperties({
-				value: localize('schemaCompare.targetLabel', 'Target')
+				value: localize('schemaCompare.targetLabel', 'Target'),
+				CSSStyles: { 'margin-bottom': '0px' }
 			}).component();
 
 			let arrowLabel = view.modelBuilder.text().withProperties({

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -3160,6 +3160,7 @@ declare module 'azdata' {
 	export interface TextComponentProperties {
 		value?: string;
 		links?: LinkArea[];
+		CSSStyles?: { [key: string]: string };
 	}
 
 	export interface LinkArea {

--- a/src/sql/workbench/electron-browser/modelComponents/text.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/text.component.ts
@@ -18,7 +18,7 @@ import { SafeHtml, DomSanitizer } from '@angular/platform-browser';
 @Component({
 	selector: 'modelview-text',
 	template: `
-		<p [style.width]="getWidth()" [innerHTML]="getValue()"></p>`
+		<p [style.width]="getWidth()" [innerHTML]="getValue()" [ngStyle]="this.CSSStyles"></p>`
 })
 export default class TextComponent extends ComponentBase implements IComponent, OnDestroy, AfterViewInit {
 	@Input() descriptor: IComponentDescriptor;


### PR DESCRIPTION
This changeset lets the css style now be specified for the text component. The text component used to use the user agent stylesheet for the css for p
![image](https://user-images.githubusercontent.com/31145923/57810988-fa621680-771d-11e9-9b0c-91c0c58c6c65.png)

before with the default css margins:
![image](https://user-images.githubusercontent.com/31145923/57811299-b9b6cd00-771e-11e9-8dc3-0ab87b236daa.png)

after specifying margin-bottom: 0px
![image](https://user-images.githubusercontent.com/31145923/57811476-3184f780-771f-11e9-99cb-b31f76856e3f.png)

