### PR TITLE
Fix #6200  schema compare after opening scmp with dacpacs failing

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -177,7 +177,7 @@ export class SchemaCompareDialog {
 	private endpointChanged(previousEndpoint: azdata.SchemaCompareEndpointInfo, updatedEndpoint: azdata.SchemaCompareEndpointInfo): boolean {
 		if (previousEndpoint && updatedEndpoint) {
 			return getEndpointName(previousEndpoint).toLowerCase() !== getEndpointName(updatedEndpoint).toLowerCase()
-				|| previousEndpoint.serverDisplayName.toLocaleLowerCase() !== updatedEndpoint.serverDisplayName.toLowerCase();
+				|| (previousEndpoint.serverDisplayName && updatedEndpoint.serverDisplayName && previousEndpoint.serverDisplayName.toLowerCase() !== updatedEndpoint.serverDisplayName.toLowerCase());
 		}
 		return false;
 	}
@@ -541,9 +541,6 @@ export class SchemaCompareDialog {
 			}
 
 			let finalName = `${srv} (${usr})`;
-			if (endpointInfo) {
-				console.error('finalname: ' + finalName + ' endpointname: ' + endpointInfo.serverDisplayName);
-			}
 			// use previously selected server or current connection if there is one
 			if (endpointInfo && !isNullOrUndefined(endpointInfo.serverName) && !isNullOrUndefined(endpointInfo.serverDisplayName)
 				&& c.options.server.toLowerCase() === endpointInfo.serverName.toLowerCase()

--- a/extensions/schema-compare/src/schemaCompareResult.ts
+++ b/extensions/schema-compare/src/schemaCompareResult.ts
@@ -880,7 +880,16 @@ export class SchemaCompareResult {
 					this.sourceEndpointInfo.ownerUri = ownerUri;
 				}
 			} else {
-				this.sourceEndpointInfo = result.sourceEndpointInfo;
+				// need to do this instead of just setting it to the result.sourceEndpointInfo because some fields are null which will cause an error when sending the compare request
+				this.sourceEndpointInfo = {
+					endpointType: azdata.SchemaCompareEndpointType.Dacpac,
+					serverDisplayName: '',
+					serverName: '',
+					databaseName: '',
+					ownerUri: '',
+					packageFilePath: result.sourceEndpointInfo.packageFilePath,
+					connectionDetails: undefined
+				};
 			}
 
 			if (result.targetEndpointInfo && result.targetEndpointInfo.endpointType === azdata.SchemaCompareEndpointType.Database) {
@@ -890,7 +899,16 @@ export class SchemaCompareResult {
 					this.targetEndpointInfo.ownerUri = ownerUri;
 				}
 			} else {
-				this.targetEndpointInfo = result.targetEndpointInfo;
+				// need to do this instead of just setting it to the result.targetEndpointInfo because some fields are null which will cause an error when sending the compare request
+				this.targetEndpointInfo = {
+					endpointType: azdata.SchemaCompareEndpointType.Dacpac,
+					serverDisplayName: '',
+					serverName: '',
+					databaseName: '',
+					ownerUri: '',
+					packageFilePath: result.targetEndpointInfo.packageFilePath,
+					connectionDetails: undefined
+				};
 			}
 
 			this.updateSourceAndTarget();


### PR DESCRIPTION
This fixes #6200 schema compare failing when opening an scmp with a dacpac. It was failing because a few fields were null which caused the compare request to fail. 

Also removing a print statement and fixing a comparison.