### PR TITLE
Fix error callback to display error message instead of {1}

### DIFF
--- a/src/sql/platform/query/common/queryRunner.ts
+++ b/src/sql/platform/query/common/queryRunner.ts
@@ -212,6 +212,9 @@ export default class QueryRunner extends Disposable {
 	private handleFailureRunQueryResult(error: any) {
 		// Attempting to launch the query failed, show the error message
 		const eol = this.getEolString();
+		if (error instanceof Error) {
+			error = error.message;
+		}
 		let message = nls.localize('query.ExecutionFailedError', 'Execution failed due to an unexpected error: {0}\t{1}', eol, error);
 		this.handleMessage(<azdata.QueryExecuteMessageParams>{
 			ownerUri: this.uri,


### PR DESCRIPTION
Fixes #5478 

Before :

![image](https://user-images.githubusercontent.com/8904110/57710833-b1d22c80-763b-11e9-903e-24f3cf8a8b4e.png)

After : 
![image](https://user-images.githubusercontent.com/28519865/58186644-258ebd80-7c6a-11e9-8680-4904f86fa3fb.png)


Note that this is a fix for displaying errors that occurred in the Tools Service layer - it looks like it's failing to parse the code correctly before sending it to the server. Normal SQL syntax errors were already displayed correctly like this :

![image](https://user-images.githubusercontent.com/28519865/58188253-1fe6a700-7c6d-11e9-80f9-1abbbf5964fb.png)
