### PR TITLE
Schema compare server dropdown changes

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -439,6 +439,9 @@ export class SchemaCompareDialog {
 			return uniqueValues;
 		}, []);
 
+		// reverse list so that most recent connections show first
+		values.reverse();
+
 		// move server of current connection to the top of the list so it is the default
 		if (idx >= 1) {
 			let tmp = values[0];

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -416,7 +416,6 @@ export class SchemaCompareDialog {
 				idx = count;
 			}
 
-			let db = c.options.databaseDisplayName;
 			let usr = c.options.user;
 			let srv = c.options.server;
 
@@ -431,6 +430,14 @@ export class SchemaCompareDialog {
 				name: srv
 			};
 		});
+
+		values = values.reduce((uniqueValues, conn) => {
+			let exists = uniqueValues.find(x => x.displayName === conn.displayName);
+			if (!exists) {
+				uniqueValues.push(conn);
+			}
+			return uniqueValues;
+		}, []);
 
 		// move server of current connection to the top of the list so it is the default
 		if (idx >= 1) {


### PR DESCRIPTION
This makes two changes to the schema compare dialog server dropdown:
1. Remove duplicate server connections #5445
2. Sort the dropdown values so that the most recent connections are at the top