### PR TITLE
Add customizable error color; fix line height in Messages

### DIFF
--- a/src/sql/platform/theme/common/colors.ts
+++ b/src/sql/platform/theme/common/colors.ts
@@ -22,3 +22,5 @@ export const cellBackground = registerColor('agent.cellBackground', { light: '#f
 export const tableHoverBackground = registerColor('agent.tableHoverColor', { light: '#dcdcdc', dark: '#444444', hc: null }, nls.localize('agentTableHoverBackground', "SQL Agent table hover background color."));
 export const jobsHeadingBackground = registerColor('agent.jobsHeadingColor', { light: '#f4f4f4', dark: '#444444', hc: '#2b56f2' }, nls.localize('agentJobsHeadingColor', "SQL Agent heading background color."));
 export const cellBorderColor = registerColor('agent.cellBorderColor', { light: null, dark: null, hc: '#2b56f2' }, nls.localize('agentCellBorderColor', "SQL Agent table cell border color."));
+
+export const resultsErrorColor = registerColor('results.error.color', { light: '#f44242', dark: '#f44242', hc: '#f44242' }, nls.localize('resultsErrorColor', "Results messages error color."));

--- a/src/sql/workbench/parts/query/browser/media/messagePanel.css
+++ b/src/sql/workbench/parts/query/browser/media/messagePanel.css
@@ -37,10 +37,6 @@
 	cursor: pointer;
 }
 
-.message-tree .error-message {
-	color: red;
-}
-
 .message-tree .batch-start:hover {
 	color: red;
 }

--- a/src/sql/workbench/parts/query/browser/messagePanel.ts
+++ b/src/sql/workbench/parts/query/browser/messagePanel.ts
@@ -255,8 +255,14 @@ export class MessagePanel extends Disposable {
 
 	public dispose() {
 		dispose(this.queryRunnerDisposables);
-		this.container = undefined;
-		this.styleElement = undefined;
+		if (this.container) {
+			this.container.remove();
+			this.container = undefined;
+		}
+		if (this.styleElement) {
+			this.styleElement.remove();
+			this.styleElement = undefined;
+		}
 		super.dispose();
 	}
 }


### PR DESCRIPTION
Adds a customizable color for messages error.
The default color is still red for all themes, I'll work with ux to get a good color for our built in themes.
Also fixed the line height logic.

Fixes #5747 