### PR TITLE
Fix editor title not updating after connect

### DIFF
--- a/src/sql/workbench/parts/query/common/queryInput.ts
+++ b/src/sql/workbench/parts/query/common/queryInput.ts
@@ -290,6 +290,7 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 				this.runQuery(selection, { displayActualQueryPlan: true });
 			}
 		}
+		this._onDidChangeLabel.fire();
 	}
 
 	public onDisconnect(): void {

--- a/src/sql/workbench/parts/query/common/queryInput.ts
+++ b/src/sql/workbench/parts/query/common/queryInput.ts
@@ -295,6 +295,7 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 
 	public onDisconnect(): void {
 		this.state.connected = false;
+		this._onDidChangeLabel.fire();
 	}
 
 	public onRunQuery(): void {


### PR DESCRIPTION
Fixes #5728 (the disconnected title staying active)

The refactor to make this more state based removed the firing of this event. While we now have the EventEmitter for the state being set to connected the _onDidChangeLabel emitter is part of the base VS EditorInput so we should still be calling that if the title is ever updated (in addition to the new state emitter)

Also added fix for disconnect not updating the title. This was actually not a regression - but it's not expected behavior regardless.

![screen](https://user-images.githubusercontent.com/28519865/58655503-1396c580-82cf-11e9-9fe3-55b629d7bb2e.gif)

