### PR TITLE
Get rid of schema compare double scrollbar

### DIFF
--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -226,7 +226,7 @@ export class SchemaCompareResult {
 		this.optionsButton.enabled = true;
 
 		if (this.comparisonResult.differences.length > 0) {
-			this.flexModel.addItem(this.splitView);
+			this.flexModel.addItem(this.splitView, { CSSStyles: { 'overflow': 'auto' } });
 
 			// only enable generate script button if the target is a db
 			if (this.targetEndpointInfo.endpointType === azdata.SchemaCompareEndpointType.Database) {

--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -226,7 +226,7 @@ export class SchemaCompareResult {
 		this.optionsButton.enabled = true;
 
 		if (this.comparisonResult.differences.length > 0) {
-			this.flexModel.addItem(this.splitView, { CSSStyles: { 'overflow': 'auto' } });
+			this.flexModel.addItem(this.splitView, { CSSStyles: { 'overflow': 'hidden' } });
 
 			// only enable generate script button if the target is a db
 			if (this.targetEndpointInfo.endpointType === azdata.SchemaCompareEndpointType.Database) {


### PR DESCRIPTION
This removes the double scrollbar by setting the overflow of the splitview container to hidden.

Before with double scroll bar:
![image](https://user-images.githubusercontent.com/31145923/58138127-d6a14380-7be9-11e9-9e97-3001d7304b2e.png)

Now: 
![image](https://user-images.githubusercontent.com/31145923/58137930-17e52380-7be9-11e9-9e7d-4a2e13826d89.png)
