### PR TITLE
Notebooks Accessibility: Remove tabindex=0 for Notebook Component

### DIFF
--- a/src/sql/workbench/parts/notebook/notebook.component.html
+++ b/src/sql/workbench/parts/notebook/notebook.component.html
@@ -7,7 +7,7 @@
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div #toolbar class="editor-toolbar actionbar-container" style="flex: 0 0 auto; display: flex; flex-flow: row; width: 100%; align-items: center;">
 	</div>
-	<div #container class="scrollable" style="flex: 1 1 auto; position: relative; outline: none" (click)="unselectActiveCell()" (scroll)="scrollHandler($event)" tabindex="0">
+	<div #container class="scrollable" style="flex: 1 1 auto; position: relative; outline: none" (click)="unselectActiveCell()" (scroll)="scrollHandler($event)">
 		<loading-spinner [loading]="isLoading"></loading-spinner>
 		<div class="notebook-cell" *ngFor="let cell of cells" (click)="selectCell(cell, $event)" [class.active]="cell.active">
 			<code-cell-component *ngIf="cell.cellType === 'code'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">


### PR DESCRIPTION
This is a fix for the accessibility bug #5616. We shouldn't have a tabindex for the notebook component, as focusing on the whole thing doesn't make sense (and tabbing appears to "disappear" when it's selected).