### PR TITLE
Fix arith abort default value

### DIFF
--- a/src/sql/workbench/parts/query/browser/query.contribution.ts
+++ b/src/sql/workbench/parts/query/browser/query.contribution.ts
@@ -437,7 +437,7 @@ let registryProperties = {
 	},
 	'mssql.query.arithAbort': {
 		'type': 'boolean',
-		'default': false,
+		'default': true,
 		'description': localize('mssql.query.arithAbort', 'Enable SET ARITHABORT option')
 	},
 	'mssql.query.statisticsTime': {


### PR DESCRIPTION
It looks like SSMS defaults to this option on by default.  We should follow that unless there is a reason not too.