### PR TITLE
Update admin-tool-ext-win extension to require ADS 1.8.0

### DIFF
--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -10,7 +10,7 @@
 	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
 	"engines": {
 		"vscode": "^1.30.1",
-		"azdata": "^1.8.0"
+		"azdata": ">=1.8.0"
 	},
 	"activationEvents": [
 		"*"

--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -10,7 +10,7 @@
 	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
 	"engines": {
 		"vscode": "^1.30.1",
-		"azdata": "*"
+		"azdata": "^1.8.0"
 	},
 	"activationEvents": [
 		"*"


### PR DESCRIPTION
There were some changes to the context keys in this release that are used by this extension so without those the menu items won't work correctly. 