### PR TITLE
Return an empty arrary from breakpoints API

### DIFF
--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -693,7 +693,7 @@ export function createApiFactory(
 				return undefined;
 			},
 			get breakpoints() {
-				return undefined;
+				return [];
 			},
 			onDidStartDebugSession(listener, thisArg?, disposables?) {
 				return undefined;


### PR DESCRIPTION
Some VS Code extensions assume this value won't be null, but will return an empty array when no breakpoints are set.