### PR TITLE
Fixing backup restore launch bug #5797 (and a test)

### DIFF
--- a/extensions/integration-tests/src/schemaCompare.test.ts
+++ b/extensions/integration-tests/src/schemaCompare.test.ts
@@ -57,24 +57,24 @@ class SchemaCompareTester {
 		const now = new Date();
 		const operationId = 'testOperationId_' + now.getTime().toString();
 
-			let source: azdata.SchemaCompareEndpointInfo = {
-				endpointType: azdata.SchemaCompareEndpointType.Dacpac,
-				packageFilePath: dacpac1,
-				serverDisplayName: '',
-				serverName: '',
-				databaseName: '',
-				ownerUri: '',
-				connectionDetails: undefined
-			};
-			let target: azdata.SchemaCompareEndpointInfo = {
-				endpointType: azdata.SchemaCompareEndpointType.Dacpac,
-				packageFilePath: dacpac2,
-				serverDisplayName: '',
-				serverName: '',
-				databaseName: '',
-				ownerUri: '',
-				connectionDetails: undefined
-			};
+		let source: azdata.SchemaCompareEndpointInfo = {
+			endpointType: azdata.SchemaCompareEndpointType.Dacpac,
+			packageFilePath: dacpac1,
+			serverDisplayName: '',
+			serverName: '',
+			databaseName: '',
+			ownerUri: '',
+			connectionDetails: undefined
+		};
+		let target: azdata.SchemaCompareEndpointInfo = {
+			endpointType: azdata.SchemaCompareEndpointType.Dacpac,
+			packageFilePath: dacpac2,
+			serverDisplayName: '',
+			serverName: '',
+			databaseName: '',
+			ownerUri: '',
+			connectionDetails: undefined
+		};
 
 		let schemaCompareResult = await schemaCompareService.schemaCompare(operationId, source, target, azdata.TaskExecutionMode.execute, null);
 		this.assertSchemaCompareResult(schemaCompareResult, operationId);
@@ -111,24 +111,24 @@ class SchemaCompareTester {
 
 			assert(schemaCompareService, 'Schema Compare Service Provider is not available');
 
-				let source: azdata.SchemaCompareEndpointInfo = {
-					endpointType: azdata.SchemaCompareEndpointType.Database,
-					packageFilePath: '',
-					serverDisplayName: '',
-					serverName: server.serverName,
-					databaseName: sourceDB,
-					ownerUri: ownerUri,
-					connectionDetails: undefined
-				};
-				let target: azdata.SchemaCompareEndpointInfo = {
-					endpointType: azdata.SchemaCompareEndpointType.Database,
-					packageFilePath: '',
-					serverDisplayName: '',
-					serverName: server.serverName,
-					databaseName: targetDB,
-					ownerUri: ownerUri,
-					connectionDetails: undefined
-				};
+			let source: azdata.SchemaCompareEndpointInfo = {
+				endpointType: azdata.SchemaCompareEndpointType.Database,
+				packageFilePath: '',
+				serverDisplayName: '',
+				serverName: server.serverName,
+				databaseName: sourceDB,
+				ownerUri: ownerUri,
+				connectionDetails: undefined
+			};
+			let target: azdata.SchemaCompareEndpointInfo = {
+				endpointType: azdata.SchemaCompareEndpointType.Database,
+				packageFilePath: '',
+				serverDisplayName: '',
+				serverName: server.serverName,
+				databaseName: targetDB,
+				ownerUri: ownerUri,
+				connectionDetails: undefined
+			};
 
 			let schemaCompareResult = await schemaCompareService.schemaCompare(operationId, source, target, azdata.TaskExecutionMode.execute, null);
 			this.assertSchemaCompareResult(schemaCompareResult, operationId);
@@ -168,24 +168,24 @@ class SchemaCompareTester {
 
 			assert(result.success === true, 'Deploy database 2 (target) should succeed');
 
-				let source: azdata.SchemaCompareEndpointInfo = {
-					endpointType: azdata.SchemaCompareEndpointType.Dacpac,
-					packageFilePath: dacpac1,
-					serverDisplayName: '',
-					serverName: '',
-					databaseName: '',
-					ownerUri: ownerUri,
-					connectionDetails: undefined
-				};
-				let target: azdata.SchemaCompareEndpointInfo = {
-					endpointType: azdata.SchemaCompareEndpointType.Database,
-					packageFilePath: '',
-					serverDisplayName: '',
-					serverName: server.serverName,
-					databaseName: targetDB,
-					ownerUri: ownerUri,
-					connectionDetails: undefined
-				};
+			let source: azdata.SchemaCompareEndpointInfo = {
+				endpointType: azdata.SchemaCompareEndpointType.Dacpac,
+				packageFilePath: dacpac1,
+				serverDisplayName: '',
+				serverName: '',
+				databaseName: '',
+				ownerUri: ownerUri,
+				connectionDetails: undefined
+			};
+			let target: azdata.SchemaCompareEndpointInfo = {
+				endpointType: azdata.SchemaCompareEndpointType.Database,
+				packageFilePath: '',
+				serverDisplayName: '',
+				serverName: server.serverName,
+				databaseName: targetDB,
+				ownerUri: ownerUri,
+				connectionDetails: undefined
+			};
 
 			assert(schemaCompareService, 'Schema Compare Service Provider is not available');
 
@@ -200,7 +200,7 @@ class SchemaCompareTester {
 		}
 	}
 
-	private assertSchemaCompareResult(schemaCompareResult: azdata.SchemaCompareResult, operationId : string): void {
+	private assertSchemaCompareResult(schemaCompareResult: azdata.SchemaCompareResult, operationId: string): void {
 		assert(schemaCompareResult.areEqual === false, `Expected: the schemas are not to be equal Actual: Equal`);
 		assert(schemaCompareResult.errorMessage === null, `Expected: there should be no error. Actual Error message: "${schemaCompareResult.errorMessage}"`);
 		assert(schemaCompareResult.success === true, `Expected: success in schema compare, Actual: Failure`);
@@ -221,5 +221,24 @@ class SchemaCompareTester {
 		});
 		assert(foundTask, 'Could not find Script task');
 		assert(foundTask.isCancelable, 'The task should be cancellable');
+
+		if (foundTask.status !== azdata.TaskStatus.Succeeded) {
+			// wait for all tasks completion before exiting test and cleaning up db otherwise tasks fail
+			let retry = 10;
+			let allCompleted = false;
+			while (retry > 0 && !allCompleted) {
+				retry--;
+				await utils.sleep(1000);
+				allCompleted = true;
+				let tasks = await taskService.getAllTasks({ listActiveTasksOnly: true });
+				tasks.tasks.forEach(t => {
+					if (t.status !== azdata.TaskStatus.Succeeded) {
+						allCompleted = false;
+					}
+				});
+			}
+			assert(tasks !== null && tasks.tasks.length > 0, 'Tasks should still show in list. This is to ensure that the tasks actually complete.');
+			assert(allCompleted === true, 'All tasks should be completed.');
+		}
 	}
 }

--- a/src/sql/workbench/common/actions.ts
+++ b/src/sql/workbench/common/actions.ts
@@ -306,7 +306,7 @@ export class RestoreAction extends Task {
 			}
 
 			if (!profile.databaseName && profile.providerName === mssqlProviderName) {
-				return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.commandNotSupportedForServer', 'Backup command is not supported in Server Context. Please select a Database and try again.'));
+				return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.commandNotSupportedForServer', 'Restore command is not supported in Server Context. Please select a Database and try again.'));
 			}
 		}
 

--- a/src/sql/workbench/common/actions.ts
+++ b/src/sql/workbench/common/actions.ts
@@ -257,6 +257,10 @@ export class BackupAction extends Task {
 			if (serverInfo && serverInfo.isCloud && profile.providerName === mssqlProviderName) {
 				return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.commandNotSupported', 'Backup command is not supported for Azure SQL databases.'));
 			}
+
+			if (!profile.databaseName && profile.providerName === mssqlProviderName) {
+				return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.commandNotSupportedForServer', 'Backup command is not supported in Server Context. Please select a Database and try again.'));
+			}
 		}
 
 		TaskUtilities.showBackup(
@@ -299,6 +303,10 @@ export class RestoreAction extends Task {
 			const serverInfo = connectionManagementService.getServerInfo(profile.id);
 			if (serverInfo && serverInfo.isCloud && profile.providerName === mssqlProviderName) {
 				return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.commandNotSupported', 'Restore command is not supported for Azure SQL databases.'));
+			}
+
+			if (!profile.databaseName && profile.providerName === mssqlProviderName) {
+				return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.commandNotSupportedForServer', 'Backup command is not supported in Server Context. Please select a Database and try again.'));
 			}
 		}
 


### PR DESCRIPTION
Fix for backup/restore launch from command pallet in context of server - errors differently in MAC and windows : https://github.com/microsoft/azuredatastudio/issues/5797 adding common path and error messages

Another change for test to complete the tasks before exiting the test other wise they show as errors in test ADS window 

Apologies for combining two PRs (did so in favor of time - since both were small)