### PR TITLE
Fix #6022 connection dialog broken

### DIFF
--- a/src/sql/platform/connection/common/connectionProfile.ts
+++ b/src/sql/platform/connection/common/connectionProfile.ts
@@ -44,11 +44,14 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 			this._id = model.id;
 			this.azureTenantId = model.azureTenantId;
 			if (this.capabilitiesService && model.providerName) {
-				const options = this.capabilitiesService.getCapabilities(model.providerName).connection.connectionOptions;
-				let appNameOption = options.find(option => option.specialValueType === ConnectionOptionSpecialType.appName);
-				if (appNameOption) {
-					let appNameKey = appNameOption.name;
-					this.options[appNameKey] = Constants.applicationName;
+				let capabilities = this.capabilitiesService.getCapabilities(model.providerName);
+				if (capabilities && capabilities.connection && capabilities.connection.connectionOptions) {
+					const options = capabilities.connection.connectionOptions;
+					let appNameOption = options.find(option => option.specialValueType === ConnectionOptionSpecialType.appName);
+					if (appNameOption) {
+						let appNameKey = appNameOption.name;
+						this.options[appNameKey] = Constants.applicationName;
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
Opening connection dialog was broken if you have a postgres connection
listed in the Connections view and the extension isn't installed.
The capabilities service breaks as it returns an undefined object.
Added handling, so now it does show as "loading..." forever
but doesn't crash