### PR TITLE
Fix #6485 big-data-cluster extension fails to load

### DIFF
--- a/extensions/big-data-cluster/extension.webpack.config.js
+++ b/extensions/big-data-cluster/extension.webpack.config.js
@@ -12,7 +12,7 @@ const withDefaults = require('../shared.webpack.config');
 module.exports = withDefaults({
 	context: __dirname,
 	entry: {
-		main: './src/extension.ts'
+		extension: './src/extension.ts'
 	},
 	externals: {
 	}


### PR DESCRIPTION
- Entry point is `extension` not `main`