### PR TITLE
Fixed bug: Execute cell should scroll to its results

### DIFF
--- a/src/sql/workbench/parts/notebook/cellViews/output.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/output.component.ts
@@ -75,6 +75,14 @@ export class OutputComponent extends AngularDisposable implements OnInit {
 		options.themeService = this._themeService;
 		// TODO handle safe/unsafe mapping
 		this.createRenderedMimetype(options, this.outputElement.nativeElement);
+		this.setFocusAndScroll(this.outputElement.nativeElement);
+	}
+
+	private setFocusAndScroll(node: HTMLElement): void {
+		if (node) {
+			node.focus();
+			node.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+		}
 	}
 
 	public layout(): void {

--- a/src/sql/workbench/parts/notebook/cellViews/output.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/output.component.ts
@@ -70,7 +70,7 @@ export class OutputComponent extends AngularDisposable implements OnInit {
 		}
 	}
 
-	private renderOutput(focusAndScroll?: boolean) {
+	private renderOutput(focusAndScroll: boolean = false): void {
 		let options = outputProcessor.getBundleOptions({ value: this.cellOutput, trusted: this.trustedMode });
 		options.themeService = this._themeService;
 		// TODO handle safe/unsafe mapping

--- a/src/sql/workbench/parts/notebook/cellViews/output.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/output.component.ts
@@ -43,7 +43,7 @@ export class OutputComponent extends AngularDisposable implements OnInit {
 	}
 
 	ngOnInit() {
-		this.renderOutput();
+		this.renderOutput(true);
 		this._initialized = true;
 		this._register(Event.debounce(this.cellModel.notebookModel.layoutChanged, (l, e) => e, 50, /*leading=*/false)
 			(() => this.renderOutput()));
@@ -70,12 +70,14 @@ export class OutputComponent extends AngularDisposable implements OnInit {
 		}
 	}
 
-	private renderOutput() {
+	private renderOutput(focusAndScroll?: boolean) {
 		let options = outputProcessor.getBundleOptions({ value: this.cellOutput, trusted: this.trustedMode });
 		options.themeService = this._themeService;
 		// TODO handle safe/unsafe mapping
 		this.createRenderedMimetype(options, this.outputElement.nativeElement);
-		this.setFocusAndScroll(this.outputElement.nativeElement);
+		if (focusAndScroll) {
+			this.setFocusAndScroll(this.outputElement.nativeElement);
+		}
 	}
 
 	private setFocusAndScroll(node: HTMLElement): void {


### PR DESCRIPTION
This resolves https://github.com/microsoft/azuredatastudio/issues/5770
This change make Notebooks window scroll to its cell execution result.

Before fix:
![Honeycam 2019-06-03 19-50-16](https://user-images.githubusercontent.com/19577035/58847747-ecc2f100-8638-11e9-9727-5d617db3b5ea.gif)

After fix:
![Honeycam 2019-06-03 19-46-46](https://user-images.githubusercontent.com/19577035/58847597-6a3a3180-8638-11e9-929b-702cb952f380.gif)