### PR TITLE
Fix Agent tabs not switching

### DIFF
--- a/src/sql/base/browser/ui/panel/panel.ts
+++ b/src/sql/base/browser/ui/panel/panel.ts
@@ -50,7 +50,7 @@ interface IInternalPanelTab {
 	disposables: IDisposable[];
 	label: HTMLElement;
 	body?: HTMLElement;
-	destoryTabBody?: boolean;
+	destroyTabBody?: boolean;
 }
 
 const defaultOptions: IPanelOptions = {
@@ -115,10 +115,10 @@ export class TabbedPanel extends Disposable {
 		return this._tabMap.has(tab.identifier);
 	}
 
-	public pushTab(tab: IPanelTab, index?: number, destoryTabBody?: boolean): PanelTabIdentifier {
+	public pushTab(tab: IPanelTab, index?: number, destroyTabBody?: boolean): PanelTabIdentifier {
 		let internalTab = { tab } as IInternalPanelTab;
 		internalTab.disposables = [];
-		internalTab.destoryTabBody = destoryTabBody;
+		internalTab.destroyTabBody = destroyTabBody;
 		this._tabMap.set(tab.identifier, internalTab);
 		this._createTab(internalTab, index);
 		if (!this._shownTabId) {
@@ -203,7 +203,7 @@ export class TabbedPanel extends Disposable {
 		this.tabHistory.push(id);
 		const tab = this._tabMap.get(this._shownTabId)!; // @anthonydresser we know this can't be undefined since we check further up if the map contains the id
 
-		if (tab.destoryTabBody && tab.body) {
+		if (tab.destroyTabBody && tab.body) {
 			tab.body.remove();
 			tab.body = undefined;
 		}

--- a/src/sql/workbench/api/node/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/node/extHostModelViewDialog.ts
@@ -22,7 +22,7 @@ const PREVIOUS_LABEL = nls.localize('dialogPreviousLabel', 'Previous');
 
 class ModelViewPanelImpl implements azdata.window.ModelViewPanel {
 	private _modelView: azdata.ModelView;
-	private static _handle: number;
+	private _handle: number;
 	protected _modelViewId: string;
 	protected _valid: boolean = true;
 	protected _onValidityChanged: vscode.Event<boolean>;
@@ -37,7 +37,7 @@ class ModelViewPanelImpl implements azdata.window.ModelViewPanel {
 
 	public registerContent(handler: (view: azdata.ModelView) => Thenable<void>): void {
 		if (!this._modelViewId) {
-			let viewId = this._viewType + ModelViewPanelImpl._handle;
+			let viewId = this._viewType + this._handle;
 			this.setModelViewId(viewId);
 			this._extHostModelView.$registerProvider(viewId, modelView => {
 				this._modelView = modelView;
@@ -47,7 +47,7 @@ class ModelViewPanelImpl implements azdata.window.ModelViewPanel {
 	}
 
 	public set handle(value: number) {
-		ModelViewPanelImpl._handle = value;
+		this._handle = value;
 	}
 
 	public setModelViewId(value: string) {


### PR DESCRIPTION
Fixes #6265

This was broken in #6185. I don't see why the handle var was moved to be static since it doesn't seem like that should be shared, and that was breaking the agent dialog since it caused all the tabs to share the same ID which broke the tab switching logic.

Also fixing a misspelling I noticed while debugging this.