### PR TITLE
Changed output channel name from 'Jupyter Notebooks' to 'Notebooks'

### DIFF
--- a/extensions/notebook/src/common/constants.ts
+++ b/extensions/notebook/src/common/constants.ts
@@ -7,7 +7,7 @@
 
 // CONFIG VALUES ///////////////////////////////////////////////////////////
 export const extensionConfigSectionName = 'dataManagement';
-export const extensionOutputChannel = 'Jupyter Notebooks';
+export const extensionOutputChannel = 'Notebooks';
 export const configLogDebugInfo = 'logDebugInfo';
 
 // JUPYTER CONFIG //////////////////////////////////////////////////////////
@@ -24,7 +24,6 @@ export const pythonPathConfigKey = 'pythonPath';
 export const existingPythonConfigKey = 'useExistingPython';
 export const notebookConfigKey = 'notebook';
 
-export const outputChannelName = 'dataManagement';
 export const hdfsHost = 'host';
 export const hdfsUser = 'user';
 


### PR DESCRIPTION
Changed output channel name from 'Jupyter Notebooks' to 'Notebooks'

This is how it finally looks:

![image](https://user-images.githubusercontent.com/19577035/58680986-21743700-831f-11e9-93ce-79a1201a8951.png)
