### PR TITLE
Add messages to title to help discoverability

### DIFF
--- a/src/sql/workbench/parts/query/common/resultsGridContribution.ts
+++ b/src/sql/workbench/parts/query/common/resultsGridContribution.ts
@@ -16,7 +16,7 @@ const configurationRegistry = <IConfigurationRegistry>Registry.as(Extensions.Con
 const resultsGridConfiguration: IConfigurationNode = {
 	id: 'resultsGrid',
 	type: 'object',
-	title: nls.localize('resultsGridConfigurationTitle', "Results Grid"),
+	title: nls.localize('resultsGridConfigurationTitle', "Results Grid and Messages"),
 	overridable: true,
 	properties: {
 		'resultsGrid.fontFamily': {


### PR DESCRIPTION
This change makes it so searching messages shows the results grid settings, helping in discoverability.
![image](https://user-images.githubusercontent.com/4324725/58593753-9dd42080-8220-11e9-93c8-8348722c2ee0.png)

Changing the actual name of the settings would break back compat so I'm not sure how important this is.