### PR TITLE
Updating Logo Source Path

### DIFF
--- a/samples/notebookSamples/SampleTSQLNotebook.ipynb
+++ b/samples/notebookSamples/SampleTSQLNotebook.ipynb
@@ -15,7 +15,7 @@
     "cells": [
         {
             "cell_type": "markdown",
-            "source": "<img src=\"https://github.com/Microsoft/azuredatastudio/samples/notebookSamples/Graphics/AzureDataStudioLogo.png?raw=true\" width=\"10%\">\r\n\r\n## SQL Notebooks in Azure Data Studio\r\n\r\nNotebooks allow rich text, images, code, and resultsets to be easily shared. This is a concept that is widely used in data science and which we feel is well suited to SQL work. \r\n",
+            "source": "<img src=\"https://github.com/Microsoft/azuredatastudio/blob/master/samples/notebookSamples/Graphics/AzureDataStudioLogo.png?raw=true\" width=\"10%\">\r\n\r\n## SQL Notebooks in Azure Data Studio\r\n\r\nNotebooks allow rich text, images, code, and resultsets to be easily shared. This is a concept that is widely used in data science and which we feel is well suited to SQL work. \r\n",
             "metadata": {}
         },
         {


### PR DESCRIPTION
The logo file doesn't show inside my notebook unless I add `blob/master/` within the path.
The path which works on my machine is: `https://github.com/Microsoft/azuredatastudio/blob/master/samples/notebookSamples/Graphics/AzureDataStudioLogo.png?raw=true`