### PR TITLE
Bug/toolbar icon revert

### DIFF
--- a/src/sql/workbench/electron-browser/modelComponents/componentWithIconBase.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/componentWithIconBase.ts
@@ -47,8 +47,8 @@ export abstract class ComponentWithIconBase extends ComponentBase {
 			removeCSSRulesContainingSelector(this._iconClass);
 			const icon = this.getLightIconPath(this.iconPath);
 			const iconDark = this.getDarkIconPath(this.iconPath) || icon;
-			createCSSRule(`.icon.${this._iconClass}`, `background-image: url("${icon}");background-size: ${this.iconHeight};`);
-			createCSSRule(`.vs-dark .icon.${this._iconClass}, .hc-black .icon.${this._iconClass}`, `background-image: url("${iconDark}");width: ${this.iconWidth};height: ${this.iconHeight};`);
+			createCSSRule(`.icon.${this._iconClass}`, `background-image: url("${icon}")`);
+			createCSSRule(`.vs-dark .icon.${this._iconClass}, .hc-black .icon.${this._iconClass}`, `background-image: url("${iconDark}")`);
 			this._changeRef.detectChanges();
 		}
 	}

--- a/src/sql/workbench/electron-browser/modelComponents/componentWithIconBase.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/componentWithIconBase.ts
@@ -47,7 +47,7 @@ export abstract class ComponentWithIconBase extends ComponentBase {
 			removeCSSRulesContainingSelector(this._iconClass);
 			const icon = this.getLightIconPath(this.iconPath);
 			const iconDark = this.getDarkIconPath(this.iconPath) || icon;
-			createCSSRule(`.icon.${this._iconClass}`, `background-image: url("${icon}");width: ${this.iconWidth};height: ${this.iconHeight};`);
+			createCSSRule(`.icon.${this._iconClass}`, `background-image: url("${icon}");background-size: ${this.iconHeight};`);
 			createCSSRule(`.vs-dark .icon.${this._iconClass}, .hc-black .icon.${this._iconClass}`, `background-image: url("${iconDark}");width: ${this.iconWidth};height: ${this.iconHeight};`);
 			this._changeRef.detectChanges();
 		}


### PR DESCRIPTION
Reverting the size change for now for the icons to work properly while we look for more proper fix to pass size. 

I tried the following to fix without reverting but didn't work.
1. Changing background-size Css property
2. Changing owner button size
