### PR TITLE
Do not add generated files from Temp if file is not dirty

### DIFF
--- a/src/vs/workbench/common/editor/editorGroup.ts
+++ b/src/vs/workbench/common/editor/editorGroup.ts
@@ -20,6 +20,7 @@ import * as CustomInputConverter from 'sql/workbench/common/customInputConverter
 import { NotebookInput } from 'sql/workbench/parts/notebook/notebookInput';
 import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
 import * as path from 'path';
+import * as os from 'os';
 
 const EditorOpenPositioning = {
 	LEFT: 'left',
@@ -668,7 +669,7 @@ export class EditorGroup extends Disposable {
 				// Do not add generated files from Temp if file is not dirty
 				if (e instanceof FileEditorInput && !e.isDirty()) {
 					let filePath = e.getResource() ? e.getResource().fsPath : undefined;
-					let tempPath = process.env[process.platform === 'win32' ? 'TEMP' : 'TMPDIR'];
+					let tempPath = os.tmpdir();
 					if (filePath && tempPath &&
 						filePath.toLocaleLowerCase().includes(path.join(tempPath.toLocaleLowerCase(), 'mssql_definition'))) {
 						return;

--- a/src/vs/workbench/common/editor/editorGroup.ts
+++ b/src/vs/workbench/common/editor/editorGroup.ts
@@ -19,6 +19,7 @@ import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorIn
 import * as CustomInputConverter from 'sql/workbench/common/customInputConverter';
 import { NotebookInput } from 'sql/workbench/parts/notebook/notebookInput';
 import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
+import * as path from 'path';
 
 const EditorOpenPositioning = {
 	LEFT: 'left',
@@ -668,7 +669,8 @@ export class EditorGroup extends Disposable {
 				if (e instanceof FileEditorInput && !e.isDirty()) {
 					let filePath = e.getResource() ? e.getResource().fsPath : undefined;
 					let tempPath = process.env[process.platform === 'win32' ? 'TEMP' : 'TMPDIR'];
-					if (filePath && tempPath && filePath.toLocaleLowerCase().includes(tempPath.toLocaleLowerCase())) {
+					if (filePath && tempPath &&
+						filePath.toLocaleLowerCase().includes(path.join(tempPath.toLocaleLowerCase(), 'mssql_definition'))) {
 						return;
 					}
 				}

--- a/src/vs/workbench/common/editor/editorGroup.ts
+++ b/src/vs/workbench/common/editor/editorGroup.ts
@@ -18,6 +18,7 @@ import { QueryInput } from 'sql/workbench/parts/query/common/queryInput';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
 import * as CustomInputConverter from 'sql/workbench/common/customInputConverter';
 import { NotebookInput } from 'sql/workbench/parts/notebook/notebookInput';
+import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
 
 const EditorOpenPositioning = {
 	LEFT: 'left',
@@ -662,6 +663,14 @@ export class EditorGroup extends Disposable {
 				if (e instanceof UntitledEditorInput && !e.isDirty()
 					&& !this.configurationService.getValue<boolean>('sql.promptToSaveGeneratedFiles')) {
 					return;
+				}
+				// Do not add generated files from Temp if file is not dirty
+				if (e instanceof FileEditorInput && !e.isDirty()) {
+					let filePath = e.getResource() ? e.getResource().fsPath : undefined;
+					let tempPath = process.env[process.platform === 'win32' ? 'TEMP' : 'TMPDIR'];
+					if (filePath && tempPath && filePath.toLocaleLowerCase().includes(tempPath.toLocaleLowerCase())) {
+						return;
+					}
 				}
 				// {{SQL CARBON EDIT}} - End
 


### PR DESCRIPTION
Fixes : #4051 

Generated scripts in Temp folder will not try to open in next ADS session if the files do not have any change.