### PR TITLE
Change hardcoded MSSQL provider name to use constant instead

### DIFF
--- a/src/sql/platform/capabilities/common/capabilitiesServiceImpl.ts
+++ b/src/sql/platform/capabilities/common/capabilitiesServiceImpl.ts
@@ -20,6 +20,7 @@ import { toObject } from 'sql/base/common/map';
 import { ConnectionProviderProperties, IConnectionProviderRegistry, Extensions as ConnectionExtensions } from 'sql/workbench/parts/connection/common/connectionProviderExtension';
 import { ICapabilitiesService, ProviderFeatures, clientCapabilities } from 'sql/platform/capabilities/common/capabilitiesService';
 import { ConnectionManagementInfo } from 'sql/platform/connection/common/connectionManagementInfo';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 const connectionRegistry = Registry.as<IConnectionProviderRegistry>(ConnectionExtensions.ConnectionProviderContributions);
 
@@ -158,7 +159,7 @@ export class CapabilitiesService extends Disposable implements ICapabilitiesServ
 	 */
 	public isFeatureAvailable(action: IAction, connectionManagementInfo: ConnectionManagementInfo): boolean {
 		let isCloud = connectionManagementInfo && connectionManagementInfo.serverInfo && connectionManagementInfo.serverInfo.isCloud;
-		let isMssql = connectionManagementInfo.connectionProfile.providerName === 'MSSQL';
+		let isMssql = connectionManagementInfo.connectionProfile.providerName === mssqlProviderName;
 		// TODO: The logic should from capabilities service.
 		if (action) {
 			let featureName: string = action.id;

--- a/src/sql/platform/connection/common/utils.ts
+++ b/src/sql/platform/connection/common/utils.ts
@@ -6,6 +6,7 @@
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { ConnectionProfileGroup } from 'sql/platform/connection/common/connectionProfileGroup';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 // CONSTANTS //////////////////////////////////////////////////////////////////////////////////////
 const msInH = 3.6e6;
@@ -136,6 +137,6 @@ export function findProfileInGroup(og: IConnectionProfile, groups: ConnectionPro
 export function isMaster(profile: IConnectionProfile): boolean {
 	// TODO: the connection profile should have a property to indicate whether the connection is a server connection or database connection
 	// created issue to track the problem: https://github.com/Microsoft/azuredatastudio/issues/5193.
-	return (profile.providerName.toLowerCase() === 'mssql' && profile.databaseName.toLowerCase() === 'master')
+	return (profile.providerName === mssqlProviderName && profile.databaseName.toLowerCase() === 'master')
 		|| (profile.providerName.toLowerCase() === 'pgsql' && profile.databaseName.toLowerCase() === 'postgres');
 }

--- a/src/sql/platform/connection/test/common/connectionStore.test.ts
+++ b/src/sql/platform/connection/test/common/connectionStore.test.ts
@@ -17,6 +17,7 @@ import { CapabilitiesTestService } from 'sqltest/stubs/capabilitiesTestService';
 import { deepClone, deepFreeze } from 'vs/base/common/objects';
 import { ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
 import { TestStorageService } from 'vs/workbench/test/workbenchTestServices';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 suite('ConnectionStore', () => {
 	let defaultNamedProfile: IConnectionProfile = deepFreeze({
@@ -31,7 +32,7 @@ suite('ConnectionStore', () => {
 		groupFullName: '',
 		getOptionsKey: undefined,
 		matches: undefined,
-		providerName: 'MSSQL',
+		providerName: mssqlProviderName,
 		options: {},
 		saveProfile: true,
 		id: undefined
@@ -121,17 +122,17 @@ suite('ConnectionStore', () => {
 			}
 		];
 		msSQLCapabilities = {
-			providerId: 'MSSQL',
+			providerId: mssqlProviderName,
 			displayName: 'MSSQL',
 			connectionOptions: connectionProvider
 		};
 
 		provider2Capabilities = {
-			providerId: 'MSSQL',
+			providerId: mssqlProviderName,
 			displayName: 'MSSQL',
 			connectionOptions: connectionProvider
 		};
-		capabilitiesService.capabilities['MSSQL'] = { connection: msSQLCapabilities };
+		capabilitiesService.capabilities[mssqlProviderName] = { connection: msSQLCapabilities };
 		capabilitiesService.capabilities['Provider2'] = { connection: provider2Capabilities };
 
 		defaultNamedConnectionProfile = new ConnectionProfile(capabilitiesService, defaultNamedProfile);
@@ -507,7 +508,7 @@ suite('ConnectionStore', () => {
 			userName: 'user',
 			password: 'password',
 			authenticationType: '',
-			providerName: 'MSSQL',
+			providerName: mssqlProviderName,
 			groupId: parentGroupId,
 			groupFullName: '',
 			savePassword: true,

--- a/src/sql/platform/query/common/queryRunner.ts
+++ b/src/sql/platform/query/common/queryRunner.ts
@@ -25,6 +25,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/resourceConfiguration';
 import { URI } from 'vs/base/common/uri';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 export interface IEditSessionReadyEvent {
 	ownerUri: string;
@@ -369,7 +370,7 @@ export default class QueryRunner extends Disposable {
 						// fire query plan available event if execution is completed
 						if (result.resultSetSummary.complete) {
 							this._onQueryPlanAvailable.fire({
-								providerId: 'MSSQL',
+								providerId: mssqlProviderName,
 								fileUri: result.ownerUri,
 								planXml: planXmlString
 							});

--- a/src/sql/workbench/api/node/extHostQueryEditor.ts
+++ b/src/sql/workbench/api/node/extHostQueryEditor.ts
@@ -7,6 +7,7 @@ import { IMainContext } from 'vs/workbench/api/common/extHost.protocol';
 import { ExtHostQueryEditorShape, SqlMainContext, MainThreadQueryEditorShape } from 'sql/workbench/api/node/sqlExtHost.protocol';
 import * as azdata from 'azdata';
 import { IQueryEvent } from 'sql/platform/query/common/queryModel';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 class ExtHostQueryDocument implements azdata.queryeditor.QueryDocument {
 	constructor(
@@ -57,13 +58,13 @@ export class ExtHostQueryEditor implements ExtHostQueryEditorShape {
 		let listener: azdata.queryeditor.QueryEventListener = this._queryListeners[handle];
 		if (listener) {
 			let planXml = event.params ? event.params.planXml : undefined;
-			listener.onQueryEvent(event.type, new ExtHostQueryDocument('MSSQL', fileUri, this._proxy), planXml);
+			listener.onQueryEvent(event.type, new ExtHostQueryDocument(mssqlProviderName, fileUri, this._proxy), planXml);
 		}
 	}
 
 	public $getQueryDocument(fileUri: string): Thenable<azdata.queryeditor.QueryDocument> {
 		return new Promise((resolve) => {
-			resolve(new ExtHostQueryDocument('MSSQL', fileUri, this._proxy));
+			resolve(new ExtHostQueryDocument(mssqlProviderName, fileUri, this._proxy));
 		});
 	}
 

--- a/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
@@ -42,6 +42,7 @@ import { ExtHostStorage } from 'vs/workbench/api/common/extHostStorage';
 import * as extHostTypes from 'vs/workbench/api/common/extHostTypes';
 import { ISchemeTransformer } from 'vs/workbench/api/common/extHostLanguageFeatures';
 import { AzureResource } from 'sql/platform/accounts/common/interfaces';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 export interface ISqlExtensionApiFactory {
 	vsCodeFactory(extension: IExtensionDescription, registry: ExtensionDescriptionRegistry, configProvider: ExtHostConfigProvider): typeof vscode;
@@ -460,7 +461,7 @@ export function createApiFactory(
 				},
 
 				registerQueryEventListener(listener: azdata.queryeditor.QueryEventListener): void {
-					extHostQueryEditor.$registerQueryInfoListener('MSSQL', listener);
+					extHostQueryEditor.$registerQueryInfoListener(mssqlProviderName, listener);
 				},
 
 				getQueryDocument(fileUri: string): Thenable<azdata.queryeditor.QueryDocument> {

--- a/src/sql/workbench/browser/parts/views/customView.ts
+++ b/src/sql/workbench/browser/parts/views/customView.ts
@@ -46,6 +46,7 @@ import { IOEShimService } from 'sql/workbench/parts/objectExplorer/common/object
 import { equalsIgnoreCase } from 'vs/base/common/strings';
 import { NodeContextKey } from 'sql/workbench/parts/dataExplorer/common/nodeContext';
 import { fillInActionBarActions, fillInContextMenuActions, ContextAwareMenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 class TitleMenus implements IDisposable {
 
@@ -612,7 +613,7 @@ class TreeRenderer implements IRenderer {
 	}
 
 	getTemplateId(tree: ITree, element: ITreeItem): string {
-		return equalsIgnoreCase(element.providerHandle, 'mssql') ? TreeRenderer.MSSQL_TREE_TEMPLATE_ID : TreeRenderer.TREE_TEMPLATE_ID;
+		return element.providerHandle === mssqlProviderName ? TreeRenderer.MSSQL_TREE_TEMPLATE_ID : TreeRenderer.TREE_TEMPLATE_ID;
 	}
 
 	renderTemplate(tree: ITree, templateId: string, container: HTMLElement): ITreeExplorerTemplateData {

--- a/src/sql/workbench/parts/dashboard/dashboardInput.ts
+++ b/src/sql/workbench/parts/dashboard/dashboardInput.ts
@@ -11,6 +11,7 @@ import { IModeService } from 'vs/editor/common/services/modeService';
 
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 export class DashboardInput extends EditorInput {
 
@@ -93,7 +94,7 @@ export class DashboardInput extends EditorInput {
 	}
 
 	private isMasterMssql(): boolean {
-		return this.connectionProfile.providerName.toLowerCase() === 'mssql'
+		return this.connectionProfile.providerName === mssqlProviderName
 			&& this.connectionProfile.databaseName.toLowerCase() === 'master';
 	}
 

--- a/src/sql/workbench/parts/dashboard/pages/serverDashboardPage.component.ts
+++ b/src/sql/workbench/parts/dashboard/pages/serverDashboardPage.component.ts
@@ -19,6 +19,7 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ILogService } from 'vs/platform/log/common/log';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 export class ServerDashboardPage extends DashboardPage implements OnInit {
 	protected propertiesWidget: WidgetConfig = {
@@ -53,7 +54,7 @@ export class ServerDashboardPage extends DashboardPage implements OnInit {
 
 		// special-case handling for MSSQL data provider
 		const connInfo = this.dashboardService.connectionManagementService.connectionInfo;
-		if (connInfo && connInfo.providerId === 'MSSQL') {
+		if (connInfo && connInfo.providerId === mssqlProviderName) {
 			// revert back to default database
 			this._letDashboardPromise = this.dashboardService.connectionManagementService.changeDatabase('master').then();
 		} else {

--- a/src/sql/workbench/parts/dashboard/widgets/properties/propertiesJson.ts
+++ b/src/sql/workbench/parts/dashboard/widgets/properties/propertiesJson.ts
@@ -5,13 +5,14 @@
 
 import { ProviderProperties } from './propertiesWidget.component';
 import * as nls from 'vs/nls';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 const azureEditionDisplayName = nls.localize('azureEdition', 'Edition');
 const azureType = nls.localize('azureType', 'Type');
 
 export const properties: Array<ProviderProperties> = [
 	{
-		provider: 'MSSQL',
+		provider: mssqlProviderName,
 		flavors: [
 			{
 				flavor: 'on_prem',

--- a/src/sql/workbench/parts/notebook/models/modelInterfaces.ts
+++ b/src/sql/workbench/parts/notebook/models/modelInterfaces.ts
@@ -21,6 +21,7 @@ import { ConnectionProfile } from 'sql/platform/connection/common/connectionProf
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { localize } from 'vs/nls';
 import { NotebookModel } from 'sql/workbench/parts/notebook/models/notebookModel';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 export interface IClientSessionOptions {
 	notebookUri: URI;
@@ -527,7 +528,7 @@ export interface ICellMagicMapper {
 
 export namespace notebookConstants {
 	export const SQL = 'SQL';
-	export const SQL_CONNECTION_PROVIDER = 'MSSQL';
+	export const SQL_CONNECTION_PROVIDER = mssqlProviderName;
 	export const sqlKernel: string = localize('sqlKernel', 'SQL');
 	export const sqlKernelSpec: nb.IKernelSpec = ({
 		name: sqlKernel,

--- a/src/sql/workbench/parts/notebook/models/notebookContexts.ts
+++ b/src/sql/workbench/parts/notebook/models/notebookContexts.ts
@@ -10,13 +10,13 @@ import { IDefaultConnection, notebookConstants } from 'sql/workbench/parts/noteb
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 export class NotebookContexts {
-	private static MSSQL_PROVIDER = 'MSSQL';
 
 	private static get DefaultContext(): IDefaultConnection {
 		let defaultConnection: ConnectionProfile = <any>{
-			providerName: NotebookContexts.MSSQL_PROVIDER,
+			providerName: mssqlProviderName,
 			id: '-1',
 			serverName: localize('selectConnection', 'Select Connection')
 		};
@@ -30,7 +30,7 @@ export class NotebookContexts {
 
 	private static get LocalContext(): IDefaultConnection {
 		let localConnection: ConnectionProfile = <any>{
-			providerName: NotebookContexts.MSSQL_PROVIDER,
+			providerName: mssqlProviderName,
 			id: '-1',
 			serverName: localize('localhost', 'localhost')
 		};

--- a/src/sql/workbench/parts/query/browser/flavorStatus.ts
+++ b/src/sql/workbench/parts/query/browser/flavorStatus.ts
@@ -23,6 +23,7 @@ import Severity from 'vs/base/common/severity';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { EditorServiceImpl } from 'vs/workbench/browser/parts/editor/editor';
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 export interface ISqlProviderEntry extends IQuickPickItem {
 	providerId: string;
@@ -45,7 +46,7 @@ class SqlProviderEntry implements ISqlProviderEntry {
 		// Note: consider adding API to connection management service to
 		// support getting display name for provider so this is consistent
 		switch (this.providerId) {
-			case 'MSSQL':
+			case mssqlProviderName:
 				return 'MSSQL';
 			default:
 				return this.providerId;
@@ -192,7 +193,7 @@ export class ChangeFlavorAction extends Action {
 		// TODO #1334 use connectionManagementService.GetProviderNames here. The challenge is that the credentials provider is returned
 		// so we need a way to filter this using a capabilities check, with isn't yet implemented
 		const ProviderOptions: ISqlProviderEntry[] = [
-			new SqlProviderEntry('MSSQL')
+			new SqlProviderEntry(mssqlProviderName)
 		];
 
 		// TODO: select the current language flavor

--- a/src/sql/workbench/services/profiler/common/profilerService.ts
+++ b/src/sql/workbench/services/profiler/common/profilerService.ts
@@ -21,6 +21,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { Memento } from 'vs/workbench/common/memento';
 import { ProfilerFilterDialog } from 'sql/workbench/parts/profiler/browser/profilerFilterDialog';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 class TwoWayMap<T, K> {
 	private forwardMap: Map<T, K>;
@@ -157,13 +158,7 @@ export class ProfilerService implements IProfilerService {
 	}
 
 	private _runAction<T>(id: ProfilerSessionID, action: (handler: azdata.ProfilerProvider) => Thenable<T>): Thenable<T> {
-		// let providerId = this._connectionService.getProviderIdFromUri(this._idMap.get(id));
-		let providerId = 'MSSQL';
-
-		if (!providerId) {
-			return Promise.reject(new Error('Connection is required in order to interact with queries'));
-		}
-		let handler = this._providers.get(providerId);
+		let handler = this._providers.get(mssqlProviderName);
 		if (handler) {
 			return action(handler);
 		} else {

--- a/src/sqltest/parts/accountManagement/firewallRuleDialogController.test.ts
+++ b/src/sqltest/parts/accountManagement/firewallRuleDialogController.test.ts
@@ -16,6 +16,7 @@ import { ErrorMessageServiceStub } from 'sqltest/stubs/errorMessageServiceStub';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { ContextKeyServiceStub } from 'sqltest/stubs/contextKeyServiceStub';
 import { Deferred } from 'sql/base/common/promise';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 // TESTS ///////////////////////////////////////////////////////////////////
 suite('Firewall rule dialog controller tests', () => {
@@ -88,7 +89,7 @@ suite('Firewall rule dialog controller tests', () => {
 			groupId: 'group id',
 			getOptionsKey: undefined,
 			matches: undefined,
-			providerName: 'MSSQL',
+			providerName: mssqlProviderName,
 			options: {},
 			saveProfile: true,
 			id: undefined

--- a/src/sqltest/parts/connection/connectionProfile.test.ts
+++ b/src/sqltest/parts/connection/connectionProfile.test.ts
@@ -10,6 +10,7 @@ import * as assert from 'assert';
 import { ConnectionOptionSpecialType, ServiceOptionType } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { CapabilitiesTestService } from 'sqltest/stubs/capabilitiesTestService';
 import { ConnectionProviderProperties } from 'sql/workbench/parts/connection/common/connectionProviderExtension';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 suite('SQL ConnectionProfileInfo tests', () => {
 	let msSQLCapabilities: ConnectionProviderProperties;
@@ -27,7 +28,7 @@ suite('SQL ConnectionProfileInfo tests', () => {
 		groupId: 'group id',
 		getOptionsKey: undefined,
 		matches: undefined,
-		providerName: 'MSSQL',
+		providerName: mssqlProviderName,
 		options: {},
 		saveProfile: true,
 		id: undefined
@@ -44,7 +45,7 @@ suite('SQL ConnectionProfileInfo tests', () => {
 			password: 'password',
 			authenticationType: ''
 		},
-		providerName: 'MSSQL',
+		providerName: mssqlProviderName,
 		savePassword: true
 	};
 
@@ -124,12 +125,12 @@ suite('SQL ConnectionProfileInfo tests', () => {
 			}
 		];
 		msSQLCapabilities = {
-			providerId: 'MSSQL',
+			providerId: mssqlProviderName,
 			displayName: 'MSSQL',
 			connectionOptions: connectionProvider
 		};
 		capabilitiesService = new CapabilitiesTestService();
-		capabilitiesService.capabilities['MSSQL'] = { connection: msSQLCapabilities };
+		capabilitiesService.capabilities[mssqlProviderName] = { connection: msSQLCapabilities };
 	});
 
 	test('set properties should set the values correctly', () => {

--- a/src/sqltest/parts/connection/connectionStatusManager.test.ts
+++ b/src/sqltest/parts/connection/connectionStatusManager.test.ts
@@ -10,6 +10,7 @@ import * as Utils from 'sql/platform/connection/common/utils';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { CapabilitiesTestService } from 'sqltest/stubs/capabilitiesTestService';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 let connections: ConnectionStatusManager;
 let capabilitiesService: CapabilitiesTestService;
@@ -26,7 +27,7 @@ let connectionProfile: IConnectionProfile = {
 	groupId: 'group id',
 	getOptionsKey: () => 'connection1',
 	matches: undefined,
-	providerName: 'MSSQL',
+	providerName: mssqlProviderName,
 	options: {},
 	saveProfile: true,
 	id: undefined
@@ -43,7 +44,7 @@ let editorConnectionProfile: IConnectionProfile = {
 	groupId: 'group id',
 	getOptionsKey: () => 'connection2',
 	matches: undefined,
-	providerName: 'MSSQL',
+	providerName: mssqlProviderName,
 	options: {},
 	saveProfile: true,
 	id: undefined
@@ -60,7 +61,7 @@ let connectionProfileWithoutDbName: IConnectionProfile = {
 	groupId: 'group id',
 	getOptionsKey: () => 'connection1',
 	matches: undefined,
-	providerName: 'MSSQL',
+	providerName: mssqlProviderName,
 	options: {},
 	saveProfile: true,
 	id: undefined

--- a/src/sqltest/parts/connection/connectionTreeActions.test.ts
+++ b/src/sqltest/parts/connection/connectionTreeActions.test.ts
@@ -28,7 +28,7 @@ import { ObjectExplorerActionsContext, ManageConnectionAction } from 'sql/workbe
 import { IConnectionResult, IConnectionParams } from 'sql/platform/connection/common/connectionManagement';
 import { TreeSelectionHandler } from 'sql/workbench/parts/objectExplorer/browser/treeSelectionHandler';
 import { CapabilitiesTestService } from 'sqltest/stubs/capabilitiesTestService';
-import { UNSAVED_GROUP_ID } from 'sql/platform/connection/common/constants';
+import { UNSAVED_GROUP_ID, mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { $ } from 'vs/base/browser/dom';
 
 suite('SQL Connection Tree Action tests', () => {
@@ -90,7 +90,7 @@ suite('SQL Connection Tree Action tests', () => {
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
-			providerName: 'MSSQL',
+			providerName: mssqlProviderName,
 			options: {},
 			saveProfile: true,
 			id: 'testId'
@@ -126,7 +126,7 @@ suite('SQL Connection Tree Action tests', () => {
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
-			providerName: 'MSSQL',
+			providerName: mssqlProviderName,
 			options: {},
 			saveProfile: true,
 			id: 'testId'
@@ -165,7 +165,7 @@ suite('SQL Connection Tree Action tests', () => {
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
-			providerName: 'MSSQL',
+			providerName: mssqlProviderName,
 			options: {},
 			saveProfile: true,
 			id: 'testId'
@@ -276,7 +276,7 @@ suite('SQL Connection Tree Action tests', () => {
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
-			providerName: 'MSSQL',
+			providerName: mssqlProviderName,
 			options: {},
 			saveProfile: true,
 			id: 'testId'
@@ -321,7 +321,7 @@ suite('SQL Connection Tree Action tests', () => {
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
-			providerName: 'MSSQL',
+			providerName: mssqlProviderName,
 			options: {},
 			saveProfile: true,
 			id: 'testId'
@@ -339,12 +339,12 @@ suite('SQL Connection Tree Action tests', () => {
 	test('RefreshConnectionAction - refresh should be called if connection status is connect', (done) => {
 		let isConnectedReturnValue: boolean = true;
 		let sqlProvider = {
-			providerId: 'MSSQL',
+			providerId: mssqlProviderName,
 			displayName: 'MSSQL',
 			connectionOptions: [],
 		};
 
-		capabilitiesService.capabilities['MSSQL'] = { connection: sqlProvider };
+		capabilitiesService.capabilities[mssqlProviderName] = { connection: sqlProvider };
 
 		let connection = new ConnectionProfile(capabilitiesService, {
 			connectionName: 'Test',
@@ -356,7 +356,7 @@ suite('SQL Connection Tree Action tests', () => {
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
-			providerName: 'MSSQL',
+			providerName: mssqlProviderName,
 			options: {},
 			saveProfile: true,
 			id: 'testID'
@@ -427,12 +427,12 @@ suite('SQL Connection Tree Action tests', () => {
 	test('RefreshConnectionAction - refresh should not be called if connection status is not connect', (done) => {
 		let isConnectedReturnValue: boolean = false;
 		let sqlProvider = {
-			providerId: 'MSSQL',
+			providerId: mssqlProviderName,
 			displayName: 'MSSQL',
 			connectionOptions: []
 		};
 
-		capabilitiesService.capabilities['MSSQL'] = { connection: sqlProvider };
+		capabilitiesService.capabilities[mssqlProviderName] = { connection: sqlProvider };
 
 		let connection = new ConnectionProfile(capabilitiesService, {
 			connectionName: 'Test',
@@ -444,7 +444,7 @@ suite('SQL Connection Tree Action tests', () => {
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
-			providerName: 'MSSQL',
+			providerName: mssqlProviderName,
 			options: {},
 			saveProfile: true,
 			id: 'testID'

--- a/src/sqltest/parts/connection/objectExplorerService.test.ts
+++ b/src/sqltest/parts/connection/objectExplorerService.test.ts
@@ -19,6 +19,7 @@ import { ConnectionOptionSpecialType, ServiceOptionType } from 'sql/workbench/ap
 import { Event, Emitter } from 'vs/base/common/event';
 import { CapabilitiesTestService } from 'sqltest/stubs/capabilitiesTestService';
 import { TestLogService } from 'vs/workbench/test/workbenchTestServices';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 suite('SQL Object Explorer Service tests', () => {
 	let sqlOEProvider: TypeMoq.Mock<ObjectExplorerProviderTestService>;
@@ -36,7 +37,6 @@ suite('SQL Object Explorer Service tests', () => {
 	let failedSessionId = '12345';
 	let numberOfSuccessfulSessions: number = 0;
 	let serverTreeView: TypeMoq.Mock<ServerTreeView>;
-	const providerId = 'MSSQL';
 
 	setup(() => {
 
@@ -105,7 +105,7 @@ suite('SQL Object Explorer Service tests', () => {
 			nodes: [NodeInfoTable1, NodeInfoTable2],
 			errorMessage: '',
 			nodePath: objectExplorerSession.rootNode.nodePath,
-			providerId: providerId
+			providerId: mssqlProviderName
 		};
 
 		objectExplorerExpandInfoRefresh = {
@@ -113,7 +113,7 @@ suite('SQL Object Explorer Service tests', () => {
 			nodes: [NodeInfoTable1, NodeInfoTable3],
 			errorMessage: '',
 			nodePath: objectExplorerSession.rootNode.nodePath,
-			providerId: providerId
+			providerId: mssqlProviderName
 		};
 		let response: azdata.ObjectExplorerSessionResponse = {
 			sessionId: objectExplorerSession.sessionId
@@ -128,7 +128,7 @@ suite('SQL Object Explorer Service tests', () => {
 
 		let onCapabilitiesRegistered = new Emitter<string>();
 		let sqlProvider = {
-			providerId: providerId,
+			providerId: mssqlProviderName,
 			displayName: 'MSSQL',
 			connectionOptions: [
 				{
@@ -219,7 +219,7 @@ suite('SQL Object Explorer Service tests', () => {
 		};
 
 		let capabilitiesService = new CapabilitiesTestService();
-		capabilitiesService.capabilities['MSSQL'] = { connection: sqlProvider };
+		capabilitiesService.capabilities[mssqlProviderName] = { connection: sqlProvider };
 
 		connection = new ConnectionProfile(capabilitiesService, {
 			connectionName: 'newName',
@@ -231,7 +231,7 @@ suite('SQL Object Explorer Service tests', () => {
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
-			providerName: 'MSSQL',
+			providerName: mssqlProviderName,
 			options: {},
 			saveProfile: true,
 			id: 'testID'
@@ -248,7 +248,7 @@ suite('SQL Object Explorer Service tests', () => {
 			password: 'test',
 			userName: 'testUsername',
 			groupId: undefined,
-			providerName: 'MSSQL',
+			providerName: mssqlProviderName,
 			options: {},
 			saveProfile: true,
 			id: 'testID2'
@@ -262,7 +262,7 @@ suite('SQL Object Explorer Service tests', () => {
 			resolve(connection);
 		}));
 
-		connectionManagementService.setup(x => x.getCapabilities('MSSQL')).returns(() => undefined);
+		connectionManagementService.setup(x => x.getCapabilities(mssqlProviderName)).returns(() => undefined);
 
 		let extensionManagementServiceMock = {
 			getInstalled: () => {
@@ -272,7 +272,7 @@ suite('SQL Object Explorer Service tests', () => {
 
 		const logService = new TestLogService();
 		objectExplorerService = new ObjectExplorerService(connectionManagementService.object, undefined, capabilitiesService, logService);
-		objectExplorerService.registerProvider('MSSQL', sqlOEProvider.object);
+		objectExplorerService.registerProvider(mssqlProviderName, sqlOEProvider.object);
 		sqlOEProvider.setup(x => x.createNewSession(TypeMoq.It.is<azdata.ConnectionInfo>(x => x.options['serverName'] === connection.serverName))).returns(() => new Promise<any>((resolve) => {
 			resolve(response);
 		}));
@@ -304,7 +304,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('create new session should create session successfully', (done) => {
-		objectExplorerService.createNewSession('MSSQL', connection).then(session => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(session => {
 			assert.equal(session !== null || session !== undefined, true);
 			assert.equal(session.sessionId, '1234');
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
@@ -319,7 +319,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('create new session should raise failed event for failed session', (done) => {
-		objectExplorerService.createNewSession('MSSQL', connectionToFail).then(session => {
+		objectExplorerService.createNewSession(mssqlProviderName, connectionToFail).then(session => {
 			assert.equal(session !== null || session !== undefined, true);
 			assert.equal(session.sessionId, failedSessionId);
 			let currentNumberOfSuccessfulSessions = numberOfSuccessfulSessions;
@@ -335,7 +335,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('close session should close session successfully', (done) => {
-		objectExplorerService.closeSession('MSSQL', objectExplorerSession).then(session => {
+		objectExplorerService.closeSession(mssqlProviderName, objectExplorerSession).then(session => {
 			assert.equal(session !== null || session !== undefined, true);
 			assert.equal(session.success, true);
 			assert.equal(session.sessionId, '1234');
@@ -347,9 +347,9 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('expand node should expand node correctly', (done) => {
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
-			objectExplorerService.expandNode('MSSQL', objectExplorerSession, 'testServerName/tables').then(expandInfo => {
+			objectExplorerService.expandNode(mssqlProviderName, objectExplorerSession, 'testServerName/tables').then(expandInfo => {
 				assert.equal(expandInfo !== null || expandInfo !== undefined, true);
 				assert.equal(expandInfo.sessionId, '1234');
 				assert.equal(expandInfo.nodes.length, 2);
@@ -365,9 +365,9 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('refresh node should refresh node correctly', (done) => {
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
-			objectExplorerService.refreshNode('MSSQL', objectExplorerSession, 'testServerName/tables').then(expandInfo => {
+			objectExplorerService.refreshNode(mssqlProviderName, objectExplorerSession, 'testServerName/tables').then(expandInfo => {
 				assert.equal(expandInfo !== null || expandInfo !== undefined, true);
 				assert.equal(expandInfo.sessionId, '1234');
 				assert.equal(expandInfo.nodes.length, 2);
@@ -385,7 +385,7 @@ suite('SQL Object Explorer Service tests', () => {
 	test('expand tree node should get correct children', (done) => {
 		let tablesNode = new TreeNode(NodeType.Folder, 'Tables', false, 'testServerName/tables', '', '', null, null, undefined, undefined);
 		tablesNode.connection = connection;
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			objectExplorerService.resolveTreeNodeChildren(objectExplorerSession, tablesNode).then(children => {
 				assert.equal(children !== null || children !== undefined, true);
@@ -406,7 +406,7 @@ suite('SQL Object Explorer Service tests', () => {
 	test('refresh tree node should children correctly', (done) => {
 		let tablesNode = new TreeNode(NodeType.Folder, 'Tables', false, 'testServerName/tables', '', '', null, null, undefined, undefined);
 		tablesNode.connection = connection;
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			objectExplorerService.refreshTreeNode(objectExplorerSession, tablesNode).then(children => {
 				assert.equal(children !== null || children !== undefined, true);
@@ -425,7 +425,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('update object explorer nodes should get active connection, create session, add to the active OE nodes successfully', (done) => {
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			objectExplorerService.updateObjectExplorerNodes(connection).then(() => {
 				let treeNode = objectExplorerService.getObjectExplorerNode(connection);
@@ -443,7 +443,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('delete object explorerNode nodes should delete session, delete the root node to the active OE node', (done) => {
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			objectExplorerService.updateObjectExplorerNodes(connection).then(() => {
 				let treeNode = objectExplorerService.getObjectExplorerNode(connection);
@@ -541,13 +541,13 @@ suite('SQL Object Explorer Service tests', () => {
 			nodes: [],
 			errorMessage: '',
 			nodePath: table1NodePath,
-			providerId: providerId
+			providerId: mssqlProviderName
 		};
 		serverTreeView.setup(x => x.isExpanded(TypeMoq.It.isAny())).returns(treeNode => {
 			return treeNode === connection || treeNode.nodePath === table1NodePath;
 		});
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			objectExplorerService.resolveTreeNodeChildren(objectExplorerSession, objectExplorerService.getObjectExplorerNode(connection)).then(childNodes => {
 				sqlOEProvider.setup(x => x.expandNode(TypeMoq.It.isAny())).callback(() => {
@@ -575,7 +575,7 @@ suite('SQL Object Explorer Service tests', () => {
 			return treeNode === connection;
 		});
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			objectExplorerService.resolveTreeNodeChildren(objectExplorerSession, objectExplorerService.getObjectExplorerNode(connection)).then(childNodes => {
 				// If I check whether the table is expanded, the answer should be no because only its parent node is expanded
@@ -599,13 +599,13 @@ suite('SQL Object Explorer Service tests', () => {
 			nodes: [],
 			errorMessage: '',
 			nodePath: table1NodePath,
-			providerId: providerId
+			providerId: mssqlProviderName
 		};
 		serverTreeView.setup(x => x.isExpanded(TypeMoq.It.isAny())).returns(treeNode => {
 			return treeNode.nodePath === table1NodePath;
 		});
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			objectExplorerService.resolveTreeNodeChildren(objectExplorerSession, objectExplorerService.getObjectExplorerNode(connection)).then(childNodes => {
 				sqlOEProvider.setup(x => x.expandNode(TypeMoq.It.isAny())).callback(() => {
@@ -634,7 +634,7 @@ suite('SQL Object Explorer Service tests', () => {
 			nodes: [],
 			errorMessage: '',
 			nodePath: table1NodePath,
-			providerId: providerId
+			providerId: mssqlProviderName
 		};
 		// Set up the OE provider so that the second expand call expands the table
 		sqlOEProvider.setup(x => x.expandNode(TypeMoq.It.is(nodeInfo => nodeInfo.nodePath === table1NodePath))).callback(() => {
@@ -648,7 +648,7 @@ suite('SQL Object Explorer Service tests', () => {
 		});
 		serverTreeView.setup(x => x.reveal(TypeMoq.It.isAny())).returns(() => Promise.resolve());
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			// If I expand the node, then it should get revealed and expanded
 			objectExplorerService.getTreeNode(connection.id, table1NodePath).then(tableNode => {
@@ -671,7 +671,7 @@ suite('SQL Object Explorer Service tests', () => {
 		});
 		serverTreeView.setup(x => x.setExpandedState(TypeMoq.It.is(treeNode => treeNode === connection), TypeMoq.It.is(state => state === TreeItemCollapsibleState.Collapsed))).returns(() => Promise.resolve());
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			objectExplorerService.resolveTreeNodeChildren(objectExplorerSession, objectExplorerService.getObjectExplorerNode(connection)).then(childNodes => {
 				// If I collapse the connection node, then the tree's collapse method should get called
@@ -692,7 +692,7 @@ suite('SQL Object Explorer Service tests', () => {
 		serverTreeView.setup(x => x.setSelected(TypeMoq.It.is((treeNode: TreeNode) => treeNode.nodePath === table1NodePath), TypeMoq.It.isAny(), undefined)).returns(() => Promise.resolve());
 		serverTreeView.setup(x => x.reveal(TypeMoq.It.isAny())).returns(() => Promise.resolve());
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			// If I select the table node, then it should be selected and revealed
 			objectExplorerService.getTreeNode(connection.id, table1NodePath).then(tableNode => {
@@ -711,7 +711,7 @@ suite('SQL Object Explorer Service tests', () => {
 
 	test('findTreeNode returns the tree node for the relevant node', (done) => {
 		let table1NodePath = objectExplorerExpandInfo.nodes[0].nodePath;
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			objectExplorerService.getTreeNode(connection.id, table1NodePath).then(treeNode => {
 				try {
@@ -728,7 +728,7 @@ suite('SQL Object Explorer Service tests', () => {
 
 	test('findTreeNode returns undefined if the requested node does not exist', (done) => {
 		let invalidNodePath = objectExplorerSession.rootNode.nodePath + '/invalidNode';
-		objectExplorerService.createNewSession('MSSQL', connection).then(result => {
+		objectExplorerService.createNewSession(mssqlProviderName, connection).then(result => {
 			objectExplorerService.onSessionCreated(1, objectExplorerSession);
 			objectExplorerService.getTreeNode(connection.id, invalidNodePath).then(nodeInfo => {
 				try {
@@ -743,7 +743,7 @@ suite('SQL Object Explorer Service tests', () => {
 
 	test('refreshInView refreshes the node, expands it, and returns the refreshed node', async () => {
 		// Set up the session and tree view
-		await objectExplorerService.createNewSession('MSSQL', connection);
+		await objectExplorerService.createNewSession(mssqlProviderName, connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		serverTreeView.setup(x => x.refreshElement(TypeMoq.It.isAny())).returns(() => Promise.resolve());
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
@@ -760,10 +760,9 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('Session can be closed even if expand requests are pending', async () => {
-		const providerId = 'MSSQL';
 
 		// Set up the session
-		await objectExplorerService.createNewSession(providerId, connection);
+		await objectExplorerService.createNewSession(mssqlProviderName, connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 
 		// Set up the provider to not respond to the second expand request, simulating a request that takes a long time to complete
@@ -771,9 +770,9 @@ suite('SQL Object Explorer Service tests', () => {
 		sqlOEProvider.setup(x => x.expandNode(TypeMoq.It.is(x => x.nodePath === nodePath))).callback(() => { }).returns(() => Promise.resolve(true));
 
 		// If I queue a second expand request (the first completes normally because of the original mock) and then close the session
-		await objectExplorerService.expandNode(providerId, objectExplorerSession, objectExplorerSession.rootNode.nodePath);
-		let expandPromise = objectExplorerService.expandNode(providerId, objectExplorerSession, objectExplorerSession.rootNode.nodePath);
-		let closeSessionResult = await objectExplorerService.closeSession(providerId, objectExplorerSession);
+		await objectExplorerService.expandNode(mssqlProviderName, objectExplorerSession, objectExplorerSession.rootNode.nodePath);
+		let expandPromise = objectExplorerService.expandNode(mssqlProviderName, objectExplorerSession, objectExplorerSession.rootNode.nodePath);
+		let closeSessionResult = await objectExplorerService.closeSession(mssqlProviderName, objectExplorerSession);
 
 		// Then the expand request has completed and the session is closed
 		let expandResult = await expandPromise;
@@ -782,7 +781,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('resolveTreeNodeChildren refreshes a node if it currently has an error', async () => {
-		await objectExplorerService.createNewSession('MSSQL', connection);
+		await objectExplorerService.createNewSession(mssqlProviderName, connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 
 		// If I call resolveTreeNodeChildren once, set an error on the node, and then call it again

--- a/src/sqltest/parts/connection/providerConnectionInfo.test.ts
+++ b/src/sqltest/parts/connection/providerConnectionInfo.test.ts
@@ -9,6 +9,7 @@ import * as azdata from 'azdata';
 import * as assert from 'assert';
 import { ConnectionOptionSpecialType, ServiceOptionType } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { CapabilitiesTestService } from 'sqltest/stubs/capabilitiesTestService';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 suite('SQL ProviderConnectionInfo tests', () => {
 	let msSQLCapabilities: any;
@@ -26,7 +27,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 		groupId: undefined,
 		getOptionsKey: undefined,
 		matches: undefined,
-		providerName: 'MSSQL',
+		providerName: mssqlProviderName,
 		options: undefined,
 		saveProfile: true,
 		id: undefined
@@ -121,13 +122,13 @@ suite('SQL ProviderConnectionInfo tests', () => {
 			}
 		];
 		msSQLCapabilities = {
-			providerId: 'MSSQL',
+			providerId: mssqlProviderName,
 			displayName: 'MSSQL',
 			connectionOptions: connectionProvider,
 		};
 		capabilities.push(msSQLCapabilities);
 		capabilitiesService = new CapabilitiesTestService();
-		capabilitiesService.capabilities['MSSQL'] = { connection: msSQLCapabilities };
+		capabilitiesService.capabilities[mssqlProviderName] = { connection: msSQLCapabilities };
 	});
 
 	test('constructor should accept undefined parameters', () => {
@@ -136,7 +137,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('set properties should set the values correctly', () => {
-		let conn = new ProviderConnectionInfo(capabilitiesService, 'MSSQL');
+		let conn = new ProviderConnectionInfo(capabilitiesService, mssqlProviderName);
 		assert.equal(conn.serverName, undefined);
 		conn.connectionName = connectionProfile.connectionName;
 		conn.serverName = connectionProfile.serverName;
@@ -153,7 +154,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('set properties should store the values in the options', () => {
-		let conn = new ProviderConnectionInfo(capabilitiesService, 'MSSQL');
+		let conn = new ProviderConnectionInfo(capabilitiesService, mssqlProviderName);
 		assert.equal(conn.serverName, undefined);
 		conn.serverName = connectionProfile.serverName;
 		conn.databaseName = connectionProfile.databaseName;
@@ -238,11 +239,10 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('getProviderFromOptionsKey should return the provider name from the options key successfully', () => {
-		let optionsKey = 'providerName:MSSQL|authenticationType:|databaseName:database|serverName:new server|userName:user';
-		let expectedProviderId: string = 'MSSQL';
+		let optionsKey = `providerName:${mssqlProviderName}|authenticationType:|databaseName:database|serverName:new server|userName:user`;
 		let actual = ProviderConnectionInfo.getProviderFromOptionsKey(optionsKey);
 
-		assert.equal(expectedProviderId, actual);
+		assert.equal(mssqlProviderName, actual);
 	});
 
 	test('getProviderFromOptionsKey should return empty string give null', () => {

--- a/src/sqltest/parts/dashboard/widgets/propertiesWidget.component.test.ts
+++ b/src/sqltest/parts/dashboard/widgets/propertiesWidget.component.test.ts
@@ -16,6 +16,7 @@ import { ConnectionManagementInfo } from 'sql/platform/connection/common/connect
 import * as TypeMoq from 'typemoq';
 import * as assert from 'assert';
 import { TestLogService } from 'vs/workbench/test/workbenchTestServices';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 class TestChangeDetectorRef extends ChangeDetectorRef {
 	reattach(): void {
@@ -75,7 +76,7 @@ suite('Dashboard Properties Widget Tests', () => {
 				'properties-widget': propertiesConfig
 			},
 			context: 'server',
-			provider: 'MSSQL',
+			provider: mssqlProviderName,
 			edition: 0
 		};
 

--- a/src/sqltest/parts/notebook/model/notebookModel.test.ts
+++ b/src/sqltest/parts/notebook/model/notebookModel.test.ts
@@ -28,6 +28,7 @@ import { TestStorageService, TestLogService } from 'vs/workbench/test/workbenchT
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 let expectedNotebookContent: nb.INotebookContents = {
 	cells: [{
@@ -101,7 +102,7 @@ suite('notebook model', function (): void {
 			notificationService: notificationService.object,
 			connectionService: queryConnectionService.object,
 			providerId: 'SQL',
-			standardKernels: [{ name: 'SQL', displayName: 'SQL', connectionProviderIds: ['MSSQL'], notebookProvider: 'sql' }],
+			standardKernels: [{ name: 'SQL', displayName: 'SQL', connectionProviderIds: [mssqlProviderName], notebookProvider: 'sql' }],
 			cellMagicMapper: undefined,
 			defaultKernel: undefined,
 			layoutChanged: undefined,

--- a/src/sqltest/parts/notebook/model/notebookUtils.test.ts
+++ b/src/sqltest/parts/notebook/model/notebookUtils.test.ts
@@ -9,6 +9,7 @@ import { IConnectionProfile } from 'azdata';
 import { CapabilitiesTestService } from 'sqltest/stubs/capabilitiesTestService';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { formatServerNameWithDatabaseNameForAttachTo, getServerFromFormattedAttachToName, getDatabaseFromFormattedAttachToName } from 'sql/workbench/parts/notebook/notebookUtils';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 suite('notebookUtils', function (): void {
 	let conn: IConnectionProfile = {
@@ -21,7 +22,7 @@ suite('notebookUtils', function (): void {
 		savePassword: true,
 		groupFullName: '',
 		groupId: '',
-		providerName: 'MSSQL',
+		providerName: mssqlProviderName,
 		saveProfile: true,
 		id: '',
 		options: {},

--- a/src/sqltest/stubs/capabilitiesTestService.ts
+++ b/src/sqltest/stubs/capabilitiesTestService.ts
@@ -10,6 +10,7 @@ import { ConnectionOptionSpecialType, ServiceOptionType } from 'sql/workbench/ap
 
 import { Event, Emitter } from 'vs/base/common/event';
 import { Action } from 'vs/base/common/actions';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 export class CapabilitiesTestService implements ICapabilitiesService {
 
@@ -94,11 +95,11 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 			}
 		];
 		let msSQLCapabilities = {
-			providerId: 'MSSQL',
+			providerId: mssqlProviderName,
 			displayName: 'MSSQL',
 			connectionOptions: connectionProvider,
 		};
-		this.capabilities['MSSQL'] = { connection: msSQLCapabilities };
+		this.capabilities[mssqlProviderName] = { connection: msSQLCapabilities };
 	}
 
 	/**

--- a/src/sqltest/stubs/connectionProviderStub.ts
+++ b/src/sqltest/stubs/connectionProviderStub.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 export class ConnectionProviderStub implements azdata.ConnectionProvider {
-	public readonly providerId = 'MSSQL';
+	public readonly providerId = mssqlProviderName;
 
 	connect(connectionUri: string, connectionInfo: azdata.ConnectionInfo): Thenable<boolean> {
 		return undefined;

--- a/src/sqltest/stubs/objectExplorerProviderTestService.ts
+++ b/src/sqltest/stubs/objectExplorerProviderTestService.ts
@@ -3,12 +3,13 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as azdata from 'azdata';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 // Test stubs for commonly used objects
 
 export class ObjectExplorerProviderTestService implements azdata.ObjectExplorerProvider {
 
-	public readonly providerId = 'MSSQL';
+	public readonly providerId = mssqlProviderName;
 
 	public createNewSession(connInfo: azdata.ConnectionInfo): Thenable<azdata.ObjectExplorerCloseSessionResponse> {
 		return Promise.resolve(undefined);

--- a/src/sqltest/workbench/api/exthostNotebook.test.ts
+++ b/src/sqltest/workbench/api/exthostNotebook.test.ts
@@ -15,6 +15,7 @@ import { ExtHostNotebook } from 'sql/workbench/api/node/extHostNotebook';
 import { MainThreadNotebookShape } from 'sql/workbench/api/node/sqlExtHost.protocol';
 import * as testUtils from '../../utils/testUtils';
 import { INotebookManagerDetails } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 suite('ExtHostNotebook Tests', () => {
 
@@ -121,7 +122,7 @@ suite('ExtHostNotebook Tests', () => {
 
 class NotebookProviderStub implements azdata.nb.NotebookProvider {
 	providerId: string = 'TestProvider';
-	standardKernels: azdata.nb.IStandardKernel[] = [{ name: 'fakeKernel', displayName: 'fakeKernel', connectionProviderIds: ['MSSQL'] }];
+	standardKernels: azdata.nb.IStandardKernel[] = [{ name: 'fakeKernel', displayName: 'fakeKernel', connectionProviderIds: [mssqlProviderName] }];
 
 	getNotebookManager(notebookUri: vscode.Uri): Thenable<azdata.nb.NotebookManager> {
 		throw new Error('Method not implemented.');


### PR DESCRIPTION
Just some cleanup so we're consistent about our use of the provider name. There's additional improvements that should be made at some point too such as updating code to query for display name instead of that being hard-coded as well, but right now I wanted to keep this PR as simple as possible. 