### PR TITLE
Fix lang pack names and versions

### DIFF
--- a/i18n/language-pack-de/package.json
+++ b/i18n/language-pack-de/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "zzlp-ads-language-pack-de",
+	"name": "ads-language-pack-de",
 	"displayName": "German Language Pack for Azure Data Studio",
 	"description": "Language pack extension for German",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"publisher": "Microsoft",
 	"repository": {
 		"type": "git",
@@ -11,7 +11,7 @@
 	"license": "SEE SOURCE EULA LICENSE IN LICENSE.txt",
 	"engines": {
 		"vscode": "^1.34.0",
-		"azdata": ">=1.8.0"
+		"azdata": ">=1.9.0"
 	},
 	"icon": "languagepack.png",
 	"categories": [

--- a/i18n/language-pack-es/package.json
+++ b/i18n/language-pack-es/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "zzlp-ads-language-pack-es",
+	"name": "ads-language-pack-es",
 	"displayName": "Spanish Language Pack for Azure Data Studio",
 	"description": "Language pack extension for Spanish",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"publisher": "Microsoft",
 	"repository": {
 		"type": "git",
@@ -11,7 +11,7 @@
 	"license": "SEE SOURCE EULA LICENSE IN LICENSE.txt",
 	"engines": {
 		"vscode": "^1.34.0",
-		"azdata": ">=1.8.0"
+		"azdata": ">=1.9.0"
 	},
 	"icon": "languagepack.png",
 	"categories": [

--- a/i18n/language-pack-fr/package.json
+++ b/i18n/language-pack-fr/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "zzlp-ads-language-pack-fr",
+	"name": "ads-language-pack-fr",
 	"displayName": "French Language Pack for Azure Data Studio",
 	"description": "Language pack extension for French",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"publisher": "Microsoft",
 	"repository": {
 		"type": "git",
@@ -11,7 +11,7 @@
 	"license": "SEE SOURCE EULA LICENSE IN LICENSE.txt",
 	"engines": {
 		"vscode": "^1.34.0",
-		"azdata": ">=1.8.0"
+		"azdata": ">=1.9.0"
 	},
 	"icon": "languagepack.png",
 	"categories": [

--- a/i18n/language-pack-it/package.json
+++ b/i18n/language-pack-it/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "zzlp-ads-language-pack-it",
+	"name": "ads-language-pack-it",
 	"displayName": "Italian Language Pack for Azure Data Studio",
 	"description": "Language pack extension for Italian",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"publisher": "Microsoft",
 	"repository": {
 		"type": "git",
@@ -11,7 +11,7 @@
 	"license": "SEE SOURCE EULA LICENSE IN LICENSE.txt",
 	"engines": {
 		"vscode": "^1.34.0",
-		"azdata": ">=1.8.0"
+		"azdata": ">=1.9.0"
 	},
 	"icon": "languagepack.png",
 	"categories": [

--- a/i18n/language-pack-ko/package.json
+++ b/i18n/language-pack-ko/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "zzlp-ads-language-pack-ko",
+	"name": "ads-language-pack-ko",
 	"displayName": "Korean Language Pack for Azure Data Studio",
 	"description": "Language pack extension for Korean",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"publisher": "Microsoft",
 	"repository": {
 		"type": "git",
@@ -11,7 +11,7 @@
 	"license": "SEE SOURCE EULA LICENSE IN LICENSE.txt",
 	"engines": {
 		"vscode": "^1.34.0",
-		"azdata": ">=1.8.0"
+		"azdata": ">=1.9.0"
 	},
 	"icon": "languagepack.png",
 	"categories": [

--- a/i18n/language-pack-pt-BR/package.json
+++ b/i18n/language-pack-pt-BR/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "zzlp-ads-language-pack-pt-br",
+	"name": "ads-language-pack-pt-br",
 	"displayName": "Portuguese (Brazil) Language Pack for Azure Data Studio",
 	"description": "Language pack extension for Portuguese (Brazil)",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"publisher": "Microsoft",
 	"repository": {
 		"type": "git",
@@ -11,7 +11,7 @@
 	"license": "SEE SOURCE EULA LICENSE IN LICENSE.txt",
 	"engines": {
 		"vscode": "^1.34.0",
-		"azdata": ">=1.8.0"
+		"azdata": ">=1.9.0"
 	},
 	"icon": "languagepack.png",
 	"categories": [

--- a/i18n/language-pack-ru/package.json
+++ b/i18n/language-pack-ru/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "zzlp-ads-language-pack-ru",
+	"name": "ads-language-pack-ru",
 	"displayName": "Russian Language Pack for Azure Data Studio",
 	"description": "Language pack extension for Russian",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"publisher": "Microsoft",
 	"repository": {
 		"type": "git",
@@ -11,7 +11,7 @@
 	"license": "SEE SOURCE EULA LICENSE IN LICENSE.txt",
 	"engines": {
 		"vscode": "^1.34.0",
-		"azdata": ">=1.8.0"
+		"azdata": ">=1.9.0"
 	},
 	"icon": "languagepack.png",
 	"categories": [

--- a/i18n/language-pack-zh-hans/package.json
+++ b/i18n/language-pack-zh-hans/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "zzlp-ads-language-pack-zh-hans",
+	"name": "ads-language-pack-zh-hans",
 	"displayName": "Chinese (Simplified) Language Pack for Azure Data Studio",
 	"description": "Language pack extension for Chinese (Simplified)",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"publisher": "Microsoft",
 	"repository": {
 		"type": "git",
@@ -11,7 +11,7 @@
 	"license": "SEE SOURCE EULA LICENSE IN LICENSE.txt",
 	"engines": {
 		"vscode": "^1.34.0",
-		"azdata": ">=1.8.0"
+		"azdata": ">=1.9.0"
 	},
 	"icon": "languagepack.png",
 	"categories": [

--- a/i18n/language-pack-zh-hant/package.json
+++ b/i18n/language-pack-zh-hant/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "zzlp-ads-language-pack-zh-hant",
+	"name": "ads-language-pack-zh-hant",
 	"displayName": "Chinese (Traditional) Language Pack for Azure Data Studio",
 	"description": "Language pack extension for Chinese (Traditional)",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"publisher": "Microsoft",
 	"repository": {
 		"type": "git",
@@ -11,7 +11,7 @@
 	"license": "SEE SOURCE EULA LICENSE IN LICENSE.txt",
 	"engines": {
 		"vscode": "^1.34.0",
-		"azdata": ">=1.8.0"
+		"azdata": ">=1.9.0"
 	},
 	"icon": "languagepack.png",
 	"categories": [


### PR DESCRIPTION
Update lang packs to target 1.9.0 and remove "zz" prefix (which was an unsuccessful attempt to get the lang packs to sort together in the Extension Manager).