### PR TITLE
handle copy in all profiler tables

### DIFF
--- a/src/sql/workbench/parts/profiler/browser/profilerCopyHandler.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerCopyHandler.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as os from 'os';
+import { IClipboardService } from 'sql/platform/clipboard/common/clipboardService';
+
+export function HandleCopyRequest(clipboardService: IClipboardService, range: Slick.Range, getCellValue: (row, cell) => string): void {
+	if (range) {
+		let results = '';
+		for (let i = range.fromRow; i <= range.toRow; i++) {
+			for (let j = range.fromCell; j <= range.toCell; j++) {
+				let value = getCellValue(i, j);
+				if (j !== range.toCell) {
+					value += '\t';
+				}
+				results += value;
+			}
+
+			if (i !== range.toRow) {
+				results += os.EOL;
+			}
+		}
+		clipboardService.writeText(results);
+	}
+}

--- a/src/sql/workbench/parts/profiler/browser/profilerCopyHandler.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerCopyHandler.ts
@@ -5,7 +5,7 @@
 import * as os from 'os';
 import { IClipboardService } from 'sql/platform/clipboard/common/clipboardService';
 
-export function HandleCopyRequest(clipboardService: IClipboardService, range: Slick.Range, getCellValue: (row, cell) => string): void {
+export function handleCopyRequest(clipboardService: IClipboardService, range: Slick.Range, getCellValue: (row, cell) => string): void {
 	if (range) {
 		let results = '';
 		for (let i = range.fromRow; i <= range.toRow; i++) {

--- a/src/sql/workbench/parts/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerEditor.ts
@@ -49,7 +49,7 @@ import { clamp } from 'vs/base/common/numbers';
 import { CopyKeybind } from 'sql/base/browser/ui/table/plugins/copyKeybind.plugin';
 import { IClipboardService } from 'sql/platform/clipboard/common/clipboardService';
 import { CellSelectionModel } from 'sql/base/browser/ui/table/plugins/cellSelectionModel.plugin';
-import { HandleCopyRequest } from 'sql/workbench/parts/profiler/browser/profilerCopyHandler';
+import { handleCopyRequest } from 'sql/workbench/parts/profiler/browser/profilerCopyHandler';
 
 class BasicView implements IView {
 	public get element(): HTMLElement {
@@ -384,7 +384,7 @@ export class ProfilerEditor extends BaseEditor {
 		detailTableCopyKeybind.onCopy((ranges: Slick.Range[]) => {
 			// we always only get 1 item in the ranges
 			if (ranges && ranges.length === 1) {
-				HandleCopyRequest(this._clipboardService, ranges[0], (row, cell) => {
+				handleCopyRequest(this._clipboardService, ranges[0], (row, cell) => {
 					const item = this._detailTableData.getItem(row);
 					// only 2 columns in this table
 					return cell === 0 ? item.label : item.value;

--- a/src/sql/workbench/parts/profiler/browser/profilerTableEditor.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerTableEditor.ts
@@ -31,7 +31,7 @@ import { IStatusbarService, StatusbarAlignment } from 'vs/platform/statusbar/com
 import { localize } from 'vs/nls';
 import { CopyKeybind } from 'sql/base/browser/ui/table/plugins/copyKeybind.plugin';
 import { IClipboardService } from 'sql/platform/clipboard/common/clipboardService';
-import { HandleCopyRequest } from 'sql/workbench/parts/profiler/browser/profilerCopyHandler';
+import { handleCopyRequest } from 'sql/workbench/parts/profiler/browser/profilerCopyHandler';
 
 export interface ProfilerTableViewState {
 	scrollTop: number;
@@ -98,7 +98,7 @@ export class ProfilerTableEditor extends BaseEditor implements IProfilerControll
 			// in context of this table, the selection mode is row selection, copy the whole row will get a lot of unwanted data
 			// ignore the passed in range and create a range so that it only copies the currently selected cell value.
 			const activeCell = this._profilerTable.activeCell;
-			HandleCopyRequest(this._clipboardService, new Slick.Range(activeCell.row, activeCell.cell), (row, cell) => {
+			handleCopyRequest(this._clipboardService, new Slick.Range(activeCell.row, activeCell.cell), (row, cell) => {
 				const fieldName = this._input.columns[cell].field;
 				return this._input.data.getItem(row)[fieldName];
 			});


### PR DESCRIPTION
#5667

there are 2 tables in profiler, adding copy support for both of them.