### PR TITLE
add --help documentation

### DIFF
--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -96,12 +96,12 @@ export const options: Option[] = [
 	{ id: 'trace-options', type: 'string' },
 	{ id: 'prof-code-loading', type: 'boolean' },
 	// {{SQL CARBON EDIT}}
-	{ id: 'database', type: 'string', alias: 'D' },
-	{ id: 'server', type: 'string', alias: 'S' },
-	{ id: 'user', type: 'string', alias: 'U' },
-	{ id: 'command', type: 'string', alias: 'c' },
-	{ id: 'aad', type: 'boolean' },
-	{ id: 'integrated', type: 'boolean', alias: 'E' },
+	{ id: 'command', type: 'string', alias: 'c', cat: 'o', args: 'command name', description: localize('commandParameter', 'Name of command to run') },
+	{ id: 'database', type: 'string', alias: 'D', cat: 'o', args: 'database', description: localize('databaseParameter', 'Database name') },
+	{ id: 'server', type: 'string', alias: 'S', cat: 'o', args: 'server', description: localize('serverParameter', 'Server name') },
+	{ id: 'user', type: 'string', alias: 'U', cat: 'o', args: 'user name', description: localize('userParameter', 'User name for server connection') },
+	{ id: 'aad', type: 'boolean', cat: 'o', description: localize('aadParameter', 'Use Azure Active Directory authentication for server connection') },
+	{ id: 'integrated', type: 'boolean', alias: 'E', cat: 'o', description: localize('integratedAuthParameter', 'Use Integrated authentication for server connection') },
 	// {{SQL CARBON EDIT}} - End
 	{ id: '_', type: 'string' }
 ];

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -96,10 +96,10 @@ export const options: Option[] = [
 	{ id: 'trace-options', type: 'string' },
 	{ id: 'prof-code-loading', type: 'boolean' },
 	// {{SQL CARBON EDIT}}
-	{ id: 'command', type: 'string', alias: 'c', cat: 'o', args: 'command name', description: localize('commandParameter', 'Name of command to run') },
+	{ id: 'command', type: 'string', alias: 'c', cat: 'o', args: 'command-name', description: localize('commandParameter', 'Name of command to run') },
 	{ id: 'database', type: 'string', alias: 'D', cat: 'o', args: 'database', description: localize('databaseParameter', 'Database name') },
 	{ id: 'server', type: 'string', alias: 'S', cat: 'o', args: 'server', description: localize('serverParameter', 'Server name') },
-	{ id: 'user', type: 'string', alias: 'U', cat: 'o', args: 'user name', description: localize('userParameter', 'User name for server connection') },
+	{ id: 'user', type: 'string', alias: 'U', cat: 'o', args: 'user-name', description: localize('userParameter', 'User name for server connection') },
 	{ id: 'aad', type: 'boolean', cat: 'o', description: localize('aadParameter', 'Use Azure Active Directory authentication for server connection') },
 	{ id: 'integrated', type: 'boolean', alias: 'E', cat: 'o', description: localize('integratedAuthParameter', 'Use Integrated authentication for server connection') },
 	// {{SQL CARBON EDIT}} - End


### PR DESCRIPTION
This change adds entries to --help for the new command line switches for invoking a command and for connecting to a server. 
For #3059 
They go into the Options group. 
I reordered the list slightly so the server connection parameters are clumped together and command sits above them.