### PR TITLE
Added 'New Notebook' task on database dashboard

### DIFF
--- a/src/sql/workbench/parts/dashboard/pages/databaseDashboardPage.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/pages/databaseDashboardPage.contribution.ts
@@ -92,10 +92,16 @@ export const databaseDashboardSettingSchema: IJSONSchema = {
 			name: 'Tasks',
 			gridItemConfig: {
 				sizex: 1,
-				sizey: 1
+				sizey: 2
 			},
 			widget: {
-				'tasks-widget': [{ name: 'backup', when: '!mssql:iscloud' }, { name: 'restore', when: '!mssql:iscloud' }, 'configureDashboard', 'newQuery']
+				'tasks-widget': [
+					{ name: 'backup', when: '!mssql:iscloud' },
+					{ name: 'restore', when: '!mssql:iscloud' },
+					'newQuery',
+					'mssqlCluster.task.newNotebook',
+					'configureDashboard'
+				]
 			}
 		},
 		{

--- a/src/sql/workbench/parts/dashboard/pages/databaseDashboardPage.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/pages/databaseDashboardPage.contribution.ts
@@ -96,10 +96,10 @@ export const databaseDashboardSettingSchema: IJSONSchema = {
 			},
 			widget: {
 				'tasks-widget': [
-					{ name: 'backup', when: '!mssql:iscloud' },
-					{ name: 'restore', when: '!mssql:iscloud' },
 					'newQuery',
 					'mssqlCluster.task.newNotebook',
+					{ name: 'backup', when: '!mssql:iscloud' },
+					{ name: 'restore', when: '!mssql:iscloud' },
 					'configureDashboard'
 				]
 			}

--- a/src/sql/workbench/parts/dashboard/widgets/explorer/explorerTree.ts
+++ b/src/sql/workbench/parts/dashboard/widgets/explorer/explorerTree.ts
@@ -33,6 +33,7 @@ import { $ } from 'vs/base/browser/dom';
 import { ExecuteCommandAction } from 'vs/platform/actions/common/actions';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { IProgressService } from 'vs/platform/progress/common/progress';
+import { NewNotebookAction } from 'sql/workbench/parts/notebook/notebookActions';
 
 export class ObjectMetadataWrapper implements ObjectMetadata {
 	public metadataType: MetadataType;
@@ -392,6 +393,7 @@ function getExplorerActions(element: TreeResource, instantiationService: IInstan
 		}
 	} else {
 		actions.push(instantiationService.createInstance(CustomExecuteCommandAction, NewQueryAction.ID, NewQueryAction.LABEL));
+		actions.push(instantiationService.createInstance(CustomExecuteCommandAction, NewNotebookAction.ID, NewNotebookAction.LABEL));
 
 		let action: IAction = instantiationService.createInstance(CustomExecuteCommandAction, RestoreAction.ID, RestoreAction.LABEL);
 		if (capabilitiesService.isFeatureAvailable(action, info)) {

--- a/src/sql/workbench/parts/dashboard/widgets/tasks/media/taskWidget.css
+++ b/src/sql/workbench/parts/dashboard/widgets/tasks/media/taskWidget.css
@@ -6,8 +6,8 @@
 tasks-widget .tile-container {
 	position: relative;
 	display: flex;
-	flex-flow: column;
-	flex-wrap: wrap;
+	flex-flow: row wrap;
+	align-content: flex-start;
 }
 
 tasks-widget .task-tile {
@@ -18,10 +18,6 @@ tasks-widget .task-tile {
 	text-align: center;
 	margin-top: 10px;
 	margin-left: 18px;
-}
-
-tasks-widget .task-tile:last-of-type {
-	margin-right: 10px;
 }
 
 tasks-widget .task-tile > div {

--- a/src/vs/platform/contextview/browser/contextMenuHandler.ts
+++ b/src/vs/platform/contextview/browser/contextMenuHandler.ts
@@ -76,7 +76,7 @@ export class ContextMenuHandler {
 					actionViewItemProvider: delegate.getActionViewItem,
 					context: delegate.getActionsContext ? delegate.getActionsContext() : null,
 					actionRunner,
-					getKeyBinding: delegate.getKeyBinding ? delegate.getKeyBinding : action => this.keybindingService.lookupKeybinding(action.id)
+					getKeyBinding: delegate.getKeyBinding
 				});
 
 				menuDisposables.push(attachMenuStyler(menu, this.themeService));

--- a/src/vs/platform/contextview/browser/contextMenuHandler.ts
+++ b/src/vs/platform/contextview/browser/contextMenuHandler.ts
@@ -76,7 +76,7 @@ export class ContextMenuHandler {
 					actionViewItemProvider: delegate.getActionViewItem,
 					context: delegate.getActionsContext ? delegate.getActionsContext() : null,
 					actionRunner,
-					getKeyBinding: delegate.getKeyBinding
+					getKeyBinding: delegate.getKeyBinding ? delegate.getKeyBinding : action => this.keybindingService.lookupKeybinding(action.id)
 				});
 
 				menuDisposables.push(attachMenuStyler(menu, this.themeService));


### PR DESCRIPTION
This PR resolves https://github.com/microsoft/azuredatastudio/issues/4945
This PR includes:
* Adding 'New Notebook' task on Database Dashboard
* Adding 'New Notebook' action on the menu when right-clicking db node in Search widget on Server Dashboard

![image](https://user-images.githubusercontent.com/19577035/59379536-be65a580-8d0b-11e9-95f7-e7a4125b505e.png)


![image](https://user-images.githubusercontent.com/19577035/59320430-376cea80-8c83-11e9-8d4a-42f635b820d7.png)
