### PR TITLE
Accessibility: Screen Reader Thinks SelectBox is a Button on Mac

### DIFF
--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -84,7 +84,11 @@ export class SelectBox extends vsSelectBox {
 		}
 
 		// explicitly set the accessible role so that the screen readers can read the control type properly
-		this.selectElement.setAttribute('role', 'combobox');
+		// for windows, this role of combobox is read as 'combo box'; for mac, the role of 'combobox' is read as a 'button'
+		// not setting a role for Mac means that it is read as a 'popup button', which is the correct behavior.
+		if (process.platform === 'win32') {
+			this.selectElement.setAttribute('role', 'combobox');
+		}
 
 		this._selectBoxOptions = selectBoxOptions;
 		let focusTracker = dom.trackFocus(this.selectElement);

--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -83,13 +83,6 @@ export class SelectBox extends vsSelectBox {
 			this.element = dom.append(container, $('.monaco-selectbox.idle'));
 		}
 
-		// explicitly set the accessible role so that the screen readers can read the control type properly
-		// for windows, this role of combobox is read as 'combo box'; for mac, the role of 'combobox' is read as a 'button'
-		// not setting a role for Mac means that it is read as a 'popup button', which is the correct behavior.
-		if (process.platform === 'win32') {
-			this.selectElement.setAttribute('role', 'combobox');
-		}
-
 		this._selectBoxOptions = selectBoxOptions;
 		let focusTracker = dom.trackFocus(this.selectElement);
 		this._register(focusTracker);


### PR DESCRIPTION
This addresses issue #5679, where a selectbox in a toolbar is read as a 'Button' when using a screen reader on Mac.

After this change, a selectbox will be read as a 'popup button'. I chatted with a couple of folks and verified that this matches VS Code behavior ass well.