### PR TITLE
Change getCurrentConnection to return full ConnectionProfile

### DIFF
--- a/src/sql/workbench/api/node/extHostConnectionManagement.ts
+++ b/src/sql/workbench/api/node/extHostConnectionManagement.ts
@@ -19,13 +19,7 @@ export class ExtHostConnectionManagement extends ExtHostConnectionManagementShap
 	}
 
 	public $getCurrentConnection(): Thenable<azdata.connection.ConnectionProfile> {
-		let connection: any = this._proxy.$getCurrentConnection();
-		connection.then((conn) => {
-			if (conn && conn.providerId) {
-				conn.providerId = conn.providerName;
-			}
-		});
-		return connection;
+		return this._proxy.$getCurrentConnectionProfile();
 	}
 
 	public $getConnections(activeConnectionsOnly?: boolean): Thenable<azdata.connection.ConnectionProfile[]> {

--- a/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
@@ -56,6 +56,10 @@ export class MainThreadConnectionManagement implements MainThreadConnectionManag
 		return Promise.resolve(this.convertConnection(TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._workbenchEditorService, true)));
 	}
 
+	public $getCurrentConnectionProfile(): Thenable<azdata.connection.ConnectionProfile> {
+		return Promise.resolve(this.convertToConnectionProfile(TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._workbenchEditorService, true)));
+	}
+
 	public $getCredentials(connectionId: string): Thenable<{ [name: string]: string }> {
 		return Promise.resolve(this._connectionManagementService.getActiveConnectionCredentials(connectionId));
 	}
@@ -120,7 +124,7 @@ export class MainThreadConnectionManagement implements MainThreadConnectionManag
 		let connection: azdata.connection.Connection = {
 			providerName: profile.providerName,
 			connectionId: profile.id,
-			options: profile.options
+			options: deepClone(profile.options)
 		};
 		return connection;
 	}

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -609,6 +609,7 @@ export interface MainThreadConnectionManagementShape extends IDisposable {
 	$getConnections(activeConnectionsOnly?: boolean): Thenable<azdata.connection.ConnectionProfile[]>;
 	$getActiveConnections(): Thenable<azdata.connection.Connection[]>;
 	$getCurrentConnection(): Thenable<azdata.connection.Connection>;
+	$getCurrentConnectionProfile(): Thenable<azdata.connection.ConnectionProfile>;
 	$getCredentials(connectionId: string): Thenable<{ [name: string]: string }>;
 	$getServerInfo(connectedId: string): Thenable<azdata.ServerInfo>;
 	$openConnectionDialog(providers: string[], initialConnectionProfile?: azdata.IConnectionProfile, connectionCompletionOptions?: azdata.IConnectionCompletionOptions): Thenable<azdata.connection.Connection>;


### PR DESCRIPTION
Note this is the full fix mentioned in #6269

For some reason getCurrentConnection - which returns a ConnectionProfile - was retrieving a Connection instead which is a very different structure (for example it uses providerName instead of providerId) which meant we had to do this remapping of properties to align with the ConnectionProfile definition as expected.

The fix here is to just actually fetch a ConnectionProfile instead from the MainThreadConnectionManagement calls. This does slightly change the result though since the ConnectionProfile returned now contains a lot more fields than Connection does. But given that callers were expecting a ConnectionProfile anyways this should just be more fixing an existing bug than changing behavior. 

I'm also included a fix for an issue I noticed where we weren't deep cloning the options when creating a Connection object which could cause issues if callers of this method started modifying properties of objects in the options bag. 