### PR TITLE
Support non-default font sizes in notebooks

### DIFF
--- a/src/sql/workbench/electron-browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/queryTextEditor.ts
@@ -134,7 +134,7 @@ export class QueryTextEditor extends BaseTextEditor {
 		let editorWidget = this.getControl() as ICodeEditor;
 		let layoutInfo = editorWidget.getLayoutInfo();
 		if (!this._scrollbarHeight) {
-			this._scrollbarHeight = editorWidget.getLayoutInfo().horizontalScrollbarHeight;
+			this._scrollbarHeight = layoutInfo.horizontalScrollbarHeight;
 		}
 		let editorWidgetModel = editorWidget.getModel();
 		if (!editorWidgetModel) {

--- a/src/sql/workbench/parts/notebook/cellViews/code.component.ts
+++ b/src/sql/workbench/parts/notebook/cellViews/code.component.ts
@@ -226,7 +226,7 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 			setTimeout(() => this._layoutEmitter.fire(), 250);
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('editor.wordWrap')) {
+			if (e.affectsConfiguration('editor.wordWrap') || e.affectsConfiguration('editor.fontSize')) {
 				this._editor.setHeightToScrollHeight(true);
 			}
 		}));


### PR DESCRIPTION
Fixes the known repro for #5217.
Fixes #5852. 

We needed to stop creating a new Configuration object every time we called the setHeightToScrollHeight method (as stress uncovered a memory leak), so this gave me an excuse to fix that as well 😄. Now, we get the layoutInfo and configuration directly from the editorWidget. Also made a change to have the notebook re-calculate lineHeight when the setting is changed.

![changefontsize](https://user-images.githubusercontent.com/40371649/60403450-1e54ac80-9b52-11e9-8e12-1e9968b2ad98.gif)
