### PR TITLE
Formatting diff editor title

### DIFF
--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -12,7 +12,7 @@ import { SchemaCompareOptionsDialog } from './dialogs/schemaCompareOptionsDialog
 import { Telemetry } from './telemetry';
 import { getTelemetryErrorType } from './utils';
 const localize = nls.loadMessageBundle();
-const diffEditorTitle = localize('schemaCompare.ObjectDefinitionsTitle', 'Object Definitions');
+const diffEditorTitle = localize('schemaCompare.CompareDetailsTitle', 'Compare Details');
 const applyConfirmation = localize('schemaCompare.ApplyConfirmation', 'Are you sure you want to update the target?');
 const reCompareToRefeshMessage = localize('schemaCompare.RecompareToRefresh', 'Press Compare to refresh the comparison.');
 const generateScriptEnabledMessage = localize('schemaCompare.generateScriptEnabledButton', 'Generate script to deploy changes to target');

--- a/src/sql/workbench/electron-browser/modelComponents/diffeditor.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/diffeditor.component.ts
@@ -30,7 +30,7 @@ import { ITextModel } from 'vs/editor/common/model';
 @Component({
 	template: `
 	<div *ngIf="_title">
-		<div class="modelview-diff-editor-title" style="width: 100%; height:100%; padding-left:3px !important; border: 1px solid #BFBDBD;">
+		<div class="modelview-diff-editor-title modelview-diff-editor-title-background">
 			{{_title}}
 		</div>
 	</div>`,

--- a/src/sql/workbench/electron-browser/modelComponents/media/editor.css
+++ b/src/sql/workbench/electron-browser/modelComponents/media/editor.css
@@ -25,9 +25,13 @@ modelview-diff-editor-component {
 }
 
 .vs-dark .modelview-diff-editor-title-background {
-	background-color: #434343
+	background-color: #434343;
+}
+
+.hc-black .modelview-diff-editor-title-background {
+	background-color: #000000;
 }
 
 .modelview-diff-editor-title-background {
-	background-color: #d5d5d5
+	background-color: #d5d5d5;
 }

--- a/src/sql/workbench/electron-browser/modelComponents/media/editor.css
+++ b/src/sql/workbench/electron-browser/modelComponents/media/editor.css
@@ -15,10 +15,19 @@ modelview-diff-editor-component {
 	display: block;
 }
 
-.vs-dark modelview-diff-editor-title {
-	background: #444444;
+.modelview-diff-editor-title {
+	width: 100%;
+	height: 100%;
+	font-weight: 700;
+	padding: 3px 3px 3px 16px;
+	text-transform: uppercase;
+	font-size: 11px
 }
 
-modelview-diff-editor-title {
-	background: #f4f4f4;
+.vs-dark .modelview-diff-editor-title-background {
+	background-color: #434343
+}
+
+.modelview-diff-editor-title-background {
+	background-color: #d5d5d5
 }


### PR DESCRIPTION
Add background color and other formatting to diff editor title to match look of OE. Also changing title for schema compare diff editor to "Compare Details" instead of "Object Definitions"

light theme:
![image](https://user-images.githubusercontent.com/31145923/59453243-5aeb7e80-8dc4-11e9-9aa4-bc069346e8e8.png)

dark theme:
![image](https://user-images.githubusercontent.com/31145923/59453273-676fd700-8dc4-11e9-9bb3-243b57fb6134.png)

high contrast black:
![image](https://user-images.githubusercontent.com/31145923/59454386-c6cee680-8dc6-11e9-8937-273b5c199832.png)
