### PR TITLE
Fix #6466 big data clusters section not appearing

### DIFF
--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -191,14 +191,14 @@ const sqlBuiltInExtensions = [
     'import',
     'profiler',
     'admin-pack',
-    'big-data-cluster',
     'dacpac',
     'schema-compare',
     'cms'
 ];
-// make resource deployment extension only available in insiders
+// make resource deployment and BDC extension only available in insiders
 if (process.env['VSCODE_QUALITY'] === 'stable') {
     sqlBuiltInExtensions.push('resource-deployment');
+    sqlBuiltInExtensions.push('big-data-cluster');
 }
 const builtInExtensions = process.env['VSCODE_QUALITY'] === 'stable' ? require('../builtInExtensions.json') : require('../builtInExtensions-insiders.json');
 // {{SQL CARBON EDIT}} - End

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -224,15 +224,15 @@ const sqlBuiltInExtensions = [
 	'import',
 	'profiler',
 	'admin-pack',
-	'big-data-cluster',
 	'dacpac',
 	'schema-compare',
 	'cms'
 ];
 
-// make resource deployment extension only available in insiders
+// make resource deployment and BDC extension only available in insiders
 if (process.env['VSCODE_QUALITY'] === 'stable') {
 	sqlBuiltInExtensions.push('resource-deployment');
+	sqlBuiltInExtensions.push('big-data-cluster');
 }
 
 


### PR DESCRIPTION
This was treated as a marketplace install.
Should be built-in but only available in Insiders