### PR TITLE
Add ability to change source and target to Schema Compare

### DIFF
--- a/extensions/integration-tests/src/schemaCompare.test.ts
+++ b/extensions/integration-tests/src/schemaCompare.test.ts
@@ -39,6 +39,7 @@ if (context.RunTest) {
 			let source: azdata.SchemaCompareEndpointInfo = {
 				endpointType: azdata.SchemaCompareEndpointType.Dacpac,
 				packageFilePath: dacpac1,
+				serverDisplayName: '',
 				serverName: '',
 				databaseName: '',
 				ownerUri: '',
@@ -46,6 +47,7 @@ if (context.RunTest) {
 			let target: azdata.SchemaCompareEndpointInfo = {
 				endpointType: azdata.SchemaCompareEndpointType.Dacpac,
 				packageFilePath: dacpac2,
+				serverDisplayName: '',
 				serverName: '',
 				databaseName: '',
 				ownerUri: '',
@@ -86,6 +88,7 @@ if (context.RunTest) {
 				let source: azdata.SchemaCompareEndpointInfo = {
 					endpointType: azdata.SchemaCompareEndpointType.Database,
 					packageFilePath: '',
+					serverDisplayName: '',
 					serverName: server.serverName,
 					databaseName: sourceDB,
 					ownerUri: ownerUri,
@@ -93,6 +96,7 @@ if (context.RunTest) {
 				let target: azdata.SchemaCompareEndpointInfo = {
 					endpointType: azdata.SchemaCompareEndpointType.Database,
 					packageFilePath: '',
+					serverDisplayName: '',
 					serverName: server.serverName,
 					databaseName: targetDB,
 					ownerUri: ownerUri,
@@ -137,6 +141,7 @@ if (context.RunTest) {
 				let source: azdata.SchemaCompareEndpointInfo = {
 					endpointType: azdata.SchemaCompareEndpointType.Dacpac,
 					packageFilePath: dacpac1,
+					serverDisplayName: '',
 					serverName: '',
 					databaseName: '',
 					ownerUri: ownerUri,
@@ -144,6 +149,7 @@ if (context.RunTest) {
 				let target: azdata.SchemaCompareEndpointInfo = {
 					endpointType: azdata.SchemaCompareEndpointType.Database,
 					packageFilePath: '',
+					serverDisplayName: '',
 					serverName: server.serverName,
 					databaseName: targetDB,
 					ownerUri: ownerUri,

--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -2,7 +2,7 @@
 	"name": "schema-compare",
 	"displayName": "%displayName%",
 	"description": "%description%",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"publisher": "Microsoft",
 	"preview": true,
 	"engines": {

--- a/extensions/schema-compare/src/controllers/mainController.ts
+++ b/extensions/schema-compare/src/controllers/mainController.ts
@@ -7,7 +7,7 @@
 
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
-import { SchemaCompareDialog } from '../dialogs/schemaCompareDialog';
+import { SchemaCompareResult } from '../schemaCompareResult';
 
 /**
  * The main controller class that initializes the extension
@@ -32,7 +32,7 @@ export default class MainController implements vscode.Disposable {
 	}
 
 	private initializeSchemaCompareDialog(): void {
-		azdata.tasks.registerTask('schemaCompare.start', (profile: azdata.IConnectionProfile) => new SchemaCompareDialog().openDialog(profile));
+		azdata.tasks.registerTask('schemaCompare.start', (profile: azdata.IConnectionProfile) => new SchemaCompareResult().start(profile));
 	}
 
 	public dispose(): void {

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -603,7 +603,7 @@ export class SchemaCompareDialog {
 		let currentDropdown = isTarget ? this.targetDatabaseDropdown : this.sourceDatabaseDropdown;
 		currentDropdown.updateProperties({ values: [], value: null });
 
-		let values = await this.getDatabaseValues(connectionId);
+		let values = await this.getDatabaseValues(connectionId, isTarget);
 		if (values && values.length > 0) {
 			currentDropdown.updateProperties({
 				values: values,

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -148,11 +148,11 @@ export class SchemaCompareDialog {
 
 		// show recompare message if it isn't the initial population of source and target
 		if (this.previousSource && this.previousTarget
-			&& (updatedSourceName !== this.previousSource || updatedTargetName !== this.previousTarget)) {
+			&& (updatedSourceName.toLowerCase() !== this.previousSource.toLowerCase() || updatedTargetName.toLowerCase() !== this.previousTarget.toLowerCase())) {
 			this.schemaCompareResult.setButtonsForRecompare();
 			let message = differentSourceMessage;
 
-			if (updatedSourceName !== this.previousSource && updatedTargetName !== this.previousTarget) {
+			if (updatedSourceName.toLowerCase() !== this.previousSource.toLowerCase() && updatedTargetName.toLowerCase() !== this.previousTarget.toLowerCase()) {
 				message = differentSourceTargetMessage;
 			} else if (updatedTargetName !== this.previousTarget) {
 				message = differentTargetMessage;
@@ -284,7 +284,7 @@ export class SchemaCompareDialog {
 		currentButton.onDidClick(async (click) => {
 			// file browser should open where the current dacpac is or the appropriate default folder
 			let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
-			let defaultUri = endpoint && endpoint.packageFilePath ? endpoint.packageFilePath : rootPath;
+			let defaultUri = endpoint && endpoint.packageFilePath && existsSync(endpoint.packageFilePath) ? endpoint.packageFilePath : rootPath;
 
 			let fileUris = await vscode.window.showOpenDialog(
 				{

--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -66,7 +66,7 @@ export class SchemaCompareResult {
 		this.SchemaCompareActionMap[azdata.SchemaUpdateAction.Add] = localize('schemaCompare.addAction', 'Add');
 
 		this.editor = azdata.workspace.createModelViewEditor(localize('schemaCompare.Title', 'Schema Compare'), { retainContextWhenHidden: true, supportsSave: true, resourceName: schemaCompareResourceName });
-    }
+	}
 
 	public async start(context: any) {
 		// if schema compare was launched from a db, set that as the source
@@ -75,6 +75,7 @@ export class SchemaCompareResult {
 			let ownerUri = await azdata.connection.getUriForConnection((profile.id));
 			this.sourceEndpointInfo = {
 				endpointType: azdata.SchemaCompareEndpointType.Database,
+				serverDisplayName: `${profile.serverName} ${profile.userName}`,
 				serverName: profile.serverName,
 				databaseName: profile.databaseName,
 				ownerUri: ownerUri,

--- a/extensions/schema-compare/src/test/schemaCompare.test.ts
+++ b/extensions/schema-compare/src/test/schemaCompare.test.ts
@@ -14,19 +14,19 @@ import { SchemaCompareTestService } from './testSchemaCompareService';
 
 // Mock test data
 const mockConnectionProfile: azdata.IConnectionProfile = {
-		connectionName: 'My Connection',
-		serverName: 'My Server',
-		databaseName: 'My Server',
-		userName: 'My User',
-		password: 'My Pwd',
-		authenticationType: 'SqlLogin',
-		savePassword: false,
-		groupFullName: 'My groupName',
-		groupId: 'My GroupId',
-		providerName: 'My Server',
-		saveProfile: true,
-		id: 'My Id',
-		options: null
+	connectionName: 'My Connection',
+	serverName: 'My Server',
+	databaseName: 'My Server',
+	userName: 'My User',
+	password: 'My Pwd',
+	authenticationType: 'SqlLogin',
+	savePassword: false,
+	groupFullName: 'My groupName',
+	groupId: 'My GroupId',
+	providerName: 'My Server',
+	saveProfile: true,
+	id: 'My Id',
+	options: null
 };
 
 const mocksource: string = 'source.dacpac';
@@ -48,10 +48,11 @@ const mockTargetEndpoint: azdata.SchemaCompareEndpointInfo = {
 	packageFilePath: mocktarget
 };
 
-describe('SchemaCompareDialog.openDialog', function(): void {
-	it('Should be correct when created.', async function(): Promise<void> {
-		let dialog = new SchemaCompareDialog();
-		await dialog.openDialog(mockConnectionProfile);
+describe('SchemaCompareDialog.openDialog', function (): void {
+	it('Should be correct when created.', async function (): Promise<void> {
+		let schemaCompareResult = new SchemaCompareResult();
+		let dialog = new SchemaCompareDialog(schemaCompareResult);
+		await dialog.openDialog();
 
 		should(dialog.dialog.title).equal('Schema Compare');
 		should(dialog.dialog.okButton.label).equal('Ok');
@@ -59,17 +60,19 @@ describe('SchemaCompareDialog.openDialog', function(): void {
 	});
 });
 
-describe('SchemaCompareResult.start', function(): void {
-	it('Should be correct when created.', async function(): Promise<void> {
+describe('SchemaCompareResult.start', function (): void {
+	it('Should be correct when created.', async function (): Promise<void> {
 		let sc = new SchemaCompareTestService();
 		azdata.dataprotocol.registerSchemaCompareServicesProvider(sc);
 
-		let result = new SchemaCompareResult(mocksource, mocktarget, mockSourceEndpoint, mockTargetEndpoint);
+		let result = new SchemaCompareResult();
+		await result.start(null);
 		let promise = new Promise(resolve => setTimeout(resolve, 3000)); // to ensure comparision result view is initialized
 		await promise;
-		await result.start();
 
-		should(result.getComparisonResult() === undefined);
+		should(result.getComparisionResult() === undefined);
+		result.sourceEndpointInfo = mockSourceEndpoint;
+		result.targetEndpointInfo = mockTargetEndpoint;
 		await result.execute();
 
 		should(result.getComparisonResult() !== undefined);

--- a/extensions/schema-compare/src/test/schemaCompare.test.ts
+++ b/extensions/schema-compare/src/test/schemaCompare.test.ts
@@ -34,6 +34,7 @@ const mocktarget: string = 'target.dacpac';
 
 const mockSourceEndpoint: azdata.SchemaCompareEndpointInfo = {
 	endpointType: azdata.SchemaCompareEndpointType.Dacpac,
+	serverDisplayName: '',
 	serverName: '',
 	databaseName: '',
 	ownerUri: '',
@@ -42,6 +43,7 @@ const mockSourceEndpoint: azdata.SchemaCompareEndpointInfo = {
 
 const mockTargetEndpoint: azdata.SchemaCompareEndpointInfo = {
 	endpointType: azdata.SchemaCompareEndpointType.Dacpac,
+	serverDisplayName: '',
 	serverName: '',
 	databaseName: '',
 	ownerUri: '',

--- a/extensions/schema-compare/src/test/schemaCompare.test.ts
+++ b/extensions/schema-compare/src/test/schemaCompare.test.ts
@@ -70,7 +70,7 @@ describe('SchemaCompareResult.start', function (): void {
 		let promise = new Promise(resolve => setTimeout(resolve, 3000)); // to ensure comparision result view is initialized
 		await promise;
 
-		should(result.getComparisionResult() === undefined);
+		should(result.getComparisonResult() === undefined);
 		result.sourceEndpointInfo = mockSourceEndpoint;
 		result.targetEndpointInfo = mockTargetEndpoint;
 		await result.execute();

--- a/extensions/schema-compare/src/test/testSchemaCompareService.ts
+++ b/extensions/schema-compare/src/test/testSchemaCompareService.ts
@@ -14,7 +14,13 @@ export class SchemaCompareTestService implements azdata.SchemaCompareServicesPro
 	}
 
 	schemaCompareGetDefaultOptions(): Thenable<azdata.SchemaCompareOptionsResult> {
-		throw new Error('Method not implemented.');
+		let result: azdata.SchemaCompareOptionsResult = {
+			defaultDeploymentOptions: undefined,
+			success: true,
+			errorMessage: ''
+		};
+
+		return Promise.resolve(result);
 	}
 
 	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: azdata.DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {

--- a/extensions/schema-compare/src/utils.ts
+++ b/extensions/schema-compare/src/utils.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 'use strict';
+import * as azdata from 'azdata';
 
 export interface IPackageInfo {
 	name: string;
@@ -30,5 +31,21 @@ export function getTelemetryErrorType(msg: string): string {
 	}
 	else {
 		return 'Other';
+	}
+}
+
+/**
+ * Return the appropriate endpoint name depending on if the endpoint is a dacpac or a database
+ * @param endpoint endpoint to get the name of
+ */
+export function getEndpointName(endpoint: azdata.SchemaCompareEndpointInfo): string {
+	if (!endpoint) {
+		return undefined;
+	}
+
+	if (endpoint.endpointType === azdata.SchemaCompareEndpointType.Database) {
+		return `${endpoint.serverName}.${endpoint.databaseName}`;
+	} else {
+		return endpoint.packageFilePath;
 	}
 }

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -1747,6 +1747,7 @@ declare module 'azdata' {
 	export interface SchemaCompareEndpointInfo {
 		endpointType: SchemaCompareEndpointType;
 		packageFilePath: string;
+		serverDisplayName: string;
 		serverName: string;
 		databaseName: string;
 		ownerUri: string;


### PR DESCRIPTION
This adds the ability to change the schema compare source and target. It also changes the start point of schema compare to be the main page rather than the dialog.

launching from database:
![changeSourceTarget2](https://user-images.githubusercontent.com/31145923/59475703-d0c20b00-8e01-11e9-846a-40153bd52ba1.gif)

launching from command palette:
![changeSourceTargetCommandPalette](https://user-images.githubusercontent.com/31145923/59636919-84c8dc00-9109-11e9-8943-ef4120923c32.gif)
