### PR TITLE
Fix #6175: Schema compare doesn't always use scmp options

### DIFF
--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -7,7 +7,7 @@
 	"preview": true,
 	"engines": {
 		"vscode": "^1.25.0",
-		"azdata": ">=1.8.0"
+		"azdata": ">=1.9.0"
 	},
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/import/Microsoft_SQL_Server_Import_Extension_and_Tools_Import_Flat_File_Preview.docx",
 	"icon": "images/sqlserver.png",

--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -266,10 +266,6 @@ export class SchemaCompareResult {
 	}
 
 	public async execute(): Promise<void> {
-		if (this.schemaCompareOptionDialog && this.schemaCompareOptionDialog.deploymentOptions) {
-			// take updates if any
-			this.deploymentOptions = this.schemaCompareOptionDialog.deploymentOptions;
-		}
 		Telemetry.sendTelemetryEvent('SchemaComparisonStarted');
 		const service = await SchemaCompareResult.getService(msSqlProvider);
 		if (!this.operationId) {


### PR DESCRIPTION
Fixes #6175. This remove resetting options to dialog options before executing the comparison since this was causing the scmp options to not be used if the options were changed before the scmp was opened. The options already get set every time the options dialog is closed.