### PR TITLE
Change keybinding for showing data explorer viewlet

### DIFF
--- a/src/sql/workbench/parts/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/parts/dataExplorer/browser/dataExplorer.contribution.ts
@@ -54,7 +54,7 @@ registry.registerWorkbenchAction(
 		OpenDataExplorerViewletAction,
 		OpenDataExplorerViewletAction.ID,
 		OpenDataExplorerViewletAction.LABEL,
-		{ primary: KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.KEY_C }),
+		{ primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_D }),
 	'View: Show Data Explorer',
 	localize('dataExplorer.view', "View")
 );


### PR DESCRIPTION
Fixes #5774

I would have liked to do ctrl + shift + c but that's taken by notebooks new cell as well as launch native terminal already. So went with ctrl + shift + d since that wasn't taken and it follows the VS Code convention of keybinds for the viewlets (Explorer == E, Search == F, SCM == G)