### PR TITLE
Fix #5566 DacFx extract/export pages not loading from command palette 

### DIFF
--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -148,7 +148,7 @@ export abstract class DacFxConfigPage extends BasePage {
 	}
 
 	protected generateFilePathFromDatabaseAndTimestamp(): string {
-		return path.join(this.getRootPath(), sanitizeStringForFilename(this.model.database) + '-' + this.getDateTime() + this.fileExtension);
+		return this.model.database ? path.join(this.getRootPath(), sanitizeStringForFilename(this.model.database) + '-' + this.getDateTime() + this.fileExtension) : '';
 	}
 
 	protected getDateTime(): string {


### PR DESCRIPTION
The DacFx wizard extract and export pages were failing to load when launched from the command palette or if the database name was unset in a the deploy page before going to the extract or export pages. The problem was that it was trying to sanitize the database name to generate a default filename, but it was failing when the database was not set.

Fixes #5566.