### PR TITLE
Only set notebookEditor <a> color in scrollable portion

### DIFF
--- a/src/sql/workbench/parts/notebook/notebookStyles.ts
+++ b/src/sql/workbench/parts/notebook/notebookStyles.ts
@@ -178,7 +178,7 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean): IDi
 		const linkForeground = theme.getColor(textLinkForeground);
 		if (linkForeground) {
 			collector.addRule(`
-			.notebookEditor a {
+			.notebookEditor .scrollable a {
 				color: ${linkForeground};
 			}
 			`);


### PR DESCRIPTION
Problem: we were setting the notebook toolbar labels as blue with a recent css change.

Fixes #6139, as the notebook toolbar is in a different div than the scrollable portion of the notebook.

After change:
![image](https://user-images.githubusercontent.com/40371649/59983659-39b23b80-95d7-11e9-93b2-45117231fed0.png)
