### PR TITLE
Fix #6163 Schema compare differences table scrollbar missing

### DIFF
--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -325,7 +325,8 @@ export class SchemaCompareResult {
 					width: 150
 				}
 			],
-			CSSStyles: { 'left': '15px' }
+			CSSStyles: { 'left': '15px' },
+			width: '98%'
 		});
 
 		this.splitView.addItem(this.differencesTable);

--- a/src/sql/workbench/electron-browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/table.component.ts
@@ -26,7 +26,7 @@ import { Emitter, Event as vsEvent } from 'vs/base/common/event';
 @Component({
 	selector: 'modelview-table',
 	template: `
-		<div #table style="width: 100%;height:100%" [style.font-size]="fontSize"></div>
+		<div #table style="height:100%;" [style.font-size]="fontSize" [style.width]="width"></div>
 	`
 })
 export default class TableComponent extends ComponentBase implements IComponent, OnDestroy, AfterViewInit {


### PR DESCRIPTION
This allows table width to be specified. Fixes #6163 where the schema compare differences table scrollbar disappeared after a left margin was added. This fixes that by setting the width to less than 100% so the scrollbar shows up again.

Before where scrollbar is missing:
![image](https://user-images.githubusercontent.com/31145923/60304520-8c009e80-98ee-11e9-93d5-3d32d2b5e2e2.png)

Now showing scrollbar again after setting width to 98%:
![image](https://user-images.githubusercontent.com/31145923/60304508-7ee3af80-98ee-11e9-97f9-c5b3199e98de.png)
