### PR TITLE
Fix #4461 Dacpac: Extract lets me save to invalid file path like 'sd' and never adds .dacpac / .bacpac

### DIFF
--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -2,7 +2,7 @@
 	"name": "dacpac",
 	"displayName": "SQL Server Dacpac",
 	"description": "SQL Server Dacpac for Azure Data Studio.",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"publisher": "Microsoft",
 	"preview": true,
 	"engines": {

--- a/extensions/dacpac/src/test/dacpac.test.ts
+++ b/extensions/dacpac/src/test/dacpac.test.ts
@@ -7,8 +7,9 @@
 import 'mocha';
 import * as should from 'should';
 import * as os from 'os';
-import { isValidFilenameCharacter, sanitizeStringForFilename } from '../wizard/api/utils';
+import { isValidFilenameCharacter, sanitizeStringForFilename, isValidBasename } from '../wizard/api/utils';
 
+const isWindows = os.type().includes('Windows');
 
 describe('Sanitize database name for filename tests', function (): void {
 	it('Should only validate if one character is passed', async () => {
@@ -25,8 +26,6 @@ describe('Sanitize database name for filename tests', function (): void {
 	});
 
 	it('Should determine invalid Windows file name characters', async () => {
-		let isWindows = os.platform() === 'win32';
-
 		// invalid only for Windows
 		should(isValidFilenameCharacter('?')).equal(isWindows ? false : true);
 		should(isValidFilenameCharacter(':')).equal(isWindows ? false : true);
@@ -45,3 +44,72 @@ describe('Sanitize database name for filename tests', function (): void {
 		should(sanitizeStringForFilename(invalidDbName)).equal(isWindows ? expectedWindows : expectedNonWindows);
 	});
 });
+
+describe('Check for invalid filename tests', function (): void {
+	it('Should determine invalid filenames', async () => {
+		// valid filename
+		should(isValidBasename(formatFileName('ValidName.dacpac'))).equal(true);
+
+		// invalid for both Windows and non-Windows
+		should(isValidBasename(formatFileName('	.dacpac'))).equal(false);
+		should(isValidBasename(formatFileName(' .dacpac'))).equal(false);
+		should(isValidBasename(formatFileName('  	.dacpac'))).equal(false);
+		should(isValidBasename(formatFileName('..dacpac'))).equal(false);
+		should(isValidBasename(formatFileName('...dacpac'))).equal(false);
+		should(isValidBasename(null)).equal(false);
+		should(isValidBasename(undefined)).equal(false);
+		should(isValidBasename('\\')).equal(false);
+		should(isValidBasename('/')).equal(false);
+
+		// most file systems do not allow files > 255 length
+		should(isValidBasename(formatFileName('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.dacpac'))).equal(false);
+	});
+
+	it('Should determine invalid Windows filenames', async () => {
+		// invalid characters only for Windows
+		should(isValidBasename(formatFileName('?.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName(':.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('*.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('<.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('>.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('|.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('".dacpac'))).equal(isWindows ? false : true);
+
+		// Windows filenames cannot end with a whitespace
+		should(isValidBasename(formatFileName('test   .dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('test	.dacpac'))).equal(isWindows ? false : true);
+	});
+
+	it('Should determine Windows forbidden filenames', async () => {
+		let isWindows = os.platform() === 'win32';
+
+		// invalid only for Windows
+		should(isValidBasename(formatFileName('CON.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('PRN.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('AUX.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('NUL.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('COM1.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('COM2.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('COM3.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('COM4.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('COM5.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('COM6.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('COM7.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('COM8.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('COM9.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('LPT1.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('LPT2.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('LPT3.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('LPT4.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('LPT5.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('LPT6.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('LPT7.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('LPT8.dacpac'))).equal(isWindows ? false : true);
+		should(isValidBasename(formatFileName('LPT9.dacpac'))).equal(isWindows ? false : true);
+	});
+});
+
+function formatFileName(filename: string): string {
+	const filePath = isWindows ? 'c:\\users\\test\\' : '/Users/test/';
+	return filePath + filename;
+}

--- a/extensions/dacpac/src/test/dacpac.test.ts
+++ b/extensions/dacpac/src/test/dacpac.test.ts
@@ -81,8 +81,6 @@ describe('Check for invalid filename tests', function (): void {
 	});
 
 	it('Should determine Windows forbidden filenames', async () => {
-		let isWindows = os.platform() === 'win32';
-
 		// invalid only for Windows
 		should(isValidBasename(formatFileName('CON.dacpac'))).equal(isWindows ? false : true);
 		should(isValidBasename(formatFileName('PRN.dacpac'))).equal(isWindows ? false : true);

--- a/extensions/dacpac/src/test/dacpac.test.ts
+++ b/extensions/dacpac/src/test/dacpac.test.ts
@@ -7,9 +7,10 @@
 import 'mocha';
 import * as should from 'should';
 import * as os from 'os';
+import * as path from 'path';
 import { isValidFilenameCharacter, sanitizeStringForFilename, isValidBasename } from '../wizard/api/utils';
 
-const isWindows = os.type().includes('Windows');
+const isWindows = os.platform() === 'win32';
 
 describe('Sanitize database name for filename tests', function (): void {
 	it('Should only validate if one character is passed', async () => {
@@ -108,6 +109,5 @@ describe('Check for invalid filename tests', function (): void {
 });
 
 function formatFileName(filename: string): string {
-	const filePath = isWindows ? 'c:\\users\\test\\' : '/Users/test/';
-	return filePath + filename;
+	return path.join(os.tmpdir(), filename);
 }

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -168,7 +168,7 @@ export abstract class DacFxConfigPage extends BasePage {
 		return vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
 	}
 
-	protected validateFilePath() {
+	protected appendFileExtensionIfNeeded() {
 		// make sure filepath ends in proper file extension if it's a valid name
 		if (!this.model.filePath.endsWith(this.fileExtension) && isValidBasename(this.model.filePath)) {
 			this.model.filePath += this.fileExtension;

--- a/extensions/dacpac/src/wizard/api/utils.ts
+++ b/extensions/dacpac/src/wizard/api/utils.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 
 const WINDOWS_INVALID_FILE_CHARS = /[\\/:\*\?"<>\|]/g;
 const UNIX_INVALID_FILE_CHARS = /[\\/]/g;
-const isWindows = os.type().includes('Windows');
+const isWindows = os.platform() === 'win32';
 const WINDOWS_FORBIDDEN_NAMES = /^(con|prn|aux|clock\$|nul|lpt[0-9]|com[0-9])$/i;
 
 /**

--- a/extensions/dacpac/src/wizard/api/utils.ts
+++ b/extensions/dacpac/src/wizard/api/utils.ts
@@ -3,8 +3,12 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as os from 'os';
-const INVALID_FILE_CHARS_Windows = /[\\/:\*\?"<>\|]/g;
-const INVALID_FILE_CHARS = /[\\/]/g;
+import * as path from 'path';
+
+const WINDOWS_INVALID_FILE_CHARS = /[\\/:\*\?"<>\|]/g;
+const UNIX_INVALID_FILE_CHARS = /[\\/]/g;
+const isWindows = os.type().includes('Windows');
+const WINDOWS_FORBIDDEN_NAMES = /^(con|prn|aux|clock\$|nul|lpt[0-9]|com[0-9])$/i;
 
 /**
  * Determines if a given character is a valid filename character
@@ -16,17 +20,16 @@ export function isValidFilenameCharacter(c: string): boolean {
 		return false;
 	}
 	let isWindows = os.platform() === 'win32';
-	INVALID_FILE_CHARS_Windows.lastIndex = 0;
-	INVALID_FILE_CHARS.lastIndex = 0;
-	if (isWindows && INVALID_FILE_CHARS_Windows.test(c)) {
+	WINDOWS_INVALID_FILE_CHARS.lastIndex = 0;
+	UNIX_INVALID_FILE_CHARS.lastIndex = 0;
+	if (isWindows && WINDOWS_INVALID_FILE_CHARS.test(c)) {
 		return false;
-	} else if (!isWindows && INVALID_FILE_CHARS.test(c)) {
+	} else if (!isWindows && UNIX_INVALID_FILE_CHARS.test(c)) {
 		return false;
 	}
 
 	return true;
 }
-
 
 /**
  * Replaces invalid filename characters in a string with underscores
@@ -40,4 +43,49 @@ export function sanitizeStringForFilename(s: string): string {
 	}
 
 	return result;
+}
+
+/**
+ * Returns true if the string is a valid filename
+ * Logic is copied from src\vs\base\common\extpath.ts
+ * @param name filename to check
+ */
+export function isValidBasename(name: string | null | undefined): boolean {
+	const invalidFileChars = isWindows ? WINDOWS_INVALID_FILE_CHARS : UNIX_INVALID_FILE_CHARS;
+
+	if (!name) {
+		return false;
+	}
+
+	if (isWindows && name[name.length - 1] === '.') {
+		return false; // Windows: file cannot end with a "."
+	}
+
+	let basename = path.parse(name).name;
+	if (!basename || basename.length === 0 || /^\s+$/.test(basename)) {
+		return false; // require a name that is not just whitespace
+	}
+
+	invalidFileChars.lastIndex = 0;
+	if (invalidFileChars.test(basename)) {
+		return false; // check for certain invalid file characters
+	}
+
+	if (isWindows && WINDOWS_FORBIDDEN_NAMES.test(basename)) {
+		return false; // check for certain invalid file names
+	}
+
+	if (basename === '.' || basename === '..') {
+		return false; // check for reserved values
+	}
+
+	if (isWindows && basename.length !== basename.trim().length) {
+		return false; // Windows: file cannot end with a whitespace
+	}
+
+	if (basename.length > 255) {
+		return false; // most file systems do not allow files > 255 length
+	}
+
+	return true;
 }

--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -161,22 +161,17 @@ export class DataTierApplicationWizard {
 		});
 
 		this.wizard.onPageChanged(async (event) => {
-			let idx = event.newPage;
-			let page = this.getPage(idx);
-
-			if (page !== undefined) {
-				page.dacFxPage.setupNavigationValidator();
-				page.dacFxPage.onPageEnter();
+			let idxLast = event.lastPage;
+			let lastPage = this.getPage(idxLast);
+			if (lastPage) {
+				lastPage.dacFxPage.onPageLeave();
 			}
 
-			//do onPageLeave for summary page so that GenerateScript button only shows up if upgrading database
-			let idxLast = event.lastPage;
-
-			if (this.isSummaryPage(idxLast)) {
-				let lastPage = this.pages.get('summary');
-				if (lastPage) {
-					lastPage.dacFxPage.onPageLeave();
-				}
+			let idx = event.newPage;
+			let page = this.getPage(idx);
+			if (page) {
+				page.dacFxPage.setupNavigationValidator();
+				page.dacFxPage.onPageEnter();
 			}
 		});
 

--- a/extensions/dacpac/src/wizard/pages/exportConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/exportConfigPage.ts
@@ -54,7 +54,7 @@ export class ExportConfigPage extends DacFxConfigPage {
 
 
 	async onPageLeave(): Promise<boolean> {
-		this.validateFilePath();
+		this.appendFileExtensionIfNeeded();
 		return true;
 	}
 

--- a/extensions/dacpac/src/wizard/pages/exportConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/exportConfigPage.ts
@@ -52,6 +52,12 @@ export class ExportConfigPage extends DacFxConfigPage {
 		return r1 && r2;
 	}
 
+
+	async onPageLeave(): Promise<boolean> {
+		this.validateFilePath();
+		return true;
+	}
+
 	public setupNavigationValidator() {
 		this.instance.registerNavigationValidator(() => {
 			if (this.databaseLoader.loading) {

--- a/extensions/dacpac/src/wizard/pages/extractConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/extractConfigPage.ts
@@ -55,6 +55,11 @@ export class ExtractConfigPage extends DacFxConfigPage {
 		return r1 && r2;
 	}
 
+	async onPageLeave(): Promise<boolean> {
+		this.validateFilePath();
+		return true;
+	}
+
 	public setupNavigationValidator() {
 		this.instance.registerNavigationValidator(() => {
 			if (this.databaseLoader.loading) {

--- a/extensions/dacpac/src/wizard/pages/extractConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/extractConfigPage.ts
@@ -56,7 +56,7 @@ export class ExtractConfigPage extends DacFxConfigPage {
 	}
 
 	async onPageLeave(): Promise<boolean> {
-		this.validateFilePath();
+		this.appendFileExtensionIfNeeded();
 		return true;
 	}
 


### PR DESCRIPTION
This adds validation for filenames if the filename is changed directly in the text box instead of in the file explorer for extract and export operations. Also adds the proper file extension if it isn't there and the filename is valid. Fixes #4461. 

![checkValidPath](https://user-images.githubusercontent.com/31145923/61492981-60118f80-a967-11e9-9657-62a9461fd2f1.gif)
