### PR TITLE
Filter templates by supported engine type

### DIFF
--- a/extensions/profiler/client/src/dialogs/profilerCreateSessionDialog.ts
+++ b/extensions/profiler/client/src/dialogs/profilerCreateSessionDialog.ts
@@ -116,6 +116,10 @@ export class CreateSessionDialog {
 		let name = this.sessionNameBox.value;
 		let selected = this.templatesBox.value.toString();
 		let temp = this.model.selectTemplate(selected);
-		profilerService.createSession(this.model.ownerUri, this.sessionNameBox.value, temp);
+		profilerService.createSession(this.model.ownerUri, this.sessionNameBox.value, temp).then(() => {
+		}, (error) => {
+			const message = error && error.message ? error.message : localize('createSessionDialog.createSessionFailed', "Failed to create a session");
+			vscode.window.showErrorMessage(message);
+		});
 	}
 }

--- a/src/sql/workbench/parts/profiler/browser/profiler.contribution.ts
+++ b/src/sql/workbench/parts/profiler/browser/profiler.contribution.ts
@@ -12,7 +12,7 @@ import * as nls from 'vs/nls';
 
 import { ProfilerInput } from 'sql/workbench/parts/profiler/browser/profilerInput';
 import { ProfilerEditor } from 'sql/workbench/parts/profiler/browser/profilerEditor';
-import { PROFILER_VIEW_TEMPLATE_SETTINGS, PROFILER_SESSION_TEMPLATE_SETTINGS, IProfilerViewTemplate, IProfilerSessionTemplate } from 'sql/workbench/services/profiler/common/interfaces';
+import { PROFILER_VIEW_TEMPLATE_SETTINGS, PROFILER_SESSION_TEMPLATE_SETTINGS, IProfilerViewTemplate, IProfilerSessionTemplate, EngineType } from 'sql/workbench/services/profiler/common/interfaces';
 
 const profilerDescriptor = new EditorDescriptor(
 	ProfilerEditor,
@@ -239,6 +239,7 @@ const profilerSessionTemplateSchema: IJSONSchema = {
 		{
 			name: 'Standard_OnPrem',
 			defaultView: 'Standard View',
+			engineTypes: [EngineType.Standalone],
 			createStatement:
 				`CREATE EVENT SESSION [{sessionName}] ON SERVER
 					ADD EVENT sqlserver.attention(
@@ -264,6 +265,7 @@ const profilerSessionTemplateSchema: IJSONSchema = {
 		},
 		{
 			name: 'Standard_Azure',
+			engineTypes: [EngineType.SQLDB],
 			defaultView: 'Standard View',
 			createStatement:
 				`CREATE EVENT SESSION [{sessionName}] ON DATABASE
@@ -290,6 +292,7 @@ const profilerSessionTemplateSchema: IJSONSchema = {
 		},
 		{
 			name: 'TSQL_OnPrem',
+			engineTypes: [EngineType.Standalone],
 			defaultView: 'TSQL View',
 			createStatement:
 				`CREATE EVENT SESSION [{sessionName}] ON SERVER

--- a/src/sql/workbench/parts/profiler/browser/profiler.contribution.ts
+++ b/src/sql/workbench/parts/profiler/browser/profiler.contribution.ts
@@ -265,7 +265,7 @@ const profilerSessionTemplateSchema: IJSONSchema = {
 		},
 		{
 			name: 'Standard_Azure',
-			engineTypes: [EngineType.SQLDB],
+			engineTypes: [EngineType.AzureSQLDB],
 			defaultView: 'Standard View',
 			createStatement:
 				`CREATE EVENT SESSION [{sessionName}] ON DATABASE

--- a/src/sql/workbench/services/profiler/common/interfaces.ts
+++ b/src/sql/workbench/services/profiler/common/interfaces.ts
@@ -148,7 +148,7 @@ export interface IProfilerViewTemplate {
 }
 
 export enum EngineType {
-	SQLDB = 'SQLDB',
+	AzureSQLDB = 'AzureSQLDB',
 	Standalone = 'Standalone'
 }
 

--- a/src/sql/workbench/services/profiler/common/interfaces.ts
+++ b/src/sql/workbench/services/profiler/common/interfaces.ts
@@ -147,8 +147,14 @@ export interface IProfilerViewTemplate {
 	columns: Array<IColumnViewTemplate>;
 }
 
+export enum EngineType {
+	SQLDB = 'SQLDB',
+	Standalone = 'Standalone'
+}
+
 export interface IProfilerSessionTemplate {
 	name: string;
+	engineTypes?: EngineType[];
 	defaultView: string;
 	createStatement: string;
 }

--- a/src/sql/workbench/services/profiler/common/profilerService.ts
+++ b/src/sql/workbench/services/profiler/common/profilerService.ts
@@ -229,9 +229,9 @@ export class ProfilerService implements IProfilerService {
 		const serverInfo = this._connectionService.getConnectionInfo(input.id).serverInfo;
 		let templates = this.getSessionTemplates();
 		if (serverInfo) {
-			const engineType = serverInfo.isCloud ? EngineType.SQLDB : EngineType.Standalone;
+			const engineType = serverInfo.isCloud ? EngineType.AzureSQLDB : EngineType.Standalone;
 			// only use the templates that matches the following criteria:
-			// 1. the template doesn't have any engine types specified - for backward compatibility (user with custom templates) or the templates applicable to both SQLDB and standalone server
+			// 1. the template doesn't have any engine types specified - for backward compatibility (user with custom templates) or the templates applicable to both AzureSQLDB and standalone server
 			// 2. the template supports the current engine type
 			templates = templates.filter(template => !template.engineTypes || template.engineTypes.length === 0 || template.engineTypes.includes(engineType));
 		}

--- a/src/sql/workbench/services/profiler/common/profilerService.ts
+++ b/src/sql/workbench/services/profiler/common/profilerService.ts
@@ -6,7 +6,7 @@
 import { IConnectionManagementService, IConnectionCompletionOptions, ConnectionType, RunQueryOnConnectionMode } from 'sql/platform/connection/common/connectionManagement';
 import {
 	ProfilerSessionID, IProfilerSession, IProfilerService, IProfilerViewTemplate, IProfilerSessionTemplate,
-	PROFILER_SETTINGS, IProfilerSettings
+	PROFILER_SETTINGS, IProfilerSettings, EngineType
 } from './interfaces';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { ProfilerInput } from 'sql/workbench/parts/profiler/browser/profilerInput';
@@ -225,8 +225,17 @@ export class ProfilerService implements IProfilerService {
 		return Promise.resolve(null);
 	}
 
-	public launchCreateSessionDialog(input?: ProfilerInput): Thenable<void> {
-		return this._commandService.executeCommand('profiler.openCreateSessionDialog', input.id, input.providerType, this.getSessionTemplates());
+	public launchCreateSessionDialog(input: ProfilerInput): Thenable<void> {
+		const serverInfo = this._connectionService.getConnectionInfo(input.id).serverInfo;
+		let templates = this.getSessionTemplates();
+		if (serverInfo) {
+			const engineType = serverInfo.isCloud ? EngineType.SQLDB : EngineType.Standalone;
+			// only use the templates that matches the following criteria:
+			// 1. the template doesn't have any engine types specified - for backward compatibility (user with custom templates) or the templates applicable to both SQLDB and standalone server
+			// 2. the template supports the current engine type
+			templates = templates.filter(template => !template.engineTypes || template.engineTypes.length === 0 || template.engineTypes.includes(engineType));
+		}
+		return this._commandService.executeCommand('profiler.openCreateSessionDialog', input.id, input.providerType, templates);
 	}
 
 	public launchFilterSessionDialog(input: ProfilerInput): void {


### PR DESCRIPTION
fix for issue #5304 
1. filter the profiler session templates by supported engine types
2. handle the error case in profiler extension when calling the provider directly so that the user can see it in case of error instead of waiting forever.

create session against standalone server:
![image](https://user-images.githubusercontent.com/13777222/59960246-9d732200-947a-11e9-845f-1df957722da5.png)

create session against SQLDB server:
![image](https://user-images.githubusercontent.com/13777222/59960254-c398c200-947a-11e9-9c37-9d41c81067e2.png)
