### PR TITLE
Widen schema compare dialog dropdowns and textboxes

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -209,7 +209,10 @@ export class SchemaCompareDialog {
 							horizontal: true,
 							titleFontSize: titleFontSize
 						})
-					.withLayout({ width: '100%' });
+					.withLayout({
+						width: '100%',
+						padding: '10px 10px 0 30px'
+					});
 			} else {
 				this.formBuilder = <azdata.FormBuilder>view.modelBuilder.formContainer()
 					.withFormItems([
@@ -230,7 +233,10 @@ export class SchemaCompareDialog {
 							horizontal: true,
 							titleFontSize: titleFontSize
 						})
-					.withLayout({ width: '100%' });
+					.withLayout({
+						width: '100%',
+						padding: '10px 10px 0 30px'
+					});
 			}
 			let formModel = this.formBuilder.component();
 			await view.initializeModel(formModel);

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -189,7 +189,7 @@ export class SchemaCompareDialog {
 
 			// if schema compare was launched from a db context menu, set that db as the source
 			if (this.database) {
-				this.formBuilder = view.modelBuilder.formContainer()
+				this.formBuilder = <azdata.FormBuilder>view.modelBuilder.formContainer()
 					.withFormItems([
 						{
 							title: SourceTitle,
@@ -208,9 +208,10 @@ export class SchemaCompareDialog {
 					], {
 							horizontal: true,
 							titleFontSize: titleFontSize
-						});
+						})
+					.withLayout({ width: '100%' });
 			} else {
-				this.formBuilder = view.modelBuilder.formContainer()
+				this.formBuilder = <azdata.FormBuilder>view.modelBuilder.formContainer()
 					.withFormItems([
 						{
 							title: SourceTitle,
@@ -228,7 +229,8 @@ export class SchemaCompareDialog {
 					], {
 							horizontal: true,
 							titleFontSize: titleFontSize
-						});
+						})
+					.withLayout({ width: '100%' });
 			}
 			let formModel = this.formBuilder.component();
 			await view.initializeModel(formModel);
@@ -306,8 +308,8 @@ export class SchemaCompareDialog {
 		databaseRadioButton.onDidClick(() => {
 			this.sourceIsDacpac = false;
 			if ((this.sourceServerDropdown.value as ConnectionDropdownValue)) {
-				this.formBuilder.insertFormItem(this.sourceServerComponent, 2, { horizontal: true, componentWidth: 300, titleFontSize: titleFontSize });
-				this.formBuilder.insertFormItem(this.sourceDatabaseComponent, 3, { horizontal: true, componentWidth: 300, titleFontSize: titleFontSize });
+				this.formBuilder.insertFormItem(this.sourceServerComponent, 2, { horizontal: true, titleFontSize: titleFontSize });
+				this.formBuilder.insertFormItem(this.sourceDatabaseComponent, 3, { horizontal: true, titleFontSize: titleFontSize });
 			} else {
 				this.formBuilder.insertFormItem(this.sourceNoActiveConnectionsText, 2, { horizontal: true, titleFontSize: titleFontSize });
 			}
@@ -361,8 +363,8 @@ export class SchemaCompareDialog {
 			this.targetIsDacpac = false;
 			this.formBuilder.removeFormItem(this.targetDacpacComponent);
 			if ((this.targetServerDropdown.value as ConnectionDropdownValue)) {
-				this.formBuilder.addFormItem(this.targetServerComponent, { horizontal: true, componentWidth: 300, titleFontSize: titleFontSize });
-				this.formBuilder.addFormItem(this.targetDatabaseComponent, { horizontal: true, componentWidth: 300, titleFontSize: titleFontSize });
+				this.formBuilder.addFormItem(this.targetServerComponent, { horizontal: true, titleFontSize: titleFontSize });
+				this.formBuilder.addFormItem(this.targetDatabaseComponent, { horizontal: true, titleFontSize: titleFontSize });
 			} else {
 				this.formBuilder.addFormItem(this.targetNoActiveConnectionsText, { horizontal: true, titleFontSize: titleFontSize });
 			}

--- a/src/sql/workbench/electron-browser/modelComponents/formContainer.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/formContainer.component.ts
@@ -50,7 +50,7 @@ class FormItem {
 			<div class="form-row" *ngIf="isFormComponent(item)" [style.height]="getRowHeight(item)">
 
 					<ng-container *ngIf="isHorizontal(item)">
-						<div class="form-cell" [style.font-size]="getItemTitleFontSize(item)" [ngClass]="{'form-group-item': isInGroup(item)}">
+						<div *ngIf="hasItemTitle(item)" class="form-cell form-cell-title" [style.font-size]="getItemTitleFontSize(item)" [ngClass]="{'form-group-item': isInGroup(item)}">
 							{{getItemTitle(item)}}<span class="form-required" *ngIf="isItemRequired(item)">*</span>
 							<span class="icon help form-info" *ngIf="itemHasInfo(item)" [title]="getItemInfo(item)"></span>
 						</div>
@@ -173,6 +173,10 @@ export default class FormContainer extends ContainerBase<FormItemLayout> impleme
 	private getItemTitle(item: FormItem): string {
 		let itemConfig = item.config;
 		return itemConfig ? itemConfig.title : '';
+	}
+
+	private hasItemTitle(item: FormItem): boolean {
+		return this.getItemTitle(item) !== '';
 	}
 
 	private getItemTitleFontSize(item: FormItem): string {

--- a/src/sql/workbench/electron-browser/modelComponents/media/formLayout.css
+++ b/src/sql/workbench/electron-browser/modelComponents/media/formLayout.css
@@ -32,6 +32,10 @@
 	display: table-cell;
 }
 
+.form-cell-title {
+	min-width: 129px; /* 129px + 5px padding right = 134px to match the connection pane label widths*/
+}
+
 .form-component-container {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
This change widens the dropdowns and textboxes in the schema compare dialog so there isn't so much blank space in the dialog. Also setting the min-width for the title labels to match the look of the connection pane.

Old:
![image](https://user-images.githubusercontent.com/31145923/58130789-cc734b00-7bd1-11e9-98ad-bae6808b81b9.png)

New:
![image](https://user-images.githubusercontent.com/31145923/58134724-8a9bd200-7bdc-11e9-9162-b725ba45c12f.png)

