### PR TITLE
Manually define JupyterServerInstallation execOptions field in notebook unit tests.

### DIFF
--- a/extensions/notebook/src/test/model/serverInstance.test.ts
+++ b/extensions/notebook/src/test/model/serverInstance.test.ts
@@ -37,6 +37,7 @@ describe('Jupyter server instance', function (): void {
 		mockOutputChannel = TypeMoq.Mock.ofType(MockOutputChannel);
 		mockInstall.setup(i => i.outputChannel).returns(() => mockOutputChannel.object);
 		mockInstall.setup(i => i.pythonExecutable).returns(() => 'python3');
+		mockInstall.object.execOptions = { env: Object.assign({}, process.env) };
 		mockUtils = TypeMoq.Mock.ofType(ServerInstanceUtils);
 		mockUtils.setup(u => u.ensureProcessEnded(TypeMoq.It.isAny())).returns(() => undefined);
 		serverInstance = new PerNotebookServerInstance({

--- a/extensions/notebook/src/test/model/serverManager.test.ts
+++ b/extensions/notebook/src/test/model/serverManager.test.ts
@@ -34,6 +34,7 @@ describe('Local Jupyter Server Manager', function (): void {
 		deferredInstall = new Deferred<void>();
 		let mockInstall = TypeMoq.Mock.ofType(JupyterServerInstallation, undefined, undefined, '/root');
 		mockInstall.setup(j => j.promptForPythonInstall()).returns(() => deferredInstall.promise);
+		mockInstall.object.execOptions = { env: Object.assign({}, process.env) };
 
 		serverManager = new LocalJupyterServerManager({
 			documentPath: expectedPath,


### PR DESCRIPTION
Porting to release branch.