### PR TITLE
Fix CMS tests

### DIFF
--- a/extensions/integration-tests/package.json
+++ b/extensions/integration-tests/package.json
@@ -55,7 +55,8 @@
     "chai": "3.5.0",
     "mocha-junit-reporter": "^1.17.0",
     "mocha-multi-reporters": "^1.1.7",
-    "vscode": "1.1.5"
+	"vscode": "1.1.5",
+	"uuid": "^3.3.2"
   },
   "dependencies": {
     "azure-keyvault": "^3.0.4",

--- a/extensions/integration-tests/package.json
+++ b/extensions/integration-tests/package.json
@@ -55,8 +55,8 @@
     "chai": "3.5.0",
     "mocha-junit-reporter": "^1.17.0",
     "mocha-multi-reporters": "^1.1.7",
-	"vscode": "1.1.5",
-	"uuid": "^3.3.2"
+    "vscode": "1.1.5",
+    "uuid": "^3.3.2"
   },
   "dependencies": {
     "azure-keyvault": "^3.0.4",

--- a/extensions/integration-tests/src/cms.test.ts
+++ b/extensions/integration-tests/src/cms.test.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as mssql from '../../mssql/src/api/mssqlapis';
 import * as utils from './utils';
+import * as uuid from 'uuid';
 import { context } from './testContext';
 import assert = require('assert');
 import { getStandaloneServer, TestServerProfile, getBdcServer } from './testConfig';
@@ -19,6 +20,10 @@ let server: TestServerProfile;
 let connectionId: string;
 let ownerUri: string;
 const SERVER_CONNECTION_TIMEOUT: number = 3000;
+const TEST_CMS_NAME = `adsTestCms_${uuid.v4()}`;
+const TEST_CMS_GROUP = `adsTestCmsGroup_${uuid.v4()}`;
+const TEST_CMS_SERVER = `adsTestCmsServer_${uuid.v4()}`;
+const TEST_CMS_REG_SERVER = `adsTestCmsRegisteredServer_${uuid.v4()}`;
 
 if (context.RunTest) {
 	suite('CMS integration test suite', () => {
@@ -45,9 +50,9 @@ if (context.RunTest) {
 
 		test('Create CMS Server', async function () {
 			// Should fail
-			let failedResult = await cmsService.createCmsServer(undefined, 'test_description', undefined, ownerUri);
-			assert(failedResult === undefined, 'Cannot add a CMS server without a name or connection');
-
+			await utils.assertThrowsAsync(
+				async () => await cmsService.createCmsServer(undefined, 'test_description', undefined, ownerUri),
+				'Cannot add a CMS server without a name or connection');
 			let connection = {
 				serverName: server.serverName,
 				userName: server.userName,
@@ -60,39 +65,40 @@ if (context.RunTest) {
 				options: {}
 			};
 
-			// Should create a CMS Server
-			let result = await cmsService.createCmsServer('test_cms', 'test_description', connection, ownerUri);
-			assert(result !== undefined, 'CMS server created successfully');
+			// Should create a CMS Server without an error
+			await cmsService.createCmsServer(TEST_CMS_NAME, 'test_description', connection, ownerUri);
 		});
 
 		test('Add and delete registered group to/from CMS server', async function () {
-			// Should fail
-			let failedResult = await cmsService.addServerGroup(ownerUri, '', undefined, 'test_description');
-			assert(failedResult === undefined, 'Cannot add a server group without a name');
+			await utils.assertThrowsAsync(
+				async () => await cmsService.addServerGroup(ownerUri, '', undefined, 'test_description'),
+				'Cannot add a server group without a name');
 
 			// Should create a server group
-			let result = await cmsService.addServerGroup(ownerUri, '', 'test_group', 'test_description');
-			assert(result === true, 'Server group added to CMS server successfully');
+			let result = await cmsService.addServerGroup(ownerUri, '', TEST_CMS_GROUP, 'test_description');
+			assert(result === true, `Server group ${TEST_CMS_GROUP} was not added to CMS server successfully`);
 
 			// Shouldn't be able to create a new server group with same name
-			let repeatResult = await cmsService.addServerGroup(ownerUri, '', 'test_group', 'test_description');
-			assert(repeatResult === undefined, 'Cannot add a server group with existing name');
+			await utils.assertThrowsAsync(
+				async () => await cmsService.addServerGroup(ownerUri, '', TEST_CMS_GROUP, 'test_description'),
+				'Cannot add a server group with existing name');
 
 			let cmsResources = await cmsService.getRegisteredServers(ownerUri, '');
-			assert(cmsResources.registeredServerGroups.length === 1, 'A server group was added successfully');
+			assert(cmsResources.registeredServerGroups.length === 1, `The server group ${TEST_CMS_GROUP} was not added successfully. Groups : [${cmsResources.registeredServerGroups.join(',')}]`);
 
 			// Should remove the server group we added above
-			let deleteResult = await cmsService.removeServerGroup(ownerUri, '', 'test_group');
-			assert(deleteResult === true, 'Server group removed from CMS server successfully');
+			let deleteResult = await cmsService.removeServerGroup(ownerUri, '', TEST_CMS_GROUP);
+			assert(deleteResult === true, `Server group ${TEST_CMS_GROUP} was not removed successfully`);
 
 			cmsResources = await cmsService.getRegisteredServers(ownerUri, '');
-			assert(cmsResources.registeredServerGroups.length === 0, 'The server group was removed successfully');
+			assert(cmsResources.registeredServerGroups.length === 0, `The server group ${TEST_CMS_GROUP} was not removed successfully. Groups : [${cmsResources.registeredServerGroups.join(',')}]`);
 		});
 
 		test('Add and delete registered server to/from CMS server', async function () {
-			// Should fail
-			let failedResult = await cmsService.addRegisteredServer(ownerUri, '', undefined, 'test_description', undefined);
-			assert(failedResult === undefined, 'Cannot add a registered without a name or connection');
+
+			await utils.assertThrowsAsync(
+				async () => cmsService.addRegisteredServer(ownerUri, '', undefined, 'test_description', undefined),
+				'Cannot add a registered without a name or connection');
 
 			let bdcServer = await getBdcServer();
 			let bdcConnection = {
@@ -108,27 +114,28 @@ if (context.RunTest) {
 			};
 
 			// Should create a registered server
-			let result = await cmsService.addRegisteredServer(ownerUri, '', 'test_registered_server', 'test_description', bdcConnection);
-			assert(result === true, 'Registered server added to CMS server successfully');
+			let result = await cmsService.addRegisteredServer(ownerUri, '', TEST_CMS_SERVER, 'test_description', bdcConnection);
+			assert(result === true, `Registered server ${TEST_CMS_SERVER} was not added to CMS server successfully`);
 
 			// Shouldn't be able to create a new registered server with same name
-			let repeatResult = await cmsService.addRegisteredServer(ownerUri, '', 'test_registered_server', 'test_description', bdcConnection);
-			assert(repeatResult === undefined, 'Cannot add a registered server with existing name');
+			await utils.assertThrowsAsync(
+				async () => await cmsService.addRegisteredServer(ownerUri, '', TEST_CMS_SERVER, 'test_description', bdcConnection),
+				'Cannot add a registered server with existing name');
 
 			// Should remove the registered server we added above
-			let deleteResult = await cmsService.removeRegisteredServer(ownerUri, '', 'test_registered_server');
-			assert(deleteResult === true, 'Registered server added to CMS server successfully');
+			let deleteResult = await cmsService.removeRegisteredServer(ownerUri, '', TEST_CMS_SERVER);
+			assert(deleteResult === true, `Registered server ${TEST_CMS_SERVER} was not removed correctly`);
 		});
 
 		test('Add and delete registered server to/from server group', async function () {
 
 			// Should create a server group
-			let result = await cmsService.addServerGroup(ownerUri, '', 'test_group', 'test_description');
-			assert(result === true, 'Server group added to CMS server successfully');
+			let result = await cmsService.addServerGroup(ownerUri, '', TEST_CMS_GROUP, 'test_description');
+			assert(result === true, `Server group ${TEST_CMS_GROUP} was not created successfully`);
 
 			// Make sure server group is created
 			let cmsResources = await cmsService.getRegisteredServers(ownerUri, '');
-			assert(cmsResources.registeredServerGroups.length === 1, 'The server group was added successfully');
+			assert(cmsResources.registeredServerGroups.length === 1, `The server group ${TEST_CMS_GROUP} was not added correctly`);
 
 			// Should create a registered server under the group
 			let bdcServer = await getBdcServer();
@@ -144,12 +151,13 @@ if (context.RunTest) {
 				options: { }
 			};
 			let relativePath = cmsResources.registeredServerGroups[0].relativePath;
-			result = await cmsService.addRegisteredServer(ownerUri, relativePath, 'test_registered_server_2', 'test_description', bdcConnection);
-			assert(result === true, 'Registered server added to server group');
+
+			result = await cmsService.addRegisteredServer(ownerUri, relativePath, TEST_CMS_REG_SERVER, 'test_description', bdcConnection);
+			assert(result === true, `Registered server ${TEST_CMS_REG_SERVER} was not added to server group successfully`);
 
 			// Should remove the server group we added above
-			let deleteResult = await cmsService.removeServerGroup(ownerUri, '', 'test_group');
-			assert(deleteResult === true, 'Server group deleted from CMS server successfully');
+			let deleteResult = await cmsService.removeServerGroup(ownerUri, '', TEST_CMS_GROUP);
+			assert(deleteResult === true, `Server group ${TEST_CMS_GROUP} was not deleted from CMS server successfully`);
 		});
 	});
 }

--- a/extensions/integration-tests/src/cms.test.ts
+++ b/extensions/integration-tests/src/cms.test.ts
@@ -110,7 +110,7 @@ if (context.RunTest) {
 				provider: bdcServer.provider,
 				version: bdcServer.version,
 				engineType: bdcServer.engineType,
-				options: { }
+				options: {}
 			};
 
 			// Should create a registered server
@@ -148,7 +148,7 @@ if (context.RunTest) {
 				provider: bdcServer.provider,
 				version: bdcServer.version,
 				engineType: bdcServer.engineType,
-				options: { }
+				options: {}
 			};
 			let relativePath = cmsResources.registeredServerGroups[0].relativePath;
 

--- a/extensions/integration-tests/src/utils.ts
+++ b/extensions/integration-tests/src/utils.ts
@@ -76,3 +76,16 @@ export async function deleteDB(dbName: string, ownerUri: string): Promise<void> 
 
 	await queryProvider.runQueryAndReturn(ownerUri, query);
 }
+
+export async function assertThrowsAsync(fn: () => Promise<any>, msg: string): Promise<void> {
+	let f = () => {
+		// Empty
+	};
+	try {
+		await fn();
+	} catch (e) {
+		f = () => { throw e; };
+	} finally {
+		assert.throws(f, msg);
+	}
+}

--- a/extensions/mssql/src/cms/cmsService.ts
+++ b/extensions/mssql/src/cms/cmsService.ts
@@ -29,7 +29,7 @@ export class CmsService {
 			},
 			e => {
 				this.client.logFailedRequest(contracts.CreateCentralManagementServerRequest.type, e);
-				return Promise.reject(e.message);
+				return Promise.reject(new Error(e.message));
 			}
 		);
 	}
@@ -42,7 +42,7 @@ export class CmsService {
 			},
 			e => {
 				this.client.logFailedRequest(contracts.ListRegisteredServersRequest.type, e);
-				return Promise.reject(e.message);
+				return Promise.reject(new Error(e.message));
 			}
 		);
 	}
@@ -55,7 +55,7 @@ export class CmsService {
 			},
 			e => {
 				this.client.logFailedRequest(contracts.AddRegisteredServerRequest.type, e);
-				return Promise.reject(e.message);
+				return Promise.reject(new Error(e.message));
 			}
 		);
 	}
@@ -68,7 +68,7 @@ export class CmsService {
 			},
 			e => {
 				this.client.logFailedRequest(contracts.RemoveRegisteredServerRequest.type, e);
-				return Promise.reject(e.message);
+				return Promise.reject(new Error(e.message));
 			}
 		);
 	}
@@ -81,7 +81,7 @@ export class CmsService {
 			},
 			e => {
 				this.client.logFailedRequest(contracts.AddServerGroupRequest.type, e);
-				return Promise.reject(e.message);
+				return Promise.reject(new Error(e.message));
 			}
 		);
 	}
@@ -94,7 +94,7 @@ export class CmsService {
 			},
 			e => {
 				this.client.logFailedRequest(contracts.RemoveServerGroupRequest.type, e);
-				return Promise.reject(e.message);
+				return Promise.reject(new Error(e.message));
 			}
 		);
 	}


### PR DESCRIPTION
Recent changes to CMS API meant the tests fail (we throw instead of returning undefined now).

Also changed the service calls to reject with an error instead of just a plain string. This is the preferred method so that you get information such as stack frames and line numbers. 