### PR TITLE
Fixed #4113 adding end-to-end to cover the failed test scenarios

### DIFF
--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -106,28 +106,28 @@ if (context.RunTest) {
 		}
 
 		test('scala language test', async function () {
-			let configLanguage = 'scala';
+			let language = 'scala';
 
-			languageTest(pySparkNotebookContent, pySpark3KernelMetadata, this.test.title, configLanguage, {
-				name: configLanguage,
+			languageTest(pySparkNotebookContent, pySpark3KernelMetadata, this.test.title, language, {
+				name: language,
 				version: '',
 				mimetype: ''
 			});
 		});
 
 		test('cplusplus language test', async function () {
-			let configLanguage = 'cplusplus';
-			languageTest(pySparkNotebookContent, pySpark3KernelMetadata, this.test.title, configLanguage, {
-				name: configLanguage,
+			let language = 'cplusplus';
+			languageTest(pySparkNotebookContent, pySpark3KernelMetadata, this.test.title, language, {
+				name: language,
 				version: '',
 				mimetype: ''
 			});
 		});
 
 		test('Empty language test', async function () {
-			let configLanguage = '';
-			languageTest(pySparkNotebookContent, pySpark3KernelMetadata, this.test.title, configLanguage, {
-				name: configLanguage,
+			let language = '';
+			languageTest(pySparkNotebookContent, pySpark3KernelMetadata, this.test.title, language, {
+				name: language,
 				version: '',
 				mimetype: 'x-scala'
 			});
@@ -135,7 +135,7 @@ if (context.RunTest) {
 	});
 }
 
-async function languageTest(content: azdata.nb.INotebookContents, kernelMetadata: any, testName: string, configLanguage: string, languageInfo?: any) {
+async function languageTest(content: azdata.nb.INotebookContents, kernelMetadata: any, testName: string, languageConfigured: string, languageInfo?: any) {
 	let notebookJson = Object.assign({}, content, { metadata: {kernelSpec: kernelMetadata, language_info: languageInfo }});
 	let uri = writeNotebookToFile(notebookJson, testName);
 	console.log(uri);
@@ -143,8 +143,8 @@ async function languageTest(content: azdata.nb.INotebookContents, kernelMetadata
 	console.log('Notebook is opened');
 
 	let language = notebook.document.cells[0].contents.metadata.language;
-	console.log('language: ' + language);
-	assert(language === configLanguage, `Expected cell language is: ${configLanguage}, Actual: ${language}`);
+	console.log('Language set in cell: ' + language);
+	assert(language === languageConfigured, `Expected cell language is: ${languageConfigured}, Actual: ${language}`);
 }
 
 async function openNotebook(content: azdata.nb.INotebookContents, kernelMetadata: any, testName: string, runAllCells?: boolean): Promise<azdata.nb.NotebookEditor> {

--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -104,7 +104,47 @@ if (context.RunTest) {
 				assert(sparkResult === '2', `Expected spark result: 2, Actual: ${sparkResult}`);
 			});
 		}
+
+		test('scala language test', async function () {
+			let configLanguage = 'scala';
+
+			languageTest(pySparkNotebookContent, pySpark3KernelMetadata, this.test.title, configLanguage, {
+				name: configLanguage,
+				version: '',
+				mimetype: ''
+			});
+		});
+
+		test('cplusplus language test', async function () {
+			let configLanguage = 'cplusplus';
+			languageTest(pySparkNotebookContent, pySpark3KernelMetadata, this.test.title, configLanguage, {
+				name: configLanguage,
+				version: '',
+				mimetype: ''
+			});
+		});
+
+		test('Empty language test', async function () {
+			let configLanguage = '';
+			languageTest(pySparkNotebookContent, pySpark3KernelMetadata, this.test.title, configLanguage, {
+				name: configLanguage,
+				version: '',
+				mimetype: 'x-scala'
+			});
+		});
 	});
+}
+
+async function languageTest(content: azdata.nb.INotebookContents, kernelMetadata: any, testName: string, configLanguage: string, languageInfo?: any) {
+	let notebookJson = Object.assign({}, content, { metadata: {kernelSpec: kernelMetadata, language_info: languageInfo }});
+	let uri = writeNotebookToFile(notebookJson, testName);
+	console.log(uri);
+	let notebook = await azdata.nb.showNotebookDocument(uri);
+	console.log('Notebook is opened');
+
+	let language = notebook.document.cells[0].contents.metadata.language;
+	console.log('language: ' + language);
+	assert(language === configLanguage, `Expected cell language is: ${configLanguage}, Actual: ${language}`);
 }
 
 async function openNotebook(content: azdata.nb.INotebookContents, kernelMetadata: any, testName: string, runAllCells?: boolean): Promise<azdata.nb.NotebookEditor> {

--- a/src/sqltest/parts/notebook/model/cell.test.ts
+++ b/src/sqltest/parts/notebook/model/cell.test.ts
@@ -88,25 +88,6 @@ suite('Cell Model', function (): void {
 		should(cell.language).equal('python');
 	});
 
-	// Failing test disabled - see https://github.com/Microsoft/azuredatastudio/issues/4113
-	/*
-	test('Should set cell language to scala if defined as scala in languageInfo', async function (): Promise<void> {
-		let cellData: nb.ICellContents = {
-			cell_type: CellTypes.Code,
-			source: 'print(\'1\')',
-			metadata: {},
-			execution_count: 1
-		};
-
-		let notebookModel = new NotebookModelStub({
-			name: 'scala',
-			version: '',
-			mimetype: ''
-		});
-		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
-		should(cell.language).equal('scala');
-	});
-	*/
 	test('Should keep cell language as python if cell has language override', async function (): Promise<void> {
 		let cellData: nb.ICellContents = {
 			cell_type: CellTypes.Code,
@@ -140,46 +121,6 @@ suite('Cell Model', function (): void {
 		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
 		should(cell.language).equal('python');
 	});
-
-	// Failing test disabled - see https://github.com/Microsoft/azuredatastudio/issues/4113
-	/*
-	test('Should match cell language to language specified if unknown language defined in languageInfo', async function (): Promise<void> {
-		let cellData: nb.ICellContents = {
-			cell_type: CellTypes.Code,
-			source: 'std::cout << "hello world";',
-			metadata: {},
-			execution_count: 1
-		};
-
-		let notebookModel = new NotebookModelStub({
-			name: 'cplusplus',
-			version: '',
-			mimetype: ''
-		});
-		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
-		should(cell.language).equal('cplusplus');
-	});
-	*/
-
-	// Failing test disabled - see https://github.com/Microsoft/azuredatastudio/issues/4113
-	/*
-	test('Should match cell language to mimetype name is not supplied in languageInfo', async function (): Promise<void> {
-		let cellData: nb.ICellContents = {
-			cell_type: CellTypes.Code,
-			source: 'print(\'1\')',
-			metadata: {},
-			execution_count: 1
-		};
-
-		let notebookModel = new NotebookModelStub({
-			name: '',
-			version: '',
-			mimetype: 'x-scala'
-		});
-		let cell = factory.createCell(cellData, { notebook: notebookModel, isTrusted: false });
-		should(cell.language).equal('scala');
-	});
-	*/
 
 	suite('Model Future handling', function (): void {
 		let future: TypeMoq.Mock<EmptyFuture>;


### PR DESCRIPTION
The old tests doesn't have enough methods to test the cell language. Adding end-to-end tests to cover the test scenarios.