### PR TITLE
Fix Add Azure Account dialog constantly reappearing

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -463,7 +463,6 @@ export class ConnectionWidget {
 		accountDropdownOptions.push(this._addAzureAccountMessage);
 		this._azureAccountDropdown.setOptions(accountDropdownOptions);
 		this._azureAccountDropdown.selectWithOptionName(oldSelection);
-		await this.onAzureAccountSelected();
 	}
 
 	private async updateRefreshCredentialsLink(): Promise<void> {


### PR DESCRIPTION
Fixes #4997 

This call to onAzureAccountSelected was unnecessary - we already have a handler that does this call when the selection changes and having it here caused it to be called immediately after returning from the Add Azure Account prompt when it still had the "Add anAccount..." selected and thus would trigger displaying the prompt again. 