### PR TITLE
update engine name from sqlops to azdata

### DIFF
--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -10,7 +10,7 @@
 	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
 	"engines": {
 		"vscode": "^1.30.1",
-		"sqlops": "*"
+		"azdata": "*"
 	},
 	"activationEvents": [
 		"*"

--- a/extensions/cms/package.json
+++ b/extensions/cms/package.json
@@ -9,7 +9,7 @@
 	"icon": "images/sqlserver.png",
 	"engines": {
 		"vscode": "^1.25.0",
-		"sqlops": "*"
+		"azdata": "*"
 	},
 	"activationEvents": [
 		"*"

--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -7,7 +7,7 @@
 	"preview": true,
 	"engines": {
 		"vscode": "^1.25.0",
-		"sqlops": "*"
+		"azdata": "*"
 	},
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",
 	"icon": "images/sqlserver.png",


### PR DESCRIPTION
sqlops is no longer recognized and will be ignored, update the with azdata in case we need to restrict the ADS versions for these extensions.