### PR TITLE
Fix Issue when SessionManager is Undefined in Rare Cases

### DIFF
--- a/src/sql/workbench/parts/notebook/models/clientSession.ts
+++ b/src/sql/workbench/parts/notebook/models/clientSession.ts
@@ -306,7 +306,7 @@ export class ClientSession implements IClientSession {
 	 */
 	public async shutdown(): Promise<void> {
 		// Always try to shut down session
-		if (this._session && this._session.id) {
+		if (this._session && this._session.id && this.notebookManager && this.notebookManager.sessionManager) {
 			await this.notebookManager.sessionManager.shutdown(this._session.id);
 		}
 	}


### PR DESCRIPTION
Fixes #5541. Simple check to see if notebookManager and notebookManager.sessionManager both exist before calling shutdown of the previous session.