### PR TITLE
Fix outputs constantly focusing on new output

### DIFF
--- a/src/sql/workbench/parts/notebook/models/cell.ts
+++ b/src/sql/workbench/parts/notebook/models/cell.ts
@@ -402,7 +402,9 @@ export class CellModel implements ICellModel {
 			// deletes transient node in the serialized JSON
 			delete output['transient'];
 			this._outputs.push(this.rewriteOutputUrls(output));
-			this.fireOutputsChanged(true);
+			// Only scroll on 1st output being added
+			let shouldScroll = this._outputs.length === 1;
+			this.fireOutputsChanged(shouldScroll);
 		}
 	}
 


### PR DESCRIPTION
- Only scroll if it's the 1st output, not for subsequent ones
- Otherwise can't use notebook while a cell is running & regularly updating the outputs