### PR TITLE
Revert user settings changes after running Existing Python Install integration test.

### DIFF
--- a/extensions/notebook/src/integrationTest/notebookIntegration.test.ts
+++ b/extensions/notebook/src/integrationTest/notebookIntegration.test.ts
@@ -51,6 +51,7 @@ describe('Notebook Extension Python Installation', function () {
 		console.log(`Expected python path: '${pythonInstallDir}'; actual: '${jupyterPath}'`);
 		should(jupyterPath).be.equal(pythonInstallDir);
 		should(JupyterServerInstallation.isPythonInstalled(apiWrapper)).be.true();
+		should(JupyterServerInstallation.getExistingPythonSetting(apiWrapper)).be.false();
 	});
 
 	it('Use Existing Python Installation', async function () {
@@ -66,12 +67,17 @@ describe('Notebook Extension Python Installation', function () {
 		console.log('Start Existing Python Installation');
 		let existingPythonPath = path.join(pythonInstallDir, pythonBundleVersion);
 		await install.startInstallProcess(false, { installPath: existingPythonPath, existingPython: true });
-		should(JupyterServerInstallation.isPythonInstalled(install.apiWrapper)).be.true();
+		let apiWrapper = install.apiWrapper;
+		should(JupyterServerInstallation.isPythonInstalled(apiWrapper)).be.true();
+		should(JupyterServerInstallation.getPythonInstallPath(apiWrapper)).be.equal(existingPythonPath);
+		should(JupyterServerInstallation.getExistingPythonSetting(apiWrapper)).be.true();
 
 		// Redo "new" install to restore original settings.
 		// The actual install should get skipped since it already exists.
 		await install.startInstallProcess(false, { installPath: pythonInstallDir, existingPython: false });
-		should(JupyterServerInstallation.isPythonInstalled(install.apiWrapper)).be.true();
+		should(JupyterServerInstallation.isPythonInstalled(apiWrapper)).be.true();
+		should(JupyterServerInstallation.getPythonInstallPath(apiWrapper)).be.equal(pythonInstallDir);
+		should(JupyterServerInstallation.getExistingPythonSetting(apiWrapper)).be.false();
 		console.log('Existing Python Installation is done');
 	});
 });

--- a/extensions/notebook/src/integrationTest/notebookIntegration.test.ts
+++ b/extensions/notebook/src/integrationTest/notebookIntegration.test.ts
@@ -45,9 +45,12 @@ describe('Notebook Extension Python Installation', function () {
 
 	it('Verify Python Installation', async function () {
 		should(installComplete).be.true('Python setup did not complete.');
-		let jupyterPath = JupyterServerInstallation.getPythonInstallPath(jupyterController.jupyterInstallation.apiWrapper);
+		let apiWrapper = jupyterController.jupyterInstallation.apiWrapper;
+		let jupyterPath = JupyterServerInstallation.getPythonInstallPath(apiWrapper);
+
 		console.log(`Expected python path: '${pythonInstallDir}'; actual: '${jupyterPath}'`);
 		should(jupyterPath).be.equal(pythonInstallDir);
+		should(JupyterServerInstallation.isPythonInstalled(apiWrapper)).be.true();
 	});
 
 	it('Use Existing Python Installation', async function () {
@@ -63,6 +66,12 @@ describe('Notebook Extension Python Installation', function () {
 		console.log('Start Existing Python Installation');
 		let existingPythonPath = path.join(pythonInstallDir, pythonBundleVersion);
 		await install.startInstallProcess(false, { installPath: existingPythonPath, existingPython: true });
+		should(JupyterServerInstallation.isPythonInstalled(install.apiWrapper)).be.true();
+
+		// Redo "new" install to restore original settings.
+		// The actual install should get skipped since it already exists.
+		await install.startInstallProcess(false, { installPath: pythonInstallDir, existingPython: false });
+		should(JupyterServerInstallation.isPythonInstalled(install.apiWrapper)).be.true();
 		console.log('Existing Python Installation is done');
 	});
 });


### PR DESCRIPTION
The Existing Python Install test updates the user settings after completion, but later notebook tests manually update the python path user setting without changing the useExistingPython setting. This caused the tests to be unable to find the python install. The easiest change here seemed to be to revert the user settings changes after running the existing python test.