### PR TITLE
Disable Manage Packages button if python is not installed

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -224,7 +224,7 @@
 			"notebook/toolbar": [
 				{
 					"command": "jupyter.cmd.managePackages",
-					"when": "providerId == jupyter"
+					"when": "providerId == jupyter && notebook:pythonInstalled"
 				}
 			]
 		},

--- a/extensions/notebook/src/common/apiWrapper.ts
+++ b/extensions/notebook/src/common/apiWrapper.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as azdata from 'azdata';
+import { CommandContext, BuiltInCommands } from './constants';
 
 /**
  * Wrapper class to act as a facade over VSCode and Data APIs and allow us to test / mock callbacks into
@@ -54,6 +55,10 @@ export class ApiWrapper {
 
 	public startBackgroundOperation(operationInfo: azdata.BackgroundOperationInfo): void {
 		azdata.tasks.startBackgroundOperation(operationInfo);
+	}
+
+	public setCommandContext(key: CommandContext | string, value: any): Thenable<any> {
+		return vscode.commands.executeCommand(BuiltInCommands.SetContext, key, value);
 	}
 
 	/**

--- a/extensions/notebook/src/common/constants.ts
+++ b/extensions/notebook/src/common/constants.ts
@@ -33,7 +33,7 @@ export enum BuiltInCommands {
 }
 
 export enum CommandContext {
-	WizardServiceEnabled = 'wizardservice:enabled'
+	NotebookPythonInstalled = 'notebook:pythonInstalled'
 }
 
 export const pythonOfflinePipPackagesUrl = 'https://go.microsoft.com/fwlink/?linkid=2092867';

--- a/extensions/notebook/src/common/constants.ts
+++ b/extensions/notebook/src/common/constants.ts
@@ -6,37 +6,23 @@
 'use strict';
 
 // CONFIG VALUES ///////////////////////////////////////////////////////////
-export const extensionConfigSectionName = 'dataManagement';
 export const extensionOutputChannel = 'Notebooks';
-export const configLogDebugInfo = 'logDebugInfo';
 
 // JUPYTER CONFIG //////////////////////////////////////////////////////////
 export const pythonBundleVersion = '0.0.1';
 export const pythonVersion = '3.6.6';
 export const sparkMagicVersion = '0.12.6.1';
-export const python3 = 'python3';
-export const pysparkkernel = 'pysparkkernel';
-export const sparkkernel = 'sparkkernel';
-export const pyspark3kernel = 'pyspark3kernel';
-export const python3DisplayName = 'Python 3';
-export const defaultSparkKernel = 'pyspark3kernel';
 export const pythonPathConfigKey = 'pythonPath';
 export const existingPythonConfigKey = 'useExistingPython';
 export const notebookConfigKey = 'notebook';
-
-export const hdfsHost = 'host';
-export const hdfsUser = 'user';
 
 export const winPlatform = 'win32';
 
 export const jupyterNotebookProviderId = 'jupyter';
 export const jupyterConfigRootFolder = 'jupyter_config';
-export const jupyterKernelsMasterFolder = 'kernels_master';
 export const jupyterNewNotebookTask = 'jupyter.task.newNotebook';
 export const jupyterOpenNotebookTask = 'jupyter.task.openNotebook';
 export const jupyterNewNotebookCommand = 'jupyter.cmd.newNotebook';
-export const jupyterCommandSetContext = 'jupyter.setContext';
-export const jupyterCommandSetKernel = 'jupyter.setKernel';
 export const jupyterReinstallDependenciesCommand = 'jupyter.reinstallDependencies';
 export const jupyterAnalyzeCommand = 'jupyter.cmd.analyzeNotebook';
 export const jupyterManagePackages = 'jupyter.cmd.managePackages';

--- a/extensions/notebook/src/jupyter/jupyterServerManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerManager.ts
@@ -102,7 +102,7 @@ export class LocalJupyterServerManager implements nb.ServerManager, vscode.Dispo
 		return this.options.documentPath;
 	}
 
-	private async doStartServer(): Promise<IServerInstance> {        // We can't find or create servers until the installation is complete
+	private async doStartServer(): Promise<IServerInstance> { // We can't find or create servers until the installation is complete
 		let installation = this.options.jupyterInstallation;
 		await installation.promptForPythonInstall();
 		this.apiWrapper.setCommandContext(CommandContext.NotebookPythonInstalled, true);

--- a/extensions/notebook/src/jupyter/jupyterServerManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerManager.ts
@@ -17,6 +17,7 @@ import JupyterServerInstallation from './jupyterServerInstallation';
 import * as utils from '../common/utils';
 import { IServerInstance } from './common';
 import { PerNotebookServerInstance, IInstanceOptions } from './serverInstance';
+import { CommandContext } from '../common/constants';
 
 export interface IServerManagerOptions {
 	documentPath: string;
@@ -104,6 +105,7 @@ export class LocalJupyterServerManager implements nb.ServerManager, vscode.Dispo
 	private async doStartServer(): Promise<IServerInstance> {        // We can't find or create servers until the installation is complete
 		let installation = this.options.jupyterInstallation;
 		await installation.promptForPythonInstall();
+		this.apiWrapper.setCommandContext(CommandContext.NotebookPythonInstalled, true);
 
 		// Calculate the path to use as the notebook-dir for Jupyter based on the path of the uri of the
 		// notebook to open. This will be the workspace folder if the notebook uri is inside a workspace

--- a/src/sql/workbench/parts/notebook/notebook.component.ts
+++ b/src/sql/workbench/parts/notebook/notebook.component.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { nb } from 'azdata';
 import { OnInit, Component, Inject, forwardRef, ElementRef, ChangeDetectorRef, ViewChild, OnDestroy } from '@angular/core';
 
 import { IColorTheme, IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
@@ -288,6 +289,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		await model.requestModelLoad(trusted);
 		model.contentChanged((change) => this.handleContentChanged(change));
 		model.onProviderIdChange((provider) => this.handleProviderIdChanged(provider));
+		model.kernelChanged((kernelArgs) => this.handleKernelChanged(kernelArgs));
 		this._model = this._register(model);
 		this.updateToolbarComponents(this._model.trustedMode);
 		this._modelRegisteredDeferred.resolve(this._model);
@@ -369,6 +371,10 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			action.enabled = false;
 		});
 		this.setContextKeyServiceWithProviderId(providerId);
+		this.fillInActionsForCurrentContext();
+	}
+
+	private handleKernelChanged(kernelArgs: nb.IKernelChangedArgs) {
 		this.fillInActionsForCurrentContext();
 	}
 


### PR DESCRIPTION
I had to add another check for action contributions after the kernel is changed, since the button state won't be refreshed without it. The actions get added to the toolbar after clicking on a kernel in the dropdown (i.e. when switching to jupyter provider), but they're hidden since python isn't installed yet. So there needs to be this other action check after kernel changes.

Also removed some unused constants in the notebook extension.

Fixes https://github.com/microsoft/azuredatastudio/issues/5955