### PR TITLE
Fix Data Explorer context menus

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -165,12 +165,12 @@
 				},
 				{
 					"command": "azure.resource.refresh",
-					"when": "viewItem =~ /^azure\\.resource\\.itemType\\.(?:account|subscription|databaseContainer|databaseServerContainer)$/",
+					"when": "viewItem =~ /^azure\\.resource\\.itemType\\.(?:account|subscription|databaseContainer|serverContainer)$/",
 					"group": "inline"
 				},
 				{
 					"command": "azure.resource.connectsqlserver",
-					"when": "viewItem == azure.resource.itemType.databaseServer",
+					"when": "viewItem == azure.resource.itemType.server",
 					"group": "inline"
 				},
 				{

--- a/extensions/azurecore/src/azureResource/constants.ts
+++ b/extensions/azurecore/src/azureResource/constants.ts
@@ -11,7 +11,7 @@ export enum AzureResourceItemType {
 	databaseContainer = 'azure.resource.itemType.databaseContainer',
 	database = 'azure.resource.itemType.database',
 	databaseServerContainer = 'azure.resource.itemType.databaseServerContainer',
-	databaseServer = 'azure.resource.itemType.databaseServer',
+	databaseServer = 'azure.resource.itemType.server',
 	message = 'azure.resource.itemType.message'
 }
 

--- a/extensions/azurecore/src/azureResource/constants.ts
+++ b/extensions/azurecore/src/azureResource/constants.ts
@@ -10,8 +10,8 @@ export enum AzureResourceItemType {
 	subscription = 'azure.resource.itemType.subscription',
 	databaseContainer = 'azure.resource.itemType.databaseContainer',
 	database = 'azure.resource.itemType.database',
-	databaseServerContainer = 'azure.resource.itemType.databaseServerContainer',
-	databaseServer = 'azure.resource.itemType.server',
+	serverContainer = 'azure.resource.itemType.serverContainer',
+	server = 'azure.resource.itemType.server',
 	message = 'azure.resource.itemType.message'
 }
 

--- a/extensions/azurecore/src/azureResource/providers/database/databaseTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/database/databaseTreeDataProvider.ts
@@ -72,7 +72,8 @@ export class AzureResourceDatabaseTreeDataProvider implements azureResource.IAzu
 					saveProfile: false,
 					options: {}
 				},
-				childProvider: 'MSSQL'
+				childProvider: 'MSSQL',
+				isDatabase: true
 			}
 		});
 	}

--- a/extensions/azurecore/src/azureResource/providers/databaseServer/commands.ts
+++ b/extensions/azurecore/src/azureResource/providers/databaseServer/commands.ts
@@ -21,7 +21,7 @@ export function registerAzureResourceDatabaseServerCommands(appContext: AppConte
 		}
 
 		const treeItem = await node.getTreeItem();
-		if (treeItem.contextValue !== AzureResourceItemType.databaseServer) {
+		if (treeItem.contextValue !== AzureResourceItemType.server) {
 			return;
 		}
 

--- a/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
@@ -56,7 +56,7 @@ export class AzureResourceDatabaseServerTreeDataProvider implements azureResourc
 					light: this._extensionContext.asAbsolutePath('resources/light/sql_server.svg')
 				},
 				collapsibleState: TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseServer,
+				contextValue: AzureResourceItemType.server,
 				payload: {
 					id: generateGuid(),
 					connectionName: undefined,
@@ -91,7 +91,7 @@ export class AzureResourceDatabaseServerTreeDataProvider implements azureResourc
 					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')
 				},
 				collapsibleState: TreeItemCollapsibleState.Collapsed,
-				contextValue: AzureResourceItemType.databaseServerContainer
+				contextValue: AzureResourceItemType.serverContainer
 			}
 		};
 	}

--- a/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
@@ -72,7 +72,8 @@ export class AzureResourceDatabaseServerTreeDataProvider implements azureResourc
 					saveProfile: false,
 					options: {}
 				},
-				childProvider: 'MSSQL'
+				childProvider: 'MSSQL',
+				isServer: true
 			}
 		});
 	}

--- a/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
@@ -143,7 +143,7 @@ describe('AzureResourceDatabaseServerTreeDataProvider.getChildren', function ():
 			should(child.treeItem.id).equal(`databaseServer_${databaseServer.name}`);
 			should(child.treeItem.label).equal(databaseServer.name);
 			should(child.treeItem.collapsibleState).equal(vscode.TreeItemCollapsibleState.Collapsed);
-			should(child.treeItem.contextValue).equal(AzureResourceItemType.databaseServer);
+			should(child.treeItem.contextValue).equal(AzureResourceItemType.server);
 		}
 	});
 });

--- a/extensions/cms/src/cmsResource/constants.ts
+++ b/extensions/cms/src/cmsResource/constants.ts
@@ -9,6 +9,6 @@ export enum CmsResourceItemType {
 	cmsMessageNodeContainer = 'cms.resource.itemType.cmsMessageNodeContainer',
 	cmsEmptyNodeContainer = 'cms.resource.itemType.cmsEmptyNodeContainer',
 	cmsNodeContainer = 'cms.resource.itemType.databaseServerContainer',
-	registeredServer = 'cms.resource.itemType.databaseServer',
+	registeredServer = 'cms.resource.itemType.server',
 	serverGroup = 'cms.resource.itemType.serverGroup'
 }

--- a/extensions/cms/src/cmsResource/constants.ts
+++ b/extensions/cms/src/cmsResource/constants.ts
@@ -8,7 +8,7 @@
 export enum CmsResourceItemType {
 	cmsMessageNodeContainer = 'cms.resource.itemType.cmsMessageNodeContainer',
 	cmsEmptyNodeContainer = 'cms.resource.itemType.cmsEmptyNodeContainer',
-	cmsNodeContainer = 'cms.resource.itemType.databaseServerContainer',
+	cmsNodeContainer = 'cms.resource.itemType.serverContainer',
 	registeredServer = 'cms.resource.itemType.server',
 	serverGroup = 'cms.resource.itemType.serverGroup'
 }

--- a/extensions/cms/src/cmsResource/tree/cmsResourceTreeNode.ts
+++ b/extensions/cms/src/cmsResource/tree/cmsResourceTreeNode.ts
@@ -91,6 +91,7 @@ export class CmsResourceTreeNode extends CmsResourceTreeNodeBase {
 		item.contextValue = CmsResourceItemType.cmsNodeContainer;
 		item.id = this._id;
 		item.tooltip = this.description;
+		item.isServer = true;
 		item.iconPath = {
 			dark: this.appContext.extensionContext.asAbsolutePath('resources/light/centralmanagement_server.svg'),
 			light: this.appContext.extensionContext.asAbsolutePath('resources/light/centralmanagement_server.svg')

--- a/extensions/cms/src/cmsResource/tree/registeredServerTreeNode.ts
+++ b/extensions/cms/src/cmsResource/tree/registeredServerTreeNode.ts
@@ -58,7 +58,8 @@ export class RegisteredServerTreeNode extends CmsResourceTreeNodeBase {
 			iconPath: {
 				dark: this.appContext.extensionContext.asAbsolutePath('resources/light/regserverserver.svg'),
 				light: this.appContext.extensionContext.asAbsolutePath('resources/light/regserverserver.svg')
-			}
+			},
+			isServer: true
 		};
 
 		return treeItem;

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -2612,6 +2612,8 @@ declare module 'azdata' {
 	export class TreeItem extends vscode.TreeItem {
 		payload?: IConnectionProfile;
 		childProvider?: string;
+		isServer?: boolean;
+		isDatabase?: boolean;
 	}
 
 	export namespace tasks {

--- a/src/sql/workbench/common/views.ts
+++ b/src/sql/workbench/common/views.ts
@@ -22,6 +22,8 @@ export interface ITreeItem extends vsITreeItem {
 	childProvider?: string;
 	payload?: IConnectionProfile; // its possible we will want this to be more generic
 	sqlIcon?: string;
+	isServer?: boolean;
+	isDatabase?: boolean;
 }
 
 export interface ITreeView extends vsITreeView {

--- a/src/sql/workbench/parts/dataExplorer/common/nodeContext.ts
+++ b/src/sql/workbench/parts/dataExplorer/common/nodeContext.ts
@@ -9,6 +9,7 @@ import { ITreeItem } from 'sql/workbench/common/views';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IQueryManagementService } from 'sql/platform/query/common/queryManagement';
+import { NodeType } from 'sql/workbench/parts/objectExplorer/common/nodeType';
 
 export interface INodeContextValue {
 	node: ITreeItem;
@@ -22,6 +23,9 @@ export class NodeContextKey extends Disposable implements IContextKey<INodeConte
 	static ViewId = new RawContextKey<string>('view', undefined);
 	static ViewItem = new RawContextKey<string>('viewItem', undefined);
 	static Node = new RawContextKey<INodeContextValue>('node', undefined);
+	static IsServer = new RawContextKey<boolean>('isServer', false);
+	static IsDatabase = new RawContextKey<boolean>('isDatabase', false);
+	static NodeType = new RawContextKey<NodeType>('nodeType', undefined);
 
 	private readonly _connectionContextKey: ConnectionContextKey;
 	private readonly _connectableKey: IContextKey<boolean>;
@@ -29,6 +33,9 @@ export class NodeContextKey extends Disposable implements IContextKey<INodeConte
 	private readonly _viewIdKey: IContextKey<string>;
 	private readonly _viewItemKey: IContextKey<string>;
 	private readonly _nodeContextKey: IContextKey<INodeContextValue>;
+	private readonly _serverKey: IContextKey<boolean>;
+	private readonly _databaseKey: IContextKey<boolean>;
+	private readonly _nodeTypeKey: IContextKey<NodeType>;
 
 	constructor(
 		@IContextKeyService contextKeyService: IContextKeyService,
@@ -42,11 +49,14 @@ export class NodeContextKey extends Disposable implements IContextKey<INodeConte
 		this._viewIdKey = NodeContextKey.ViewId.bindTo(contextKeyService);
 		this._viewItemKey = NodeContextKey.ViewItem.bindTo(contextKeyService);
 		this._nodeContextKey = NodeContextKey.Node.bindTo(contextKeyService);
+		this._serverKey = NodeContextKey.IsServer.bindTo(contextKeyService);
+		this._databaseKey = NodeContextKey.IsDatabase.bindTo(contextKeyService);
 		this._connectionContextKey = new ConnectionContextKey(contextKeyService, queryManagementService);
 	}
 
 	set(value: INodeContextValue) {
-		if (value.node && value.node.payload) {
+		if (this.isConnectableNode(value)) {
+			// Show default connection context menu actions for servers and databases
 			this._connectableKey.set(true);
 			this._connectedKey.set(this.oeService.isNodeConnected(value.viewId, value.node));
 			this._connectionContextKey.set(value.node.payload);
@@ -59,6 +69,14 @@ export class NodeContextKey extends Disposable implements IContextKey<INodeConte
 			this._viewItemKey.set(value.node.contextValue);
 		} else {
 			this._viewItemKey.reset();
+		}
+		if (value.node.isDatabase) {
+			this._databaseKey.set(true);
+			this._serverKey.set(false);
+		}
+		if (value.node.isServer) {
+			this._serverKey.set(true);
+			this._databaseKey.set(false);
 		}
 		this._nodeContextKey.set(value);
 		this._viewIdKey.set(value.viewId);
@@ -75,5 +93,14 @@ export class NodeContextKey extends Disposable implements IContextKey<INodeConte
 
 	get(): INodeContextValue | undefined {
 		return this._nodeContextKey.get();
+	}
+
+	private isConnectableNode(nodeContextValue: INodeContextValue): boolean {
+		if (nodeContextValue.node) {
+			return ((nodeContextValue.node.isDatabase) ||
+				(nodeContextValue.node.isServer) ||
+				(nodeContextValue.node.contextValue === NodeType.Database));
+		}
+		return false;
 	}
 }

--- a/src/sql/workbench/parts/dataExplorer/common/nodeContext.ts
+++ b/src/sql/workbench/parts/dataExplorer/common/nodeContext.ts
@@ -25,7 +25,6 @@ export class NodeContextKey extends Disposable implements IContextKey<INodeConte
 	static Node = new RawContextKey<INodeContextValue>('node', undefined);
 	static IsServer = new RawContextKey<boolean>('isServer', false);
 	static IsDatabase = new RawContextKey<boolean>('isDatabase', false);
-	static NodeType = new RawContextKey<NodeType>('nodeType', undefined);
 
 	private readonly _connectionContextKey: ConnectionContextKey;
 	private readonly _connectableKey: IContextKey<boolean>;
@@ -35,7 +34,6 @@ export class NodeContextKey extends Disposable implements IContextKey<INodeConte
 	private readonly _nodeContextKey: IContextKey<INodeContextValue>;
 	private readonly _serverKey: IContextKey<boolean>;
 	private readonly _databaseKey: IContextKey<boolean>;
-	private readonly _nodeTypeKey: IContextKey<NodeType>;
 
 	constructor(
 		@IContextKeyService contextKeyService: IContextKeyService,

--- a/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
+++ b/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
@@ -6,7 +6,6 @@
 import { localize } from 'vs/nls';
 import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { DISCONNECT_COMMAND_ID, MANAGE_COMMAND_ID, NEW_QUERY_COMMAND_ID, REFRESH_COMMAND_ID } from './nodeCommands';
-import { ContextKeyExpr, ContextKeyRegexExpr } from 'vs/platform/contextkey/common/contextkey';
 import { NodeContextKey } from 'sql/workbench/parts/dataExplorer/common/nodeContext';
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
@@ -19,10 +18,6 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	when: NodeContextKey.IsConnected
 });
 
-// The weird regex is because we want this to generically apply to Database and Server nodes but right now
-// there isn't a consistent standard for the values there. We can't just search for database or server being
-// in the string at all because there's lots of node types which have those values (such as ServerLevelLogin)
-// that we don't want these menu items showing up on.
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: 'connection',
 	order: 2,
@@ -30,13 +25,9 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		id: NEW_QUERY_COMMAND_ID,
 		title: localize('newQuery', 'New Query')
 	},
-	when: ContextKeyExpr.and(
-		NodeContextKey.IsConnectable,
-		new ContextKeyRegexExpr('viewItem', /.+itemType\.database.*|^database$/i))
+	when: NodeContextKey.IsConnectable
 });
 
-// Note that we don't show this for Databases under Server nodes (viewItem == Database) because
-// of an issue there where the connection always being master instead of the actual DB
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: 'connection',
 	order: 1,
@@ -44,9 +35,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		id: MANAGE_COMMAND_ID,
 		title: localize('manage', 'Manage')
 	},
-	when: ContextKeyExpr.and(
-		NodeContextKey.IsConnectable,
-		new ContextKeyRegexExpr('viewItem', /.+itemType\.database.*/i))
+	when: NodeContextKey.IsConnectable
 });
 
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {

--- a/src/sql/workbench/parts/objectExplorer/common/objectExplorerViewTreeShim.ts
+++ b/src/sql/workbench/parts/objectExplorer/common/objectExplorerViewTreeShim.ts
@@ -158,26 +158,14 @@ export class OEShimService extends Disposable implements IOEShimService {
 		icon = icon.toLowerCase();
 		// Change the database if the node has a different database
 		// than its parent
-		let updatedPayload: IConnectionProfile = undefined;
+		let databaseChanged = false;
+		let updatedPayload: IConnectionProfile | any = {};
 		if (node.nodeTypeId === NodeType.Database) {
 			const database = node.getDatabaseName();
 			if (database) {
-				updatedPayload = {
-					connectionName: parentNode.payload.connectionName,
-					serverName: parentNode.payload.serverName,
-					databaseName: node.getDatabaseName(),
-					userName: parentNode.payload.userName,
-					password: parentNode.payload.password,
-					authenticationType: parentNode.payload.authenticationType,
-					savePassword: parentNode.payload.savePassword,
-					groupFullName: parentNode.payload.groupFullName,
-					groupId: parentNode.payload.groupId,
-					providerName: parentNode.payload.providerName,
-					saveProfile: false,
-					id: parentNode.payload.id,
-					azureTenantId: parentNode.payload.azureTenantId,
-					options: parentNode.payload.options
-				};
+				databaseChanged = true;
+				updatedPayload = Object.assign(updatedPayload, parentNode.payload);
+				updatedPayload.databaseName = node.getDatabaseName();
 			}
 		}
 		let newTreeItem: ITreeItem = {
@@ -189,7 +177,7 @@ export class OEShimService extends Disposable implements IOEShimService {
 			},
 			childProvider: node.childProvider || parentNode.childProvider,
 			providerHandle: parentNode.childProvider,
-			payload: node.payload || (updatedPayload ? updatedPayload : parentNode.payload),
+			payload: node.payload || (databaseChanged ? updatedPayload : parentNode.payload),
 			contextValue: node.nodeTypeId,
 			sqlIcon: icon
 		};

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -483,7 +483,9 @@ export class ExtHostTreeView<T> extends Disposable {
 			collapsibleState: isUndefinedOrNull(extensionTreeItem.collapsibleState) ? TreeItemCollapsibleState.None : extensionTreeItem.collapsibleState,
 			// {{SQL CARBON EDIT}}
 			payload: extensionTreeItem.payload,
-			childProvider: extensionTreeItem.childProvider
+			childProvider: extensionTreeItem.childProvider,
+			isServer: extensionTreeItem.isServer,
+			isDatabase: extensionTreeItem.isDatabase
 		};
 
 		return item;


### PR DESCRIPTION
This PR fixes a bunch of issues -
1. Fixes https://github.com/microsoft/azuredatastudio/issues/5850.
2. Data Explorer now shows the same context actions for Servers and Databases (Manage and New Query) with the correct database. 
3. Fixed bug where using context menu action on a database node under a server node would always connect to master.
4. Remove regex logic for node context