### PR TITLE
Fix instances of listeners not being disposed in Query Editor

### DIFF
--- a/src/sql/workbench/parts/query/browser/queryEditor.ts
+++ b/src/sql/workbench/parts/query/browser/queryEditor.ts
@@ -251,6 +251,7 @@ export class QueryEditor extends BaseEditor {
 
 		if (oldInput) {
 			this.currentTextEditor.clearInput();
+			this.resultsEditor.clearInput();
 		}
 
 		// If we're switching editor types switch out the views

--- a/src/sql/workbench/parts/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/parts/query/browser/queryResultsView.ts
@@ -305,11 +305,14 @@ export class QueryResultsView extends Disposable {
 					disposeable.dispose();
 				}
 			});
+			this.runnerDisposables.push(disposeable);
 		}
 	}
 
 	clearInput() {
 		this._input = undefined;
+		dispose(this.runnerDisposables);
+		this.runnerDisposables = [];
 		this.resultsTab.clear();
 		this.messagesTab.clear();
 		this.qpTab.clear();
@@ -391,6 +394,7 @@ export class QueryResultsView extends Disposable {
 
 	public dispose() {
 		dispose(this.runnerDisposables);
+		this.runnerDisposables = [];
 		super.dispose();
 	}
 

--- a/src/sql/workbench/parts/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/parts/query/browser/queryResultsView.ts
@@ -298,14 +298,14 @@ export class QueryResultsView extends Disposable {
 		if (info) {
 			this.setQueryRunner(info.queryRunner);
 		} else {
-			let disposeable = this.queryModelService.onRunQueryStart(c => {
+			let disposable = this.queryModelService.onRunQueryStart(c => {
 				if (c === input.uri) {
 					let info = this.queryModelService._getQueryInfo(input.uri);
 					this.setQueryRunner(info.queryRunner);
-					disposeable.dispose();
+					disposable.dispose();
 				}
 			});
-			this.runnerDisposables.push(disposeable);
+			this.runnerDisposables.push(disposable);
 		}
 	}
 


### PR DESCRIPTION
Pretty high pri issue.

If you open up editors side by side, running a query in the second would cause the results to show up in both. There were a couple of these issues with more editors. This fixes the main issue.