### PR TITLE
add db name to xevent session and view

### DIFF
--- a/src/sql/workbench/parts/profiler/browser/profiler.contribution.ts
+++ b/src/sql/workbench/parts/profiler/browser/profiler.contribution.ts
@@ -86,6 +86,14 @@ const profilerViewTemplateSchema: IJSONSchema = {
 				{
 					name: 'Duration',
 					eventsMapped: ['duration']
+				},
+				{
+					name: 'DatabaseID',
+					eventsMapped: ['database_id']
+				},
+				{
+					name: 'DatabaseName',
+					eventsMapped: ['database_name']
 				}
 			]
 		},
@@ -107,6 +115,14 @@ const profilerViewTemplateSchema: IJSONSchema = {
 				{
 					name: 'StartTime',
 					eventsMapped: ['timestamp']
+				},
+				{
+					name: 'DatabaseID',
+					eventsMapped: ['database_id']
+				},
+				{
+					name: 'DatabaseName',
+					eventsMapped: ['database_name']
 				}
 			]
 		},
@@ -197,6 +213,14 @@ const profilerViewTemplateSchema: IJSONSchema = {
 				{
 					name: 'Duration',
 					eventsMapped: ['duration']
+				},
+				{
+					name: 'DatabaseID',
+					eventsMapped: ['database_id']
+				},
+				{
+					name: 'DatabaseName',
+					eventsMapped: ['database_name']
 				}
 			]
 		},
@@ -218,6 +242,14 @@ const profilerViewTemplateSchema: IJSONSchema = {
 				{
 					name: 'SPID',
 					eventsMapped: ['session_id']
+				},
+				{
+					name: 'DatabaseID',
+					eventsMapped: ['database_id']
+				},
+				{
+					name: 'DatabaseName',
+					eventsMapped: ['database_name']
 				}
 			]
 		}
@@ -251,13 +283,13 @@ const profilerSessionTemplateSchema: IJSONSchema = {
 					ADD EVENT sqlserver.logout(
 						ACTION(package0.event_sequence,sqlserver.client_app_name,sqlserver.client_pid,sqlserver.nt_username,sqlserver.server_principal_name,sqlserver.session_id)),
 					ADD EVENT sqlserver.rpc_completed(
-						ACTION(package0.event_sequence,sqlserver.client_app_name,sqlserver.client_pid,sqlserver.database_id,sqlserver.nt_username,sqlserver.query_hash,sqlserver.server_principal_name,sqlserver.session_id)
+						ACTION(package0.event_sequence,sqlserver.client_app_name,sqlserver.client_pid,sqlserver.database_id,sqlserver.database_name,sqlserver.nt_username,sqlserver.query_hash,sqlserver.server_principal_name,sqlserver.session_id)
 						WHERE ([package0].[equal_boolean]([sqlserver].[is_system],(0)))),
 					ADD EVENT sqlserver.sql_batch_completed(
-						ACTION(package0.event_sequence,sqlserver.client_app_name,sqlserver.client_pid,sqlserver.database_id,sqlserver.nt_username,sqlserver.query_hash,sqlserver.server_principal_name,sqlserver.session_id)
+						ACTION(package0.event_sequence,sqlserver.client_app_name,sqlserver.client_pid,sqlserver.database_id,sqlserver.database_name,sqlserver.nt_username,sqlserver.query_hash,sqlserver.server_principal_name,sqlserver.session_id)
 						WHERE ([package0].[equal_boolean]([sqlserver].[is_system],(0)))),
 					ADD EVENT sqlserver.sql_batch_starting(
-						ACTION(package0.event_sequence,sqlserver.client_app_name,sqlserver.client_pid,sqlserver.database_id,sqlserver.nt_username,sqlserver.query_hash,sqlserver.server_principal_name,sqlserver.session_id)
+						ACTION(package0.event_sequence,sqlserver.client_app_name,sqlserver.client_pid,sqlserver.database_id,sqlserver.database_name,sqlserver.nt_username,sqlserver.query_hash,sqlserver.server_principal_name,sqlserver.session_id)
 						WHERE ([package0].[equal_boolean]([sqlserver].[is_system],(0))))
 					ADD TARGET package0.ring_buffer(SET max_events_limit=(1000),max_memory=(51200))
 					WITH (MAX_MEMORY=8192 KB,EVENT_RETENTION_MODE=ALLOW_SINGLE_EVENT_LOSS,MAX_DISPATCH_LATENCY=5 SECONDS,MAX_EVENT_SIZE=0 KB,MEMORY_PARTITION_MODE=PER_CPU,TRACK_CAUSALITY=ON,STARTUP_STATE=OFF)`
@@ -300,10 +332,10 @@ const profilerSessionTemplateSchema: IJSONSchema = {
 					ADD EVENT sqlserver.logout(
 						ACTION(package0.event_sequence,sqlserver.session_id)),
 					ADD EVENT sqlserver.rpc_starting(
-						ACTION(package0.event_sequence,sqlserver.session_id,sqlserver.database_name)
+						ACTION(package0.event_sequence,sqlserver.session_id,sqlserver.database_id,sqlserver.database_name)
 						WHERE ([package0].[equal_boolean]([sqlserver].[is_system],(0)))),
 					ADD EVENT sqlserver.sql_batch_starting(
-						ACTION(package0.event_sequence,sqlserver.session_id,sqlserver.database_name)
+						ACTION(package0.event_sequence,sqlserver.session_id,sqlserver.database_id,sqlserver.database_name)
 						WHERE ([package0].[equal_boolean]([sqlserver].[is_system],(0))))
 					ADD TARGET package0.ring_buffer(SET max_events_limit=(1000),max_memory=(51200))
 					WITH (MAX_MEMORY=8192 KB,EVENT_RETENTION_MODE=ALLOW_SINGLE_EVENT_LOSS,MAX_DISPATCH_LATENCY=5 SECONDS,MAX_EVENT_SIZE=0 KB,MEMORY_PARTITION_MODE=PER_CPU,TRACK_CAUSALITY=ON,STARTUP_STATE=OFF)`


### PR DESCRIPTION
#5932 

add database name and database id fields to the applicable events and also add database id and database name columns to the views. with these changes, users will be able to filter the events by database name