### PR TITLE
Fix connectionId remapping

### DIFF
--- a/src/sql/workbench/api/node/extHostConnectionManagement.ts
+++ b/src/sql/workbench/api/node/extHostConnectionManagement.ts
@@ -21,7 +21,7 @@ export class ExtHostConnectionManagement extends ExtHostConnectionManagementShap
 	public $getCurrentConnection(): Thenable<azdata.connection.ConnectionProfile> {
 		let connection: any = this._proxy.$getCurrentConnection();
 		connection.then((conn) => {
-			if (conn && conn.providerId) {
+			if (conn) {
 				conn.providerId = conn.providerName;
 			}
 		});


### PR DESCRIPTION
Undo change made in #6264 - this incorrectly was causing the remapping of providerName -> providerId to not happen (the object we get back is a Connection which has a providerName, but we're returning a ConnectionProfile which uses providerId instead). Without this extensions calling this method that expected a providerId were getting undefined instead and breaking (such as Agent)

Note I'll be following up with a different fix that is more thorough since I don't see any reason why we should have to do this remapping anyways. I don't want that in for July though since it's a lot riskier of a move - this PR is meant for the July release to just fix the issue since it's pretty critical. 