### PR TITLE
Fix #5809: Data-tier wizard "Source Server" shouldn't show database name

### DIFF
--- a/extensions/dacpac/src/wizard/api/basePage.ts
+++ b/extensions/dacpac/src/wizard/api/basePage.ts
@@ -67,19 +67,14 @@ export abstract class BasePage {
 				}
 			}
 
-			let db = c.options.databaseDisplayName;
 			let usr = c.options.user;
 			let srv = c.options.server;
-
-			if (!db) {
-				db = localize('basePage.defaultDb', '<default>');
-			}
 
 			if (!usr) {
 				usr = localize('basePage.defaultUser', 'default');
 			}
 
-			let finalName = `${srv}, ${db} (${usr})`;
+			let finalName = `${srv} (${usr})`;
 			return {
 				connection: c,
 				displayName: finalName,

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -96,9 +96,7 @@ export abstract class DacFxConfigPage extends BasePage {
 	}
 
 	protected async createDatabaseDropdown(): Promise<azdata.FormComponent> {
-		this.databaseDropdown = this.view.modelBuilder.dropDown().withProperties({
-			required: true
-		}).component();
+		this.databaseDropdown = this.view.modelBuilder.dropDown().component();
 
 		// Handle database changes
 		this.databaseDropdown.onValueChanged(async () => {
@@ -107,7 +105,9 @@ export abstract class DacFxConfigPage extends BasePage {
 			this.model.filePath = this.fileTextBox.value;
 		});
 
-		this.databaseLoader = this.view.modelBuilder.loadingComponent().withItem(this.databaseDropdown).component();
+		this.databaseLoader = this.view.modelBuilder.loadingComponent().withItem(this.databaseDropdown).withProperties({
+			required: true
+		}).component();
 
 		return {
 			component: this.databaseLoader,

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -157,14 +157,17 @@ export class DeployConfigPage extends DacFxConfigPage {
 	}
 
 	protected async createDeployDatabaseDropdown(): Promise<azdata.FormComponent> {
-		this.databaseDropdown = this.view.modelBuilder.dropDown().withProperties({
-			required: true
-		}).component();
+		this.databaseDropdown = this.view.modelBuilder.dropDown().component();
+
 		//Handle database changes
 		this.databaseDropdown.onValueChanged(async () => {
 			this.model.database = (<azdata.CategoryValue>this.databaseDropdown.value).name;
 		});
-		this.databaseLoader = this.view.modelBuilder.loadingComponent().withItem(this.databaseDropdown).component();
+
+		this.databaseLoader = this.view.modelBuilder.loadingComponent().withItem(this.databaseDropdown).withProperties({
+			required: true
+		}).component();
+
 		return {
 			component: this.databaseLoader,
 			title: localize('dacFx.targetDatabaseDropdownTitle', 'Database Name')

--- a/extensions/import/src/wizard/api/basePage.ts
+++ b/extensions/import/src/wizard/api/basePage.ts
@@ -64,19 +64,14 @@ export abstract class BasePage {
 				}
 			}
 
-			let db = c.options.databaseDisplayName;
 			let usr = c.options.user;
 			let srv = c.options.server;
-
-			if (!db) {
-				db = '<default>';
-			}
 
 			if (!usr) {
 				usr = 'default';
 			}
 
-			let finalName = `${srv}, ${db} (${usr})`;
+			let finalName = `${srv} (${usr})`;
 			return {
 				connection: c,
 				displayName: finalName,


### PR DESCRIPTION
Fixes #5809. Removes database name from server dropdowns and adds the required asterisk to the database dropdown titles.

![image](https://user-images.githubusercontent.com/31145923/59938791-d83d7180-940a-11e9-9e16-fa45cc5e4208.png)
