### PR TITLE
Made Notebook to update only for difference instead of entire content (reopened)

### DIFF
--- a/src/sql/workbench/parts/notebook/notebookInput.ts
+++ b/src/sql/workbench/parts/notebook/notebookInput.ts
@@ -112,8 +112,7 @@ export class NotebookEditorModel extends EditorModel {
 		let updatedContent = JSON.stringify(notebookModel.toJSON(), undefined, '    ').replace(/\n/g, os.EOL);
 		let existingContent = this.textEditorModel.textEditorModel.getValue();
 
-		let detector: DifferenceDetector = new DifferenceDetector();
-		let diff = detector.getDifference(existingContent, updatedContent);
+		let diff = DifferenceDetector.getDiff(existingContent, updatedContent);
 		if (diff) {
 			this.textEditorModel.textEditorModel.applyEdits([{
 				range: diff.range,
@@ -418,19 +417,13 @@ class DifferenceDetector {
 	private existingContentTail: string;
 	private commonHead: string;
 	private commonTail: string;
-	private textModel: ITextModel;
 
-	private initialize(): void {
-		this.updatedContent = undefined;
-		this.updatedContentTail = undefined;
-		this.existingContent = undefined;
-		this.existingContentTail = undefined;
-		this.commonHead = undefined;
-		this.commonTail = undefined;
+	public static getDiff(existingContent: string, updatedContent: string): { range: Range, text: string } {
+		let instance: DifferenceDetector = new DifferenceDetector();
+		return instance.getDifference(existingContent, updatedContent);
 	}
 
-	public getDifference(existingContent: string, updatedContent: string): { range: Range, text: string } {
-		this.initialize();
+	private getDifference(existingContent: string, updatedContent: string): { range: Range, text: string } {
 		this.existingContent = existingContent;
 		this.updatedContent = updatedContent;
 
@@ -463,8 +456,9 @@ class DifferenceDetector {
 	}
 
 	private getAll(): { range: Range, text: string } {
-		let endLine = this.textModel.getLineCount();
-		let endCol = this.textModel.getLineMaxColumn(endLine);
+		let lineAndColumn = this.getEndLineAndColumnNum(this.existingContent);
+		let endLine = lineAndColumn[0];
+		let endCol = lineAndColumn[1] + 1;
 		return { range: new Range(1, 1, endLine, endCol), text: this.updatedContent };
 	}
 


### PR DESCRIPTION
Currently, Notebook updates entire content of its model when any content change happens.
It updates entire content even when a single line is added to the content.
For example, when running following command (file size =~ 35MB) with Python3 Kernel in Notebook
```
!type C:\Users\gelee\Downloads\controller_log_42.log
```
Notebook keeps updating entire content of model every time output line is appended.
Notebook eventually try to write entire log file text to its model as it reads ending part of the log file.
This blows up ADS with super high memory. (ADS crashed after the memory usage hit 7GB in my case)

New logic only updates for the difference, and resolves https://github.com/microsoft/azuredatastudio/issues/5446

After this fix, ADS is not blown up when running the command, and highest memory usage is about 2GB in my testing.

![demo](https://user-images.githubusercontent.com/19577035/59484964-cc5d1880-8e28-11e9-8ec2-a88cb1c8c108.gif)

