### PR TITLE
Add settings sync extension to "gallery"

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3377,10 +3377,6 @@
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://github.com/shanalikhan/code-settings-sync/releases/download/v3.4.3/code-settings-sync-3.4.3.vsix"
-								},
-								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
 									"source": "https://github.com/shanalikhan/code-settings-sync/releases/tag/v3.4.3"
 								},

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3259,10 +3259,6 @@
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://github.com/shanalikhan/code-settings-sync/releases/download/v3.4.3/code-settings-sync-3.4.3.vsix"
-								},
-								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
 									"source": "https://github.com/shanalikhan/code-settings-sync/releases/tag/v3.4.3"
 								},

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -2491,6 +2491,67 @@
 					],
 					"statistics": [],
 					"flags": "preview"
+				},
+				{
+					"extensionId": "53",
+					"extensionName": "code-settings-sync",
+					"displayName": "Settings Sync",
+					"shortDescription": "Synchronize Settings, Snippets, Themes, File Icons, Launch, Keybindings, Workspaces and Extensions Across Multiple Machines Using GitHub Gist.",
+					"publisher": {
+						"displayName": "Shan Khan",
+						"publisherId": "Shan",
+						"publisherName": "Shan"
+					},
+					"versions": [
+						{
+							"version": "3.3.1",
+							"lastUpdated": "6/26/2019",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+									"source": "https://github.com/shanalikhan/code-settings-sync/releases/download/v3.3.1/code-settings-sync-3.3.1.vsix"
+								},
+								{
+									"assetType": "Microsoft.SQLOps.DownloadPage",
+									"source": "https://github.com/shanalikhan/code-settings-sync/releases/tag/v3.3.1"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/images/cloud.png"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/LICENSE"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+									"value": ""
+								},
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": ">=1.35.1"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/shanalikhan/code-settings-sync"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": "preview"
 				}
 			],
 			"resultMetadata": [
@@ -2499,7 +2560,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 42
+							"count": 53
 						}
 					]
 				}

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1784,6 +1784,67 @@
 					],
 					"statistics": [],
 					"flags": "preview"
+				},
+				{
+					"extensionId": "42",
+					"extensionName": "code-settings-sync",
+					"displayName": "Settings Sync",
+					"shortDescription": "Synchronize Settings, Snippets, Themes, File Icons, Launch, Keybindings, Workspaces and Extensions Across Multiple Machines Using GitHub Gist.",
+					"publisher": {
+						"displayName": "Shan Khan",
+						"publisherId": "Shan",
+						"publisherName": "Shan"
+					},
+					"versions": [
+						{
+							"version": "3.3.1",
+							"lastUpdated": "6/26/2019",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+									"source": "https://github.com/shanalikhan/code-settings-sync/releases/download/v3.3.1/code-settings-sync-3.3.1.vsix"
+								},
+								{
+									"assetType": "Microsoft.SQLOps.DownloadPage",
+									"source": "https://github.com/shanalikhan/code-settings-sync/releases/tag/v3.3.1"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/images/cloud.png"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/LICENSE"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+									"value": ""
+								},
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": ">=1.35.1"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/shanalikhan/code-settings-sync"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": "preview"
 				}
 			],
 			"resultMetadata": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -2491,67 +2491,6 @@
 					],
 					"statistics": [],
 					"flags": "preview"
-				},
-				{
-					"extensionId": "53",
-					"extensionName": "code-settings-sync",
-					"displayName": "Settings Sync",
-					"shortDescription": "Synchronize Settings, Snippets, Themes, File Icons, Launch, Keybindings, Workspaces and Extensions Across Multiple Machines Using GitHub Gist.",
-					"publisher": {
-						"displayName": "Shan Khan",
-						"publisherId": "Shan",
-						"publisherName": "Shan"
-					},
-					"versions": [
-						{
-							"version": "3.3.1",
-							"lastUpdated": "6/26/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://github.com/shanalikhan/code-settings-sync/releases/download/v3.3.1/code-settings-sync-3.3.1.vsix"
-								},
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/shanalikhan/code-settings-sync/releases/tag/v3.3.1"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/images/cloud.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/shanalikhan/code-settings-sync/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.35.1"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/shanalikhan/code-settings-sync"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
 				}
 			],
 			"resultMetadata": [
@@ -2560,7 +2499,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 53
+							"count": 42
 						}
 					]
 				}


### PR DESCRIPTION
This change will add the [Settings Sync extension](https://github.com/shanalikhan/code-settings-sync/), popular with VS Code, to Azure Data Studio. The changes in the extension have already taken place so it should work; it just needs to be added to the "gallery" JSON.

Ref: https://github.com/shanalikhan/code-settings-sync/issues/926