### PR TITLE
Fixing column plugin to not have extra whitespaces

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -23,11 +23,9 @@ const defaultOptions: ICheckboxSelectColumnOptions = {
 	width: 30
 };
 
-const checkboxTemplate = `
-							<div style="display: flex; align-items: center; flex-direction: column">
+const checkboxTemplate = `<div style="display: flex; align-items: center; flex-direction: column">
 								<input type="checkbox" {0}>
-							</div>
-`;
+							</div>`;
 
 export class CheckboxSelectColumn<T> implements Slick.Plugin<T> {
 	private _options: ICheckboxSelectColumnOptions;


### PR DESCRIPTION
Fixes #5371 Restore dialog checkBoxes not visible 
Reason: table cells now preserve white spaces in table which causes checkbox template to be dislocated (https://github.com/microsoft/azuredatastudio/pull/4983)
Fix: remove extra white spaces

(Please suggest if you think the original bug should be fixed in a different way. )