### PR TITLE
Fix notebook to not save connections added through dropdown

### DIFF
--- a/src/sql/workbench/parts/notebook/notebookActions.ts
+++ b/src/sql/workbench/parts/notebook/notebookActions.ts
@@ -15,7 +15,7 @@ import { INotebookModel } from 'sql/workbench/parts/notebook/models/modelInterfa
 import { CellType, CellTypes } from 'sql/workbench/parts/notebook/models/contracts';
 import { NotebookComponent } from 'sql/workbench/parts/notebook/notebook.component';
 import { getErrorMessage, getServerFromFormattedAttachToName, getDatabaseFromFormattedAttachToName } from 'sql/workbench/parts/notebook/notebookUtils';
-import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
+import { IConnectionManagementService, ConnectionType } from 'sql/platform/connection/common/connectionManagement';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { noKernel } from 'sql/workbench/services/notebook/common/sessionManager';
@@ -494,7 +494,7 @@ export class AttachToDropdown extends SelectBox {
 		try {
 			let connection = await this._connectionDialogService.openDialogAndWait(this._connectionManagementService,
 				{
-					connectionType: 1,
+					connectionType: ConnectionType.temporary,
 					providers: this.model.getApplicableConnectionProviderIds(this.model.clientSession.kernel.name)
 				},
 				useProfile ? this.model.connectionProfile : undefined);


### PR DESCRIPTION
Fixes #5769

![screen](https://user-images.githubusercontent.com/28519865/60553712-580beb80-9ce9-11e9-9acc-bf2eb5569c0f.gif)

This isn't the full fix that I'd like to do at some point - which is to decouple the concept of this connection type and the saving of the connection. There's also some other things like that we should probably just hide the group dropdown if we're not saving the connection since it doesn't do anything anyways. But this is meant as a targeted fix to stop this broken behavior now and then we'll revisit a more thorough refactor later. 

