### PR TITLE
show not supported message for backup for Azure

### DIFF
--- a/src/sql/workbench/common/actions.ts
+++ b/src/sql/workbench/common/actions.ts
@@ -239,22 +239,22 @@ export class BackupAction extends Task {
 	}
 
 	runTask(accessor: ServicesAccessor, profile: IConnectionProfile): void | Promise<void> {
-		let configurationService = accessor.get<IConfigurationService>(IConfigurationService);
-		let previewFeaturesEnabled: boolean = configurationService.getValue('workbench')['enablePreviewFeatures'];
+		const configurationService = accessor.get<IConfigurationService>(IConfigurationService);
+		const previewFeaturesEnabled: boolean = configurationService.getValue('workbench')['enablePreviewFeatures'];
 		if (!previewFeaturesEnabled) {
 			return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.isPreviewFeature', 'You must enable preview features in order to use backup'));
 		}
 
-		let connectionManagementService = accessor.get<IConnectionManagementService>(IConnectionManagementService);
+		const connectionManagementService = accessor.get<IConnectionManagementService>(IConnectionManagementService);
 		if (!profile) {
-			let objectExplorerService = accessor.get<IObjectExplorerService>(IObjectExplorerService);
-			let workbenchEditorService = accessor.get<IEditorService>(IEditorService);
+			const objectExplorerService = accessor.get<IObjectExplorerService>(IObjectExplorerService);
+			const workbenchEditorService = accessor.get<IEditorService>(IEditorService);
 			profile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionManagementService, workbenchEditorService);
 		}
 		if (profile) {
-			let serverInfo = connectionManagementService.getServerInfo(profile.id);
+			const serverInfo = connectionManagementService.getServerInfo(profile.id);
 			if (serverInfo && serverInfo.isCloud) {
-				return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.commandNotSupported', 'Backup command is not supported for Azure Sql databases.'));
+				return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.commandNotSupported', 'Backup command is not supported for Azure SQL databases.'));
 			}
 		}
 
@@ -282,22 +282,22 @@ export class RestoreAction extends Task {
 	}
 
 	runTask(accessor: ServicesAccessor, profile: IConnectionProfile): void | Promise<void> {
-		let configurationService = accessor.get<IConfigurationService>(IConfigurationService);
-		let previewFeaturesEnabled: boolean = configurationService.getValue('workbench')['enablePreviewFeatures'];
+		const configurationService = accessor.get<IConfigurationService>(IConfigurationService);
+		const previewFeaturesEnabled: boolean = configurationService.getValue('workbench')['enablePreviewFeatures'];
 		if (!previewFeaturesEnabled) {
 			return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.isPreviewFeature', 'You must enable preview features in order to use restore'));
 		}
 
 		let connectionManagementService = accessor.get<IConnectionManagementService>(IConnectionManagementService);
 		if (!profile) {
-			let objectExplorerService = accessor.get<IObjectExplorerService>(IObjectExplorerService);
-			let workbenchEditorService = accessor.get<IEditorService>(IEditorService);
+			const objectExplorerService = accessor.get<IObjectExplorerService>(IObjectExplorerService);
+			const workbenchEditorService = accessor.get<IEditorService>(IEditorService);
 			profile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionManagementService, workbenchEditorService);
 		}
 		if (profile) {
-			let serverInfo = connectionManagementService.getServerInfo(profile.id);
+			const serverInfo = connectionManagementService.getServerInfo(profile.id);
 			if (serverInfo && serverInfo.isCloud) {
-				return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.commandNotSupported', 'Restore command is not supported for Azure Sql databases.'));
+				return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.commandNotSupported', 'Restore command is not supported for Azure SQL databases.'));
 			}
 		}
 

--- a/src/sql/workbench/common/actions.ts
+++ b/src/sql/workbench/common/actions.ts
@@ -239,16 +239,23 @@ export class BackupAction extends Task {
 	}
 
 	runTask(accessor: ServicesAccessor, profile: IConnectionProfile): void | Promise<void> {
-		if (!profile) {
-			let objectExplorerService = accessor.get<IObjectExplorerService>(IObjectExplorerService);
-			let connectionManagementService = accessor.get<IConnectionManagementService>(IConnectionManagementService);
-			let workbenchEditorService = accessor.get<IEditorService>(IEditorService);
-			profile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionManagementService, workbenchEditorService);
-		}
 		let configurationService = accessor.get<IConfigurationService>(IConfigurationService);
 		let previewFeaturesEnabled: boolean = configurationService.getValue('workbench')['enablePreviewFeatures'];
 		if (!previewFeaturesEnabled) {
 			return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.isPreviewFeature', 'You must enable preview features in order to use backup'));
+		}
+
+		let connectionManagementService = accessor.get<IConnectionManagementService>(IConnectionManagementService);
+		if (!profile) {
+			let objectExplorerService = accessor.get<IObjectExplorerService>(IObjectExplorerService);
+			let workbenchEditorService = accessor.get<IEditorService>(IEditorService);
+			profile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionManagementService, workbenchEditorService);
+		}
+		if (profile) {
+			let serverInfo = connectionManagementService.getServerInfo(profile.id);
+			if (serverInfo && serverInfo.isCloud) {
+				return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.commandNotSupported', 'Backup command is not supported for Azure Sql databases.'));
+			}
 		}
 
 		TaskUtilities.showBackup(
@@ -279,6 +286,19 @@ export class RestoreAction extends Task {
 		let previewFeaturesEnabled: boolean = configurationService.getValue('workbench')['enablePreviewFeatures'];
 		if (!previewFeaturesEnabled) {
 			return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.isPreviewFeature', 'You must enable preview features in order to use restore'));
+		}
+
+		let connectionManagementService = accessor.get<IConnectionManagementService>(IConnectionManagementService);
+		if (!profile) {
+			let objectExplorerService = accessor.get<IObjectExplorerService>(IObjectExplorerService);
+			let workbenchEditorService = accessor.get<IEditorService>(IEditorService);
+			profile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionManagementService, workbenchEditorService);
+		}
+		if (profile) {
+			let serverInfo = connectionManagementService.getServerInfo(profile.id);
+			if (serverInfo && serverInfo.isCloud) {
+				return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.commandNotSupported', 'Restore command is not supported for Azure Sql databases.'));
+			}
 		}
 
 		TaskUtilities.showRestore(


### PR DESCRIPTION
Fixes : #5628 

This PR contains 
1. Show _not supported_ messages for backup and restore if opened from command pallet for an azure db
2. Adding profile creation if not present for restore (same as backup) for robustness
3. reordering some code to reduce unnecessary calls.