### PR TITLE
Use in proc markdown by default in Stable

### DIFF
--- a/src/sql/workbench/parts/notebook/notebook.contribution.ts
+++ b/src/sql/workbench/parts/notebook/notebook.contribution.ts
@@ -53,7 +53,7 @@ configurationRegistry.registerConfiguration({
 	'properties': {
 		'notebook.useInProcMarkdown': {
 			'type': 'boolean',
-			'default': product.quality === 'stable' ? false : true,
+			'default': true,
 			'description': localize('notebook.inProcMarkdown', 'Use in-process markdown viewer to render text cells more quickly (Experimental).')
 		}
 	}


### PR DESCRIPTION
Use in proc markdown by default in stable (which was the plan for the July release). It's being called out in the relnotes, so making sure that the default experience is the one that we advertise 😄 