### PR TITLE
Add telemetry for all commands

### DIFF
--- a/src/sql/platform/telemetry/telemetry.contribution.ts
+++ b/src/sql/platform/telemetry/telemetry.contribution.ts
@@ -9,15 +9,20 @@ import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
+import { ICommandService, ICommandEvent } from 'vs/platform/commands/common/commands';
 
 export class SqlTelemetryContribution extends Disposable implements IWorkbenchContribution {
 
 	constructor(
 		@ITelemetryService private telemetryService: ITelemetryService,
-		@IStorageService storageService: IStorageService
+		@IStorageService storageService: IStorageService,
+		@ICommandService commandService: ICommandService
 	) {
 		super();
 
+		this._register(
+			commandService.onWillExecuteCommand(
+				(e: ICommandEvent) => telemetryService.publicLog('adsCommandExecuted', { id: e.commandId })));
 		const dailyLastUseDate: number = Date.parse(storageService.get('telemetry.dailyLastUseDate', StorageScope.GLOBAL, '0'));
 		const weeklyLastUseDate: number = Date.parse(storageService.get('telemetry.weeklyLastUseDate', StorageScope.GLOBAL, '0'));
 		const monthlyLastUseDate: number = Date.parse(storageService.get('telemetry.monthlyLastUseDate', StorageScope.GLOBAL, '0'));


### PR DESCRIPTION
The commandExecuted event was only being sent from actions - not for all commands. So instead hooking up a listener for any command being sent and logging our own event to capture all the events.

Note that while investigating this I found that it seems like the old commandExecuted event wasn't even being sent anymore that I could see - it appears that something in the latest update changed so that the code path is never invoked anymore (whether this is a VSCode bug or not I can't tell). So we shouldn't be relying on the old event anyways. 