### PR TITLE
Automatically detect existing Python/Conda installs in Configure Python dialog.

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -336,6 +336,7 @@
 		"error-ex": "^1.3.1",
 		"figures": "^2.0.0",
 		"fs-extra": "^5.0.0",
+		"glob": "^7.1.1",
 		"node-fetch": "^2.3.0",
 		"request": "^2.88.0",
 		"temp-write": "^3.4.0",
@@ -345,6 +346,7 @@
 	"devDependencies": {
 		"@types/decompress": "^4.2.3",
 		"@types/fs-extra": "^5.0.0",
+		"@types/glob": "^7.1.1",
 		"@types/mocha": "^5.2.5",
 		"@types/node": "^11.9.3",
 		"@types/request": "^2.48.1",

--- a/extensions/notebook/src/dialog/configurePythonDialog.ts
+++ b/extensions/notebook/src/dialog/configurePythonDialog.ts
@@ -157,11 +157,10 @@ export class ConfigurePythonDialog {
 				}
 			} else {
 				let defaultPath = JupyterServerInstallation.DefaultPythonLocation;
-				let defaultValue = {
+				dropdownValues = [{
 					displayName: `${defaultPath} (Default)`,
 					name: defaultPath
-				};
-				dropdownValues = [defaultValue];
+				}];
 			}
 
 			this.usingCustomPath = false;

--- a/extensions/notebook/src/dialog/configurePythonDialog.ts
+++ b/extensions/notebook/src/dialog/configurePythonDialog.ts
@@ -156,7 +156,7 @@ export class ConfigurePythonDialog {
 					}];
 				}
 			} else {
-				let defaultPath = JupyterServerInstallation.getPythonInstallPath(this.apiWrapper);
+				let defaultPath = JupyterServerInstallation.DefaultPythonLocation;
 				let defaultValue = {
 					displayName: `${defaultPath} (Default)`,
 					name: defaultPath

--- a/extensions/notebook/src/dialog/configurePythonDialog.ts
+++ b/extensions/notebook/src/dialog/configurePythonDialog.ts
@@ -22,7 +22,7 @@ export class ConfigurePythonDialog {
 	private readonly DialogTitle = localize('configurePython.dialogName', "Configure Python for Notebooks");
 	private readonly InstallButtonText = localize('configurePython.okButtonText', "Install");
 	private readonly CancelButtonText = localize('configurePython.cancelButtonText', "Cancel");
-	private readonly BrowseButtonText = localize('configurePython.browseButtonText', "Change location");
+	private readonly BrowseButtonText = localize('configurePython.browseButtonText', "Browse");
 	private readonly LocationTextBoxTitle = localize('configurePython.locationTextBoxText', "Python Install Location");
 	private readonly SelectFileLabel = localize('configurePython.selectFileLabel', "Select");
 	private readonly InstallationNote = localize('configurePython.installNote', "This installation will take some time. It is recommended to not close the application until the installation is complete.");
@@ -90,7 +90,7 @@ export class ConfigurePythonDialog {
 			this.browseButton = view.modelBuilder.button()
 				.withProperties<azdata.ButtonProperties>({
 					label: this.BrowseButtonText,
-					width: '100px'
+					width: '70px'
 				}).component();
 			this.browseButton.onDidClick(() => this.handleBrowse());
 

--- a/extensions/notebook/src/dialog/configurePythonDialog.ts
+++ b/extensions/notebook/src/dialog/configurePythonDialog.ts
@@ -151,7 +151,7 @@ export class ConfigurePythonDialog {
 					});
 				} else {
 					dropdownValues = [{
-						displayName: 'No Python installs found.',
+						displayName: 'No supported Python versions found.',
 						name: ''
 					}];
 				}

--- a/extensions/notebook/src/dialog/configurePythonDialog.ts
+++ b/extensions/notebook/src/dialog/configurePythonDialog.ts
@@ -145,7 +145,7 @@ export class ConfigurePythonDialog {
 				if (pythonPaths && pythonPaths.length > 0) {
 					dropdownValues = pythonPaths.map(path => {
 						return {
-							displayName: `${path.installDir} (${path.version})`,
+							displayName: `${path.installDir} (Python ${path.version})`,
 							name: path.installDir
 						};
 					});

--- a/extensions/notebook/src/dialog/pythonPathLookup.ts
+++ b/extensions/notebook/src/dialog/pythonPathLookup.ts
@@ -1,0 +1,158 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as glob from 'glob';
+
+import * as utils from '../common/utils';
+import * as constants from '../common/constants';
+
+export interface PythonPathInfo {
+	installDir: string;
+	version: string;
+}
+
+export class PythonPathLookup {
+	private condaLocations: string[];
+	constructor() {
+		if (process.platform !== constants.winPlatform) {
+			let userFolder = process.env['HOME'];
+			this.condaLocations = [
+				'/opt/*conda*/bin/python3',
+				'/usr/share/*conda*/bin/python3',
+				`${userFolder}/*conda*/bin/python3`
+			];
+		} else {
+			let userFolder = process.env['USERPROFILE'].replace('\\', '/').replace('C:', '');
+			this.condaLocations = [
+				'/ProgramData/[Mm]iniconda*/python.exe',
+				'/ProgramData/[Aa]naconda*/python.exe',
+				`${userFolder}/[Mm]iniconda*/python.exe`,
+				`${userFolder}/[Aa]naconda*/python.exe`,
+				`${userFolder}/AppData/Local/Continuum/[Mm]iniconda*/python.exe`,
+				`${userFolder}/AppData/Local/Continuum/[Aa]naconda*/python.exe`
+			];
+		}
+	}
+
+	public async getSuggestions(): Promise<PythonPathInfo[]> {
+		let pythonSuggestions = await this.getPythonSuggestions();
+		let condaSuggestions = await this.getCondaSuggestions();
+
+		if (pythonSuggestions) {
+			if (condaSuggestions && condaSuggestions.length > 0) {
+				pythonSuggestions = pythonSuggestions.concat(condaSuggestions);
+			}
+			return this.getInfoForPaths(pythonSuggestions);
+		} else {
+			return [];
+		}
+	}
+
+	private async getCondaSuggestions(): Promise<string[]> {
+		try {
+			let condaResults = await Promise.all(this.condaLocations.map(location => this.globSearch(location)));
+			let condaFiles = condaResults.reduce((first, second) => first.concat(second));
+			return condaFiles.filter(condaPath => condaPath && condaPath.length > 0);
+		} catch (err) {
+		}
+		return [];
+	}
+
+	private globSearch(globPattern: string): Promise<string[]> {
+		return new Promise<string[]>((resolve, reject) => {
+			glob(globPattern, (err, files) => {
+				if (err) {
+					return reject(err);
+				}
+				resolve(Array.isArray(files) ? files : []);
+			});
+		});
+	}
+
+	private async getPythonSuggestions(): Promise<string[]> {
+		let pathsToCheck = this.getPythonCommands();
+
+		let pythonPaths = await Promise.all(pathsToCheck.map(item => this.getPythonPath(item)));
+		let results: string[] = [];
+		if (pythonPaths) {
+			results = pythonPaths.filter(path => path && path.length > 0);
+		}
+		return results;
+	}
+
+	private async getPythonPath(options: { command: string; args?: string[] }): Promise<string> {
+		try {
+			let args = Array.isArray(options.args) ? options.args : [];
+			args = args.concat(['-c', '"import sys;print(sys.executable)"']);
+			const cmd = `"${options.command}" ${args.join(' ')}`;
+			let output = await utils.executeBufferedCommand(cmd, {});
+			let value = output ? output.trim() : '';
+			if (value.length > 0 && fs.existsSync(value)) {
+				return value;
+			}
+		} catch (err) {
+			// Ignore errors here, since this python version will just be excluded.
+		}
+
+		return undefined;
+	}
+
+	private getPythonCommands(): { command: string; args?: string[] }[] {
+		const paths = ['python3.7', 'python3.6', 'python3', 'python2', 'python']
+			.map(item => { return { command: item }; });
+		if (process.platform !== constants.winPlatform) {
+			return paths;
+		}
+
+		const versions = ['3.7', '3.6', '3', '2'];
+		return paths.concat(versions.map(version => {
+			return { command: 'py', args: [`-${version}`] };
+		}));
+	}
+
+	private async getInfoForPaths(pythonPaths: string[]): Promise<PythonPathInfo[]> {
+		let pathsInfo = await Promise.all(pythonPaths.map(path => this.getInfoForPath(path)));
+
+		// Remove duplicate paths, and entries with missing values
+		let pathSet = new Set<string>();
+		return pathsInfo.filter(path => {
+			if (!path || !path.installDir || !path.version) {
+				return false;
+			}
+
+			let key = `${path.installDir} ${path.version}`;
+			if (pathSet.has(key)) {
+				return false;
+			} else {
+				pathSet.add(key);
+				return true;
+			}
+		});
+	}
+
+	private async getInfoForPath(pythonPath: string): Promise<PythonPathInfo> {
+		try {
+			let cmd = `"${pythonPath}" --version`;
+			let output = await utils.executeBufferedCommand(cmd, {});
+			let pythonVersion = output ? output.trim() : '';
+
+			cmd = `"${pythonPath}" -c "import sys;print(sys.exec_prefix)"`;
+			output = await utils.executeBufferedCommand(cmd, {});
+			let pythonPrefix = output ? output.trim() : '';
+
+			if (pythonVersion.length > 0 && pythonPrefix.length > 0) {
+				return {
+					installDir: pythonPrefix,
+					version: pythonVersion
+				};
+			}
+		} catch (err) {
+			// Ignore errors here, since this python version will just be excluded.
+		}
+
+		return undefined;
+	}
+}

--- a/extensions/notebook/src/dialog/pythonPathLookup.ts
+++ b/extensions/notebook/src/dialog/pythonPathLookup.ts
@@ -76,9 +76,11 @@ export class PythonPathLookup {
 		let pathsToCheck = this.getPythonCommands();
 
 		let pythonPaths = await Promise.all(pathsToCheck.map(item => this.getPythonPath(item)));
-		let results: string[] = [];
+		let results: string[];
 		if (pythonPaths) {
 			results = pythonPaths.filter(path => path && path.length > 0);
+		} else {
+			results = [];
 		}
 		return results;
 	}
@@ -135,9 +137,11 @@ export class PythonPathLookup {
 
 	private async getInfoForPath(pythonPath: string): Promise<PythonPathInfo> {
 		try {
-			let cmd = `"${pythonPath}" --version`;
+			// "python --version" returns nothing from executeBufferedCommand with Python 2.X,
+			// so use sys.version_info here instead.
+			let cmd = `"${pythonPath}" -c "import sys;print('.'.join(str(i) for i in sys.version_info[:3]))"`;
 			let output = await utils.executeBufferedCommand(cmd, {});
-			let pythonVersion = output ? output.trim() : '';
+			let pythonVersion = output ? `Python ${output.trim()}` : '';
 
 			cmd = `"${pythonPath}" -c "import sys;print(sys.exec_prefix)"`;
 			output = await utils.executeBufferedCommand(cmd, {});
@@ -152,7 +156,6 @@ export class PythonPathLookup {
 		} catch (err) {
 			// Ignore errors here, since this python version will just be excluded.
 		}
-
 		return undefined;
 	}
 }

--- a/extensions/notebook/src/dialog/pythonPathLookup.ts
+++ b/extensions/notebook/src/dialog/pythonPathLookup.ts
@@ -103,13 +103,13 @@ export class PythonPathLookup {
 	}
 
 	private getPythonCommands(): { command: string; args?: string[] }[] {
-		const paths = ['python3.7', 'python3.6', 'python3', 'python2', 'python']
+		const paths = ['python3.7', 'python3.6', 'python3', 'python']
 			.map(item => { return { command: item }; });
 		if (process.platform !== constants.winPlatform) {
 			return paths;
 		}
 
-		const versions = ['3.7', '3.6', '3', '2'];
+		const versions = ['3.7', '3.6', '3'];
 		return paths.concat(versions.map(version => {
 			return { command: 'py', args: [`-${version}`] };
 		}));

--- a/extensions/notebook/src/dialog/pythonPathLookup.ts
+++ b/extensions/notebook/src/dialog/pythonPathLookup.ts
@@ -121,7 +121,12 @@ export class PythonPathLookup {
 		// Remove duplicate paths, and entries with missing values
 		let pathSet = new Set<string>();
 		return pathsInfo.filter(path => {
-			if (!path || !path.installDir || !path.version) {
+			if (!path || !path.installDir || !path.version || path.installDir.length === 0 || path.version.length === 0) {
+				return false;
+			}
+
+			let majorVersion = Number.parseInt(path.version.substring(0, path.version.indexOf('.')));
+			if (Number.isNaN(majorVersion) || majorVersion < 3) {
 				return false;
 			}
 
@@ -141,7 +146,7 @@ export class PythonPathLookup {
 			// so use sys.version_info here instead.
 			let cmd = `"${pythonPath}" -c "import sys;print('.'.join(str(i) for i in sys.version_info[:3]))"`;
 			let output = await utils.executeBufferedCommand(cmd, {});
-			let pythonVersion = output ? `Python ${output.trim()}` : '';
+			let pythonVersion = output ? output.trim() : '';
 
 			cmd = `"${pythonPath}" -c "import sys;print(sys.exec_prefix)"`;
 			output = await utils.executeBufferedCommand(cmd, {});

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -53,7 +53,7 @@ export default class JupyterServerInstallation {
 	private _forceInstall: boolean;
 	private _installInProgress: boolean;
 
-	private static readonly DefaultPythonLocation = path.join(utils.getUserHome(), 'azuredatastudio-python');
+	public static readonly DefaultPythonLocation = path.join(utils.getUserHome(), 'azuredatastudio-python');
 
 	constructor(extensionPath: string, outputChannel: OutputChannel, apiWrapper: ApiWrapper, pythonInstallationPath?: string) {
 		this.extensionPath = extensionPath;

--- a/extensions/notebook/yarn.lock
+++ b/extensions/notebook/yarn.lock
@@ -92,6 +92,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/events@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
+  integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
 "@types/form-data@*":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.2.1.tgz#ee2b3b8eaa11c0938289953606b745b738c54b1e"
@@ -105,6 +110,20 @@
   integrity sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==
   dependencies:
     "@types/node" "*"
+
+"@types/glob@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/minimatch@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/mocha@^5.2.5":
   version "5.2.6"


### PR DESCRIPTION
The detection logic here is imported from the vscode-python extension for the most part. Anaconda installs are detected using a regex search for common install locations. Python installs are detected by fetching the version info from whatever python versions are present in PATH. A small downside of this change is that the Install Location field in the dialog is no longer directly editable, since we include version info as part of the entries for better clarity. The Browse button still works as expected, though.

I also made some small improvements to error handling in the actual install code. Some code would still run after a reject call, since there weren't any return statements. For example, a python download could continue in the background even if the process couldn't access the install path.

Seems like there are some assumptions in the install and notebook code that the process will have read access to the install path. This means a user can't select built-in python installs on Mac/Linux, since we would try to create notebook files in a system directory like /usr. This is a broader issue that would need to be handled in a future PR.


Fixes https://github.com/microsoft/azuredatastudio/issues/5471

![image](https://user-images.githubusercontent.com/12820011/58733267-e880a480-83a8-11e9-9463-28e9b6ac3325.png)
