### PR TITLE
Remove VS redist license

### DIFF
--- a/extensions/admin-tool-ext-win/license/Visual Studio Redist.txt
+++ b/extensions/admin-tool-ext-win/license/Visual Studio Redist.txt
@@ -1,3 +1,0 @@
-Distributable Code for Microsoft Visual Studio 2017 and Microsoft Visual Studio 2017 SDK (Includes Utilities & BuildServer Files)
-
-For the latest version of this Redist file, please visit http://go.microsoft.com/fwlink/?LinkId=823098


### PR DESCRIPTION
This isn't necessary since we aren't providing the VS binaries as redist-able. VS has signed off as confirming that the main extension license is enough to cover the VS binaries as well.