### PR TITLE
Update installer warning to refer to ADS instead of VS Code

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -133,7 +133,7 @@ begin
 
   #if "user" == InstallTarget
     if not WizardSilent() and IsAdminLoggedOn() then begin
-      if MsgBox('This User Installer is not meant to be run as an Administrator. If you would like to install VS Code for all users in this system, download the System Installer instead from https://code.visualstudio.com. Are you sure you want to continue?', mbError, MB_OKCANCEL) = IDCANCEL then begin
+      if MsgBox('This User Installer is not meant to be run as an Administrator. If you would like to install Azure Data Studio for all users in this system, download the System Installer instead from https://docs.microsoft.com/sql/azure-data-studio/download. Are you sure you want to continue?', mbError, MB_OKCANCEL) = IDCANCEL then begin
         Result := False;
       end;
     end;


### PR DESCRIPTION
Fixes #5535 

![image](https://user-images.githubusercontent.com/28519865/58031239-df542580-7ad4-11e9-89f9-7a6514276887.png)
