### PR TITLE
set the auto release for insider build

### DIFF
--- a/build/azure-pipelines/common/publish.ts
+++ b/build/azure-pipelines/common/publish.ts
@@ -215,11 +215,15 @@ async function publish(commit: string, quality: string, platform: string, type: 
 
 	console.log('Asset:', JSON.stringify(asset, null, '  '));
 
+	// {{SQL CARBON EDIT}}
+	// Insiders: nightly build from master
+	const isReleased = (quality === 'insider' && /^master$|^refs\/heads\/master$/.test(sourceBranch) && /Project Collection Service Accounts|Microsoft.VisualStudio.Services.TFS/.test(queuedBy));
+
 	const release = {
 		id: commit,
 		timestamp: (new Date()).getTime(),
 		version,
-		isReleased: false,
+		isReleased: isReleased,
 		sourceBranch,
 		queuedBy,
 		assets: [] as Array<Asset>,


### PR DESCRIPTION
in recent vscode merge, the isReleased flag is set to false, as a result we don’t have insider build for a week. now I am adding back the logic that worked for us before.