### PR TITLE
Fix #5702 Schema Compare Diff is editable

### DIFF
--- a/src/sql/workbench/electron-browser/modelComponents/diffeditor.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/diffeditor.component.ts
@@ -81,14 +81,12 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 		this.editorUriRight = uri2.toString();
 
 		let cancellationTokenSource = new CancellationTokenSource();
-		let modeService = this._modeService;
-		let modelService = this._modelService;
 		this._textModelService.registerTextModelContentProvider('diffEditor', {
-			provideTextContent: function (resource: URI): Promise<ITextModel> {
+			provideTextContent: (resource: URI): Promise<ITextModel> => {
 				if (resource.scheme === 'diffEditor') {
 					let modelContent = '';
-					let languageSelection = modeService.create('plaintext');
-					return Promise.resolve(modelService.createModel(modelContent, languageSelection, resource));
+					let languageSelection = this._modeService.create('plaintext');
+					return Promise.resolve(this._modelService.createModel(modelContent, languageSelection, resource));
 				}
 
 				return Promise.resolve(null!);

--- a/src/sql/workbench/electron-browser/modelComponents/diffeditor.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/diffeditor.component.ts
@@ -81,21 +81,17 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 		this.editorUriRight = uri2.toString();
 
 		let cancellationTokenSource = new CancellationTokenSource();
-		this._textModelService.registerTextModelContentProvider('diffEditor', {
+		let textModelContentProvider = this._textModelService.registerTextModelContentProvider('sqlDiffEditor', {
 			provideTextContent: (resource: URI): Promise<ITextModel> => {
-				if (resource.scheme === 'diffEditor') {
-					let modelContent = '';
-					let languageSelection = this._modeService.create('plaintext');
-					return Promise.resolve(this._modelService.createModel(modelContent, languageSelection, resource));
-				}
-
-				return Promise.resolve(null!);
+				let modelContent = '';
+				let languageSelection = this._modeService.create('plaintext');
+				return Promise.resolve(this._modelService.createModel(modelContent, languageSelection, resource));
 			}
 		});
 
-		let editorinput1 = this._instantiationService.createInstance(ResourceEditorInput, 'source', 'description', uri1, undefined);
-		let editorinput2 = this._instantiationService.createInstance(ResourceEditorInput, 'target', 'description', uri2, undefined);
-		this._editorInput = this._instantiationService.createInstance(DiffEditorInput, 'MyEditor', 'My description', editorinput1, editorinput2, true);
+		let editorinput1 = this._instantiationService.createInstance(ResourceEditorInput, 'source', undefined, uri1, undefined);
+		let editorinput2 = this._instantiationService.createInstance(ResourceEditorInput, 'target', undefined, uri2, undefined);
+		this._editorInput = this._instantiationService.createInstance(DiffEditorInput, 'DiffEditor', undefined, editorinput1, editorinput2, true);
 		this._editor.setInput(this._editorInput, undefined, cancellationTokenSource.token);
 
 
@@ -109,10 +105,11 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 		this._register(this._editor);
 		this._register(this._editorInput);
 		this._register(this._editorModel);
+		this._register(textModelContentProvider);
 	}
 
 	private createUri(input: string): URI {
-		let uri = URI.from({ scheme: 'diffEditor', path: `${this.descriptor.type}-${this.descriptor.id}-${input}` });
+		let uri = URI.from({ scheme: 'sqlDiffEditor', path: `${this.descriptor.type}-${this.descriptor.id}-${input}` });
 		return uri;
 	}
 

--- a/src/sql/workbench/electron-browser/modelComponents/diffeditor.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/diffeditor.component.ts
@@ -27,14 +27,6 @@ import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { ITextModel } from 'vs/editor/common/model';
 
-class ServiceAccessor {
-	constructor(
-		@ITextModelService public textModelResolverService: ITextModelService,
-		@IModelService public modelService: IModelService,
-		@IModeService public modeService: IModeService
-	) { }
-}
-
 @Component({
 	template: `
 	<div *ngIf="_title">
@@ -63,7 +55,8 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 		@Inject(forwardRef(() => ElementRef)) el: ElementRef,
 		@Inject(IInstantiationService) private _instantiationService: IInstantiationService,
 		@Inject(IModelService) private _modelService: IModelService,
-		@Inject(IModeService) private _modeService: IModeService
+		@Inject(IModeService) private _modeService: IModeService,
+		@Inject(ITextModelService) private _textModelService: ITextModelService
 	) {
 		super(changeRef, el);
 	}
@@ -88,13 +81,14 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 		this.editorUriRight = uri2.toString();
 
 		let cancellationTokenSource = new CancellationTokenSource();
-		let accessor = this._instantiationService.createInstance(ServiceAccessor);
-		accessor.textModelResolverService.registerTextModelContentProvider('diffEditor', {
+		let modeService = this._modeService;
+		let modelService = this._modelService;
+		this._textModelService.registerTextModelContentProvider('diffEditor', {
 			provideTextContent: function (resource: URI): Promise<ITextModel> {
 				if (resource.scheme === 'diffEditor') {
 					let modelContent = '';
-					let languageSelection = accessor.modeService.create('plaintext');
-					return Promise.resolve(accessor.modelService.createModel(modelContent, languageSelection, resource));
+					let languageSelection = modeService.create('plaintext');
+					return Promise.resolve(modelService.createModel(modelContent, languageSelection, resource));
 				}
 
 				return Promise.resolve(null!);

--- a/src/sql/workbench/electron-browser/modelComponents/diffeditor.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/diffeditor.component.ts
@@ -82,7 +82,7 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 		let editorinput1 = this._instantiationService.createInstance(UntitledEditorInput, uri1, false, 'plaintext', '', '');
 		let editorinput2 = this._instantiationService.createInstance(UntitledEditorInput, uri2, false, 'plaintext', '', '');
 		this._editorInput = this._instantiationService.createInstance(DiffEditorInput, 'MyEditor', 'My description', editorinput1, editorinput2, true);
-		this._editor.setInput(this._editorInput, undefined, cancellationTokenSource.token);
+		this._editor.setInput(this._editorInput, undefined, cancellationTokenSource.token, true);
 
 
 		this._editorInput.resolve().then(model => {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -84,7 +84,8 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 		return this.instantiationService.createInstance(DiffEditorWidget, parent, configuration);
 	}
 
-	async setInput(input: EditorInput, options: EditorOptions, token: CancellationToken): Promise<void> {
+	// {{SQL CARBON EDIT}}
+	async setInput(input: EditorInput, options: EditorOptions, token: CancellationToken, isReadOnly?: boolean): Promise<void> {
 
 		// Dispose previous diff navigator
 		this.diffNavigatorDisposables = dispose(this.diffNavigatorDisposables);
@@ -132,7 +133,8 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 			this.diffNavigatorDisposables.push(this.diffNavigator);
 
 			// Readonly flag
-			diffEditor.updateOptions({ readOnly: resolvedDiffEditorModel.isReadonly() });
+			// {{SQL CARBON EDIT}}
+			diffEditor.updateOptions({ readOnly: isReadOnly ? true : resolvedDiffEditorModel.isReadonly() });
 		} catch (error) {
 
 			// In case we tried to open a file and the response indicates that this is not a text file, fallback to binary diff.

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -84,8 +84,7 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 		return this.instantiationService.createInstance(DiffEditorWidget, parent, configuration);
 	}
 
-	// {{SQL CARBON EDIT}}
-	async setInput(input: EditorInput, options: EditorOptions, token: CancellationToken, isReadOnly?: boolean): Promise<void> {
+	async setInput(input: EditorInput, options: EditorOptions, token: CancellationToken): Promise<void> {
 
 		// Dispose previous diff navigator
 		this.diffNavigatorDisposables = dispose(this.diffNavigatorDisposables);
@@ -133,8 +132,7 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 			this.diffNavigatorDisposables.push(this.diffNavigator);
 
 			// Readonly flag
-			// {{SQL CARBON EDIT}}
-			diffEditor.updateOptions({ readOnly: isReadOnly ? true : resolvedDiffEditorModel.isReadonly() });
+			diffEditor.updateOptions({ readOnly: resolvedDiffEditorModel.isReadonly() });
 		} catch (error) {
 
 			// In case we tried to open a file and the response indicates that this is not a text file, fallback to binary diff.


### PR DESCRIPTION
The diff view was editable but it should be diff only. This can be misleading since making changes in the diff editor won't be applied. Fixes #5702

previously:
![editableDiff](https://user-images.githubusercontent.com/31145923/58517267-a87ab100-815f-11e9-98be-c503e569e49f.gif)

Fixed:
![image](https://user-images.githubusercontent.com/31145923/58597823-87cd5c80-822e-11e9-9d75-52deec285566.png)
