### PR TITLE
Change service installation messages to not steal focus

### DIFF
--- a/extensions/import/src/services/serviceClient.ts
+++ b/extensions/import/src/services/serviceClient.ts
@@ -113,16 +113,16 @@ export class ServiceClient {
 				case Events.INSTALL_START:
 					this.outputChannel.show(true);
 					this.statusView.show();
-					this.outputChannel.appendLine(localize('installingServiceChannelMsg', 'Installing {0} service to {1}', Constants.serviceName, args[0]));
-					this.statusView.text = localize('installingServiceStatusMsg', 'Installing Service');
+					this.outputChannel.appendLine(localize('installingServiceDetailed', 'Installing {0} service to {1}', Constants.serviceName, args[0]));
+					this.statusView.text = localize('installingService', 'Installing Service');
 					break;
 				case Events.INSTALL_END:
-					this.outputChannel.appendLine(localize('installedServiceChannelMsg', 'Installed'));
+					this.outputChannel.appendLine(localize('serviceInstalled', 'Installed'));
 					break;
 				case Events.DOWNLOAD_START:
-					this.outputChannel.appendLine(localize('downloadingServiceChannelMsg', 'Downloading {0}', args[0]));
-					this.outputChannel.append(localize('downloadingServiceSizeChannelMsg', '({0} KB)', Math.ceil(args[1] / 1024).toLocaleString(vscode.env.language)));
-					this.statusView.text = localize('downloadingServiceStatusMsg', 'Downloading Service');
+					this.outputChannel.appendLine(localize('downloadingService', 'Downloading {0}', args[0]));
+					this.outputChannel.append(localize('downloadingServiceSize', '({0} KB)', Math.ceil(args[1] / 1024).toLocaleString(vscode.env.language)));
+					this.statusView.text = localize('downloadingServiceStatus', 'Downloading Service');
 					break;
 				case Events.DOWNLOAD_PROGRESS:
 					let newDots = Math.ceil(args[0] / 5);
@@ -132,7 +132,7 @@ export class ServiceClient {
 					}
 					break;
 				case Events.DOWNLOAD_END:
-					this.outputChannel.appendLine(localize('downloadServiceDoneChannelMsg', 'Done!'));
+					this.outputChannel.appendLine(localize('downloadingServiceComplete', 'Done!'));
 					break;
 			}
 		};

--- a/extensions/import/src/services/serviceClient.ts
+++ b/extensions/import/src/services/serviceClient.ts
@@ -134,6 +134,9 @@ export class ServiceClient {
 				case Events.DOWNLOAD_END:
 					this.outputChannel.appendLine(localize('downloadingServiceComplete', 'Done!'));
 					break;
+				default:
+					console.error(`Unknown event from Server Provider ${e}`);
+					break;
 			}
 		};
 	}

--- a/extensions/import/src/services/serviceClient.ts
+++ b/extensions/import/src/services/serviceClient.ts
@@ -109,20 +109,20 @@ export class ServiceClient {
 	private generateHandleServerProviderEvent(): EventAndListener {
 		let dots = 0;
 		return (e: string, ...args: any[]) => {
-			this.outputChannel.show();
-			this.statusView.show();
 			switch (e) {
 				case Events.INSTALL_START:
-					this.outputChannel.appendLine(localize('installingServiceDetailed', 'Installing {0} service to {1}', Constants.serviceName, args[0]));
-					this.statusView.text = localize('installingService', 'Installing Service');
+					this.outputChannel.show(true);
+					this.statusView.show();
+					this.outputChannel.appendLine(localize('installingServiceChannelMsg', 'Installing {0} service to {1}', Constants.serviceName, args[0]));
+					this.statusView.text = localize('installingServiceStatusMsg', 'Installing Service');
 					break;
 				case Events.INSTALL_END:
-					this.outputChannel.appendLine(localize('serviceInstalled', 'Installed'));
+					this.outputChannel.appendLine(localize('installedServiceChannelMsg', 'Installed'));
 					break;
 				case Events.DOWNLOAD_START:
-					this.outputChannel.appendLine(localize('downloadingService', 'Downloading {0}', args[0]));
-					this.outputChannel.append(`(${Math.ceil(args[1] / 1024)} KB)`);
-					this.statusView.text = localize('downloadingServiceStatus', 'Downloading Service');
+					this.outputChannel.appendLine(localize('downloadingServiceChannelMsg', 'Downloading {0}', args[0]));
+					this.outputChannel.append(localize('downloadingServiceSizeChannelMsg', '({0} KB)', Math.ceil(args[1] / 1024).toLocaleString(vscode.env.language)));
+					this.statusView.text = localize('downloadingServiceStatusMsg', 'Downloading Service');
 					break;
 				case Events.DOWNLOAD_PROGRESS:
 					let newDots = Math.ceil(args[0] / 5);
@@ -132,9 +132,7 @@ export class ServiceClient {
 					}
 					break;
 				case Events.DOWNLOAD_END:
-					this.outputChannel.appendLine(localize('downloadingServiceComplete', 'Done!'));
-					break;
-				default:
+					this.outputChannel.appendLine(localize('downloadServiceDoneChannelMsg', 'Done!'));
 					break;
 			}
 		};

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -362,20 +362,20 @@ function generateServerOptions(executablePath: string): ServerOptions {
 function generateHandleServerProviderEvent() {
 	let dots = 0;
 	return (e: string, ...args: any[]) => {
-		outputChannel.show();
-		statusView.show();
 		switch (e) {
 			case Events.INSTALL_START:
-				outputChannel.appendLine(`Installing ${Constants.serviceName} service to ${args[0]}`);
-				statusView.text = 'Installing Service';
+				outputChannel.show(true);
+				statusView.show();
+				outputChannel.appendLine(localize('installingServiceChannelMsg', 'Installing {0} service to {1}', Constants.serviceName, args[0]));
+				statusView.text = localize('installingServiceStatusMsg', 'Installing Service');
 				break;
 			case Events.INSTALL_END:
-				outputChannel.appendLine('Installed');
+				outputChannel.appendLine(localize('installedServiceChannelMsg', 'Installed'));
 				break;
 			case Events.DOWNLOAD_START:
-				outputChannel.appendLine(`Downloading ${args[0]}`);
-				outputChannel.append(`(${Math.ceil(args[1] / 1024)} KB)`);
-				statusView.text = 'Downloading Service';
+				outputChannel.appendLine(localize('downloadingServiceChannelMsg', 'Downloading {0}', args[0]));
+				outputChannel.append(localize('downloadingServiceSizeChannelMsg', '({0} KB)', Math.ceil(args[1] / 1024).toLocaleString(vscode.env.language)));
+				statusView.text = localize('downloadingServiceStatusMsg', 'Downloading Service');
 				break;
 			case Events.DOWNLOAD_PROGRESS:
 				let newDots = Math.ceil(args[0] / 5);
@@ -385,7 +385,7 @@ function generateHandleServerProviderEvent() {
 				}
 				break;
 			case Events.DOWNLOAD_END:
-				outputChannel.appendLine('Done!');
+				outputChannel.appendLine(localize('downloadServiceDoneChannelMsg', 'Done!'));
 				break;
 		}
 	};

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -387,6 +387,9 @@ function generateHandleServerProviderEvent() {
 			case Events.DOWNLOAD_END:
 				outputChannel.appendLine(localize('downloadServiceDoneChannelMsg', 'Done!'));
 				break;
+			default:
+				console.error(`Unknown event from Server Provider ${e}`);
+				break;
 		}
 	};
 }


### PR DESCRIPTION
- Change showing of message window to not take focus when shown
- Only show the message window on install start so that if user closes it it'll stay closed (we can assume they're not interested in the messages if they close it after the initial one)
- Localize the displayed messages

Fixes #6157 #5149 #6110