### PR TITLE
Make sure the first Connection Dialog has correct provider.

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -143,10 +143,6 @@ export class ConnectionDialogService implements IConnectionDialogService {
 				if (filteredKeys && filteredKeys.length > 0) {
 					defaultProvider = filteredKeys[0];
 				}
-				else {
-					// CMS isn't default unless called by the extension specifically
-					defaultProvider = keys.filter(provider => provider === Constants.cmsProviderName)[0];
-				}
 			}
 		}
 		if (!defaultProvider && this._configurationService) {

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -144,7 +144,8 @@ export class ConnectionDialogService implements IConnectionDialogService {
 					defaultProvider = filteredKeys[0];
 				}
 				else {
-					defaultProvider = keys[0];
+					// CMS isn't default unless called by the extension specifically
+					defaultProvider = keys.filter(provider => provider === Constants.cmsProviderName)[0];
 				}
 			}
 		}
@@ -304,18 +305,19 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	private handleShowUiComponent(input: OnShowUIResponse) {
 		if (input.selectedProviderType) {
 			// If the call is for specific providers
-			let isParamProvider: boolean = false;
+			let isProviderInParams: boolean = false;
 			if (this._params && this._params.providers) {
 				this._params.providers.forEach((provider) => {
 					if (input.selectedProviderType === this._providerNameToDisplayNameMap[provider]) {
-						isParamProvider = true;
+						isProviderInParams = true;
 						this._currentProviderType = provider;
 					}
 				});
 			}
-			if (!isParamProvider) {
+			if (!isProviderInParams) {
 				this._currentProviderType = Object.keys(this._providerNameToDisplayNameMap).find((key) =>
-					this._providerNameToDisplayNameMap[key] === input.selectedProviderType
+					this._providerNameToDisplayNameMap[key] === input.selectedProviderType &&
+					key !== Constants.cmsProviderName
 				);
 			}
 		}

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -313,6 +313,12 @@ export class ExtensionService extends Disposable implements IExtensionService {
 			}
 		}
 
+		// {{SQL CARBON EDIT}}
+		// Forces a reload for CMS extension
+		if (extension.name === 'cms') {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -313,12 +313,6 @@ export class ExtensionService extends Disposable implements IExtensionService {
 			}
 		}
 
-		// {{SQL CARBON EDIT}}
-		// Forces a reload for CMS extension
-		if (extension.name === 'cms') {
-			return false;
-		}
-
 		return true;
 	}
 


### PR DESCRIPTION
Fixes -
1. Choose `MSSQL` for the first connection dialog that opens automatically when the app is opened for the first time/has no servers (and has CMS extension installed).