### PR TITLE
Backup to open correctly from insights dialog

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -413,6 +413,24 @@ export abstract class Modal extends Disposable implements IThemable {
 	}
 
 	/**
+	* removes the button matching the provided labled from the footer of the modal
+	* @param label Label on the button
+	*/
+	protected removeFooterButton(label: string): void {
+		let buttonIndex = this._footerButtons.findIndex(e => {
+			try {
+				return e && e.element.innerText === label;
+			} catch {
+				return false;
+			}
+		});
+		let button = this._footerButtons[buttonIndex];
+		DOM.removeNode(button.element);
+		button.dispose();
+		this._footerButtons.splice(buttonIndex, 1);
+	}
+
+	/**
 	 * Show an error in the error message element
 	 * @param message Text to show in the message
 	 * @param level Severity level of the message

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -418,16 +418,14 @@ export abstract class Modal extends Disposable implements IThemable {
 	*/
 	protected removeFooterButton(label: string): void {
 		let buttonIndex = this._footerButtons.findIndex(e => {
-			try {
-				return e && e.element.innerText === label;
-			} catch {
-				return false;
-			}
+			return e && e.element && e.element.innerText === label;
 		});
-		let button = this._footerButtons[buttonIndex];
-		DOM.removeNode(button.element);
-		button.dispose();
-		this._footerButtons.splice(buttonIndex, 1);
+		if (buttonIndex > -1 && buttonIndex < this._footerButtons.length) {
+			let button = this._footerButtons[buttonIndex];
+			DOM.removeNode(button.element);
+			button.dispose();
+			this._footerButtons.splice(buttonIndex, 1);
+		}
 	}
 
 	/**

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -413,7 +413,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	}
 
 	/**
-	* removes the button matching the provided labled from the footer of the modal
+	* removes the footer button matching the provided label
 	* @param label Label on the button
 	*/
 	protected removeFooterButton(label: string): void {

--- a/src/sql/workbench/services/insights/browser/insightsDialogView.ts
+++ b/src/sql/workbench/services/insights/browser/insightsDialogView.ts
@@ -339,9 +339,7 @@ export class InsightsDialogView extends Modal {
 				let commandLabel = types.isString(commandAction.title) ? commandAction.title : commandAction.title.value;
 				if (task) {
 					// need to remove and add fresh because the onDidClick action from previous addition is not called
-					if (this.findFooterButton(commandLabel)) {
-						this.removeFooterButton(commandLabel);
-					}
+					this.removeFooterButton(commandLabel);
 					let button = this.addFooterButton(commandLabel, () => {
 						let element = this._topTable.getSelectedRows();
 						let resource: ListResource;

--- a/src/sql/workbench/services/insights/browser/insightsDialogView.ts
+++ b/src/sql/workbench/services/insights/browser/insightsDialogView.ts
@@ -337,7 +337,11 @@ export class InsightsDialogView extends Modal {
 				let task = tasks.includes(action);
 				let commandAction = MenuRegistry.getCommand(action);
 				let commandLabel = types.isString(commandAction.title) ? commandAction.title : commandAction.title.value;
-				if (task && !this.findFooterButton(commandLabel)) {
+				if (task) {
+					// need to remove and add fresh because the onDidClick action from previous addition is not called
+					if (this.findFooterButton(commandLabel)) {
+						this.removeFooterButton(commandLabel);
+					}
 					let button = this.addFooterButton(commandLabel, () => {
 						let element = this._topTable.getSelectedRows();
 						let resource: ListResource;


### PR DESCRIPTION
Fixes #5401 

Insights dialog was reusing custom buttons added in first render (since modal html element preserves the footer buttons) but the OnDidClick function for these returned buttons wasn't coming correctly from previous iteration - removing and recreating footer button solves this issues.


![backup from insights](https://user-images.githubusercontent.com/46980425/58600597-214e3b80-823a-11e9-88b3-d77372661c10.gif)
