### PR TITLE
Plumb editor state change through to state object

### DIFF
--- a/src/sql/workbench/parts/query/browser/queryEditor.ts
+++ b/src/sql/workbench/parts/query/browser/queryEditor.ts
@@ -365,6 +365,9 @@ export class QueryEditor extends BaseEditor {
 		if (this.resultsVisible) {
 			this.splitview.removeView(1, Sizing.Distribute);
 			this.resultsVisible = false;
+			if (this.input && this.input.state) {
+				this.input.state.resultsVisible = false;
+			}
 		}
 	}
 
@@ -380,6 +383,9 @@ export class QueryEditor extends BaseEditor {
 				onDidChange: Event.None
 			}, initialViewSize);
 			this.resultsVisible = true;
+			if (this.input && this.input.state) {
+				this.input.state.resultsVisible = true;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #5919 Fix it so we update the input whenever the results visibility is toggled in the editor so that we update the state correctly. This fixes the issue where the results visible event wouldn't fire because the visibility state hadn't been updated so was kept as the original value. 