### PR TITLE
Show message to recompare when schema compare options change

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -7,6 +7,7 @@
 import * as nls from 'vscode-nls';
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
+import { SchemaCompareResult } from '../schemaCompareResult';
 
 const localize = nls.loadMessageBundle();
 
@@ -14,6 +15,8 @@ export class SchemaCompareOptionsDialog {
 	private static readonly OkButtonText: string = localize('SchemaCompareOptionsDialog.Ok', 'Ok');
 	private static readonly CancelButtonText: string = localize('SchemaCompareOptionsDialog.Cancel', 'Cancel');
 	private static readonly ResetButtonText: string = localize('SchemaCompareOptionsDialog.Reset', 'Reset');
+	private static readonly CompareButtonText: string = localize('SchemaCompareOptionsDialog.Compare', 'Compare');
+	private static readonly OptionsChangedMessage: string = localize('schemaCompareOptions.recompareMessage', 'Options have changed. Press Compare to see the comparison.');
 	private static readonly OptionsLabel: string = localize('SchemaCompare.SchemaCompareOptionsDialogLabel', 'Schema Compare Options');
 	private static readonly GeneralOptionsLabel: string = localize('SchemaCompare.GeneralOptionsLabel', 'General Options');
 	private static readonly ObjectTypesOptionsLabel: string = localize('SchemaCompare.ObjectTypesOptionsLabel', 'Include Object Types');
@@ -406,7 +409,7 @@ export class SchemaCompareOptionsDialog {
 		SchemaCompareOptionsDialog.ServerTriggers
 	].sort();
 
-	constructor(defaultOptions: azdata.DeploymentOptions) {
+	constructor(defaultOptions: azdata.DeploymentOptions, private schemaComparison: SchemaCompareResult) {
 		this.deploymentOptions = defaultOptions;
 	}
 
@@ -442,7 +445,11 @@ export class SchemaCompareOptionsDialog {
 		this.SetDeploymentOptions();
 		this.SetObjectTypeOptions();
 		if (this.optionsChanged) {
-			vscode.window.showInformationMessage(localize('schemaCompareOptions.recompareMessage', 'Options have changed. Press Compare to see the comparison.'));
+			vscode.window.showWarningMessage(SchemaCompareOptionsDialog.OptionsChangedMessage, SchemaCompareOptionsDialog.CompareButtonText).then(async (result) => {
+				if (result === SchemaCompareOptionsDialog.CompareButtonText) {
+					this.schemaComparison.startCompare();
+				}
+			});
 		}
 		this.disposeListeners();
 	}

--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -15,8 +15,9 @@ export class SchemaCompareOptionsDialog {
 	private static readonly OkButtonText: string = localize('SchemaCompareOptionsDialog.Ok', 'Ok');
 	private static readonly CancelButtonText: string = localize('SchemaCompareOptionsDialog.Cancel', 'Cancel');
 	private static readonly ResetButtonText: string = localize('SchemaCompareOptionsDialog.Reset', 'Reset');
-	private static readonly CompareButtonText: string = localize('SchemaCompareOptionsDialog.Compare', 'Compare');
-	private static readonly OptionsChangedMessage: string = localize('schemaCompareOptions.recompareMessage', 'Options have changed. Press Compare to see the comparison.');
+	private static readonly YesButtonText: string = localize('SchemaCompareOptionsDialog.Yes', 'Yes');
+	private static readonly NoButtonText: string = localize('SchemaCompareOptionsDialog.No', 'No');
+	private static readonly OptionsChangedMessage: string = localize('schemaCompareOptions.RecompareMessage', 'Options have changed. Recompare to see the comparison?');
 	private static readonly OptionsLabel: string = localize('SchemaCompare.SchemaCompareOptionsDialogLabel', 'Schema Compare Options');
 	private static readonly GeneralOptionsLabel: string = localize('SchemaCompare.GeneralOptionsLabel', 'General Options');
 	private static readonly ObjectTypesOptionsLabel: string = localize('SchemaCompare.ObjectTypesOptionsLabel', 'Include Object Types');
@@ -445,8 +446,8 @@ export class SchemaCompareOptionsDialog {
 		this.SetDeploymentOptions();
 		this.SetObjectTypeOptions();
 		if (this.optionsChanged) {
-			vscode.window.showWarningMessage(SchemaCompareOptionsDialog.OptionsChangedMessage, SchemaCompareOptionsDialog.CompareButtonText).then((result) => {
-				if (result === SchemaCompareOptionsDialog.CompareButtonText) {
+			vscode.window.showWarningMessage(SchemaCompareOptionsDialog.OptionsChangedMessage, SchemaCompareOptionsDialog.YesButtonText, SchemaCompareOptionsDialog.NoButtonText).then((result) => {
+				if (result === SchemaCompareOptionsDialog.YesButtonText) {
 					this.schemaComparison.startCompare();
 				}
 			});

--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -445,7 +445,7 @@ export class SchemaCompareOptionsDialog {
 		this.SetDeploymentOptions();
 		this.SetObjectTypeOptions();
 		if (this.optionsChanged) {
-			vscode.window.showWarningMessage(SchemaCompareOptionsDialog.OptionsChangedMessage, SchemaCompareOptionsDialog.CompareButtonText).then(async (result) => {
+			vscode.window.showWarningMessage(SchemaCompareOptionsDialog.OptionsChangedMessage, SchemaCompareOptionsDialog.CompareButtonText).then((result) => {
 				if (result === SchemaCompareOptionsDialog.CompareButtonText) {
 					this.schemaComparison.startCompare();
 				}

--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -256,6 +256,7 @@ export class SchemaCompareOptionsDialog {
 	private disposableListeners: vscode.Disposable[] = [];
 
 	private excludedObjectTypes: azdata.SchemaObjectType[] = [];
+	private optionsChanged: boolean = false;
 
 	private optionsLabels: string[] = [
 		SchemaCompareOptionsDialog.IgnoreTableOptions,
@@ -440,6 +441,10 @@ export class SchemaCompareOptionsDialog {
 	protected async execute() {
 		this.SetDeploymentOptions();
 		this.SetObjectTypeOptions();
+		if (this.optionsChanged) {
+			vscode.window.showInformationMessage(localize('schemaCompareOptions.recompareMessage', 'Options have changed. Press Compare to see the comparison.'));
+		}
+	}
 		this.disposeListeners();
 	}
 
@@ -451,6 +456,7 @@ export class SchemaCompareOptionsDialog {
 		let service = await azdata.dataprotocol.getProvider<azdata.SchemaCompareServicesProvider>('MSSQL', azdata.DataProviderType.SchemaCompareServicesProvider);
 		let result = await service.schemaCompareGetDefaultOptions();
 		this.deploymentOptions = result.defaultDeploymentOptions;
+		this.optionsChanged = true;
 
 		this.updateOptionsTable();
 		this.optionsFlexBuilder.removeItem(this.optionsTable);

--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -444,7 +444,6 @@ export class SchemaCompareOptionsDialog {
 		if (this.optionsChanged) {
 			vscode.window.showInformationMessage(localize('schemaCompareOptions.recompareMessage', 'Options have changed. Press Compare to see the comparison.'));
 		}
-	}
 		this.disposeListeners();
 	}
 
@@ -501,6 +500,7 @@ export class SchemaCompareOptionsDialog {
 				if (checkboxState && checkboxState.row !== undefined) {
 					let label = this.optionsLabels[checkboxState.row];
 					this.optionsLookup[label] = checkboxState.checked;
+					this.optionsChanged = true;
 				}
 			}));
 
@@ -532,6 +532,7 @@ export class SchemaCompareOptionsDialog {
 				if (checkboxState && checkboxState.row !== undefined) {
 					let label = this.objectTypeLabels[checkboxState.row];
 					this.objectsLookup[label] = checkboxState.checked;
+					this.optionsChanged = true;
 				}
 			}));
 

--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -382,7 +382,7 @@ export class SchemaCompareResult {
 		return script;
 	}
 
-	private startCompare(): void {
+	public startCompare(): void {
 		this.flexModel.removeItem(this.splitView);
 		this.flexModel.removeItem(this.noDifferencesLabel);
 		this.flexModel.removeItem(this.startText);
@@ -467,7 +467,7 @@ export class SchemaCompareResult {
 				this.deploymentOptions = this.schemaCompareOptionDialog.deploymentOptions;
 			}
 			// create fresh every time
-			this.schemaCompareOptionDialog = new SchemaCompareOptionsDialog(this.deploymentOptions);
+			this.schemaCompareOptionDialog = new SchemaCompareOptionsDialog(this.deploymentOptions, this);
 			await this.schemaCompareOptionDialog.openDialog();
 		});
 	}


### PR DESCRIPTION
With this change, the message "Options have changed. Press Compare to see the comparison." will show if any options were changed to notify the user to recompare. 

![optionsChangedMessage](https://user-images.githubusercontent.com/31145923/58503127-ddc1d780-813c-11e9-9ff5-c8d259b5a32e.gif)


Updated look: 
![image](https://user-images.githubusercontent.com/31145923/58518392-e24db680-8163-11e9-961c-a34da28ceb6f.png)
