### PR TITLE
Focus messages on error

### DIFF
--- a/src/sql/workbench/parts/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/parts/query/browser/queryResultsView.ts
@@ -223,6 +223,11 @@ export class QueryResultsView extends Disposable {
 			this.input.state.visibleTabs = new Set();
 			this.input.state.activeTab = this.resultsTab.identifier;
 		}));
+		this.runnerDisposables.push(runner.onMessage(e => {
+			if (e.isError) {
+				this._panelView.showTab(this.messagesTab.identifier);
+			}
+		}));
 		this.runnerDisposables.push(runner.onQueryEnd(() => {
 			if (!this.hasResults(runner)) {
 				this.hideResults();


### PR DESCRIPTION
This will move focus to messages on error even if the user is doing something in the results grid (consistent with ssms)