### PR TITLE
Bump SqlToolsService to 1.5.0-alpha.105

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.103",
+	"version": "1.5.0-alpha.105",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",


### PR DESCRIPTION
Contains fix for #4825, schema compare fixes and change to default OE connection nodes to always be at server level