### PR TITLE
Fix for Schema compare Options dialog double scroll

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -488,7 +488,7 @@ export class SchemaCompareOptionsDialog {
 
 			uberOptionsFlexBuilder.addItem(this.optionsFlexBuilder, { CSSStyles: { 'overflow': 'scroll', 'height': '65vh' } });
 			uberOptionsFlexBuilder.addItem(this.descriptionHeading, { CSSStyles: { 'font-weight': 'bold', 'height': '30px' } });
-			uberOptionsFlexBuilder.addItem(this.descriptionText, { CSSStyles: { 'padding': '4px', 'overflow': 'auto', 'height': '10vh' } });
+			uberOptionsFlexBuilder.addItem(this.descriptionText, { CSSStyles: { 'padding': '4px', 'overflow': 'scroll', 'height': '10vh' } });
 			await view.initializeModel(uberOptionsFlexBuilder);
 		});
 	}

--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -460,7 +460,6 @@ export class SchemaCompareOptionsDialog {
 			this.optionsFlexBuilder = view.modelBuilder.flexContainer()
 				.withLayout({
 					flexFlow: 'column',
-					height: 760,
 				}).component();
 
 			this.descriptionHeading = view.modelBuilder.table().withProperties({
@@ -470,13 +469,11 @@ export class SchemaCompareOptionsDialog {
 						headerCssClass: 'no-borders',
 						toolTip: 'Option Description'
 					},
-				],
-				height: 30
+				]
 			}).component();
 
 			this.descriptionText = view.modelBuilder.text().withProperties({
-				value: ' ',
-				height: 100
+				value: ' '
 			}).component();
 
 			this.GetGeneralOptionCheckBoxes(view);
@@ -489,9 +486,9 @@ export class SchemaCompareOptionsDialog {
 					flexFlow: 'column',
 				}).component();
 
-			uberOptionsFlexBuilder.addItem(this.optionsFlexBuilder, { CSSStyles: { 'overflow': 'scroll' } });
-			uberOptionsFlexBuilder.addItem(this.descriptionHeading, { CSSStyles: { 'font-weight': 'bold' } });
-			uberOptionsFlexBuilder.addItem(this.descriptionText, { CSSStyles: { 'padding': '4px' } });
+			uberOptionsFlexBuilder.addItem(this.optionsFlexBuilder, { CSSStyles: { 'overflow': 'scroll', 'height': '65vh' } });
+			uberOptionsFlexBuilder.addItem(this.descriptionHeading, { CSSStyles: { 'font-weight': 'bold', 'height': '30px' } });
+			uberOptionsFlexBuilder.addItem(this.descriptionText, { CSSStyles: { 'padding': '4px', 'overflow': 'auto', 'height': '10vh' } });
 			await view.initializeModel(uberOptionsFlexBuilder);
 		});
 	}


### PR DESCRIPTION
Options dialog shows two scroll bar - using vh to fit the elements to window better. Using % didn't work.
(Not sure if this fixes the problem all resolutions but fixes for laptop/desktop window resigning)

**Before** 
![doublescrollbarprevious](https://user-images.githubusercontent.com/46980425/58210858-4291b380-7c9f-11e9-87f3-3d7118b4cf57.gif)

**After**
![doublescrollbar](https://user-images.githubusercontent.com/46980425/58210542-83d59380-7c9e-11e9-881d-7985c8b3b22c.gif)

Tracking as part of issue #5481 
