### PR TITLE
Rename SchemaCompareResult to SchemaCompareMainWindow

### DIFF
--- a/extensions/schema-compare/src/controllers/mainController.ts
+++ b/extensions/schema-compare/src/controllers/mainController.ts
@@ -7,7 +7,7 @@
 
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
-import { SchemaCompareResult } from '../schemaCompareResult';
+import { SchemaCompareMainWindow } from '../schemaCompareMainWindow';
 
 /**
  * The main controller class that initializes the extension
@@ -32,7 +32,7 @@ export default class MainController implements vscode.Disposable {
 	}
 
 	private initializeSchemaCompareDialog(): void {
-		azdata.tasks.registerTask('schemaCompare.start', (profile: azdata.IConnectionProfile) => new SchemaCompareResult().start(profile));
+		azdata.tasks.registerTask('schemaCompare.start', (profile: azdata.IConnectionProfile) => new SchemaCompareMainWindow().start(profile));
 	}
 
 	public dispose(): void {

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -8,7 +8,7 @@ import * as nls from 'vscode-nls';
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import * as os from 'os';
-import { SchemaCompareResult } from '../schemaCompareResult';
+import { SchemaCompareMainWindow } from '../schemaCompareMainWindow';
 import { isNullOrUndefined } from 'util';
 import { existsSync } from 'fs';
 import { Telemetry } from '../telemetry';
@@ -63,7 +63,7 @@ export class SchemaCompareDialog {
 	private previousSource: azdata.SchemaCompareEndpointInfo;
 	private previousTarget: azdata.SchemaCompareEndpointInfo;
 
-	constructor(private schemaCompareResult: SchemaCompareResult) {
+	constructor(private schemaCompareResult: SchemaCompareMainWindow) {
 		this.previousSource = schemaCompareResult.sourceEndpointInfo;
 		this.previousTarget = schemaCompareResult.targetEndpointInfo;
 	}

--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -7,7 +7,7 @@
 import * as nls from 'vscode-nls';
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
-import { SchemaCompareResult } from '../schemaCompareResult';
+import { SchemaCompareMainWindow } from '../schemaCompareMainWindow';
 
 const localize = nls.loadMessageBundle();
 
@@ -410,7 +410,7 @@ export class SchemaCompareOptionsDialog {
 		SchemaCompareOptionsDialog.ServerTriggers
 	].sort();
 
-	constructor(defaultOptions: azdata.DeploymentOptions, private schemaComparison: SchemaCompareResult) {
+	constructor(defaultOptions: azdata.DeploymentOptions, private schemaComparison: SchemaCompareMainWindow) {
 		this.deploymentOptions = defaultOptions;
 	}
 

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -33,7 +33,7 @@ enum ResetButtonState {
 	afterCompareComplete
 }
 
-export class SchemaCompareResult {
+export class SchemaCompareMainWindow {
 	private differencesTable: azdata.TableComponent;
 	private loader: azdata.LoadingComponent;
 	private startText: azdata.TextComponent;
@@ -268,7 +268,7 @@ export class SchemaCompareResult {
 
 	public async execute(): Promise<void> {
 		Telemetry.sendTelemetryEvent('SchemaComparisonStarted');
-		const service = await SchemaCompareResult.getService(msSqlProvider);
+		const service = await SchemaCompareMainWindow.getService(msSqlProvider);
 		if (!this.operationId) {
 			// create once per page
 			this.operationId = generateGuid();
@@ -584,7 +584,7 @@ export class SchemaCompareResult {
 
 		// cancel compare
 		if (this.operationId) {
-			const service = await SchemaCompareResult.getService(msSqlProvider);
+			const service = await SchemaCompareMainWindow.getService(msSqlProvider);
 			const result = await service.schemaCompareCancel(this.operationId);
 
 			if (!result || !result.success) {
@@ -616,7 +616,7 @@ export class SchemaCompareResult {
 				'startTime:': Date.now().toString(),
 				'operationId': this.comparisonResult.operationId
 			});
-			const service = await SchemaCompareResult.getService(msSqlProvider);
+			const service = await SchemaCompareMainWindow.getService(msSqlProvider);
 			const result = await service.schemaCompareGenerateScript(this.comparisonResult.operationId, this.targetEndpointInfo.serverName, this.targetEndpointInfo.databaseName, azdata.TaskExecutionMode.script);
 			if (!result || !result.success) {
 				Telemetry.sendTelemetryEvent('SchemaCompareGenerateScriptFailed', {
@@ -677,7 +677,7 @@ export class SchemaCompareResult {
 					// disable apply and generate script buttons because the results are no longer valid after applying the changes
 					this.setButtonsForRecompare();
 
-					const service = await SchemaCompareResult.getService(msSqlProvider);
+					const service = await SchemaCompareMainWindow.getService(msSqlProvider);
 					const result = await service.schemaComparePublishChanges(this.comparisonResult.operationId, this.targetEndpointInfo.serverName, this.targetEndpointInfo.databaseName, azdata.TaskExecutionMode.execute);
 					if (!result || !result.success) {
 						Telemetry.sendTelemetryEvent('SchemaCompareApplyFailed', {
@@ -863,7 +863,7 @@ export class SchemaCompareResult {
 			}
 
 			let fileUri = fileUris[0];
-			const service = await SchemaCompareResult.getService('MSSQL');
+			const service = await SchemaCompareMainWindow.getService('MSSQL');
 			let startTime = Date.now();
 			const result = await service.schemaCompareOpenScmp(fileUri.fsPath);
 			if (!result || !result.success) {
@@ -962,7 +962,7 @@ export class SchemaCompareResult {
 
 			let startTime = Date.now();
 			Telemetry.sendTelemetryEvent('SchemaCompareSaveScmp');
-			const service = await SchemaCompareResult.getService(msSqlProvider);
+			const service = await SchemaCompareMainWindow.getService(msSqlProvider);
 			const result = await service.schemaCompareSaveScmp(this.sourceEndpointInfo, this.targetEndpointInfo, azdata.TaskExecutionMode.execute, this.deploymentOptions, filePath.fsPath, sourceExcludes, targetExcludes);
 			if (!result || !result.success) {
 				Telemetry.sendTelemetryEvent('SchemaCompareSaveScmpFailed', {
@@ -1012,7 +1012,7 @@ export class SchemaCompareResult {
 
 	private async GetDefaultDeploymentOptions(): Promise<void> {
 		// Same as dacfx default options
-		const service = await SchemaCompareResult.getService(msSqlProvider);
+		const service = await SchemaCompareMainWindow.getService(msSqlProvider);
 		let result = await service.schemaCompareGetDefaultOptions();
 		this.deploymentOptions = result.defaultDeploymentOptions;
 	}

--- a/extensions/schema-compare/src/test/schemaCompare.test.ts
+++ b/extensions/schema-compare/src/test/schemaCompare.test.ts
@@ -9,7 +9,7 @@ import * as should from 'should';
 import * as azdata from 'azdata';
 import 'mocha';
 import { SchemaCompareDialog } from './../dialogs/schemaCompareDialog';
-import { SchemaCompareResult } from './../schemaCompareResult';
+import { SchemaCompareMainWindow } from '../schemaCompareMainWindow';
 import { SchemaCompareTestService } from './testSchemaCompareService';
 
 // Mock test data
@@ -54,7 +54,7 @@ const mockTargetEndpoint: azdata.SchemaCompareEndpointInfo = {
 
 describe('SchemaCompareDialog.openDialog', function (): void {
 	it('Should be correct when created.', async function (): Promise<void> {
-		let schemaCompareResult = new SchemaCompareResult();
+		let schemaCompareResult = new SchemaCompareMainWindow();
 		let dialog = new SchemaCompareDialog(schemaCompareResult);
 		await dialog.openDialog();
 
@@ -69,7 +69,7 @@ describe('SchemaCompareResult.start', function (): void {
 		let sc = new SchemaCompareTestService();
 		azdata.dataprotocol.registerSchemaCompareServicesProvider(sc);
 
-		let result = new SchemaCompareResult();
+		let result = new SchemaCompareMainWindow();
 		await result.start(null);
 		let promise = new Promise(resolve => setTimeout(resolve, 5000)); // to ensure comparison result view is initialized
 		await promise;


### PR DESCRIPTION
Rename SchemaCompareResult to SchemaCompareMainWindow to be more clear since it is now the start point and main page of Schema Compare.