### PR TITLE
Fixed issue on rendering checkbox status of tree node

### DIFF
--- a/src/sql/workbench/api/common/extHostModelViewTree.ts
+++ b/src/sql/workbench/api/common/extHostModelViewTree.ts
@@ -161,8 +161,10 @@ export class ExtHostTreeView<T> extends vsTreeExt.ExtHostTreeView<T> {
 	}
 
 	protected createTreeNode(element: T, extensionTreeItem: azdata.TreeComponentItem, parent?: vsTreeExt.TreeNode): vsTreeExt.TreeNode {
-		let item = super.createTreeNode(element, extensionTreeItem, parent);
-		item = Object.assign({}, item, { checked: extensionTreeItem.checked, enabled: extensionTreeItem.enabled });
-		return item;
+		let node = super.createTreeNode(element, extensionTreeItem, parent);
+		if (node.item) {
+			node.item = Object.assign({}, node.item, { checked: extensionTreeItem.checked, enabled: extensionTreeItem.enabled });
+		}
+		return node;
 	}
 }

--- a/src/sql/workbench/api/common/extHostModelViewTree.ts
+++ b/src/sql/workbench/api/common/extHostModelViewTree.ts
@@ -163,7 +163,7 @@ export class ExtHostTreeView<T> extends vsTreeExt.ExtHostTreeView<T> {
 	protected createTreeNode(element: T, extensionTreeItem: azdata.TreeComponentItem, parent?: vsTreeExt.TreeNode): vsTreeExt.TreeNode {
 		let node = super.createTreeNode(element, extensionTreeItem, parent);
 		if (node.item) {
-			node.item = Object.assign({}, node.item, { checked: extensionTreeItem.checked, enabled: extensionTreeItem.enabled });
+			node.item = Object.assign(node.item, { checked: extensionTreeItem.checked, enabled: extensionTreeItem.enabled });
 		}
 		return node;
 	}

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -467,6 +467,8 @@ export class ExtHostTreeView<T> extends Disposable {
 			tooltip: typeof extensionTreeItem.tooltip === 'string' ? extensionTreeItem.tooltip : undefined,
 			command: extensionTreeItem.command ? this.commands.toInternal(extensionTreeItem.command, disposable) : undefined,
 			contextValue: extensionTreeItem.contextValue,
+			enabled: (<any>element).enabled,
+			checked: (<any>element).checked,
 			icon,
 			iconDark: this.getDarkIconPath(extensionTreeItem) || icon,
 			themeIcon: extensionTreeItem.iconPath instanceof ThemeIcon ? { id: extensionTreeItem.iconPath.id } : undefined,

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -467,8 +467,6 @@ export class ExtHostTreeView<T> extends Disposable {
 			tooltip: typeof extensionTreeItem.tooltip === 'string' ? extensionTreeItem.tooltip : undefined,
 			command: extensionTreeItem.command ? this.commands.toInternal(extensionTreeItem.command, disposable) : undefined,
 			contextValue: extensionTreeItem.contextValue,
-			enabled: (<any>element).enabled,
-			checked: (<any>element).checked,
 			icon,
 			iconDark: this.getDarkIconPath(extensionTreeItem) || icon,
 			themeIcon: extensionTreeItem.iconPath instanceof ThemeIcon ? { id: extensionTreeItem.iconPath.id } : undefined,


### PR DESCRIPTION
* Issue: Checkbox status is always rendered as `-`

* Cause: `checked` and `enabled` field are missing when item created from tree data model for rendering.
Therefore, `checked` field always has `unidentified` value on rendering time.
(Missing `enabled` field did not cause issue since `unidentified` is considered as `true` for `enabled` field.)

Before fix:
![image](https://user-images.githubusercontent.com/19577035/61681456-5cad3980-acc2-11e9-9784-6aea1c606b14.png)

After fix: 
![image](https://user-images.githubusercontent.com/19577035/61681078-cc222980-acc0-11e9-85d9-e8d419197232.png)
