### PR TITLE
Notebooks: Add Command + Keyboard Shortcut to Clear Outputs of Active Cell

### DIFF
--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -392,24 +392,19 @@ class NotebookTester {
 
 	async verifyClearOutputs(notebook: azdata.nb.NotebookEditor): Promise<void> {
 		let cellWithOutputs = notebook.document.cells[0].contents && notebook.document.cells[0].contents.outputs && notebook.document.cells[0].contents.outputs.length > 0;
-		assert(cellWithOutputs === true, 'First notebook cell has no outputs');
-		console.log('Before clearing cell outputs');
+		assert(cellWithOutputs === true, 'Expected first cell to have outputs');
 		let clearedOutputs = await notebook.clearOutput(notebook.document.cells[0]);
 		let firstCell = notebook.document.cells[0];
 		assert(firstCell.contents && firstCell.contents.outputs && firstCell.contents.outputs.length === 0, `Expected Output: 0, Actual: '${firstCell.contents.outputs.length}'`);
 		assert(clearedOutputs, 'Outputs of requested code cell should be cleared');
-		console.log('After clearing cell outputs');
 	}
 
 	async cellLanguageTest(content: azdata.nb.INotebookContents, testName: string, languageConfigured: string, metadataInfo: any) {
 		let notebookJson = Object.assign({}, content, { metadata: metadataInfo });
 		let uri = writeNotebookToFile(notebookJson, testName);
-		console.log('Notebook uri ' + uri);
 		let notebook = await azdata.nb.showNotebookDocument(uri);
-		console.log('Notebook is opened');
 		await notebook.document.save();
 		let languageInNotebook = notebook.document.cells[0].contents.metadata.language;
-		console.log('Language set in cell: ' + languageInNotebook);
 		assert(languageInNotebook === languageConfigured, `Expected cell language is: ${languageConfigured}, Actual: ${languageInNotebook}`);
 	}
 }

--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -36,6 +36,10 @@ if (context.RunTest) {
 			await (new NotebookTester()).sqlNbMultipleCellsTest(this.test.title);
 		});
 
+		test('Clear cell output - SQL notebook', async function () {
+			await (new NotebookTester()).sqlNbClearOutputs(this.test.title);
+		});
+
 		test('Clear all outputs - SQL notebook ', async function () {
 			await (new NotebookTester()).sqlNbClearAllOutputs(this.test.title);
 		});
@@ -131,6 +135,11 @@ class NotebookTester {
 	async sqlNbClearAllOutputs(title: string): Promise<void> {
 		let notebook = await this.openNotebook(sqlNotebookContent, sqlKernelMetadata, title + this.invocationCount++);
 		await this.verifyClearAllOutputs(notebook);
+	}
+
+	async sqlNbClearOutputs(title: string): Promise<void> {
+		let notebook = await this.openNotebook(sqlNotebookContent, sqlKernelMetadata, title + this.invocationCount++);
+		await this.verifyClearOutputs(notebook);
 	}
 
 	@stressify({ dop: NotebookTester.ParallelCount })
@@ -380,6 +389,18 @@ class NotebookTester {
 		assert(clearedOutputs, 'Outputs of all the code cells from Python notebook should be cleared');
 		console.log('After clearing cell outputs');
 	}
+
+	async verifyClearOutputs(notebook: azdata.nb.NotebookEditor): Promise<void> {
+		let cellWithOutputs = notebook.document.cells[0].contents && notebook.document.cells[0].contents.outputs && notebook.document.cells[0].contents.outputs.length > 0;
+		assert(cellWithOutputs === true, 'First notebook cell has no outputs');
+		console.log('Before clearing cell outputs');
+		let clearedOutputs = await notebook.clearOutput(notebook.document.cells[0]);
+		let firstCell = notebook.document.cells[0];
+		assert(firstCell.contents && firstCell.contents.outputs && firstCell.contents.outputs.length === 0, `Expected Output: 0, Actual: '${firstCell.contents.outputs.length}'`);
+		assert(clearedOutputs, 'Outputs of requested code cell should be cleared');
+		console.log('After clearing cell outputs');
+	}
+
 	async cellLanguageTest(content: azdata.nb.INotebookContents, testName: string, languageConfigured: string, metadataInfo: any) {
 		let notebookJson = Object.assign({}, content, { metadata: metadataInfo });
 		let uri = writeNotebookToFile(notebookJson, testName);

--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -66,6 +66,10 @@
 				"icon": "resources/dark/touchbar_run_cell.png"
 			},
 			{
+				"command": "notebook.command.clearactivecellresult",
+				"title": "%notebook.command.clearactivecellresult%"
+			},
+			{
 				"command": "notebook.command.runallcells",
 				"title": "%notebook.command.runallcells%"
 			},
@@ -156,6 +160,10 @@
 					"when": "notebookEditorVisible"
 				},
 				{
+					"command": "notebook.command.clearactivecellresult",
+					"when": "notebookEditorVisible"
+				},
+				{
 					"command": "notebook.command.runallcells",
 					"when": "notebookEditorVisible"
 				},
@@ -232,6 +240,11 @@
 			{
 				"command": "notebook.command.runactivecell",
 				"key": "F5",
+				"when": "activeEditor == workbench.editor.notebookEditor"
+			},
+			{
+				"command": "notebook.command.clearactivecellresult",
+				"key": "Ctrl+Shift+R",
 				"when": "activeEditor == workbench.editor.notebookEditor"
 			},
 			{

--- a/extensions/notebook/package.nls.json
+++ b/extensions/notebook/package.nls.json
@@ -10,6 +10,7 @@
 	"notebook.command.open": "Open Notebook",
 	"notebook.analyzeJupyterNotebook": "Analyze in Notebook",
 	"notebook.command.runactivecell": "Run Cell",
+	"notebook.command.clearactivecellresult": "Clear Cell Result",
 	"notebook.command.runallcells": "Run Cells",
 	"notebook.command.addcode": "Add Code Cell",
 	"notebook.command.addtext": "Add Text Cell",

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -42,6 +42,9 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.runallcells', () => {
 		runAllCells();
 	}));
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.clearactivecellresult', () => {
+		clearActiveCellOutput();
+	}));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.addcell', async () => {
 		let cellType: CellType;
 		try {
@@ -144,6 +147,19 @@ async function runActiveCell(): Promise<void> {
 		let notebook = azdata.nb.activeNotebookEditor;
 		if (notebook) {
 			await notebook.runCell();
+		} else {
+			throw new Error(noNotebookVisible);
+		}
+	} catch (err) {
+		vscode.window.showErrorMessage(getErrorMessage(err));
+	}
+}
+
+async function clearActiveCellOutput(): Promise<void> {
+	try {
+		let notebook = azdata.nb.activeNotebookEditor;
+		if (notebook) {
+			await notebook.clearOutput();
 		} else {
 			throw new Error(noNotebookVisible);
 		}

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -4402,7 +4402,7 @@ declare module 'azdata' {
 			runAllCells(): Thenable<boolean>;
 
 			/**
-			 * Clears the outputs of the actice code cell in a notebook.
+			 * Clears the outputs of the active code cell in a notebook.
 			 */
 			clearOutput(cell?: NotebookCell): Thenable<boolean>;
 

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -4401,6 +4401,11 @@ declare module 'azdata' {
 			 */
 			runAllCells(): Thenable<boolean>;
 
+			/**
+			 * Clears the outputs of the actice code cell in a notebook.
+			 */
+			clearOutput(cell?: NotebookCell): Thenable<boolean>;
+
 			/** Clears the outputs of all code cells in a Notebook
 			* @return A promise that resolves with a value indicating if the outputs are cleared or not.
 			*/

--- a/src/sql/workbench/api/node/extHostNotebookEditor.ts
+++ b/src/sql/workbench/api/node/extHostNotebookEditor.ts
@@ -159,6 +159,11 @@ export class ExtHostNotebookEditor implements azdata.nb.NotebookEditor, IDisposa
 		return this._proxy.$runAllCells(this._id);
 	}
 
+	public clearOutput(cell: azdata.nb.NotebookCell): Thenable<boolean> {
+		let uri = cell ? cell.uri : undefined;
+		return this._proxy.$clearOutput(this._id, uri);
+	}
+
 	public clearAllOutputs(): Thenable<boolean> {
 		return this._proxy.$clearAllOutputs(this._id);
 	}

--- a/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
@@ -407,7 +407,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 			cell = editor.model.activeCell;
 		}
 		if (!cell || (cell && cell.cellType !== CellTypes.Code)) {
-			return Promise.reject(new Error(localize('runActiveCell', "F5 shortcut key requires a code cell to be selected. Please select a code cell to run.")));
+			return Promise.reject(localize('clearResultActiveCell', "Clear result requires a code cell to be selected. Please select a code cell to run."));
 		}
 
 		return editor.clearOutput(cell);

--- a/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/node/mainThreadNotebookDocumentsAndEditors.ts
@@ -139,6 +139,13 @@ class MainThreadNotebookEditor extends Disposable {
 		return this.editor.runAllCells();
 	}
 
+	public clearOutput(cell: ICellModel): Promise<boolean> {
+		if (!this.editor) {
+			return Promise.resolve(false);
+		}
+		return this.editor.clearOutput(cell);
+	}
+
 	public clearAllOutputs(): Promise<boolean> {
 		if (!this.editor) {
 			return Promise.resolve(false);
@@ -382,6 +389,28 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 			return Promise.reject(disposed(`TextEditor(${id})`));
 		}
 		return editor.runAllCells();
+	}
+
+	$clearOutput(id: string, cellUri: UriComponents): Promise<boolean> {
+		// Requires an editor and the matching cell in that editor
+		let editor = this.getEditor(id);
+		if (!editor) {
+			return Promise.reject(disposed(`TextEditor(${id})`));
+		}
+		let cell: ICellModel;
+		if (cellUri) {
+			let uriString = URI.revive(cellUri).toString();
+			cell = editor.cells.find(c => c.cellUri.toString() === uriString);
+			// If it's markdown what should we do? Show notification??
+		} else {
+			// Use the active cell in this case, or 1st cell if there's none active
+			cell = editor.model.activeCell;
+		}
+		if (!cell || (cell && cell.cellType !== CellTypes.Code)) {
+			return Promise.reject(new Error(localize('runActiveCell', "F5 shortcut key requires a code cell to be selected. Please select a code cell to run.")));
+		}
+
+		return editor.clearOutput(cell);
 	}
 
 	$clearAllOutputs(id: string): Promise<boolean> {

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -914,6 +914,7 @@ export interface MainThreadNotebookDocumentsAndEditorsShape extends IDisposable 
 	$tryApplyEdits(id: string, modelVersionId: number, edits: ISingleNotebookEditOperation[], opts: IUndoStopOptions): Promise<boolean>;
 	$runCell(id: string, cellUri: UriComponents): Promise<boolean>;
 	$runAllCells(id: string): Promise<boolean>;
+	$clearOutput(id: string, cellUri: UriComponents): Promise<boolean>;
 	$clearAllOutputs(id: string): Promise<boolean>;
 	$changeKernel(id: string, kernel: azdata.nb.IKernelInfo): Promise<boolean>;
 }

--- a/src/sql/workbench/parts/notebook/notebook.component.ts
+++ b/src/sql/workbench/parts/notebook/notebook.component.ts
@@ -535,6 +535,26 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		return true;
 	}
 
+	public async clearOutput(cell: ICellModel): Promise<boolean> {
+		try {
+			await this.modelReady;
+			let uriString = cell.cellUri.toString();
+			if (this._model.cells.findIndex(c => c.cellUri.toString() === uriString) > -1) {
+				this.selectCell(cell);
+				// Clear outputs of the requested cell if cell type is code cell.
+				// If cell is markdown cell, clearOutputs() is a no-op
+				if (cell.cellType === CellTypes.Code) {
+					(cell as CellModel).clearOutputs();
+				}
+				return true;
+			} else {
+				return Promise.reject(new Error(localize('cellNotFound', "cell with URI {0} was not found in this model", uriString)));
+			}
+		} catch (e) {
+			return Promise.reject(e);
+		}
+	}
+
 	public async clearAllOutputs(): Promise<boolean> {
 		try {
 			await this.modelReady;

--- a/src/sql/workbench/services/notebook/common/notebookService.ts
+++ b/src/sql/workbench/services/notebook/common/notebookService.ts
@@ -129,5 +129,6 @@ export interface INotebookEditor {
 	executeEdits(edits: ISingleNotebookEditOperation[]): boolean;
 	runCell(cell: ICellModel): Promise<boolean>;
 	runAllCells(): Promise<boolean>;
+	clearOutput(cell: ICellModel): Promise<boolean>;
 	clearAllOutputs(): Promise<boolean>;
 }


### PR DESCRIPTION
Implements #6019.

Chose Ctrl+Shift+R as Ctrl+Shift+O was already taken. In Jupyter, they use Ctrl+O, which obviously won't work.

Added a command to the command palette, and gave it a keybinding. Also added an integration test.