### PR TITLE
CMS - set auth option back to default when cancelled

### DIFF
--- a/src/sql/workbench/services/connection/browser/cmsConnectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/cmsConnectionWidget.ts
@@ -108,8 +108,9 @@ export class CmsConnectionWidget extends ConnectionWidget {
 			} else {
 				authTypeOption.defaultValue = this.getAuthTypeDisplayName(AuthenticationType.SqlLogin);
 			}
-			this._authTypeSelectBox.setOptions(authTypeOption.categoryValues.map(c => c.displayName), 1);
 		}
+		this._authTypeSelectBox.setOptions(authTypeOption.categoryValues.map(c => c.displayName), 1);
+		this._authTypeSelectBox.selectWithOptionName(authTypeOption.defaultValue);
 	}
 
 	private addServerDescriptionOption(): void {


### PR DESCRIPTION

Edit - had the wrong issue. Here's the correct one - https://github.com/microsoft/azuredatastudio/issues/5856