### PR TITLE
Improve notebook link handling

### DIFF
--- a/src/sql/workbench/parts/notebook/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/linkHandler.directive.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Directive, Inject, HostListener, Input } from '@angular/core';
+
+import { URI } from 'vs/base/common/uri';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { onUnexpectedError } from 'vs/base/common/errors';
+import product from 'vs/platform/product/node/product';
+
+const knownSchemes = new Set(['http', 'https', 'file', 'mailto', 'data', `${product.urlProtocol}`, 'azuredatastudio', 'azuredatastudio-insiders', 'vscode', 'vscode-insiders', 'vscode-resource']);
+@Directive({
+	selector: '[link-handler]',
+})
+export class LinkHandlerDirective {
+
+	@Input() isTrusted: boolean;
+	constructor(@Inject(IOpenerService) private readonly openerService: IOpenerService) {
+	}
+
+	@HostListener('click', ['$event'])
+	onclick(event: MouseEvent): void {
+		// Note: this logic is taken from the VSCode handling of links in markdown
+		// Untrusted cells will not support commands or raw HTML tags
+		// Finally, we should consider supporting relative paths - created #5238 to track
+		let target: HTMLElement = event.target as HTMLElement;
+		if (target.tagName !== 'A') {
+			target = target.parentElement;
+			if (!target || target.tagName !== 'A') {
+				return;
+			}
+		}
+		try {
+			const href = target['href'];
+			if (href) {
+				this.handleLink(href);
+			}
+		} catch (err) {
+			onUnexpectedError(err);
+		} finally {
+			event.preventDefault();
+		}
+	}
+
+	private handleLink(content: string): void {
+		let uri: URI | undefined;
+		try {
+			uri = URI.parse(content);
+		} catch {
+			// ignore
+		}
+		if (uri && this.openerService && this.isSupportedLink(uri)) {
+			this.openerService.open(uri).catch(onUnexpectedError);
+		}
+	}
+
+	private isSupportedLink(link: URI): boolean {
+		if (knownSchemes.has(link.scheme)) {
+			return true;
+		}
+		return !!this.isTrusted && link.scheme === 'command';
+	}
+}

--- a/src/sql/workbench/parts/notebook/cellViews/outputArea.component.html
+++ b/src/sql/workbench/parts/notebook/cellViews/outputArea.component.html
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 -->
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
-	<div #outputarea class="notebook-output" style="flex: 0 0 auto;">
+	<div #outputarea link-handler [isTrusted]="isTrusted" class="notebook-output" style="flex: 0 0 auto;">
 		<output-component *ngFor="let output of cellModel.outputs" [cellOutput]="output" [trustedMode] = "cellModel.trustedMode" [cellModel]="cellModel" [activeCellId]="activeCellId">
 		</output-component>
 	</div>

--- a/src/sql/workbench/parts/notebook/cellViews/outputArea.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/outputArea.component.ts
@@ -9,7 +9,6 @@ import { AngularDisposable } from 'sql/base/node/lifecycle';
 import { ICellModel } from 'sql/workbench/parts/notebook/models/modelInterfaces';
 import * as themeColors from 'vs/workbench/common/theme';
 import { IWorkbenchThemeService, IColorTheme } from 'vs/workbench/services/themes/common/workbenchThemeService';
-import { IOpenerService } from 'vs/platform/opener/common/opener';
 
 export const OUTPUT_AREA_SELECTOR: string = 'output-area-component';
 
@@ -25,7 +24,6 @@ export class OutputAreaComponent extends AngularDisposable implements OnInit {
 
 	constructor(
 		@Inject(IWorkbenchThemeService) private themeService: IWorkbenchThemeService,
-		@Inject(IOpenerService) private readonly openerService: IOpenerService,
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef
 	) {
 		super();

--- a/src/sql/workbench/parts/notebook/cellViews/outputArea.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/outputArea.component.ts
@@ -9,6 +9,7 @@ import { AngularDisposable } from 'sql/base/node/lifecycle';
 import { ICellModel } from 'sql/workbench/parts/notebook/models/modelInterfaces';
 import * as themeColors from 'vs/workbench/common/theme';
 import { IWorkbenchThemeService, IColorTheme } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
 
 export const OUTPUT_AREA_SELECTOR: string = 'output-area-component';
 
@@ -24,6 +25,7 @@ export class OutputAreaComponent extends AngularDisposable implements OnInit {
 
 	constructor(
 		@Inject(IWorkbenchThemeService) private themeService: IWorkbenchThemeService,
+		@Inject(IOpenerService) private readonly openerService: IOpenerService,
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef
 	) {
 		super();
@@ -42,6 +44,10 @@ export class OutputAreaComponent extends AngularDisposable implements OnInit {
 				}
 			}));
 		}
+	}
+
+	public get isTrusted(): boolean {
+		return this.cellModel.trustedMode;
 	}
 
 	private setFocusAndScroll(node: HTMLElement): void {

--- a/src/sql/workbench/parts/notebook/cellViews/textCell.component.html
+++ b/src/sql/workbench/parts/notebook/cellViews/textCell.component.html
@@ -10,7 +10,7 @@
 		</code-component>
 	</div>
 	<div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: row">
-		<div #preview class ="notebook-preview" style="flex: 1 1 auto" (dblclick)="toggleEditMode()">
+		<div #preview link-handler [isTrusted]="isTrusted" class="notebook-preview" style="flex: 1 1 auto" (dblclick)="toggleEditMode()">
 		</div>
 		<div #moreactions class="moreActions" style="flex: 0 0 auto; display: flex; flex-flow:column;width: 20px; min-height: 20px; max-height: 20px; padding-top: 0px; orientation: portrait">
 		</div>

--- a/src/sql/workbench/parts/notebook/notebook.module.ts
+++ b/src/sql/workbench/parts/notebook/notebook.module.ts
@@ -13,7 +13,6 @@ import { IBootstrapParams, ISelector, providerIterator } from 'sql/platform/boot
 import { CommonServiceInterface } from 'sql/platform/bootstrap/node/commonServiceInterface.service';
 import { EditableDropDown } from 'sql/platform/electron-browser/editableDropdown/editableDropdown.component';
 import { NotebookComponent } from 'sql/workbench/parts/notebook/notebook.component';
-
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { CodeComponent } from 'sql/workbench/parts/notebook/cellViews/code.component';
 import { CodeCellComponent } from 'sql/workbench/parts/notebook/cellViews/codeCell.component';
@@ -26,6 +25,7 @@ import LoadingSpinner from 'sql/workbench/electron-browser/modelComponents/loadi
 import { Checkbox } from 'sql/base/electron-browser/ui/checkbox/checkbox.component';
 import { SelectBox } from 'sql/platform/ui/electron-browser/selectBox/selectBox.component';
 import { InputBox } from 'sql/base/electron-browser/ui/inputBox/inputBox.component';
+import { LinkHandlerDirective } from 'sql/workbench/parts/notebook/cellViews/linkHandler.directive';
 
 export const NotebookModule = (params, selector: string, instantiationService: IInstantiationService): any => {
 	@NgModule({
@@ -43,7 +43,8 @@ export const NotebookModule = (params, selector: string, instantiationService: I
 			ComponentHostDirective,
 			OutputAreaComponent,
 			OutputComponent,
-			StdInComponent
+			StdInComponent,
+			LinkHandlerDirective
 		],
 		entryComponents: [NotebookComponent],
 		imports: [

--- a/src/sql/workbench/parts/notebook/notebookStyles.ts
+++ b/src/sql/workbench/parts/notebook/notebookStyles.ts
@@ -178,7 +178,7 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean): IDi
 		const linkForeground = theme.getColor(textLinkForeground);
 		if (linkForeground) {
 			collector.addRule(`
-			.notebookEditor a:link {
+			.notebookEditor a {
 				color: ${linkForeground};
 			}
 			`);


### PR DESCRIPTION
- Single click now works for links inside Output areas
- Command links in untrusted notebooks have link color
- Refactored to use directive so code is in 1 place and can be easily
  added elsewhere if needed