### PR TITLE
Connection dialog cleanup

### DIFF
--- a/src/sql/platform/connection/common/constants.ts
+++ b/src/sql/platform/connection/common/constants.ts
@@ -29,6 +29,5 @@ export const azureMFA = 'AzureMFA';
 
 /* CMS constants */
 export const cmsProviderName = 'MSSQL-CMS';
-export const cmsProviderDisplayName = localize('constants.cmsProviderDisplayName', 'Microsoft SQL Server - CMS');
 
 export const UNSAVED_GROUP_ID = 'unsaved';

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -67,7 +67,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	private _options: IConnectionCompletionOptions;
 	private _inputModel: IConnectionProfile;
 	private _providerNameToDisplayNameMap: { [providerDisplayName: string]: string } = {};
-	private _providerTypes: string[] = [];
+	private _providerDisplayNames: string[] = [];
 	private _currentProviderType: string = Constants.mssqlProviderName;
 	private _connecting: boolean = false;
 	private _connectionErrorTitle = localize('connectionError', 'Connection error');
@@ -100,7 +100,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			this._capabilitiesService.onCapabilitiesRegistered(() => {
 				this.setConnectionProviders();
 				if (this._connectionDialog) {
-					this._connectionDialog.updateConnectionProviders(this._providerTypes, this._providerNameToDisplayNameMap);
+					this._connectionDialog.updateConnectionProviders(this._providerDisplayNames, this._providerNameToDisplayNameMap);
 				}
 			});
 		}
@@ -111,10 +111,10 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	 */
 	private setConnectionProviders() {
 		if (this._capabilitiesService) {
-			this._providerTypes = [];
+			this._providerDisplayNames = [];
 			this._providerNameToDisplayNameMap = {};
 			entries(this._capabilitiesService.providers).forEach(p => {
-				this._providerTypes.push(p[1].connection.displayName);
+				this._providerDisplayNames.push(p[1].connection.displayName);
 				this._providerNameToDisplayNameMap[p[0]] = p[1].connection.displayName;
 			});
 		}
@@ -297,12 +297,12 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	}
 
 	private handleShowUiComponent(input: OnShowUIResponse) {
-		if (input.selectedProviderType) {
+		if (input.selectedProviderDisplayName) {
 			// If the call is for specific providers
 			let isProviderInParams: boolean = false;
 			if (this._params && this._params.providers) {
 				this._params.providers.forEach((provider) => {
-					if (input.selectedProviderType === this._providerNameToDisplayNameMap[provider]) {
+					if (input.selectedProviderDisplayName === this._providerNameToDisplayNameMap[provider]) {
 						isProviderInParams = true;
 						this._currentProviderType = provider;
 					}
@@ -310,7 +310,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			}
 			if (!isProviderInParams) {
 				this._currentProviderType = Object.keys(this._providerNameToDisplayNameMap).find((key) =>
-					this._providerNameToDisplayNameMap[key] === input.selectedProviderType &&
+					this._providerNameToDisplayNameMap[key] === input.selectedProviderDisplayName &&
 					key !== Constants.cmsProviderName
 				);
 			}
@@ -429,7 +429,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 
 	private doShowDialog(params: INewConnectionParams): Promise<void> {
 		if (!this._connectionDialog) {
-			this._connectionDialog = this._instantiationService.createInstance(ConnectionDialogWidget, this._providerTypes, this._providerNameToDisplayNameMap[this._model.providerName], this._providerNameToDisplayNameMap);
+			this._connectionDialog = this._instantiationService.createInstance(ConnectionDialogWidget, this._providerDisplayNames, this._providerNameToDisplayNameMap[this._model.providerName], this._providerNameToDisplayNameMap);
 			this._connectionDialog.onCancel(() => {
 				this._connectionDialog.databaseDropdownExpanded = this.uiController.databaseDropdownExpanded;
 				this.handleOnCancel(this._connectionDialog.newConnectionParams);

--- a/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
@@ -39,7 +39,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 
 export interface OnShowUIResponse {
-	selectedProviderType: string;
+	selectedProviderDisplayName: string;
 	container: HTMLElement;
 }
 
@@ -85,7 +85,7 @@ export class ConnectionDialogWidget extends Modal {
 	private _connecting = false;
 
 	constructor(
-		private providerTypeOptions: string[],
+		private providerDisplayNameOptions: string[],
 		private selectedProviderType: string,
 		private providerNameToDisplayNameMap: { [providerDisplayName: string]: string },
 		@IInstantiationService private _instantiationService: IInstantiationService,
@@ -106,29 +106,29 @@ export class ConnectionDialogWidget extends Modal {
 	 * Update the available connection providers, this is called when new providers are registered
 	 * So that the connection type dropdown always has up to date values
 	 */
-	public updateConnectionProviders(providerTypeOptions: string[],
+	public updateConnectionProviders(
+		providerTypeDisplayNameOptions: string[],
 		providerNameToDisplayNameMap: { [providerDisplayName: string]: string }) {
-		this.providerTypeOptions = providerTypeOptions;
+		this.providerDisplayNameOptions = providerTypeDisplayNameOptions;
 		this.providerNameToDisplayNameMap = providerNameToDisplayNameMap;
 		this.refresh();
 	}
 
 	public refresh(): void {
-		let filteredProviderTypes = this.providerTypeOptions;
+		let filteredProviderDisplayNames = this.providerDisplayNameOptions;
 
 		if (this._newConnectionParams && this._newConnectionParams.providers) {
 			const validProviderNames = Object.keys(this.providerNameToDisplayNameMap).filter(x => this.includeProvider(x, this._newConnectionParams));
 			if (validProviderNames && validProviderNames.length > 0) {
-				filteredProviderTypes = filteredProviderTypes.filter(x => validProviderNames.find(
+				filteredProviderDisplayNames = filteredProviderDisplayNames.filter(x => validProviderNames.find(
 					v => this.providerNameToDisplayNameMap[v] === x) !== undefined
 				);
 			}
-		} else {
-			filteredProviderTypes = filteredProviderTypes.filter(x => x !== Constants.cmsProviderName);
 		}
-		this._providerTypeSelectBox.setOptions(filteredProviderTypes.filter((providerType, index) =>
-			// Remove duplicate listings
-			filteredProviderTypes.indexOf(providerType) === index)
+
+		this._providerTypeSelectBox.setOptions(filteredProviderDisplayNames.filter((providerDisplayName, index) =>
+			// Remove duplicate listings (CMS uses the same display name)
+			filteredProviderDisplayNames.indexOf(providerDisplayName) === index)
 		);
 	}
 
@@ -140,7 +140,7 @@ export class ConnectionDialogWidget extends Modal {
 		this._body = DOM.append(container, DOM.$('.connection-dialog'));
 
 		const connectTypeLabel = localize('connectType', "Connection type");
-		this._providerTypeSelectBox = new SelectBox(this.providerTypeOptions, this.selectedProviderType, this._contextViewService, undefined, { ariaLabel: connectTypeLabel });
+		this._providerTypeSelectBox = new SelectBox(this.providerDisplayNameOptions, this.selectedProviderType, this._contextViewService, undefined, { ariaLabel: connectTypeLabel });
 		// Recent connection tab
 		const recentConnectionTab = DOM.$('.connection-recent-tab');
 		const recentConnectionContainer = DOM.append(recentConnectionTab, DOM.$('.connection-recent', { id: 'recentConnection' }));
@@ -259,10 +259,10 @@ export class ConnectionDialogWidget extends Modal {
 		}));
 	}
 
-	private onProviderTypeSelected(selectedProviderType: string) {
+	private onProviderTypeSelected(selectedProviderDisplayName: string) {
 		// Show connection form based on server type
 		DOM.clearNode(this._connectionUIContainer);
-		this._onShowUiComponent.fire({ selectedProviderType: selectedProviderType, container: this._connectionUIContainer });
+		this._onShowUiComponent.fire({ selectedProviderDisplayName: selectedProviderDisplayName, container: this._connectionUIContainer });
 		this.initDialog();
 	}
 
@@ -445,10 +445,10 @@ export class ConnectionDialogWidget extends Modal {
 		this.refresh();
 	}
 
-	public updateProvider(displayName: string) {
-		this._providerTypeSelectBox.selectWithOptionName(displayName);
+	public updateProvider(providerDisplayName: string) {
+		this._providerTypeSelectBox.selectWithOptionName(providerDisplayName);
 
-		this.onProviderTypeSelected(displayName);
+		this.onProviderTypeSelected(providerDisplayName);
 	}
 
 	public dispose(): void {


### PR DESCRIPTION
1. Updated names to accurately reflect what they contain (provider display names vs the actual provider type). 

2. Removed some code that was filtering out the CMS type - this wasn't working as expected since it was checking the provider type (MSSQL-CMS) but the list contains the display name (Microsoft SQL Server). As CMS is currently handled now what it's doing isn't even necessary - the "duplicate" value of Microsoft SQL Server is removed by the code below it that strips out duplicate values

3. Remove unused cmsProviderDisplayName constant - not only was this unused but it was also inaccurate as the display name is just Microsoft SQL Server as defined in the package.json for the CMS extension. 