### PR TITLE
Provide a default result grid height

### DIFF
--- a/src/sql/workbench/parts/query/browser/queryEditor.ts
+++ b/src/sql/workbench/parts/query/browser/queryEditor.ts
@@ -333,13 +333,14 @@ export class QueryEditor extends BaseEditor {
 
 	private addResultsEditor() {
 		if (!this.resultsVisible) {
+			let initialViewSize = Math.round(Math.max(this.dimension.height * 0.7, this.dimension.height - 150));
 			this.splitview.addView({
 				element: this.resultsEditorContainer,
 				layout: size => this.resultsEditor && this.resultsEditor.layout(new DOM.Dimension(this.dimension.width, size)),
 				minimumSize: 0,
 				maximumSize: Number.POSITIVE_INFINITY,
 				onDidChange: Event.None
-			}, Sizing.Distribute);
+			}, initialViewSize);
 			this.resultsVisible = true;
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/5705.

Here's an example of a default split with this change.

![image](https://user-images.githubusercontent.com/599935/58522698-61e48100-8176-11e9-8053-388415be9f9d.png)
