### PR TITLE
fix for: https://github.com/microsoft/azuredatastudio/issues/6110

### DIFF
--- a/test/smoke/src/areas/editor/editors.ts
+++ b/test/smoke/src/areas/editor/editors.ts
@@ -24,7 +24,7 @@ export class Editors {
 
 	async waitForActiveEditor(filename: string): Promise<any> {
 		const selector = `.editor-instance .monaco-editor[data-uri$="${filename}"] textarea`;
-		return this.code.waitForActiveElement(selector);
+		return this.code.waitForActiveElement(selector, /*retry count*/ 300);
 	}
 
 	async waitForEditorFocus(fileName: string, untitled: boolean = false): Promise<void> {

--- a/test/smoke/src/sql/queryEditor/queryEditors.ts
+++ b/test/smoke/src/sql/queryEditor/queryEditors.ts
@@ -38,7 +38,7 @@ export class QueryEditors extends Editors {
 	 */
 	async waitForActiveTab(fileName: string, isDirty: boolean = false): Promise<void> {
 		// For now assume all opened tabs are disconnected until we have a need to open connected tabs
-		await this.vsCode.waitForElement(`.tabs-container div.tab.active${isDirty ? '.dirty' : ''}[aria-selected="true"][aria-label="${fileName} - disconnected, tab"]`);
+		await this.vsCode.waitForElement(`.tabs-container div.tab.active${isDirty ? '.dirty' : ''}[aria-selected="true"][aria-label="${fileName} - disconnected, tab"]`,/* accept function */ result => !!result,  /*retry count*/ 300);
 	}
 
 


### PR DESCRIPTION
The QueryEditor smoke tests were timing out in lab and my dev box (but not on Alex Ren's dev box) when opening a file and waiting for it to gain focus. Increasing number of retries, which increases the amount of time the test waits for the tab to become Active tab to improve reliability of execution across environments.