### PR TITLE
Fixed bug: Notebooks Vertical Scrollbar is Unnecessary for Some Grid Outputs

### DIFF
--- a/src/sql/workbench/parts/notebook/outputs/tableRenderers.ts
+++ b/src/sql/workbench/parts/notebook/outputs/tableRenderers.ts
@@ -67,7 +67,7 @@ export function renderDataResource(
 	detailTable.registerPlugin(new AdditionalKeyBindings());
 	let numRows = detailTable.grid.getDataLength();
 	// Need to include column headers and scrollbar, so that's why 1 needs to be added
-	let rowsHeight = (numRows + 1) * RESULTS_GRID_DEFAULTS.rowHeight + BOTTOM_PADDING_AND_SCROLLBAR;
+	let rowsHeight = ((numRows + 1) * RESULTS_GRID_DEFAULTS.rowHeight + BOTTOM_PADDING_AND_SCROLLBAR) + numRows;
 	// if no rows are in the grid, set height to 100% of the container's height
 	if (numRows === 0) {
 		tableContainer.style.height = '100%';

--- a/src/sql/workbench/parts/notebook/outputs/tableRenderers.ts
+++ b/src/sql/workbench/parts/notebook/outputs/tableRenderers.ts
@@ -67,7 +67,7 @@ export function renderDataResource(
 	detailTable.registerPlugin(new AdditionalKeyBindings());
 	let numRows = detailTable.grid.getDataLength();
 	// Need to include column headers and scrollbar, so that's why 1 needs to be added
-	let rowsHeight = ((numRows + 1) * RESULTS_GRID_DEFAULTS.rowHeight + BOTTOM_PADDING_AND_SCROLLBAR) + numRows;
+	let rowsHeight = (numRows + 1) * RESULTS_GRID_DEFAULTS.rowHeight + BOTTOM_PADDING_AND_SCROLLBAR + numRows;
 	// if no rows are in the grid, set height to 100% of the container's height
 	if (numRows === 0) {
 		tableContainer.style.height = '100%';


### PR DESCRIPTION
This is for fixing bug: https://github.com/microsoft/azuredatastudio/issues/5836
It was because we did not count border pixels for the rows.
We need to add 1 pixel for each rows bottom border.
This code change fixes that.

Before fix:
![image](https://user-images.githubusercontent.com/19577035/58838718-57156a80-8614-11e9-88c0-77f099406030.png)

After fix:
![image](https://user-images.githubusercontent.com/19577035/58838563-ed955c00-8613-11e9-9e57-1ec776b21cd4.png)
