### PR TITLE
Fix query files not being editable

### DIFF
--- a/src/sql/workbench/parts/query/browser/queryEditor.ts
+++ b/src/sql/workbench/parts/query/browser/queryEditor.ts
@@ -13,6 +13,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { TextResourceEditor } from 'vs/workbench/browser/parts/editor/textResourceEditor';
+import { TextFileEditor } from 'vs/workbench/contrib/files/browser/editors/textFileEditor';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { CancellationToken } from 'vs/base/common/cancellation';
@@ -32,6 +33,9 @@ import * as queryContext from 'sql/workbench/parts/query/common/queryContext';
 import { Taskbar, ITaskbarContent } from 'sql/base/browser/ui/taskbar/taskbar';
 import * as actions from 'sql/workbench/parts/query/browser/queryActions';
 import { IRange } from 'vs/editor/common/core/range';
+import { IEditorDescriptorService } from 'sql/workbench/services/queryEditor/common/editorDescriptorService';
+import { BaseTextEditor } from 'vs/workbench/browser/parts/editor/textEditor';
+import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
 
 /**
  * Editor that hosts 2 sub-editors: A TextResourceEditor for SQL file editing, and a QueryResultsEditor
@@ -47,7 +51,10 @@ export class QueryEditor extends BaseEditor {
 
 	private resultsEditorContainer: HTMLElement;
 	// could be untitled or resource editor
-	private textEditor: TextResourceEditor;
+	//private textEditor: TextFileEditor;
+	private textResourceEditor: TextResourceEditor;
+	private textFileEditor: TextFileEditor;
+	private currentTextEditor: BaseTextEditor;
 	private textEditorContainer: HTMLElement;
 
 	private taskbar: Taskbar;
@@ -75,6 +82,7 @@ export class QueryEditor extends BaseEditor {
 		@IStorageService storageService: IStorageService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IEditorService private readonly editorService: IEditorService,
+		@IEditorDescriptorService private readonly editorDescriptorService: IEditorDescriptorService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
@@ -104,12 +112,15 @@ export class QueryEditor extends BaseEditor {
 		this._register(this.splitview.onDidSashReset(() => this.splitview.distributeViewSizes()));
 
 		this.textEditorContainer = DOM.$('.text-editor-container');
-		this.textEditor = this._register(this.instantiationService.createInstance(TextResourceEditor));
-		this.textEditor.create(this.textEditorContainer);
+		//this.textEditor = this._register(this.instantiationService.createInstance(TextFileEditor));
+		this.textResourceEditor = this._register(this.instantiationService.createInstance(TextResourceEditor));
+		this.textFileEditor = this._register(this.instantiationService.createInstance(TextFileEditor));
+		this.currentTextEditor = this.textResourceEditor;
+		this.currentTextEditor.create(this.textEditorContainer);
 
 		this.splitview.addView({
 			element: this.textEditorContainer,
-			layout: size => this.textEditor.layout(new DOM.Dimension(this.dimension.width, size)),
+			layout: size => this.currentTextEditor.layout(new DOM.Dimension(this.dimension.width, size)),
 			minimumSize: 0,
 			maximumSize: Number.POSITIVE_INFINITY,
 			onDidChange: Event.None
@@ -228,23 +239,47 @@ export class QueryEditor extends BaseEditor {
 		this.taskbar.setContent(content);
 	}
 
-	public setInput(newInput: QueryInput, options: EditorOptions, token: CancellationToken): Promise<void> {
+	public async setInput(newInput: QueryInput, options: EditorOptions, token: CancellationToken): Promise<void> {
 		const oldInput = this.input;
 
 		if (newInput.matches(oldInput)) {
 			return Promise.resolve();
 		}
 
-		return Promise.all([
+		// const descriptor = this.editorDescriptorService.getEditor(newInput.sql);
+		// let editor = descriptor.instantiate(this.instantiationService);
+		// editor.create(this.textEditorContainer);
+		// editor.setVisible(this.isVisible(), this.group);
+		// this.textEditor = <BaseTextEditor>editor;
+		if (oldInput) {
+			this.currentTextEditor.clearInput();
+		}
+
+		const newTextEditor = newInput.sql instanceof FileEditorInput ? this.textFileEditor : this.textResourceEditor;
+		if (newTextEditor !== this.currentTextEditor) {
+			this.currentTextEditor = newTextEditor;
+			this.splitview.removeView(0, Sizing.Distribute);
+			this.currentTextEditor.create(this.textEditorContainer);
+
+			this.splitview.addView({
+				element: this.textEditorContainer,
+				layout: size => this.currentTextEditor.layout(new DOM.Dimension(this.dimension.width, size)),
+				minimumSize: 0,
+				maximumSize: Number.POSITIVE_INFINITY,
+				onDidChange: Event.None
+			}, Sizing.Distribute, 0);
+		}
+
+		await Promise.all([
 			super.setInput(newInput, options, token),
-			this.textEditor.setInput(newInput.sql, options, token),
+			this.currentTextEditor.setInput(newInput.sql, options, token),
 			this.resultsEditor.setInput(newInput.results, options)
-		]).then(() => {
-			dispose(this.inputDisposables);
-			this.inputDisposables = [];
-			this.inputDisposables.push(this.input.state.onChange(c => this.updateState(c)));
-			this.updateState({ connectingChange: true, connectedChange: true, executingChange: true, resultsVisibleChange: true });
-		});
+		]);
+
+		dispose(this.inputDisposables);
+		this.inputDisposables = [];
+		this.inputDisposables.push(this.input.state.onChange(c => this.updateState(c)));
+		this.updateState({ connectingChange: true, connectedChange: true, executingChange: true, resultsVisibleChange: true });
 	}
 
 	public toggleResultsEditorVisibility() {
@@ -259,7 +294,7 @@ export class QueryEditor extends BaseEditor {
 	 * Sets this editor and the 2 sub-editors to visible.
 	 */
 	public setEditorVisible(visible: boolean, group: IEditorGroup): void {
-		this.textEditor.setVisible(visible, group);
+		this.currentTextEditor.setVisible(visible, group);
 		this.resultsEditor.setVisible(visible, group);
 		super.setEditorVisible(visible, group);
 
@@ -292,7 +327,7 @@ export class QueryEditor extends BaseEditor {
 	 * input should be freed.
 	 */
 	public clearInput(): void {
-		this.textEditor.clearInput();
+		this.currentTextEditor.clearInput();
 		this.resultsEditor.clearInput();
 		super.clearInput();
 	}
@@ -301,7 +336,7 @@ export class QueryEditor extends BaseEditor {
 	 * Sets focus on this editor. Specifically, it sets the focus on the hosted text editor.
 	 */
 	public focus(): void {
-		this.textEditor.focus();
+		this.currentTextEditor.focus();
 	}
 
 	/**
@@ -317,11 +352,11 @@ export class QueryEditor extends BaseEditor {
 	 * Returns the editor control for the text editor.
 	 */
 	public getControl(): IEditorControl {
-		return this.textEditor.getControl();
+		return this.currentTextEditor.getControl();
 	}
 
 	public setOptions(options: EditorOptions): void {
-		this.textEditor.setOptions(options);
+		this.currentTextEditor.setOptions(options);
 	}
 
 	private removeResultsEditor() {
@@ -353,8 +388,8 @@ export class QueryEditor extends BaseEditor {
 	// helper functions
 
 	public isSelectionEmpty(): boolean {
-		if (this.textEditor && this.textEditor.getControl()) {
-			let control = this.textEditor.getControl();
+		if (this.currentTextEditor && this.currentTextEditor.getControl()) {
+			let control = this.currentTextEditor.getControl();
 			let codeEditor: ICodeEditor = <ICodeEditor>control;
 
 			if (codeEditor) {
@@ -372,8 +407,8 @@ export class QueryEditor extends BaseEditor {
 	 * is no selected text.
 	 */
 	public getSelection(checkIfRange: boolean = true): ISelectionData {
-		if (this.textEditor && this.textEditor.getControl()) {
-			let vscodeSelection = this.textEditor.getControl().getSelection();
+		if (this.currentTextEditor && this.currentTextEditor.getControl()) {
+			let vscodeSelection = this.currentTextEditor.getControl().getSelection();
 
 			// If the selection is a range of characters rather than just a cursor position, return the range
 			let isRange: boolean =
@@ -395,8 +430,8 @@ export class QueryEditor extends BaseEditor {
 	}
 
 	public getAllSelection(): ISelectionData {
-		if (this.textEditor && this.textEditor.getControl()) {
-			let control = this.textEditor.getControl();
+		if (this.currentTextEditor && this.currentTextEditor.getControl()) {
+			let control = this.currentTextEditor.getControl();
 			let codeEditor: ICodeEditor = <ICodeEditor>control;
 			if (codeEditor) {
 				let model = codeEditor.getModel();
@@ -415,8 +450,8 @@ export class QueryEditor extends BaseEditor {
 	}
 
 	public getAllText(): string {
-		if (this.textEditor && this.textEditor.getControl()) {
-			let control = this.textEditor.getControl();
+		if (this.currentTextEditor && this.currentTextEditor.getControl()) {
+			let control = this.currentTextEditor.getControl();
 			let codeEditor: ICodeEditor = <ICodeEditor>control;
 			if (codeEditor) {
 				let value = codeEditor.getValue();
@@ -431,8 +466,8 @@ export class QueryEditor extends BaseEditor {
 	}
 
 	public getSelectionText(): string {
-		if (this.textEditor && this.textEditor.getControl()) {
-			let control = this.textEditor.getControl();
+		if (this.currentTextEditor && this.currentTextEditor.getControl()) {
+			let control = this.currentTextEditor.getControl();
 			let codeEditor: ICodeEditor = <ICodeEditor>control;
 			let vscodeSelection = control.getSelection();
 


### PR DESCRIPTION
Fixes #5684 

This behavior was broken by the editor refactor cf8f890 - previously we were rebuilding the Editor each time based on the type of the QueryEditorInput, so when the input was a FileEditorInput we'd be given a TextFileEditor. The refactor changed the editor to always be a TextResourceEditor - which doesn't allow editing of anything but Untitled inputs.

The fix is to create two editors and swap between them as necessary as the input changes. 