### PR TITLE
Notebooks: Fix for standard in component losing focus when hovering over code cell

### DIFF
--- a/src/sql/workbench/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/code.component.ts
@@ -232,7 +232,7 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 		}));
 		this._register(this.model.layoutChanged(() => this._layoutEmitter.fire(), this));
 		this._register(this.cellModel.onExecutionStateChange(event => {
-			if (event === CellExecutionState.Running) {
+			if (event === CellExecutionState.Running && !this.cellModel.stdInVisible) {
 				this.setFocusAndScroll();
 			}
 		}));

--- a/src/sql/workbench/parts/notebook/cellViews/codeCell.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/codeCell.component.ts
@@ -81,6 +81,7 @@ export class CodeCellComponent extends CellView implements OnInit, OnChanges {
 		if (msg) {
 			this.stdIn = msg;
 			this.inputDeferred = new Deferred();
+			this.cellModel.stdInVisible = true;
 			this._changeRef.detectChanges();
 			return this.awaitStdIn();
 		}
@@ -97,11 +98,12 @@ export class CodeCellComponent extends CellView implements OnInit, OnChanges {
 			// Clean up so no matter what, the stdIn request goes away
 			this.stdIn = undefined;
 			this.inputDeferred = undefined;
+			this.cellModel.stdInVisible = false;
 			this._changeRef.detectChanges();
 		}
 	}
 
 	get isStdInVisible(): boolean {
-		return !!(this.stdIn && this.inputDeferred);
+		return this.cellModel.stdInVisible;
 	}
 }

--- a/src/sql/workbench/parts/notebook/models/cell.ts
+++ b/src/sql/workbench/parts/notebook/models/cell.ts
@@ -42,6 +42,7 @@ export class CellModel implements ICellModel {
 	private _stdInHandler: nb.MessageHandler<nb.IStdinMessage>;
 	private _onCellLoaded = new Emitter<string>();
 	private _loaded: boolean;
+	private _stdInVisible: boolean;
 
 	constructor(cellData: nb.ICellContents,
 		private _options: ICellModelOptions,
@@ -56,6 +57,7 @@ export class CellModel implements ICellModel {
 			this._source = '';
 		}
 		this._isEditMode = this._cellType !== CellTypes.Markdown;
+		this._stdInVisible = false;
 		if (_options && _options.isTrusted) {
 			this._isTrusted = true;
 		} else {
@@ -198,6 +200,14 @@ export class CellModel implements ICellModel {
 		if (val) {
 			this._onCellLoaded.fire(this._cellType);
 		}
+	}
+
+	public get stdInVisible(): boolean {
+		return this._stdInVisible;
+	}
+
+	public set stdInVisible(val: boolean) {
+		this._stdInVisible = val;
 	}
 
 	private notifyExecutionComplete(): void {

--- a/src/sql/workbench/parts/notebook/models/modelInterfaces.ts
+++ b/src/sql/workbench/parts/notebook/models/modelInterfaces.ts
@@ -467,6 +467,7 @@ export interface ICellModel {
 	equals(cellModel: ICellModel): boolean;
 	toJSON(): nb.ICellContents;
 	loaded: boolean;
+	stdInVisible: boolean;
 	readonly onLoaded: Event<string>;
 }
 


### PR DESCRIPTION
Fixes #6106. We've gotten a bunch of feedback over the past day especially that this behavior could be improved and is confusing.

We were always calling setFocusAndScroll() on a hover of a code cell component, which meant that the input box would lose focus if a user moved their mouse inside the active code cell. With this change, users can move their mouse freely, and the input box won't lose focus. 