### PR TITLE
Specifies node version to run project

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "license": "MIT",
   "main": "./out/main",
   "private": true,
+  "engines":{
+    "node": ">=10.15.1 <11.0.0"
+  },
   "scripts": {
     "test": "mocha",
     "preinstall": "node build/npm/preinstall.js",


### PR DESCRIPTION
Going through the getting started wiki page, we specify a node version to run the project but it's never mentioned in package.json.