### PR TITLE
Add column sizing for Import Wizards preview data page

### DIFF
--- a/extensions/import/src/wizard/pages/prosePreviewPage.ts
+++ b/extensions/import/src/wizard/pages/prosePreviewPage.ts
@@ -36,7 +36,7 @@ export class ProsePreviewPage extends ImportPage {
 			data: null,
 			columns: null,
 			fontSize: 32,
-			forceFitColumns: false
+			forceFitColumns: azdata.ColumnSizingMode.AutoFit
 		}).component();
 		this.refresh = this.view.modelBuilder.button().withProperties({
 			label: localize('flatFileImport.refresh', 'Refresh'),

--- a/extensions/import/src/wizard/pages/prosePreviewPage.ts
+++ b/extensions/import/src/wizard/pages/prosePreviewPage.ts
@@ -35,6 +35,7 @@ export class ProsePreviewPage extends ImportPage {
 		this.table = this.view.modelBuilder.table().withProperties<azdata.TableComponentProperties>({
 			data: null,
 			columns: null,
+			fontSize: 32,
 			forceFitColumns: false
 		}).component();
 		this.refresh = this.view.modelBuilder.button().withProperties({

--- a/extensions/import/src/wizard/pages/prosePreviewPage.ts
+++ b/extensions/import/src/wizard/pages/prosePreviewPage.ts
@@ -33,9 +33,8 @@ export class ProsePreviewPage extends ImportPage {
 
 	async start(): Promise<boolean> {
 		this.table = this.view.modelBuilder.table().withProperties<azdata.TableComponentProperties>({
-			data: null,
-			columns: null,
-			fontSize: 32,
+			data: undefined,
+			columns: undefined,
 			forceFitColumns: azdata.ColumnSizingMode.AutoFit
 		}).component();
 		this.refresh = this.view.modelBuilder.button().withProperties({

--- a/extensions/import/src/wizard/pages/prosePreviewPage.ts
+++ b/extensions/import/src/wizard/pages/prosePreviewPage.ts
@@ -32,7 +32,11 @@ export class ProsePreviewPage extends ImportPage {
 	}
 
 	async start(): Promise<boolean> {
-		this.table = this.view.modelBuilder.table().component();
+		this.table = this.view.modelBuilder.table().withProperties<azdata.TableComponentProperties>({
+			data: null,
+			columns: null,
+			forceFitColumns: false
+		}).component();
 		this.refresh = this.view.modelBuilder.button().withProperties({
 			label: localize('flatFileImport.refresh', 'Refresh'),
 			isFile: false

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rxjs": "5.4.0",
     "sanitize-html": "^1.19.1",
     "semver": "^5.5.0",
-    "slickgrid": "github:anthonydresser/SlickGrid#2.3.29",
+    "slickgrid": "github:anthonydresser/SlickGrid#2.3.30",
     "spdlog": "^0.9.0",
     "sudo-prompt": "9.0.0",
     "v8-inspect-profiler": "^0.0.20",

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -3211,6 +3211,7 @@ declare module 'azdata' {
 		columns: string[] | TableColumn[];
 		fontSize?: number | string;
 		selectedRows?: number[];
+		forceFitColumns?: boolean;
 	}
 
 	export interface FileBrowserTreeProperties extends ComponentProperties {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -3208,8 +3208,8 @@ declare module 'azdata' {
 
 	export enum ColumnSizingMode {
 		ForceFit = 0,	// all columns will be sized to fit in viewable space, no horiz scroll bar
-		AutoFit = 1,	// columns will be ForceFit unless there are too many.  If too many component will revert to default column sizing
-		Default = 2		// columns use default sizing based on cell data, horiz scroll bar present if more cells than visible in view area
+		AutoFit = 1,	// columns will be ForceFit up to a certain number; currently 3.  At 4 or more the behavior will switch to NO force fit
+		DataFit = 2		// columns use sizing based on cell data, horiz scroll bar present if more cells than visible in view area
 	}
 
 	export interface TableComponentProperties extends ComponentProperties {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -3206,12 +3206,18 @@ declare module 'azdata' {
 		customAction = 1
 	}
 
+	export enum ColumnSizingMode {
+		ForceFit = 0,	// all columns will be sized to fit in viewable space, no horiz scroll bar
+		AutoFit = 1,	// columns will be ForceFit unless there are too many.  If too many component will revert to default column sizing
+		Default = 2		// columns use default sizing based on cell data, horiz scroll bar present if more cells than visible in view area
+	}
+
 	export interface TableComponentProperties extends ComponentProperties {
 		data: any[][];
 		columns: string[] | TableColumn[];
 		fontSize?: number | string;
 		selectedRows?: number[];
-		forceFitColumns?: boolean;
+		forceFitColumns?: ColumnSizingMode;
 	}
 
 	export interface FileBrowserTreeProperties extends ComponentProperties {

--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -334,4 +334,9 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 
 		this.styleElement.innerHTML = content.join('\n');
 	}
+
+	public setOptions(newOptions: Slick.GridOptions<T>) {
+		this._grid.setOptions(newOptions);
+		this._grid.invalidate();
+	}
 }

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -169,6 +169,12 @@ export enum ModelComponentTypes {
 	Hyperlink
 }
 
+export enum ColumnSizingMode {
+	ForceFit = 0,	// all columns will be sized to fit in viewable space, no horiz scroll bar
+	AutoFit = 1,	// columns will be ForceFit unless there are too many.  If too many component will revert to default column sizing
+	Default = 2		// columns use default sizing based on cell data, horiz scroll bar present if more cells than visible in view area
+}
+
 export enum AgentSubSystem {
 	TransactSql = 1,
 	ActiveScripting = 2,

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -171,8 +171,8 @@ export enum ModelComponentTypes {
 
 export enum ColumnSizingMode {
 	ForceFit = 0,	// all columns will be sized to fit in viewable space, no horiz scroll bar
-	AutoFit = 1,	// columns will be ForceFit unless there are too many.  If too many component will revert to default column sizing
-	Default = 2		// columns use default sizing based on cell data, horiz scroll bar present if more cells than visible in view area
+	AutoFit = 1,	// columns will be ForceFit up to a certain number; currently 3.  At 4 or more the behavior will switch to NO force fit
+	DataFit = 2		// columns use sizing based on cell data, horiz scroll bar present if more cells than visible in view area
 }
 
 export enum AgentSubSystem {

--- a/src/sql/workbench/api/node/extHostModelView.ts
+++ b/src/sql/workbench/api/node/extHostModelView.ts
@@ -1126,6 +1126,13 @@ class TableComponentWrapper extends ComponentWrapper implements azdata.TableComp
 		this.setProperty('selectedRows', v);
 	}
 
+	public get forceFitColumns(): boolean {
+		return this.properties['forceFitColumns'];
+	}
+	public set forceFitColunms(v: boolean) {
+		this.setProperty('forceFitColumns', v);
+	}
+
 	public get onRowSelected(): vscode.Event<any> {
 		let emitter = this._emitterMap.get(ComponentEventType.onSelectedRowChanged);
 		return emitter && emitter.event;

--- a/src/sql/workbench/api/node/extHostModelView.ts
+++ b/src/sql/workbench/api/node/extHostModelView.ts
@@ -1126,10 +1126,10 @@ class TableComponentWrapper extends ComponentWrapper implements azdata.TableComp
 		this.setProperty('selectedRows', v);
 	}
 
-	public get forceFitColumns(): boolean {
+	public get forceFitColumns(): azdata.ColumnSizingMode {
 		return this.properties['forceFitColumns'];
 	}
-	public set forceFitColunms(v: boolean) {
+	public set forceFitColunms(v: azdata.ColumnSizingMode) {
 		this.setProperty('forceFitColumns', v);
 	}
 

--- a/src/sql/workbench/api/node/extHostModelView.ts
+++ b/src/sql/workbench/api/node/extHostModelView.ts
@@ -13,7 +13,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 
 import { SqlMainContext, ExtHostModelViewShape, MainThreadModelViewShape, ExtHostModelViewTreeViewsShape } from 'sql/workbench/api/node/sqlExtHost.protocol';
-import { IItemConfig, ModelComponentTypes, IComponentShape, IComponentEventArgs, ComponentEventType } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { IItemConfig, ModelComponentTypes, IComponentShape, IComponentEventArgs, ComponentEventType, ColumnSizingMode } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 
 class ModelBuilderImpl implements azdata.ModelBuilder {
@@ -1126,10 +1126,10 @@ class TableComponentWrapper extends ComponentWrapper implements azdata.TableComp
 		this.setProperty('selectedRows', v);
 	}
 
-	public get forceFitColumns(): azdata.ColumnSizingMode {
+	public get forceFitColumns(): ColumnSizingMode {
 		return this.properties['forceFitColumns'];
 	}
-	public set forceFitColunms(v: azdata.ColumnSizingMode) {
+	public set forceFitColunms(v: ColumnSizingMode) {
 		this.setProperty('forceFitColumns', v);
 	}
 

--- a/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
@@ -554,7 +554,8 @@ export function createApiFactory(
 				ActionOnCellCheckboxCheck: sqlExtHostTypes.ActionOnCellCheckboxCheck,
 				StepCompletionAction: sqlExtHostTypes.StepCompletionAction,
 				AgentSubSystem: sqlExtHostTypes.AgentSubSystem,
-				ExtensionNodeType: sqlExtHostTypes.ExtensionNodeType
+				ExtensionNodeType: sqlExtHostTypes.ExtensionNodeType,
+				ColumnSizingMode: sqlExtHostTypes.ColumnSizingMode
 			};
 		},
 

--- a/src/sql/workbench/electron-browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/table.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 
 import * as azdata from 'azdata';
+import { ColumnSizingMode } from 'sql/workbench/api/common/sqlExtHostTypes';
 
 import { ComponentBase } from 'sql/workbench/electron-browser/modelComponents/componentBase';
 import { IComponent, IComponentDescriptor, IModelStore, ComponentEventType } from 'sql/workbench/electron-browser/modelComponents/interfaces';
@@ -163,16 +164,21 @@ export default class TableComponent extends ComponentBase implements IComponent,
 
 		// convert the tri-state viewmodel columnSizingMode to be either true or false for SlickGrid
 		switch (this.forceFitColumns) {
-			case azdata.ColumnSizingMode.Default: {
+			case ColumnSizingMode.Default: {
 				forceFit = false;
 				break;
 			}
-			case azdata.ColumnSizingMode.ForceFit: {
+			case ColumnSizingMode.ForceFit: {
 				forceFit = true;
 				break;
 			}
-			case azdata.ColumnSizingMode.AutoFit: {
+			case ColumnSizingMode.AutoFit: {
 				// determine if force fit should be on or off based on the number of columns
+				// this can be made more sophisticated if need be in the future.  a simple
+				// check for 3 or less force fits causes the small number of columns to fill the
+				// screen better.  4 or more, slickgrid seems to do a good job filling the view and having forceFit
+				// false enables the scroll bar and avoids the over-packing should there be a very large
+				// number of columns
 				if (this._table.columns.length > 3) {
 					forceFit = false;
 				}
@@ -181,7 +187,6 @@ export default class TableComponent extends ComponentBase implements IComponent,
 				}
 				break;
 			}
-
 		}
 		let updateOptions = <Slick.GridOptions<any>>{
 			forceFitColumns: forceFit
@@ -282,6 +287,6 @@ export default class TableComponent extends ComponentBase implements IComponent,
 	}
 
 	public get forceFitColumns() {
-		return this.getPropertyOrDefault<azdata.TableComponentProperties, azdata.ColumnSizingMode>((props) => props.forceFitColumns, azdata.ColumnSizingMode.Default);
+		return this.getPropertyOrDefault<azdata.TableComponentProperties, ColumnSizingMode>((props) => props.forceFitColumns, ColumnSizingMode.Default);
 	}
 }

--- a/src/sql/workbench/electron-browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/table.component.ts
@@ -119,7 +119,7 @@ export default class TableComponent extends ComponentBase implements IComponent,
 				syncColumnCellResize: true,
 				enableColumnReorder: false,
 				enableCellNavigation: true,
-				forceFitColumns: false
+				forceFitColumns: this.forceFitColumns
 			};
 
 			this._table = new Table<Slick.SlickData>(this._inputContainer.nativeElement, { dataProvider: this._tableData, columns: this._tableColumns }, options);
@@ -179,6 +179,7 @@ export default class TableComponent extends ComponentBase implements IComponent,
 		if (this.selectedRows) {
 			this._table.setSelectedRows(this.selectedRows);
 		}
+		let forceFit: boolean = this.forceFitColumns;
 
 		for (let col in this._checkboxColumns) {
 			this.registerCheckboxPlugin(this._checkboxColumns[col]);
@@ -249,5 +250,9 @@ export default class TableComponent extends ComponentBase implements IComponent,
 
 	public set selectedRows(newValue: number[]) {
 		this.setPropertyFromUI<azdata.TableComponentProperties, number[]>((props, value) => props.selectedRows = value, newValue);
+	}
+
+	public get forceFitColumns() {
+		return this.getPropertyOrDefault<azdata.TableComponentProperties, boolean>((props) => props.forceFitColumns, true);
 	}
 }

--- a/src/sql/workbench/electron-browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/table.component.ts
@@ -119,7 +119,7 @@ export default class TableComponent extends ComponentBase implements IComponent,
 				syncColumnCellResize: true,
 				enableColumnReorder: false,
 				enableCellNavigation: true,
-				forceFitColumns: false// this.forceFitColumns
+				forceFitColumns: true // default to true during init, actual value will be updated when setProperties() is called
 			};
 
 			this._table = new Table<Slick.SlickData>(this._inputContainer.nativeElement, { dataProvider: this._tableData, columns: this._tableColumns }, options);
@@ -159,10 +159,32 @@ export default class TableComponent extends ComponentBase implements IComponent,
 	private layoutTable(): void {
 		let width: number = this.convertSizeToNumber(this.width);
 		let height: number = this.convertSizeToNumber(this.height);
+		let forceFit: boolean = true;
 
-		// update the slickgrid options
+		// convert the tri-state viewmodel columnSizingMode to be either true or false for SlickGrid
+		switch (this.forceFitColumns) {
+			case azdata.ColumnSizingMode.Default: {
+				forceFit = false;
+				break;
+			}
+			case azdata.ColumnSizingMode.ForceFit: {
+				forceFit = true;
+				break;
+			}
+			case azdata.ColumnSizingMode.AutoFit: {
+				// determine if force fit should be on or off based on the number of columns
+				if (this._table.columns.length > 3) {
+					forceFit = false;
+				}
+				else {
+					forceFit = true;
+				}
+				break;
+			}
+
+		}
 		let updateOptions = <Slick.GridOptions<any>>{
-			forceFitColumns: this.forceFitColumns
+			forceFitColumns: forceFit
 		};
 		this._table.setOptions(updateOptions);
 
@@ -260,6 +282,6 @@ export default class TableComponent extends ComponentBase implements IComponent,
 	}
 
 	public get forceFitColumns() {
-		return this.getPropertyOrDefault<azdata.TableComponentProperties, boolean>((props) => props.forceFitColumns, true);
+		return this.getPropertyOrDefault<azdata.TableComponentProperties, azdata.ColumnSizingMode>((props) => props.forceFitColumns, azdata.ColumnSizingMode.Default);
 	}
 }

--- a/src/sql/workbench/electron-browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/table.component.ts
@@ -119,7 +119,7 @@ export default class TableComponent extends ComponentBase implements IComponent,
 				syncColumnCellResize: true,
 				enableColumnReorder: false,
 				enableCellNavigation: true,
-				forceFitColumns: true
+				forceFitColumns: false
 			};
 
 			this._table = new Table<Slick.SlickData>(this._inputContainer.nativeElement, { dataProvider: this._tableData, columns: this._tableColumns }, options);

--- a/src/sql/workbench/electron-browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/table.component.ts
@@ -119,7 +119,7 @@ export default class TableComponent extends ComponentBase implements IComponent,
 				syncColumnCellResize: true,
 				enableColumnReorder: false,
 				enableCellNavigation: true,
-				forceFitColumns: this.forceFitColumns
+				forceFitColumns: false// this.forceFitColumns
 			};
 
 			this._table = new Table<Slick.SlickData>(this._inputContainer.nativeElement, { dataProvider: this._tableData, columns: this._tableColumns }, options);
@@ -159,9 +159,17 @@ export default class TableComponent extends ComponentBase implements IComponent,
 	private layoutTable(): void {
 		let width: number = this.convertSizeToNumber(this.width);
 		let height: number = this.convertSizeToNumber(this.height);
+
+		// update the slickgrid options
+		let updateOptions = <Slick.GridOptions<any>>{
+			forceFitColumns: this.forceFitColumns
+		};
+		this._table.setOptions(updateOptions);
+
 		this._table.layout(new Dimension(
 			width && width > 0 ? width : getContentWidth(this._inputContainer.nativeElement),
 			height && height > 0 ? height : getContentHeight(this._inputContainer.nativeElement)));
+		this._table.resizeCanvas();
 	}
 
 	public setLayout(): void {
@@ -179,7 +187,6 @@ export default class TableComponent extends ComponentBase implements IComponent,
 		if (this.selectedRows) {
 			this._table.setSelectedRows(this.selectedRows);
 		}
-		let forceFit: boolean = this.forceFitColumns;
 
 		for (let col in this._checkboxColumns) {
 			this.registerCheckboxPlugin(this._checkboxColumns[col]);

--- a/src/sql/workbench/electron-browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/electron-browser/modelComponents/table.component.ts
@@ -164,12 +164,8 @@ export default class TableComponent extends ComponentBase implements IComponent,
 
 		// convert the tri-state viewmodel columnSizingMode to be either true or false for SlickGrid
 		switch (this.forceFitColumns) {
-			case ColumnSizingMode.Default: {
+			case ColumnSizingMode.DataFit: {
 				forceFit = false;
-				break;
-			}
-			case ColumnSizingMode.ForceFit: {
-				forceFit = true;
 				break;
 			}
 			case ColumnSizingMode.AutoFit: {
@@ -179,12 +175,13 @@ export default class TableComponent extends ComponentBase implements IComponent,
 				// screen better.  4 or more, slickgrid seems to do a good job filling the view and having forceFit
 				// false enables the scroll bar and avoids the over-packing should there be a very large
 				// number of columns
-				if (this._table.columns.length > 3) {
-					forceFit = false;
-				}
-				else {
-					forceFit = true;
-				}
+				forceFit = (this._table.columns.length <= 3);
+				break;
+			}
+			case ColumnSizingMode.ForceFit:
+			default: {
+				// default behavior for the table component (used primarily in wizards) is to forcefit the columns
+				forceFit = true;
 				break;
 			}
 		}
@@ -287,6 +284,6 @@ export default class TableComponent extends ComponentBase implements IComponent,
 	}
 
 	public get forceFitColumns() {
-		return this.getPropertyOrDefault<azdata.TableComponentProperties, ColumnSizingMode>((props) => props.forceFitColumns, ColumnSizingMode.Default);
+		return this.getPropertyOrDefault<azdata.TableComponentProperties, ColumnSizingMode>((props) => props.forceFitColumns, ColumnSizingMode.ForceFit);
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8336,9 +8336,9 @@ slice-ansi@^2.0.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-"slickgrid@github:anthonydresser/SlickGrid#2.3.29":
-  version "2.3.29"
-  resolved "https://codeload.github.com/anthonydresser/SlickGrid/tar.gz/40b88f10d36d35f350838d1a2142c4b790701709"
+"slickgrid@github:anthonydresser/SlickGrid#2.3.30":
+  version "2.3.30"
+  resolved "https://codeload.github.com/anthonydresser/SlickGrid/tar.gz/c941811d833504dfaf40b29b69044a42595bfafb"
   dependencies:
     jquery ">=1.8.0"
     jquery-ui ">=1.8.0"


### PR DESCRIPTION
This PR improves the preview data view in the Import Wizard.  Previously, all data was force fit into the grid view.  The TableComponent was hard coded to always use "forceFitColumns" for grids in wizard pages.  This PR introduces the ability for an extension to specify 3 modes for column sizing:

1) forceFitColumns on - this is the default so that existing wizards are not changed, columns are "fit" to the grid view
2) forceFitColumns off - don't force fit the columns to the grid view
3) forceFitColumns auto - determine to fit the columns to the view based on the number of columns

forceFitColumns auto is used for the preview data.  Right now auto is a simple check of <= 3 columns will be fit to the view, 4 or more columns are not force fit to the view

This PR additionally brings in an update to slick grid.  SlickGrid had an issue where if the forceFitColumns option was changed after creation the horiz scrollbar CSS property was not updated to reflect the change.