### PR TITLE
Fix #5379 markdown Gray code makes code look wrong

### DIFF
--- a/src/sql/workbench/parts/notebook/cellViews/media/highlight.css
+++ b/src/sql/workbench/parts/notebook/cellViews/media/highlight.css
@@ -46,6 +46,15 @@ https://raw.githubusercontent.com/isagalaev/highlight.js/master/src/styles/vs201
 	color: #DCDCDC;
 }
 
+.notebook-preview pre code .hljs-subst,
+.notebook-preview pre code .hljs-function,
+.notebook-preview pre code .hljs-title,
+.notebook-preview pre code .hljs-params,
+.notebook-preview pre code .hljs-formula {
+	color: var(--vscode-editor-foreground);
+}
+
+
 .notebook-preview .hljs-comment,
 .notebook-preview .hljs-quote {
 	color: #57A64A;


### PR DESCRIPTION
Fixes #5379 Notebook: markdown Gray code makes Typescript code look wrong 
- Inside a code block, just use foreground color.

Before:
![image](https://user-images.githubusercontent.com/10819925/59222056-82043f00-8b7d-11e9-932d-6858c62169df.png)

After:
![image](https://user-images.githubusercontent.com/10819925/59221993-67ca6100-8b7d-11e9-906d-ad6ff1f82ea7.png)

