### PR TITLE
Split TSLint MSSDL Required Rules into separate config

### DIFF
--- a/tslint-gci.json
+++ b/tslint-gci.json
@@ -1,22 +1,6 @@
 {
-	"extends": "./tslint.json",
+	"extends": ["./tslint.json", "./tslint.mssdl.required.json"],
 	"rules": {
-		"no-banned-terms": true,
-		"no-delete-expression": true,
-		"no-document-domain": true,
-		"no-disable-auto-sanitization": true,
-		"no-duplicate-parameter-names": true,
-		"no-exec-script": true,
-		"no-function-constructor-with-string-args": true,
-		"no-octal-literal": true,
-		"no-reserved-keywords": false,
-		"variable-name": {
-			"options": ["ban-keywords"]
-		},
-		"no-string-based-set-immediate": true,
-		"no-string-based-set-interval": true,
-		"no-string-based-set-timeout": true,
-		"no-eval": true
 	},
 	"defaultSeverity": "error",
 	"rulesDirectory": "./node_modules/tslint-microsoft-contrib/",

--- a/tslint.mssdl.required.json
+++ b/tslint.mssdl.required.json
@@ -1,0 +1,25 @@
+{
+	"rules": {
+		"no-banned-terms": true,
+		"no-delete-expression": true,
+		"no-disable-auto-sanitization": true,
+		"no-document-domain": true,
+		"no-duplicate-parameter-names": true,
+		"no-eval": true,
+		"no-exec-script": true,
+		"no-function-constructor-with-string-args": true,
+		"no-octal-literal": true,
+		// The actual SDL list includes no-reserved-keywords currently but this has been deprecated
+		// in tslint-microsoft-contrib in favor of using the ban-keywords option below. So to avoid
+		// making many unnecessary changes we just use ban-keywords here instead
+		"no-reserved-keywords": false,
+		"variable-name": {
+			"options": [
+				"ban-keywords"
+			]
+		},
+		"no-string-based-set-immediate": true,
+		"no-string-based-set-interval": true,
+		"no-string-based-set-timeout": true
+	}
+}


### PR DESCRIPTION
This is so the TSA scans can use that file without also having the other rules (we scan many different repos using the same tslint config file and some of them have errors for non-MSSDL required rules. I plan on fixing these at some point but for the TSA scans it's just important to get the MSSDL ones enabled for now)