### PR TITLE
Made connection icon to be remembered by memento in ConnectionManagementService

### DIFF
--- a/src/sql/platform/connection/common/connectionManagementService.ts
+++ b/src/sql/platform/connection/common/connectionManagementService.ts
@@ -566,15 +566,19 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 					if (!this._mementoObj.CONNECTION_ICON_ID) {
 						this._mementoObj.CONNECTION_ICON_ID = <any>{};
 					}
-					this._mementoObj.CONNECTION_ICON_ID[connectionProfile.id] = iconId;
-					this._mementoContext.saveMemento();
+					if (this._mementoObj.CONNECTION_ICON_ID[connectionProfile.id] !== iconId) {
+						this._mementoObj.CONNECTION_ICON_ID[connectionProfile.id] = iconId;
+						this._mementoContext.saveMemento();
+					}
 				}
 			});
 		}
 	}
 
 	public getConnectionIconId(connectionId: string): string {
-		if (!connectionId || !this._mementoObj || !this._mementoObj.CONNECTION_ICON_ID) { return undefined; }
+		if (!connectionId || !this._mementoObj || !this._mementoObj.CONNECTION_ICON_ID) {
+			return undefined;
+		}
 		return this._mementoObj.CONNECTION_ICON_ID[connectionId];
 	}
 

--- a/src/sqltest/parts/connection/connectionManagementService.test.ts
+++ b/src/sqltest/parts/connection/connectionManagementService.test.ts
@@ -162,6 +162,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			resourceProviderStubMock.object,
 			undefined,
 			accountManagementService.object,
+			undefined,
 			undefined
 		);
 		return connectionManagementService;


### PR DESCRIPTION
This PR makes connection icon to be remembered by memento in ConnectionManagementService so that connections can be rendered with correct icon after ADS execution.

![GIF](https://user-images.githubusercontent.com/19577035/57958708-8c505780-78b5-11e9-946c-3c55f5c645ac.gif)
