### PR TITLE
Added option to force reload extensions

### DIFF
--- a/extensions/cms/package.json
+++ b/extensions/cms/package.json
@@ -14,6 +14,7 @@
 	"activationEvents": [
 		"*"
 	],
+	"forceReload": true,
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Microsoft/azuredatastudio.git"

--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -236,6 +236,8 @@ export interface IExtensionDescription extends IExtensionManifest {
 	readonly isUnderDevelopment: boolean;
 	readonly extensionLocation: URI;
 	enableProposedApi?: boolean;
+	// {{ SQL CARBON EDIT }}
+	readonly forceReload?: boolean;
 }
 
 export function isLanguagePackExtension(manifest: IExtensionManifest): boolean {

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -305,6 +305,11 @@ export class ExtensionService extends Disposable implements IExtensionService {
 			return false;
 		}
 
+		// {{ SQL CARBON EDIT }}
+		if (extension.forceReload) {
+			return false;
+		}
+
 		const extensionDescription = this._registry.getExtensionDescription(extension.identifier);
 		if (extensionDescription) {
 			// ignore adding an extension which is already running and cannot be removed


### PR DESCRIPTION
Added the ability to force extensions to reload, with CMS being the first extension to use this.

Fixes https://github.com/microsoft/azuredatastudio/issues/5889 and https://github.com/microsoft/azuredatastudio/issues/5846