### PR TITLE
Bug/schema compare apply confirmation

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.96",
+	"version": "1.5.0-alpha.98",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",

--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -13,7 +13,7 @@ import { Telemetry } from './telemetry';
 import { getTelemetryErrorType } from './utils';
 const localize = nls.loadMessageBundle();
 const diffEditorTitle = localize('schemaCompare.ObjectDefinitionsTitle', 'Object Definitions');
-const appliyConfirmation = localize('schemaCompare.ApplyConfirmation', 'Are you sure that you want to update the target?');
+const applyConfirmation = localize('schemaCompare.ApplyConfirmation', 'Are you sure you want to update the target?');
 
 export class SchemaCompareResult {
 	private differencesTable: azdata.TableComponent;
@@ -183,7 +183,7 @@ export class SchemaCompareResult {
 			this.deploymentOptions = this.schemaCompareOptionDialog.deploymentOptions;
 		}
 		Telemetry.sendTelemetryEvent('SchemaComparisonStarted');
-		let service = await SchemaCompareResult.getService('MSSQL');
+		const service = await SchemaCompareResult.getService('MSSQL');
 		this.comparisonResult = await service.schemaCompare(this.sourceEndpointInfo, this.targetEndpointInfo, azdata.TaskExecutionMode.execute, this.deploymentOptions);
 		if (!this.comparisonResult || !this.comparisonResult.success) {
 			Telemetry.sendTelemetryEventForError('SchemaComparisonFailed', {
@@ -432,8 +432,8 @@ export class SchemaCompareResult {
 				'startTime:': Date.now().toString(),
 				'operationId': this.comparisonResult.operationId
 			});
-			let service = await SchemaCompareResult.getService('MSSQL');
-			let result = await service.schemaCompareGenerateScript(this.comparisonResult.operationId, this.targetEndpointInfo.serverName, this.targetEndpointInfo.databaseName, azdata.TaskExecutionMode.script);
+			const service = await SchemaCompareResult.getService('MSSQL');
+			const result = await service.schemaCompareGenerateScript(this.comparisonResult.operationId, this.targetEndpointInfo.serverName, this.targetEndpointInfo.databaseName, azdata.TaskExecutionMode.script);
 			if (!result || !result.success) {
 				Telemetry.sendTelemetryEvent('SchemaCompareGenerateScriptFailed', {
 					'errorType': getTelemetryErrorType(result.errorMessage),
@@ -487,14 +487,14 @@ export class SchemaCompareResult {
 		const yesString = localize('schemaCompare.ApplyYes', 'Yes');
 		this.applyButton.onDidClick(async (click) => {
 
-			vscode.window.showWarningMessage(appliyConfirmation, { modal: true }, yesString).then(async (result) => {
+			vscode.window.showWarningMessage(applyConfirmation, { modal: true }, yesString).then(async (result) => {
 				if (result === yesString) {
 					Telemetry.sendTelemetryEvent('SchemaCompareApplyStarted', {
 						'startTime': Date.now().toString(),
 						'operationId': this.comparisonResult.operationId
 					});
-					let service = await SchemaCompareResult.getService('MSSQL');
-					let result = await service.schemaComparePublishChanges(this.comparisonResult.operationId, this.targetEndpointInfo.serverName, this.targetEndpointInfo.databaseName, azdata.TaskExecutionMode.execute);
+					const service = await SchemaCompareResult.getService('MSSQL');
+					const result = await service.schemaComparePublishChanges(this.comparisonResult.operationId, this.targetEndpointInfo.serverName, this.targetEndpointInfo.databaseName, azdata.TaskExecutionMode.execute);
 					if (!result || !result.success) {
 						Telemetry.sendTelemetryEvent('SchemaCompareApplyFailed', {
 							'errorType': getTelemetryErrorType(result.errorMessage),
@@ -579,7 +579,7 @@ export class SchemaCompareResult {
 
 	private async GetDefaultDeploymentOptions(): Promise<void> {
 		// Same as dacfx default options
-		let service = await SchemaCompareResult.getService('MSSQL');
+		const service = await SchemaCompareResult.getService('MSSQL');
 		let result = await service.schemaCompareGetDefaultOptions();
 		this.deploymentOptions = result.defaultDeploymentOptions;
 	}


### PR DESCRIPTION
This PR adds a confirmation dialog same as SSDT when apply button is clicked before applying the changes to server. This fixes #5691

Looks like following :
![image](https://user-images.githubusercontent.com/46980425/58511430-a6a8f180-814f-11e9-9f17-d98ea2c2b3ad.png)

Bundled up update of sqltools service version for previous schema compare changes
