### PR TITLE
Allow data explorer to use connect

### DIFF
--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -80,7 +80,7 @@ export interface IConnectionManagementService {
 	/**
 	 * Opens the connection dialog to create new connection
 	 */
-	showConnectionDialog(params?: INewConnectionParams, model?: IConnectionProfile, connectionResult?: IConnectionResult): Promise<void>;
+	showConnectionDialog(params?: INewConnectionParams, options?: IConnectionCompletionOptions, model?: IConnectionProfile, connectionResult?: IConnectionResult): Promise<void>;
 
 	/**
 	 * Opens the add server group dialog

--- a/src/sql/platform/connection/common/connectionManagement.ts
+++ b/src/sql/platform/connection/common/connectionManagement.ts
@@ -57,7 +57,7 @@ export interface IConnectionResult {
 export interface IConnectionCallbacks {
 	onConnectStart(): void;
 	onConnectReject(error?: string): void;
-	onConnectSuccess(params?: INewConnectionParams): void;
+	onConnectSuccess(params: INewConnectionParams, profile: IConnectionProfile): void;
 	onDisconnect(): void;
 	onConnectCanceled(): void;
 }
@@ -305,7 +305,7 @@ export interface IConnectableInput {
 	uri: string;
 	onConnectStart(): void;
 	onConnectReject(error?: string): void;
-	onConnectSuccess(params?: INewConnectionParams): void;
+	onConnectSuccess(params: INewConnectionParams, profile: IConnectionProfile): void;
 	onDisconnect(): void;
 	onConnectCanceled(): void;
 }

--- a/src/sql/platform/connection/common/connectionManagementService.ts
+++ b/src/sql/platform/connection/common/connectionManagementService.ts
@@ -475,6 +475,8 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 						this._connectionStore.savePassword(connection).then(() => {
 							resolve(connectionResult);
 						});
+					} else {
+						resolve(connectionResult);
 					}
 				} else if (connectionResult && connectionResult.errorMessage) {
 					this.handleConnectionError(connection, uri, options, callbacks, connectionResult).then(result => {

--- a/src/sql/platform/connection/common/connectionManagementService.ts
+++ b/src/sql/platform/connection/common/connectionManagementService.ts
@@ -188,7 +188,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	 * @param params Include the uri, type of connection
 	 * @param model the existing connection profile to create a new one from
 	 */
-	public showConnectionDialog(params?: INewConnectionParams, model?: IConnectionProfile, connectionResult?: IConnectionResult): Promise<void> {
+	public showConnectionDialog(params?: INewConnectionParams, options?: IConnectionCompletionOptions, model?: IConnectionProfile, connectionResult?: IConnectionResult): Promise<void> {
 		let self = this;
 		return new Promise<void>((resolve, reject) => {
 			if (!params) {
@@ -197,7 +197,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			if (!model && params.input && params.input.uri) {
 				model = this._connectionStatusManager.getConnectionProfile(params.input.uri);
 			}
-			self._connectionDialogService.showDialog(self, params, model, connectionResult).then(() => {
+			self._connectionDialogService.showDialog(self, params, model, connectionResult, options).then(() => {
 				resolve();
 			}, dialogError => {
 				this.logService.warn('failed to open the connection dialog. error: ' + dialogError);
@@ -322,7 +322,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 					runQueryOnCompletion: RunQueryOnConnectionMode.none,
 					showDashboard: options.showDashboard
 				};
-				this.showConnectionDialog(params, connection, connectionResult).then(() => {
+				this.showConnectionDialog(params, options, connection, connectionResult).then(() => {
 					resolve(connectionResult);
 				}).catch(err => {
 					reject(err);

--- a/src/sql/platform/connection/common/connectionManagementService.ts
+++ b/src/sql/platform/connection/common/connectionManagementService.ts
@@ -460,7 +460,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 					this.tryAddActiveConnection(connectionMgmtInfo, connection, options.saveTheConnection);
 
 					if (callbacks.onConnectSuccess) {
-						callbacks.onConnectSuccess(options.params);
+						callbacks.onConnectSuccess(options.params, connectionResult.connectionProfile);
 					}
 					if (options.saveTheConnection) {
 						this.saveToSettings(uri, connection).then(value => {
@@ -471,7 +471,11 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 						connection.saveProfile = false;
 						this.doActionsAfterConnectionComplete(uri, options);
 					}
-					resolve(connectionResult);
+					if (connection.savePassword) {
+						this._connectionStore.savePassword(connection).then(() => {
+							resolve(connectionResult);
+						});
+					}
 				} else if (connectionResult && connectionResult.errorMessage) {
 					this.handleConnectionError(connection, uri, options, callbacks, connectionResult).then(result => {
 						resolve(result);

--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -12,6 +12,8 @@ import { generateUuid } from 'vs/base/common/uuid';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { isString } from 'vs/base/common/types';
 import { deepClone } from 'vs/base/common/objects';
+import { ConnectionOptionSpecialType } from 'sql/workbench/api/common/sqlExtHostTypes';
+import * as Constants from 'sql/platform/connection/common/constants';
 
 // Concrete implementation of the IConnectionProfile interface
 
@@ -41,6 +43,12 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 			this.saveProfile = model.saveProfile;
 			this._id = model.id;
 			this.azureTenantId = model.azureTenantId;
+			const options = this.capabilitiesService.getCapabilities(model.providerName).connection.connectionOptions;
+			let appNameOption = options.find(option => option.specialValueType === ConnectionOptionSpecialType.appName);
+			if (appNameOption) {
+				let appNameKey = appNameOption.name;
+				this.options[appNameKey] = Constants.applicationName;
+			}
 		} else {
 			//Default for a new connection
 			this.savePassword = false;

--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -43,11 +43,13 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 			this.saveProfile = model.saveProfile;
 			this._id = model.id;
 			this.azureTenantId = model.azureTenantId;
-			const options = this.capabilitiesService.getCapabilities(model.providerName).connection.connectionOptions;
-			let appNameOption = options.find(option => option.specialValueType === ConnectionOptionSpecialType.appName);
-			if (appNameOption) {
-				let appNameKey = appNameOption.name;
-				this.options[appNameKey] = Constants.applicationName;
+			if (this.capabilitiesService) {
+				const options = this.capabilitiesService.getCapabilities(model.providerName).connection.connectionOptions;
+				let appNameOption = options.find(option => option.specialValueType === ConnectionOptionSpecialType.appName);
+				if (appNameOption) {
+					let appNameKey = appNameOption.name;
+					this.options[appNameKey] = Constants.applicationName;
+				}
 			}
 		} else {
 			//Default for a new connection

--- a/src/sql/platform/connection/common/connectionStore.ts
+++ b/src/sql/platform/connection/common/connectionStore.ts
@@ -124,6 +124,10 @@ export class ConnectionStore {
 			});
 	}
 
+	public savePassword(profile: IConnectionProfile): Promise<boolean> {
+		return this.saveProfilePasswordIfNeeded(profile);
+	}
+
 	/**
 	 * Saves a connection profile group to the user settings.
 	 *

--- a/src/sql/workbench/parts/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/parts/objectExplorer/browser/connectionTreeAction.ts
@@ -158,7 +158,7 @@ export class AddServerAction extends Action {
 			saveProfile: true,
 			id: element.id
 		};
-		this._connectionManagementService.showConnectionDialog(undefined, connection);
+		this._connectionManagementService.showConnectionDialog(undefined, undefined, connection);
 		return Promise.resolve(true);
 	}
 }

--- a/src/sql/workbench/parts/objectExplorer/common/objectExplorerViewTreeShim.ts
+++ b/src/sql/workbench/parts/objectExplorer/common/objectExplorerViewTreeShim.ts
@@ -48,12 +48,23 @@ export class OEShimService extends Disposable implements IOEShimService {
 		let connProfile = new ConnectionProfile(this.capabilities, node.payload);
 		connProfile.saveProfile = false;
 		if (this.cm.providerRegistered(providerId)) {
-			let userProfile = await this.cd.openDialogAndWait(this.cm, { connectionType: ConnectionType.default, showDashboard: false }, connProfile, undefined, false);
-			if (userProfile) {
-				connProfile = new ConnectionProfile(this.capabilities, userProfile);
-			} else {
-				return Promise.reject('User canceled');
-			}
+			await new Promise(async (resolve, reject) => {
+				await this.cm.connect(connProfile, undefined,
+					{ showConnectionDialogOnError: true, showFirewallRuleOnError: true, saveTheConnection: false, showDashboard: false, params: undefined },
+					{
+						onConnectSuccess: async e => {
+							let existingConnection = this.cm.findExistingConnection(connProfile);
+							connProfile = new ConnectionProfile(this.capabilities, await this.cm.addSavedPassword(existingConnection));
+							resolve();
+						},
+						onConnectCanceled: () => {
+							reject('User canceled');
+						},
+						onConnectReject: undefined,
+						onConnectStart: undefined,
+						onDisconnect: undefined
+					});
+			});
 		}
 		let sessionResp = await this.oe.createNewSession(providerId, connProfile);
 		let disp = this.oe.onUpdateObjectExplorerNodes(e => {

--- a/src/sql/workbench/parts/objectExplorer/common/objectExplorerViewTreeShim.ts
+++ b/src/sql/workbench/parts/objectExplorer/common/objectExplorerViewTreeShim.ts
@@ -52,8 +52,8 @@ export class OEShimService extends Disposable implements IOEShimService {
 				await this.cm.connect(connProfile, undefined,
 					{ showConnectionDialogOnError: true, showFirewallRuleOnError: true, saveTheConnection: false, showDashboard: false, params: undefined },
 					{
-						onConnectSuccess: async e => {
-							let existingConnection = this.cm.findExistingConnection(connProfile);
+						onConnectSuccess: async (e, profile) => {
+							let existingConnection = this.cm.findExistingConnection(profile);
 							connProfile = new ConnectionProfile(this.capabilities, await this.cm.addSavedPassword(existingConnection));
 							resolve();
 						},

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -65,6 +65,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	private _connectionControllerMap: { [providerDisplayName: string]: IConnectionComponentController } = {};
 	private _model: ConnectionProfile;
 	private _params: INewConnectionParams;
+	private _options: IConnectionCompletionOptions;
 	private _inputModel: IConnectionProfile;
 	private _providerNameToDisplayNameMap: { [providerDisplayName: string]: string } = {};
 	private _providerTypes: string[] = [];
@@ -239,7 +240,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		if (fromEditor && params && params.input) {
 			uri = params.input.uri;
 		}
-		let options: IConnectionCompletionOptions = {
+		let options: IConnectionCompletionOptions = this._options || {
 			params: params,
 			saveTheConnection: true,
 			showDashboard: params && params.showDashboard !== undefined ? params.showDashboard : !fromEditor,
@@ -393,10 +394,12 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		connectionManagementService: IConnectionManagementService,
 		params?: INewConnectionParams,
 		model?: IConnectionProfile,
-		connectionResult?: IConnectionResult): Thenable<void> {
+		connectionResult?: IConnectionResult,
+		connectionOptions?: IConnectionCompletionOptions): Thenable<void> {
 
 		this._connectionManagementService = connectionManagementService;
 
+		this._options = connectionOptions;
 		this._params = params;
 		this._inputModel = model;
 		return new Promise<void>((resolve, reject) => {

--- a/src/sql/workbench/services/connection/common/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/common/connectionDialogService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { INewConnectionParams, IConnectionResult, IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
+import { INewConnectionParams, IConnectionResult, IConnectionManagementService, IConnectionCompletionOptions } from 'sql/platform/connection/common/connectionManagement';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 
 export const IConnectionDialogService = createDecorator<IConnectionDialogService>('connectionDialogService');
@@ -13,7 +13,7 @@ export interface IConnectionDialogService {
 	/**
 	 * Opens the connection dialog and returns the promise for successfully opening the dialog
 	 */
-	showDialog(connectionManagementService: IConnectionManagementService, params: INewConnectionParams, model: IConnectionProfile, connectionResult?: IConnectionResult): Thenable<void>;
+	showDialog(connectionManagementService: IConnectionManagementService, params: INewConnectionParams, model: IConnectionProfile, connectionResult?: IConnectionResult, connectionOptions?: IConnectionCompletionOptions): Thenable<void>;
 
 	/**
 	 * Opens the connection dialog and returns the promise when connection is made

--- a/src/sqltest/parts/connection/connectionManagementService.test.ts
+++ b/src/sqltest/parts/connection/connectionManagementService.test.ts
@@ -93,11 +93,12 @@ suite('SQL ConnectionManagementService tests', () => {
 		let root = new ConnectionProfileGroup(ConnectionProfileGroup.RootGroupName, undefined, ConnectionProfileGroup.RootGroupName, undefined, undefined);
 		root.connections = [ConnectionProfile.fromIConnectionProfile(capabilitiesService, connectionProfile)];
 
-		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined)).returns(() => Promise.resolve(none));
-		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined)).returns(() => Promise.resolve(none));
-		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined)).returns(() => Promise.resolve(none));
-		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined)).returns(() => Promise.resolve(none));
-		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(none));
+		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined)).returns(() => Promise.resolve(none));
+		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, TypeMoq.It.isAny())).returns(() => Promise.resolve(none));
+		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined, TypeMoq.It.isAny())).returns(() => Promise.resolve(none));
+		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined, undefined)).returns(() => Promise.resolve(none));
+		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined)).returns(() => Promise.resolve(none));
+		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(none));
 
 		connectionStore.setup(x => x.addRecentConnection(TypeMoq.It.isAny())).returns(() => Promise.resolve());
 		connectionStore.setup(x => x.saveProfile(TypeMoq.It.isAny())).returns(() => Promise.resolve(connectionProfile));
@@ -112,6 +113,7 @@ suite('SQL ConnectionManagementService tests', () => {
 				() => Promise.resolve({ profile: connectionProfileWithEmptyUnsavedPassword, savedCred: false }));
 		connectionStore.setup(x => x.isPasswordRequired(TypeMoq.It.isAny())).returns(() => true);
 		connectionStore.setup(x => x.getConnectionProfileGroups(false, undefined)).returns(() => [root]);
+		connectionStore.setup(x => x.savePassword(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
 
 		mssqlConnectionProvider.setup(x => x.connect(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => undefined);
 
@@ -166,13 +168,14 @@ suite('SQL ConnectionManagementService tests', () => {
 		return connectionManagementService;
 	}
 
-	function verifyShowConnectionDialog(connectionProfile: IConnectionProfile, connectionType: ConnectionType, uri: string, connectionResult?: IConnectionResult, didShow: boolean = true): void {
+	function verifyShowConnectionDialog(connectionProfile: IConnectionProfile, connectionType: ConnectionType, uri: string, options: boolean, connectionResult?: IConnectionResult, didShow: boolean = true): void {
 		if (connectionProfile) {
 			connectionDialogService.verify(x => x.showDialog(
 				TypeMoq.It.isAny(),
 				TypeMoq.It.is<INewConnectionParams>(p => p.connectionType === connectionType && (uri === undefined || p.input.uri === uri)),
 				TypeMoq.It.is<IConnectionProfile>(c => c !== undefined && c.serverName === connectionProfile.serverName),
-				connectionResult ? TypeMoq.It.is<IConnectionResult>(r => r.errorMessage === connectionResult.errorMessage && r.callStack === connectionResult.callStack) : undefined),
+				connectionResult ? TypeMoq.It.is<IConnectionResult>(r => r.errorMessage === connectionResult.errorMessage && r.callStack === connectionResult.callStack) : undefined,
+				options ? TypeMoq.It.isAny() : undefined),
 				didShow ? TypeMoq.Times.once() : TypeMoq.Times.never());
 
 		} else {
@@ -180,7 +183,8 @@ suite('SQL ConnectionManagementService tests', () => {
 				TypeMoq.It.isAny(),
 				TypeMoq.It.is<INewConnectionParams>(p => p.connectionType === connectionType && ((uri === undefined && p.input === undefined) || p.input.uri === uri)),
 				undefined,
-				connectionResult ? TypeMoq.It.is<IConnectionResult>(r => r.errorMessage === connectionResult.errorMessage && r.callStack === connectionResult.callStack) : undefined),
+				connectionResult ? TypeMoq.It.is<IConnectionResult>(r => r.errorMessage === connectionResult.errorMessage && r.callStack === connectionResult.callStack) : undefined,
+				options ? TypeMoq.It.isAny() : undefined),
 				didShow ? TypeMoq.Times.once() : TypeMoq.Times.never());
 		}
 	}
@@ -243,7 +247,7 @@ suite('SQL ConnectionManagementService tests', () => {
 
 	test('showConnectionDialog should open the dialog with default type given no parameters', done => {
 		connectionManagementService.showConnectionDialog().then(() => {
-			verifyShowConnectionDialog(undefined, ConnectionType.default, undefined);
+			verifyShowConnectionDialog(undefined, ConnectionType.default, undefined, false);
 			done();
 		}).catch(err => {
 			done(err);
@@ -264,7 +268,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			runQueryOnCompletion: RunQueryOnConnectionMode.executeQuery
 		};
 		connectionManagementService.showConnectionDialog(params).then(() => {
-			verifyShowConnectionDialog(undefined, params.connectionType, params.input.uri);
+			verifyShowConnectionDialog(undefined, params.connectionType, params.input.uri, false);
 			done();
 		}).catch(err => {
 			done(err);
@@ -291,7 +295,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			assert.notEqual(saveConnection, undefined, `profile was not added to the connections`);
 			assert.equal(saveConnection.serverName, connectionProfile.serverName, `Server names are different`);
 			connectionManagementService.showConnectionDialog(params).then(() => {
-				verifyShowConnectionDialog(connectionProfile, params.connectionType, params.input.uri);
+				verifyShowConnectionDialog(connectionProfile, params.connectionType, params.input.uri, false);
 				done();
 			}).catch(err => {
 				done(err);
@@ -426,7 +430,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			assert.equal(result.connected, expectedConnection);
 			assert.equal(result.errorMessage, connectionResult.errorMessage);
 			verifyShowFirewallRuleDialog(connectionProfile, false);
-			verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, connectionResult);
+			verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, true, connectionResult);
 			done();
 		}).catch(err => {
 			done(err);
@@ -458,7 +462,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			assert.equal(result.connected, expectedConnection);
 			assert.equal(result.errorMessage, connectionResult.errorMessage);
 			verifyShowFirewallRuleDialog(connectionProfile, false);
-			verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, connectionResult, false);
+			verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, true, connectionResult, false);
 			done();
 		}).catch(err => {
 			done(err);
@@ -522,7 +526,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			assert.equal(result.connected, expectedConnection);
 			assert.equal(result.errorMessage, connectionResult.errorMessage);
 			verifyShowFirewallRuleDialog(connectionProfile, false);
-			verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, connectionResult, false);
+			verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, true, connectionResult, false);
 			done();
 		}).catch(err => {
 			done(err);
@@ -558,7 +562,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			assert.equal(result.connected, expectedConnection);
 			assert.equal(result.errorMessage, connectionResult.errorMessage);
 			verifyShowFirewallRuleDialog(connectionProfile, true);
-			verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, connectionResult, true);
+			verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, true, connectionResult, true);
 			done();
 		}).catch(err => {
 			done(err);
@@ -594,7 +598,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			assert.equal(result.connected, expectedConnection);
 			assert.equal(result.errorMessage, connectionResult.errorMessage);
 			verifyShowFirewallRuleDialog(connectionProfile, true);
-			verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, connectionResult, false);
+			verifyShowConnectionDialog(connectionProfile, ConnectionType.default, uri, true, connectionResult, false);
 			done();
 		}).catch(err => {
 			done(err);
@@ -622,7 +626,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		connect(uri, options, false, connectionProfileWithEmptyUnsavedPassword).then(result => {
 			assert.equal(result.connected, expectedConnection);
 			assert.equal(result.errorMessage, connectionResult.errorMessage);
-			verifyShowConnectionDialog(connectionProfileWithEmptyUnsavedPassword, ConnectionType.default, uri, connectionResult);
+			verifyShowConnectionDialog(connectionProfileWithEmptyUnsavedPassword, ConnectionType.default, uri, true, connectionResult);
 			verifyShowFirewallRuleDialog(connectionProfile, false);
 			done();
 		}).catch(err => {
@@ -651,7 +655,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		connect(uri, options, false, connectionProfileWithEmptySavedPassword).then(result => {
 			assert.equal(result.connected, expectedConnection);
 			assert.equal(result.errorMessage, connectionResult.errorMessage);
-			verifyShowConnectionDialog(connectionProfileWithEmptySavedPassword, ConnectionType.default, uri, connectionResult, false);
+			verifyShowConnectionDialog(connectionProfileWithEmptySavedPassword, ConnectionType.default, uri, true, connectionResult, false);
 			done();
 		}).catch(err => {
 			done(err);
@@ -691,7 +695,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		connect(uri, options, false, connectionProfileWithEmptySavedPassword).then(result => {
 			assert.equal(result.connected, expectedConnection);
 			assert.equal(result.errorMessage, connectionResult.errorMessage);
-			verifyShowConnectionDialog(connectionProfileWithEmptySavedPassword, ConnectionType.editor, uri, connectionResult, false);
+			verifyShowConnectionDialog(connectionProfileWithEmptySavedPassword, ConnectionType.editor, uri, true, connectionResult, false);
 			done();
 		}).catch(err => {
 			done(err);

--- a/src/sqltest/parts/connection/connectionTreeActions.test.ts
+++ b/src/sqltest/parts/connection/connectionTreeActions.test.ts
@@ -56,7 +56,7 @@ suite('SQL Connection Tree Action tests', () => {
 		connectionManagementService.setup(x => x.showDashboard(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
 		connectionManagementService.setup(x => x.isProfileConnected(TypeMoq.It.isAny())).returns(() => isConnectedReturnValue);
 		connectionManagementService.setup(x => x.isProfileConnecting(TypeMoq.It.isAny())).returns(() => false);
-		connectionManagementService.setup(x => x.showConnectionDialog(undefined, TypeMoq.It.isAny())).returns(() => new Promise<void>((resolve, reject) => resolve()));
+		connectionManagementService.setup(x => x.showConnectionDialog(undefined, undefined, TypeMoq.It.isAny())).returns(() => new Promise<void>((resolve, reject) => resolve()));
 		connectionManagementService.setup(x => x.onConnect).returns(() => new Emitter<IConnectionParams>().event);
 		connectionManagementService.setup(x => x.onDisconnect).returns(() => new Emitter<any>().event);
 		connectionManagementService.setup(x => x.deleteConnectionGroup(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
@@ -189,7 +189,7 @@ suite('SQL Connection Tree Action tests', () => {
 		let connectionTreeAction: AddServerAction = new AddServerAction(AddServerAction.ID, AddServerAction.LABEL, connectionManagementService.object);
 		let conProfGroup = new ConnectionProfileGroup('testGroup', undefined, 'testGroup', undefined, undefined);
 		connectionTreeAction.run(conProfGroup).then((value) => {
-			connectionManagementService.verify(x => x.showConnectionDialog(undefined, TypeMoq.It.isAny()), TypeMoq.Times.once());
+			connectionManagementService.verify(x => x.showConnectionDialog(undefined, undefined, TypeMoq.It.isAny()), TypeMoq.Times.once());
 		}).then(() => done(), (err) => done(err));
 	});
 

--- a/src/sqltest/parts/notebook/model/notebookUtils.test.ts
+++ b/src/sqltest/parts/notebook/model/notebookUtils.test.ts
@@ -21,7 +21,7 @@ suite('notebookUtils', function (): void {
 		savePassword: true,
 		groupFullName: '',
 		groupId: '',
-		providerName: '',
+		providerName: 'MSSQL',
 		saveProfile: true,
 		id: '',
 		options: {},

--- a/src/sqltest/parts/query/editor/queryActions.test.ts
+++ b/src/sqltest/parts/query/editor/queryActions.test.ts
@@ -115,7 +115,7 @@ suite('SQL QueryAction Tests', () => {
 
 		// ... Mock "showDialog" ConnectionDialogService
 		let connectionDialogService = TypeMoq.Mock.ofType(ConnectionDialogService, TypeMoq.MockBehavior.Loose);
-		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined))
+		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined, undefined))
 			.callback((service: IConnectionManagementService, params: INewConnectionParams) => {
 				connectionParams = params;
 				countCalledShowDialog++;
@@ -221,7 +221,7 @@ suite('SQL QueryAction Tests', () => {
 
 		// ... Mock "showDialog" ConnectionDialogService
 		let connectionDialogService = TypeMoq.Mock.ofType(ConnectionDialogService, TypeMoq.MockBehavior.Loose);
-		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined))
+		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined, undefined))
 			.callback((service: IConnectionManagementService, params: INewConnectionParams) => {
 				showDialogConnectionParams = params;
 				countCalledShowDialog++;
@@ -379,7 +379,7 @@ suite('SQL QueryAction Tests', () => {
 
 		// ... Mock "showDialog" ConnectionDialogService
 		let connectionDialogService = TypeMoq.Mock.ofType(ConnectionDialogService, TypeMoq.MockBehavior.Loose);
-		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined))
+		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined, undefined))
 			.callback((service: IConnectionManagementService, params: INewConnectionParams) => {
 				connectionParams = params;
 				countCalledShowDialog++;
@@ -425,7 +425,7 @@ suite('SQL QueryAction Tests', () => {
 
 		// ... Mock "showDialog" ConnectionDialogService
 		let connectionDialogService = TypeMoq.Mock.ofType(ConnectionDialogService, TypeMoq.MockBehavior.Loose);
-		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined))
+		connectionDialogService.setup(x => x.showDialog(TypeMoq.It.isAny(), TypeMoq.It.isAny(), undefined, undefined, undefined))
 			.callback((service: IConnectionManagementService, params: INewConnectionParams) => {
 				calledShowDialog++;
 				connectionParams = params;

--- a/src/sqltest/stubs/capabilitiesTestService.ts
+++ b/src/sqltest/stubs/capabilitiesTestService.ts
@@ -99,7 +99,6 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 			connectionOptions: connectionProvider,
 		};
 		this.capabilities['MSSQL'] = { connection: msSQLCapabilities };
-
 	}
 
 	/**

--- a/src/sqltest/stubs/connectionDialogTestService.ts
+++ b/src/sqltest/stubs/connectionDialogTestService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { INewConnectionParams, IConnectionResult, IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
+import { INewConnectionParams, IConnectionResult, IConnectionManagementService, IConnectionCompletionOptions } from 'sql/platform/connection/common/connectionManagement';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { IConnectionDialogService } from 'sql/workbench/services/connection/common/connectionDialogService';
 
@@ -11,7 +11,7 @@ export class ConnectionDialogTestService implements IConnectionDialogService {
 	_serviceBrand: any;
 
 	public showDialog(connectionManagementService: IConnectionManagementService,
-		params: INewConnectionParams, model: IConnectionProfile, connectionResult?: IConnectionResult): Promise<void> {
+		params: INewConnectionParams, model: IConnectionProfile, connectionResult?: IConnectionResult, connectionOptions?: IConnectionCompletionOptions): Promise<void> {
 		let none: void;
 		return Promise.resolve(none);
 	}

--- a/src/sqltest/stubs/connectionManagementService.test.ts
+++ b/src/sqltest/stubs/connectionManagementService.test.ts
@@ -41,7 +41,7 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 
 	}
 
-	showConnectionDialog(params?: INewConnectionParams, model?: IConnectionProfile, connectionResult?: IConnectionResult): Promise<void> {
+	showConnectionDialog(params?: INewConnectionParams, options?: IConnectionCompletionOptions, model?: IConnectionProfile, connectionResult?: IConnectionResult): Promise<void> {
 		return undefined;
 	}
 


### PR DESCRIPTION
Adds the necessary changes to enable the data explorer to utilize the connect method which gets the connection dialog and firewall rule perks.