### PR TITLE
Fixing model view editor to layout correctly with native and custom setting

### DIFF
--- a/src/sql/workbench/electron-browser/modelComponents/modelViewEditor.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/modelViewEditor.ts
@@ -85,7 +85,7 @@ export class ModelViewEditor extends BaseEditor {
 			const containerRect = modelViewContainer.parentElement.getBoundingClientRect();
 
 			modelViewContainer.style.position = 'absolute';
-			modelViewContainer.style.top = `${frameRect.top}px`;
+			modelViewContainer.style.top = `${frameRect.top - containerRect.top}px`;
 			modelViewContainer.style.left = `${frameRect.left - containerRect.left}px`;
 			modelViewContainer.style.width = `${frameRect.width}px`;
 			modelViewContainer.style.height = `${frameRect.height}px`;


### PR DESCRIPTION
With the recent change to respect custom settings for title bar style  - the model view editor was getting extra top space. Which in turn causes issue with schema compare rendering. Adding this is a quick fix for model view editor to work in both custom and native window settings. 

Before fix
![image](https://user-images.githubusercontent.com/46980425/58363264-40258a00-7e56-11e9-8411-fc77330ff9ca.png)

After fix
![image](https://user-images.githubusercontent.com/46980425/58363245-15d3cc80-7e56-11e9-89e1-27f8e392e369.png)