### PR TITLE
extension recommendation on application launch

### DIFF
--- a/product.json
+++ b/product.json
@@ -53,6 +53,10 @@
 		"Redgate.sql-search",
 		"IDERA.sqldm-performance-insights"
 	],
+	"recommendedExtensionsOnAppLaunch": [
+		"Microsoft.admin-pack",
+		"msrvida.azdata-sanddance"
+	],
 	"extensionsGallery": {
 		"serviceUrl": "https://sqlopsextensions.blob.core.windows.net/marketplace/v1/extensionsGallery.json"
 	}

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -304,6 +304,9 @@ export interface IExtensionTipsService {
 	toggleIgnoredRecommendation(extensionId: string, shouldIgnore: boolean): void;
 	getAllIgnoredRecommendations(): { global: string[], workspace: string[] };
 	onRecommendationChange: Event<RecommendationChangeNotification>;
+
+	// {{SQL CARBON EDIT}}
+	getAppLaunchRecommendations(): Promise<IExtensionRecommendation[]>;
 }
 
 export const enum ExtensionRecommendationReason {

--- a/src/vs/platform/product/node/product.ts
+++ b/src/vs/platform/product/node/product.ts
@@ -37,6 +37,7 @@ export interface IProductConfiguration {
 	extensionTips: { [id: string]: string; };
 	// {{SQL CARBON EDIT}}
 	recommendedExtensions: string[];
+	recommendedExtensionsOnAppLaunch: string[];
 	extensionImportantTips: { [id: string]: { name: string; pattern: string; }; };
 	exeBasedExtensionTips: { [id: string]: { friendlyName: string, windowsPath?: string, recommendations: string[] }; };
 	extensionKeywords: { [extension: string]: string[]; };

--- a/src/vs/workbench/browser/web.simpleservices.ts
+++ b/src/vs/workbench/browser/web.simpleservices.ts
@@ -417,6 +417,12 @@ export class SimpleExtensionTipsService implements IExtensionTipsService {
 	getAllIgnoredRecommendations(): { global: string[]; workspace: string[]; } {
 		return Object.create(null);
 	}
+
+	// {{SQL CARBON EDIT}}
+	getAppLaunchRecommendations(): Promise<IExtensionRecommendation[]> {
+		return Promise.resolve([]);
+	}
+	// End of {{SQL CARBON EDIT}}
 }
 
 registerSingleton(IExtensionTipsService, SimpleExtensionTipsService, true);

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionTipsService.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionTipsService.ts
@@ -11,14 +11,14 @@ import { match } from 'vs/base/common/glob';
 import * as json from 'vs/base/common/json';
 import {
 	IExtensionManagementService, IExtensionGalleryService, IExtensionTipsService, ExtensionRecommendationReason, EXTENSION_IDENTIFIER_PATTERN,
-	IExtensionsConfigContent, RecommendationChangeNotification, IExtensionRecommendation, ExtensionRecommendationSource, InstallOperation
+	IExtensionsConfigContent, RecommendationChangeNotification, IExtensionRecommendation, ExtensionRecommendationSource, InstallOperation, ILocalExtension
 } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { ITextModel } from 'vs/editor/common/model';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import product from 'vs/platform/product/node/product';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { ShowRecommendedExtensionsAction, InstallWorkspaceRecommendedExtensionsAction, InstallRecommendedExtensionAction } from 'vs/workbench/contrib/extensions/electron-browser/extensionsActions';
+import { ShowRecommendedExtensionsAction, InstallWorkspaceRecommendedExtensionsAction, InstallRecommendedExtensionAction, ShowAppLaunchRecommendedExtensionsAction, InstallAppLaunchRecommendedExtensionsAction } from 'vs/workbench/contrib/extensions/electron-browser/extensionsActions';
 import Severity from 'vs/base/common/severity';
 import { IWorkspaceContextService, IWorkspaceFolder, IWorkspace, IWorkspaceFoldersChangeEvent, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { IFileService } from 'vs/platform/files/common/files';
@@ -169,6 +169,9 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 				}
 			}
 		}));
+
+		// {{SQL CARBON EDIT}} Extension Recommendation on ADS Launch
+		this.promptADSLaunchRecommendedExtensions();
 	}
 
 	private isEnabled(): boolean {
@@ -1041,4 +1044,93 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 	dispose() {
 		this._disposables = dispose(this._disposables);
 	}
+
+	// {{SQL CARBON EDIT}}
+	private promptADSLaunchRecommendedExtensions() {
+		const storageKey = 'extensionsAssistant/AppLaunchRecommendationsIgnore';
+
+		if (this.storageService.getBoolean(storageKey, StorageScope.GLOBAL, false)) {
+			return;
+		}
+
+		let recommendations: IExtensionRecommendation[];
+		let localExtensions: ILocalExtension[];
+		const getRecommendationPromise = this.getAppLaunchRecommendations().then(recs => { recommendations = recs; });
+		const getLocalExtensionPromise = this.extensionsService.getInstalled(ExtensionType.User).then(local => { localExtensions = local; });
+		Promise.all([getRecommendationPromise, getLocalExtensionPromise]).then(() => {
+			if (!recommendations.every(rec => { return localExtensions.findIndex(local => local.identifier.id.toLocaleLowerCase() === rec.extensionId.toLocaleLowerCase()) !== -1; })) {
+				return new Promise<void>(c => {
+					this.notificationService.prompt(
+						Severity.Info,
+						localize('AppLaunchRecommended', "Azure Data Studio has extension recommendations."),
+						[{
+							label: localize('installAll', "Install All"),
+							run: () => {
+								/* __GDPR__
+								"extensionAppLaunchRecommendations:popup" : {
+									"userReaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+								}
+								*/
+								this.telemetryService.publicLog('extensionAppLaunchRecommendations:popup', { userReaction: 'install' });
+								const installAllAction = this.instantiationService.createInstance(InstallAppLaunchRecommendedExtensionsAction, InstallAppLaunchRecommendedExtensionsAction.ID, localize('installAll', "Install All"), recommendations);
+								installAllAction.run();
+								installAllAction.dispose();
+								c(undefined);
+							}
+						}, {
+							label: localize('showRecommendations', "Show Recommendations"),
+							run: () => {
+								/* __GDPR__
+									"extensionAppLaunchRecommendations:popup" : {
+										"userReaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+									}
+								*/
+								this.telemetryService.publicLog('extensionAppLaunchRecommendations:popup', { userReaction: 'show' });
+
+								const showAction = this.instantiationService.createInstance(ShowAppLaunchRecommendedExtensionsAction, ShowAppLaunchRecommendedExtensionsAction.ID, localize('showRecommendations', "Show Recommendations"));
+								showAction.run();
+								showAction.dispose();
+								c(undefined);
+							}
+						}, {
+							label: choiceNever,
+							isSecondary: true,
+							run: () => {
+								/* __GDPR__
+									"extensionAppLaunchRecommendations:popup" : {
+										"userReaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+									}
+								*/
+								this.telemetryService.publicLog('extensionAppLaunchRecommendations:popup', { userReaction: 'neverShowAgain' });
+								this.storageService.store(storageKey, true, StorageScope.GLOBAL);
+								c(undefined);
+							}
+						}],
+						{
+							sticky: true,
+							onCancel: () => {
+								/* __GDPR__
+									"extensionAppLaunchRecommendations:popup" : {
+										"userReaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+									}
+								*/
+								this.telemetryService.publicLog('extensionAppLaunchRecommendations:popup', { userReaction: 'cancelled' });
+								c(undefined);
+							}
+						}
+					);
+				});
+			} else {
+				return Promise.resolve();
+			}
+		});
+	}
+
+	getAppLaunchRecommendations(): Promise<IExtensionRecommendation[]> {
+		return Promise.resolve((product.recommendedExtensionsOnAppLaunch || [])
+			.filter(extensionId => this.isExtensionAllowedToBeRecommended(extensionId))
+			.map(extensionId => (<IExtensionRecommendation>{ extensionId, sources: ['application'] })));
+	}
+
+	// End of {{SQL CARBON EDIT}}
 }

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionsViews.ts
@@ -414,6 +414,12 @@ export class ExtensionsListView extends ViewletPanel {
 			options.sortBy = SortBy.InstallCount;
 		}
 
+		// {{SQL CARBON EDIT}}
+		if (/@recommendedOnAppLaunch/i.test(query.value)) {
+			return this.getAppLaunchRecommendations(token);
+		}
+		// End of {{SQL CARBON EDIT}}
+
 		if (ExtensionsListView.isWorkspaceRecommendedExtensionsQuery(query.value)) {
 			return this.getWorkspaceRecommendationsModel(query, options, token);
 		} else if (ExtensionsListView.isKeymapsRecommendedExtensionsQuery(query.value)) {
@@ -657,6 +663,28 @@ export class ExtensionsListView extends ViewletPanel {
 				});
 			});
 	}
+
+	// {{SQL CARBON EDIT}}
+	private getAppLaunchRecommendations(token: CancellationToken): Promise<IPagedModel<IExtension>> {
+		return this.extensionsWorkbenchService.queryLocal()
+			.then(result => result.filter(e => e.type === ExtensionType.User))
+			.then(local => {
+				return this.tipsService.getAppLaunchRecommendations().then((recommmended) => {
+					const installedExtensions = local.map(x => `${x.publisher}.${x.name}`);
+					return this.extensionsWorkbenchService.queryGallery(token).then((pager) => {
+						// filter out installed extensions and the extensions not in the recommended list
+						pager.firstPage = pager.firstPage.filter((p) => {
+							const extensionId = `${p.publisher}.${p.name}`;
+							return installedExtensions.indexOf(extensionId) === -1 && recommmended.findIndex(ext => ext.extensionId === extensionId) !== -1;
+						});
+						pager.total = pager.firstPage.length;
+						pager.pageSize = pager.firstPage.length;
+						return this.getPagedModel(pager);
+					});
+				});
+			});
+	}
+	// End of {{SQL CARBON EDIT}}
 
 	// Given all recommendations, trims and returns recommendations in the relevant order after filtering out installed extensions
 	private getTrimmedRecommendations(installedExtensions: IExtension[], value: string, fileBasedRecommendations: IExtensionRecommendation[], otherRecommendations: IExtensionRecommendation[], workpsaceRecommendations: IExtensionRecommendation[]): string[] {


### PR DESCRIPTION
implement the first extension recommendation when ADS launches.

In our original review, we decided to only add admin-pack for this scenario, but the new project going on is asking to add sanddance also to the recommendation list.

here is how it looks, you can Install All, Show recommendations, never show again...

![image](https://user-images.githubusercontent.com/13777222/59788654-0bec9000-9281-11e9-8aa6-58878b3ad5a9.png)

![image](https://user-images.githubusercontent.com/13777222/59788677-1575f800-9281-11e9-8809-f7691457ff7b.png)
