### PR TITLE
Fix schema compare dialog widths changing

### DIFF
--- a/src/sql/workbench/electron-browser/modelComponents/media/formLayout.css
+++ b/src/sql/workbench/electron-browser/modelComponents/media/formLayout.css
@@ -33,7 +33,7 @@
 }
 
 .form-cell-title {
-	min-width: 129px; /* 129px + 5px padding right = 134px to match the connection pane label widths*/
+	width: 129px; /* 129px + 5px padding right = 134px to match the connection pane label widths*/
 }
 
 .form-component-container {


### PR DESCRIPTION
This fixes the widths of the dropdowns and textboxes sometimes changing when the radio buttons are clicked