### PR TITLE
Fix #6217 DacFx: Connection Dialog has no ConnectionProfile loaded 

### DIFF
--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -2,7 +2,7 @@
 	"name": "dacpac",
 	"displayName": "SQL Server Dacpac",
 	"description": "SQL Server Dacpac for Azure Data Studio.",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"publisher": "Microsoft",
 	"preview": true,
 	"engines": {

--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -86,9 +86,9 @@ export class DataTierApplicationWizard {
 		}
 
 		this.connection = await azdata.connection.getCurrentConnection();
-		if (!this.connection) {
+		if (!this.connection || (profile && this.connection.connectionId !== profile.id)) {
 			// @TODO: remove cast once azdata update complete - karlb 3/1/2019
-			this.connection = <azdata.connection.ConnectionProfile><any>await azdata.connection.openConnectionDialog();
+			this.connection = <azdata.connection.ConnectionProfile><any>await azdata.connection.openConnectionDialog(undefined, profile);
 
 			// don't open the wizard if connection dialog is cancelled
 			if (!this.connection) {


### PR DESCRIPTION
Fixes #6217. Now the connection dialog opens with the connection details of the server the wizard was launched from.

![dacfxNoConnections2](https://user-images.githubusercontent.com/31145923/60459887-231f6c00-9bf7-11e9-9c7d-6c3e1606d7de.gif)
