### PR TITLE
Check null ref in get connection

### DIFF
--- a/src/sql/workbench/api/node/extHostConnectionManagement.ts
+++ b/src/sql/workbench/api/node/extHostConnectionManagement.ts
@@ -21,7 +21,9 @@ export class ExtHostConnectionManagement extends ExtHostConnectionManagementShap
 	public $getCurrentConnection(): Thenable<azdata.connection.ConnectionProfile> {
 		let connection: any = this._proxy.$getCurrentConnection();
 		connection.then((conn) => {
-			conn.providerId = conn.providerName;
+			if (conn) {
+				conn.providerId = conn.providerName;
+			}
 		});
 		return connection;
 	}


### PR DESCRIPTION
This doesn't seem to fail anything but creates an error log in schema compare tests with mock data and in console if called out of context.