### PR TITLE
Fix Dacfx filepaths getting regenerated ever time page is entered

### DIFF
--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -125,9 +125,13 @@ export abstract class DacFxConfigPage extends BasePage {
 		}
 
 		let values = await this.getDatabaseValues();
-		this.model.database = values[0].name;
-		this.model.filePath = this.generateFilePathFromDatabaseAndTimestamp();
-		this.fileTextBox.value = this.model.filePath;
+
+		// only update values and regenerate filepath if this is the first time and database isn't set yet
+		if (this.model.database !== values[0].name) {
+			this.model.database = values[0].name;
+			this.model.filePath = this.generateFilePathFromDatabaseAndTimestamp();
+			this.fileTextBox.value = this.model.filePath;
+		}
 
 		this.databaseDropdown.updateProperties({
 			values: values


### PR DESCRIPTION
This fixes dacpac filepath for extract and bacpac filepath for export getting regenerated every time the config pages are entered instead of remembering if filepath if it was manually changed.

Fixes #5834. 