### PR TITLE
Fixes/improvements for SsmsMin extension

### DIFF
--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -55,7 +55,12 @@
 				},
 				{
 					"command": "adminToolExtWin.launchSsmsMinPropertiesDialog",
-					"when": "isWindows && connectionProvider == MSSQL && nodeType && nodeType =~ /^(Server|Database|Table|Column|Index|Statistic|View|ServerLevelLogin|ServerLevelServerRole|ServerLevelCredential|ServerLevelServerAudit|ServerLevelServerAuditSpecification|StoredProcedure|ScalarValuedFunction|TableValuedFunction|AggregateFunction|Synonym|Assembly|UserDefinedDataType|UserDefinedType|UserDefinedTableType|Sequence|User|DatabaseRole|ApplicationRole|Schema|SecurityPolicy|ServerLevelLinkedServer)$/",
+					"when": "isWindows && connectionProvider == MSSQL && serverInfo && !isCloud && nodeType && nodeType == Server",
+					"group": "z-AdminToolExt@2"
+				},
+				{
+					"command": "adminToolExtWin.launchSsmsMinPropertiesDialog",
+					"when": "isWindows && connectionProvider == MSSQL && serverInfo && nodeType && nodeType =~ /^(Database|Table|Column|Index|Statistic|View|ServerLevelLogin|ServerLevelServerRole|ServerLevelCredential|ServerLevelServerAudit|ServerLevelServerAuditSpecification|StoredProcedure|ScalarValuedFunction|TableValuedFunction|AggregateFunction|Synonym|Assembly|UserDefinedDataType|UserDefinedType|UserDefinedTableType|Sequence|User|DatabaseRole|ApplicationRole|Schema|SecurityPolicy|ServerLevelLinkedServer)$/",
 					"group": "z-AdminToolExt@2"
 				}
 			]

--- a/extensions/admin-tool-ext-win/src/main.ts
+++ b/extensions/admin-tool-ext-win/src/main.ts
@@ -15,9 +15,7 @@ const ssmsMinVer = JSON.parse(JSON.stringify(require('./config.json'))).version;
 
 let exePath: string;
 const runningProcesses: Map<number, ChildProcess> = new Map<number, ChildProcess>();
-let statusBarItem: vscode.StatusBarItem;
-let statusBarItemTimer: NodeJS.Timer;
-const STATUS_BAR_ITEM_DISPLAY_TIME_MS: number = 2000;
+
 interface SmoMapping {
 	action: string;
 	urnName: string;
@@ -68,8 +66,6 @@ export interface LaunchSsmsDialogParams {
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	// This is for Windows-specific support so do nothing on other platforms
 	if (process.platform === 'win32') {
-		statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-
 		Telemetry.sendTelemetryEvent('startup/ExtensionActivated');
 		exePath = path.join(context.extensionPath, 'ssmsmin', 'Windows', ssmsMinVer, 'ssmsmin.exe');
 		registerCommands(context);

--- a/extensions/admin-tool-ext-win/src/test/utils.test.ts
+++ b/extensions/admin-tool-ext-win/src/test/utils.test.ts
@@ -65,11 +65,6 @@ describe('buildSsmsMinCommandArgs Method Tests', () => {
 	});
 });
 
-const azureServerName = 'my\'Server';
-const fullAzureServerName = `${azureServerName}.database.windows.net`;
-const escapedAzureServerName = doubleEscapeSingleQuotes(azureServerName);
-const serverName = 'My\'Server';
-const escapedServerName = doubleEscapeSingleQuotes(serverName);
 const dbName = 'My\'Db';
 const escapedDbName = doubleEscapeSingleQuotes(dbName);
 const dbSchema = 'db\'sch';
@@ -80,26 +75,22 @@ const tableSchema = 'tbl\'sch';
 const escapedTableSchema = doubleEscapeSingleQuotes(tableSchema);
 
 describe('buildUrn Method Tests', () => {
-	it('Azure Server Name is trimmed correctly', async function(): Promise<void> {
-		should(await buildUrn(fullAzureServerName, undefined)).equal(`Server[@Name=\'${escapedAzureServerName}\']`);
-	});
-
 	it('Urn should be correct with just server', async function (): Promise<void> {
-		should(await buildUrn(serverName, undefined)).equal(`Server[@Name=\'${escapedServerName}\']`);
+		should(await buildUrn(undefined)).equal('Server');
 	});
 
 	it('Urn should be correct with Server and only Databases folder', async function (): Promise<void> {
 		const leafNode: ExtHostObjectExplorerNodeStub =
 			new ExtHostObjectExplorerNodeStub('Databases', undefined, 'Folder', undefined);
-		should(await buildUrn(serverName, leafNode)).equal(`Server[@Name='${escapedServerName}']`);
+		should(await buildUrn(leafNode)).equal('Server');
 	});
 
 	it('Urn should be correct with Server and Database node', async function (): Promise<void> {
 		const leafNode: ExtHostObjectExplorerNodeStub =
 			new ExtHostObjectExplorerNodeStub('Databases', undefined, 'Folder', undefined)
 				.createChild(dbName, dbSchema, 'Database');
-		should(await buildUrn(serverName, leafNode)).equal(
-			`Server[@Name='${escapedServerName}']/Database[@Name='${escapedDbName}' and @Schema='${escapedDbSchema}']`);
+		should(await buildUrn(leafNode)).equal(
+			`Server/Database[@Name='${escapedDbName}' and @Schema='${escapedDbSchema}']`);
 	});
 
 	it('Urn should be correct with Multiple levels of Nodes', async function (): Promise<void> {
@@ -108,8 +99,8 @@ describe('buildUrn Method Tests', () => {
 				.createChild(dbName, dbSchema, 'Database')
 				.createChild('Tables', undefined, 'Folder')
 				.createChild(tableName, tableSchema, 'Table');
-		should(await buildUrn(serverName, rootNode)).equal(
-			`Server[@Name='${escapedServerName}']/Database[@Name='${escapedDbName}' and @Schema='${escapedDbSchema}']/Table[@Name='${escapedTableName}' and @Schema='${escapedTableSchema}']`);
+		should(await buildUrn(rootNode)).equal(
+			`Server/Database[@Name='${escapedDbName}' and @Schema='${escapedDbSchema}']/Table[@Name='${escapedTableName}' and @Schema='${escapedTableSchema}']`);
 	});
 });
 

--- a/extensions/admin-tool-ext-win/src/test/utils.test.ts
+++ b/extensions/admin-tool-ext-win/src/test/utils.test.ts
@@ -36,8 +36,8 @@ describe('buildSsmsMinCommandArgs Method Tests', () => {
 			urn: 'Server\\Database\\Table'
 		};
 		const args = buildSsmsMinCommandArgs(params);
-		// User is omitted since UseAAD is true
-		should(args).equal('-a "myAction" -S "myServer" -D "myDatabase" -G -u "Server\\Database\\Table"');
+
+		should(args).equal('-a "myAction" -S "myServer" -D "myDatabase" -U "user" -G -u "Server\\Database\\Table"');
 	});
 
 	it('Should be built correctly and names escaped correctly', function (): void {
@@ -50,8 +50,8 @@ describe('buildSsmsMinCommandArgs Method Tests', () => {
 			urn: 'Server\\Database[\'myDatabase\'\'"/\\[]tricky\']\\Table["myTable\'""/\\[]tricky"]'
 		};
 		const args = buildSsmsMinCommandArgs(params);
-		// User is omitted since UseAAD is true
-		should(args).equal('-a "myAction\'\\"/\\[]tricky" -S "myServer\'\\"/\\[]tricky" -D "myDatabase\'\\"/\\[]tricky" -G -u "Server\\Database[\'myDatabase\'\'\\"/\\[]tricky\']\\Table[\\"myTable\'\\"\\"/\\[]tricky\\"]"');
+
+		should(args).equal('-a "myAction\'\\"/\\[]tricky" -S "myServer\'\\"/\\[]tricky" -D "myDatabase\'\\"/\\[]tricky" -U "user\'\\"/\\[]tricky" -G -u "Server\\Database[\'myDatabase\'\'\\"/\\[]tricky\']\\Table[\\"myTable\'\\"\\"/\\[]tricky\\"]"');
 	});
 
 	it('Should be built correctly with only action and server', function (): void {
@@ -65,6 +65,9 @@ describe('buildSsmsMinCommandArgs Method Tests', () => {
 	});
 });
 
+const azureServerName = 'my\'Server';
+const fullAzureServerName = `${azureServerName}.database.windows.net`;
+const escapedAzureServerName = doubleEscapeSingleQuotes(azureServerName);
 const serverName = 'My\'Server';
 const escapedServerName = doubleEscapeSingleQuotes(serverName);
 const dbName = 'My\'Db';
@@ -77,6 +80,10 @@ const tableSchema = 'tbl\'sch';
 const escapedTableSchema = doubleEscapeSingleQuotes(tableSchema);
 
 describe('buildUrn Method Tests', () => {
+	it('Azure Server Name is trimmed correctly', async function(): Promise<void> {
+		should(await buildUrn(fullAzureServerName, undefined)).equal(`Server[@Name=\'${escapedAzureServerName}\']`);
+	});
+
 	it('Urn should be correct with just server', async function (): Promise<void> {
 		should(await buildUrn(serverName, undefined)).equal(`Server[@Name=\'${escapedServerName}\']`);
 	});


### PR DESCRIPTION
 - Update extension menu when clauses so that the items are only shown for connected nodes (currently nodes need to be connected to launch the dialogs)
- Also hide server properties for Azure servers (Azure servers aren't supported by server properties dialog)
- Add status bar item for feedback that a dialog is being launched since it can take a while to show up
- Fix server name in URN for Azure servers - those require using the "true name" which is everything but the .database.windows.net. This doesn't handle other clouds but I need to look more into how to solve that problem, for now this will solve the majority of the cases. 