### PR TITLE
Add double quotes for localize hygiene check

### DIFF
--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -195,6 +195,10 @@ const useStrictFilter = [
 	'src/**'
 ];
 
+const sqlFilter = [
+	'src/sql/**'
+];
+
 // {{SQL CARBON EDIT}}
 const copyrightHeaderLines = [
 	'/*---------------------------------------------------------------------------------------------',
@@ -284,6 +288,23 @@ function hygiene(some) {
 
 		this.emit('data', file);
 	});
+
+	const localizeDoubleQuotes = es.through(function (file) {
+		const lines = file.__lines;
+		lines.forEach((line, i) => {
+			if (/localize/.test(line)) {
+				//console.error(file.relative + '(' + (i + 1) + ',1): Message parameter to localize calls should be double-quotes');
+				//errorCount++;
+			}
+			if (/localize\(['"].*['"],\s'.*'\)/.test(line)) {
+				console.error(file.relative + '(' + (i + 1) + ',1): Message parameter to localize calls should be double-quotes');
+				errorCount++;
+			}
+		});
+
+		this.emit('data', file);
+	});
+
 	// {{SQL CARBON EDIT}} END
 
 	const formatting = es.map(function (file, cb) {
@@ -352,7 +373,9 @@ function hygiene(some) {
 		.pipe(tsl)
 		// {{SQL CARBON EDIT}}
 		.pipe(filter(useStrictFilter))
-		.pipe(useStrict);
+		.pipe(useStrict)
+		.pipe(filter(sqlFilter))
+		.pipe(localizeDoubleQuotes);
 
 	const javascript = result
 		.pipe(filter(eslintFilter))

--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -292,10 +292,6 @@ function hygiene(some) {
 	const localizeDoubleQuotes = es.through(function (file) {
 		const lines = file.__lines;
 		lines.forEach((line, i) => {
-			if (/localize/.test(line)) {
-				//console.error(file.relative + '(' + (i + 1) + ',1): Message parameter to localize calls should be double-quotes');
-				//errorCount++;
-			}
 			if (/localize\(['"].*['"],\s'.*'\)/.test(line)) {
 				console.error(file.relative + '(' + (i + 1) + ',1): Message parameter to localize calls should be double-quotes');
 				errorCount++;

--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -374,6 +374,7 @@ function hygiene(some) {
 		// {{SQL CARBON EDIT}}
 		.pipe(filter(useStrictFilter))
 		.pipe(useStrict)
+		// Only look at files under the sql folder since we don't want to cause conflicts with VS code
 		.pipe(filter(sqlFilter))
 		.pipe(localizeDoubleQuotes);
 

--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -37,7 +37,7 @@ const defaultOptions: ICheckboxSelectColumnOptions = {
 	columnId: '_checkbox_selector',
 	cssClass: undefined,
 	headerCssClass: undefined,
-	toolTip: nls.localize('selectDeselectAll', 'Select/Deselect All'),
+	toolTip: nls.localize('selectDeselectAll', "Select/Deselect All"),
 	width: 30
 };
 

--- a/src/sql/base/browser/ui/table/plugins/rowDetailView.ts
+++ b/src/sql/base/browser/ui/table/plugins/rowDetailView.ts
@@ -310,7 +310,7 @@ export class RowDetailView<T extends Slick.SlickData> {
 		item._collapsed = true;
 		item._isPadding = false;
 		item._parent = parent;
-		item.name = parent.message ? parent.message : nls.localize('rowDetailView.loadError', 'Loading Error...');
+		item.name = parent.message ? parent.message : nls.localize('rowDetailView.loadError', "Loading Error...");
 		parent._child = item;
 		return item;
 	}

--- a/src/sql/platform/accounts/browser/accountDialog.ts
+++ b/src/sql/platform/accounts/browser/accountDialog.ts
@@ -126,7 +126,7 @@ export class AccountDialog extends Modal {
 		@ILogService logService: ILogService
 	) {
 		super(
-			localize('linkedAccounts', 'Linked accounts'),
+			localize('linkedAccounts', "Linked accounts"),
 			TelemetryKeys.Accounts,
 			telemetryService,
 			layoutService,
@@ -164,7 +164,7 @@ export class AccountDialog extends Modal {
 	public render() {
 		super.render();
 		attachModalDialogStyler(this, this._themeService);
-		this._closeButton = this.addFooterButton(localize('accountDialog.close', 'Close'), () => this.close());
+		this._closeButton = this.addFooterButton(localize('accountDialog.close', "Close"), () => this.close());
 		this.registerListeners();
 	}
 
@@ -176,14 +176,14 @@ export class AccountDialog extends Modal {
 
 		this._noaccountViewContainer = DOM.$('div.no-account-view');
 		const noAccountTitle = DOM.append(this._noaccountViewContainer, DOM.$('.no-account-view-label'));
-		const noAccountLabel = localize('accountDialog.noAccountLabel', 'There is no linked account. Please add an account.');
+		const noAccountLabel = localize('accountDialog.noAccountLabel', "There is no linked account. Please add an account.");
 		noAccountTitle.innerText = noAccountLabel;
 
 		// Show the add account button for the first provider
 		// Todo: If we have more than 1 provider, need to show all add account buttons for all providers
 		const buttonSection = DOM.append(this._noaccountViewContainer, DOM.$('div.button-section'));
 		this._addAccountButton = new Button(buttonSection);
-		this._addAccountButton.label = localize('accountDialog.addConnection', 'Add an account');
+		this._addAccountButton.label = localize('accountDialog.addConnection', "Add an account");
 		this._register(this._addAccountButton.onDidClick(() => {
 			(<IProviderViewUiComponent>values(this._providerViewsMap)[0]).addAccountAction.run();
 		}));

--- a/src/sql/platform/accounts/browser/accountDialogController.ts
+++ b/src/sql/platform/accounts/browser/accountDialogController.ts
@@ -12,7 +12,7 @@ import { IErrorMessageService } from 'sql/platform/errorMessage/common/errorMess
 export class AccountDialogController {
 
 	// MEMBER VARIABLES ////////////////////////////////////////////////////
-	private _addAccountErrorTitle = localize('accountDialog.addAccountErrorTitle', 'Error adding account');
+	private _addAccountErrorTitle = localize('accountDialog.addAccountErrorTitle', "Error adding account");
 
 	private _accountDialog: AccountDialog;
 	public get accountDialog(): AccountDialog { return this._accountDialog; }

--- a/src/sql/platform/accounts/browser/accountListRenderer.ts
+++ b/src/sql/platform/accounts/browser/accountListRenderer.ts
@@ -115,7 +115,7 @@ export class AccountListRenderer extends AccountPickerListRenderer {
 	public renderElement(account: azdata.Account, index: number, templateData: AccountListTemplate): void {
 		super.renderElement(account, index, templateData);
 		if (account.isStale) {
-			templateData.content.innerText = localize('refreshCredentials', 'You need to refresh the credentials for this account.');
+			templateData.content.innerText = localize('refreshCredentials', "You need to refresh the credentials for this account.");
 		} else {
 			templateData.content.innerText = '';
 		}

--- a/src/sql/platform/accounts/browser/accountManagement.contribution.ts
+++ b/src/sql/platform/accounts/browser/accountManagement.contribution.ts
@@ -21,11 +21,11 @@ const account: IJSONSchema = {
 	type: 'object',
 	properties: {
 		id: {
-			description: localize('carbon.extension.contributes.account.id', 'Identifier of the account type'),
+			description: localize('carbon.extension.contributes.account.id', "Identifier of the account type"),
 			type: 'string'
 		},
 		icon: {
-			description: localize('carbon.extension.contributes.account.icon', '(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration'),
+			description: localize('carbon.extension.contributes.account.icon', "(Optional) Icon which is used to represent the accpunt in the UI. Either a file path or a themable configuration"),
 			anyOf: [{
 				type: 'string'
 			},
@@ -33,11 +33,11 @@ const account: IJSONSchema = {
 				type: 'object',
 				properties: {
 					light: {
-						description: localize('carbon.extension.contributes.account.icon.light', 'Icon path when a light theme is used'),
+						description: localize('carbon.extension.contributes.account.icon.light', "Icon path when a light theme is used"),
 						type: 'string'
 					},
 					dark: {
-						description: localize('carbon.extension.contributes.account.icon.dark', 'Icon path when a dark theme is used'),
+						description: localize('carbon.extension.contributes.account.icon.dark', "Icon path when a dark theme is used"),
 						type: 'string'
 					}
 				}

--- a/src/sql/platform/accounts/browser/autoOAuthDialog.ts
+++ b/src/sql/platform/accounts/browser/autoOAuthDialog.ts
@@ -74,8 +74,8 @@ export class AutoOAuthDialog extends Modal {
 		this.backButton.onDidClick(() => this.cancel());
 		this._register(attachButtonStyler(this.backButton, this._themeService, { buttonBackground: SIDE_BAR_BACKGROUND, buttonHoverBackground: SIDE_BAR_BACKGROUND }));
 
-		this._copyAndOpenButton = this.addFooterButton(localize('copyAndOpen', 'Copy & Open'), () => this.addAccount());
-		this._closeButton = this.addFooterButton(localize('oauthDialog.cancel', 'Cancel'), () => this.cancel());
+		this._copyAndOpenButton = this.addFooterButton(localize('copyAndOpen', "Copy & Open"), () => this.addAccount());
+		this._closeButton = this.addFooterButton(localize('oauthDialog.cancel', "Cancel"), () => this.cancel());
 		this.registerListeners();
 		this._userCodeInputBox.disable();
 		this._websiteInputBox.disable();
@@ -90,8 +90,8 @@ export class AutoOAuthDialog extends Modal {
 		this._descriptionElement = append(body, $('.auto-oauth-description-section.new-section'));
 
 		const addAccountSection = append(body, $('.auto-oauth-info-section.new-section'));
-		this._userCodeInputBox = this.createInputBoxHelper(addAccountSection, localize('userCode', 'User code'));
-		this._websiteInputBox = this.createInputBoxHelper(addAccountSection, localize('website', 'Website'));
+		this._userCodeInputBox = this.createInputBoxHelper(addAccountSection, localize('userCode', "User code"));
+		this._websiteInputBox = this.createInputBoxHelper(addAccountSection, localize('website', "Website"));
 	}
 
 	private createInputBoxHelper(container: HTMLElement, label: string): InputBox {

--- a/src/sql/platform/accounts/browser/autoOAuthDialogController.ts
+++ b/src/sql/platform/accounts/browser/autoOAuthDialogController.ts
@@ -32,7 +32,7 @@ export class AutoOAuthDialogController {
 	public openAutoOAuthDialog(providerId: string, title: string, message: string, userCode: string, uri: string): Thenable<void> {
 		if (this._providerId !== null) {
 			// If a oauth flyout is already open, return an error
-			const errorMessage = localize('oauthFlyoutIsAlreadyOpen', 'Cannot start auto OAuth. An auto OAuth is already in progress.');
+			const errorMessage = localize('oauthFlyoutIsAlreadyOpen', "Cannot start auto OAuth. An auto OAuth is already in progress.");
 			this._errorMessageService.showDialog(Severity.Error, '', errorMessage);
 			return Promise.reject(new Error('Auto OAuth dialog already open'));
 		}

--- a/src/sql/platform/accounts/browser/firewallRuleDialog.ts
+++ b/src/sql/platform/accounts/browser/firewallRuleDialog.ts
@@ -120,7 +120,7 @@ export class FirewallRuleDialog extends Modal {
 
 		this._helpLink = DOM.append(textDescriptionContainer, DOM.$('a.help-link'));
 		this._helpLink.setAttribute('href', firewallHelpUri);
-		this._helpLink.innerHTML += localize('firewallRuleHelpDescription', 'Learn more about firewall settings');
+		this._helpLink.innerHTML += localize('firewallRuleHelpDescription', "Learn more about firewall settings");
 		this._helpLink.onclick = () => {
 			this._windowsService.openExternal(firewallHelpUri);
 		};
@@ -140,7 +140,7 @@ export class FirewallRuleDialog extends Modal {
 		this._accountPickerService.renderAccountPicker(DOM.append(azureAccountSection, DOM.$('.dialog-input')));
 
 		const firewallRuleSection = DOM.append(body, DOM.$('.firewall-rule-section.new-section'));
-		const firewallRuleLabel = localize('filewallRule', 'Firewall rule');
+		const firewallRuleLabel = localize('filewallRule', "Firewall rule");
 		this.createLabelElement(firewallRuleSection, firewallRuleLabel, true);
 		const radioContainer = DOM.append(firewallRuleSection, DOM.$('.radio-section'));
 		const form = DOM.append(radioContainer, DOM.$('form.firewall-rule'));
@@ -153,7 +153,7 @@ export class FirewallRuleDialog extends Modal {
 		this._IPAddressInput.setAttribute('name', 'firewallRuleChoice');
 		this._IPAddressInput.setAttribute('value', 'ipAddress');
 		const IPAddressDescription = DOM.append(IPAddressContainer, DOM.$('div.option-description'));
-		IPAddressDescription.innerText = localize('addIPAddressLabel', 'Add my client IP ');
+		IPAddressDescription.innerText = localize('addIPAddressLabel', "Add my client IP ");
 		this._IPAddressElement = DOM.append(IPAddressContainer, DOM.$('div.option-ip-address'));
 
 		const subnetIpRangeContainer = DOM.append(subnetIPRangeDiv, DOM.$('div.option-container'));
@@ -162,7 +162,7 @@ export class FirewallRuleDialog extends Modal {
 		this._subnetIPRangeInput.setAttribute('name', 'firewallRuleChoice');
 		this._subnetIPRangeInput.setAttribute('value', 'ipRange');
 		const subnetIPRangeDescription = DOM.append(subnetIpRangeContainer, DOM.$('div.option-description'));
-		subnetIPRangeDescription.innerText = localize('addIpRangeLabel', 'Add my subnet IP range');
+		subnetIPRangeDescription.innerText = localize('addIpRangeLabel', "Add my subnet IP range");
 		const subnetIPRangeSection = DOM.append(subnetIPRangeDiv, DOM.$('.subnet-ip-range-input'));
 
 		const inputContainer = DOM.append(subnetIPRangeSection, DOM.$('.dialog-input-section'));

--- a/src/sql/platform/accounts/browser/firewallRuleDialogController.ts
+++ b/src/sql/platform/accounts/browser/firewallRuleDialogController.ts
@@ -21,8 +21,8 @@ export class FirewallRuleDialogController {
 	private _connection: IConnectionProfile;
 	private _resourceProviderId: string;
 
-	private _addAccountErrorTitle = localize('firewallDialog.addAccountErrorTitle', 'Error adding account');
-	private _firewallRuleErrorTitle = localize('firewallRuleError', 'Firewall rule error');
+	private _addAccountErrorTitle = localize('firewallDialog.addAccountErrorTitle', "Error adding account");
+	private _firewallRuleErrorTitle = localize('firewallRuleError', "Firewall rule error");
 	private _deferredPromise: Deferred<boolean>;
 
 	constructor(

--- a/src/sql/platform/accounts/common/accountActions.ts
+++ b/src/sql/platform/accounts/common/accountActions.ts
@@ -20,7 +20,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 export class AddAccountAction extends Action {
 	// CONSTANTS ///////////////////////////////////////////////////////////
 	public static ID = 'account.addLinkedAccount';
-	public static LABEL = localize('addAccount', 'Add an account');
+	public static LABEL = localize('addAccount', "Add an account");
 
 	// EVENTING ////////////////////////////////////////////////////////////
 	private _addAccountCompleteEmitter: Emitter<void>;
@@ -67,7 +67,7 @@ export class AddAccountAction extends Action {
  */
 export class RemoveAccountAction extends Action {
 	public static ID = 'account.removeAccount';
-	public static LABEL = localize('removeAccount', 'Remove account');
+	public static LABEL = localize('removeAccount', "Remove account");
 
 	constructor(
 		private _account: azdata.Account,
@@ -82,8 +82,8 @@ export class RemoveAccountAction extends Action {
 		// Ask for Confirm
 		const confirm: IConfirmation = {
 			message: localize('confirmRemoveUserAccountMessage', "Are you sure you want to remove '{0}'?", this._account.displayInfo.displayName),
-			primaryButton: localize('accountActions.yes', 'Yes'),
-			secondaryButton: localize('accountActions.no', 'No'),
+			primaryButton: localize('accountActions.yes', "Yes"),
+			secondaryButton: localize('accountActions.no', "No"),
 			type: 'question'
 		};
 
@@ -95,7 +95,7 @@ export class RemoveAccountAction extends Action {
 					// Must handle here as this is an independent action
 					this._notificationService.notify({
 						severity: Severity.Error,
-						message: localize('removeAccountFailed', 'Failed to remove account')
+						message: localize('removeAccountFailed', "Failed to remove account")
 					});
 					return false;
 				});
@@ -109,7 +109,7 @@ export class RemoveAccountAction extends Action {
  */
 export class ApplyFilterAction extends Action {
 	public static ID = 'account.applyFilters';
-	public static LABEL = localize('applyFilters', 'Apply Filters');
+	public static LABEL = localize('applyFilters', "Apply Filters");
 
 	constructor(
 		id: string,
@@ -129,7 +129,7 @@ export class ApplyFilterAction extends Action {
  */
 export class RefreshAccountAction extends Action {
 	public static ID = 'account.refresh';
-	public static LABEL = localize('refreshAccount', 'Reenter your credentials');
+	public static LABEL = localize('refreshAccount', "Reenter your credentials");
 	public account: azdata.Account;
 
 	constructor(
@@ -148,7 +148,7 @@ export class RefreshAccountAction extends Action {
 					}
 				));
 		} else {
-			const errorMessage = localize('NoAccountToRefresh', 'There is no account to refresh');
+			const errorMessage = localize('NoAccountToRefresh', "There is no account to refresh");
 			return Promise.reject(errorMessage);
 		}
 	}

--- a/src/sql/platform/connection/common/connectionManagementService.ts
+++ b/src/sql/platform/connection/common/connectionManagementService.ts
@@ -446,7 +446,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			}
 			let tokenFillSuccess = await this.fillInOrClearAzureToken(connection);
 			if (!tokenFillSuccess) {
-				throw new Error(nls.localize('connection.noAzureAccount', 'Failed to get Azure account token for connection'));
+				throw new Error(nls.localize('connection.noAzureAccount', "Failed to get Azure account token for connection"));
 			}
 			this.createNewConnection(uri, connection).then(connectionResult => {
 				if (connectionResult && connectionResult.connected) {
@@ -485,7 +485,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 					});
 				} else {
 					if (callbacks.onConnectReject) {
-						callbacks.onConnectReject(nls.localize('connectionNotAcceptedError', 'Connection Not Accepted'));
+						callbacks.onConnectReject(nls.localize('connectionNotAcceptedError', "Connection Not Accepted"));
 					}
 					resolve(connectionResult);
 				}
@@ -500,7 +500,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 
 	private handleConnectionError(connection: IConnectionProfile, uri: string, options: IConnectionCompletionOptions, callbacks: IConnectionCallbacks, connectionResult: IConnectionResult) {
 		return new Promise<IConnectionResult>((resolve, reject) => {
-			let connectionNotAcceptedError = nls.localize('connectionNotAcceptedError', 'Connection Not Accepted');
+			let connectionNotAcceptedError = nls.localize('connectionNotAcceptedError', "Connection Not Accepted");
 			if (options.showFirewallRuleOnError && connectionResult.errorCode) {
 				this.handleFirewallRuleError(connection, connectionResult).then(success => {
 					if (success) {
@@ -1068,11 +1068,11 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		return new Promise<boolean>((resolve, reject) => {
 			// Setup our cancellation choices
 			let choices: { key, value }[] = [
-				{ key: nls.localize('connectionService.yes', 'Yes'), value: true },
-				{ key: nls.localize('connectionService.no', 'No'), value: false }
+				{ key: nls.localize('connectionService.yes', "Yes"), value: true },
+				{ key: nls.localize('connectionService.no', "No"), value: false }
 			];
 
-			self._quickInputService.pick(choices.map(x => x.key), { placeHolder: nls.localize('cancelConnectionConfirmation', 'Are you sure you want to cancel this connection?'), ignoreFocusLost: true }).then((choice) => {
+			self._quickInputService.pick(choices.map(x => x.key), { placeHolder: nls.localize('cancelConnectionConfirmation', "Are you sure you want to cancel this connection?"), ignoreFocusLost: true }).then((choice) => {
 				let confirm = choices.find(x => x.key === choice);
 				resolve(confirm && confirm.value);
 			});

--- a/src/sql/platform/dashboard/browser/dashboardRegistry.ts
+++ b/src/sql/platform/dashboard/browser/dashboardRegistry.ts
@@ -113,7 +113,7 @@ const dashboardPropertyFlavorContrib: IJSONSchema = {
 	type: 'object',
 	properties: {
 		id: {
-			description: nls.localize('dashboard.properties.flavor.id', 'Id of the flavor'),
+			description: nls.localize('dashboard.properties.flavor.id', "Id of the flavor"),
 			type: 'string'
 		},
 		condition: {

--- a/src/sql/platform/dashboard/browser/insightRegistry.ts
+++ b/src/sql/platform/dashboard/browser/insightRegistry.ts
@@ -77,7 +77,7 @@ export interface IInsightRegistry {
 }
 
 class InsightRegistry implements IInsightRegistry {
-	private _insightSchema: IJSONSchema = { type: 'object', description: nls.localize('schema.dashboardWidgets.InsightsRegistry', 'Widget used in the dashboards'), properties: {}, additionalProperties: false };
+	private _insightSchema: IJSONSchema = { type: 'object', description: nls.localize('schema.dashboardWidgets.InsightsRegistry', "Widget used in the dashboards"), properties: {}, additionalProperties: false };
 	private _extensionInsights: { [x: string]: IInsightsConfig } = {};
 	private _idToCtor: { [x: string]: Type<IInsightsView> } = {};
 

--- a/src/sql/platform/dashboard/browser/widgetRegistry.ts
+++ b/src/sql/platform/dashboard/browser/widgetRegistry.ts
@@ -31,9 +31,9 @@ export interface IDashboardWidgetRegistry {
 }
 
 class DashboardWidgetRegistry implements IDashboardWidgetRegistry {
-	private _allSchema: CustomIJSONSchema = { type: 'object', description: nls.localize('schema.dashboardWidgets.all', 'Widget used in the dashboards'), properties: {}, extensionProperties: {}, additionalProperties: false };
-	private _dashboardWidgetSchema: CustomIJSONSchema = { type: 'object', description: nls.localize('schema.dashboardWidgets.database', 'Widget used in the dashboards'), properties: {}, extensionProperties: {}, additionalProperties: false };
-	private _serverWidgetSchema: CustomIJSONSchema = { type: 'object', description: nls.localize('schema.dashboardWidgets.server', 'Widget used in the dashboards'), properties: {}, extensionProperties: {}, additionalProperties: false };
+	private _allSchema: CustomIJSONSchema = { type: 'object', description: nls.localize('schema.dashboardWidgets.all', "Widget used in the dashboards"), properties: {}, extensionProperties: {}, additionalProperties: false };
+	private _dashboardWidgetSchema: CustomIJSONSchema = { type: 'object', description: nls.localize('schema.dashboardWidgets.database', "Widget used in the dashboards"), properties: {}, extensionProperties: {}, additionalProperties: false };
+	private _serverWidgetSchema: CustomIJSONSchema = { type: 'object', description: nls.localize('schema.dashboardWidgets.server', "Widget used in the dashboards"), properties: {}, extensionProperties: {}, additionalProperties: false };
 
 	/**
 	 * Register a dashboard widget

--- a/src/sql/platform/dialog/common/dialogTypes.ts
+++ b/src/sql/platform/dialog/common/dialogTypes.ts
@@ -37,8 +37,8 @@ export class DialogTab extends ModelViewPane {
 }
 
 export class Dialog extends ModelViewPane {
-	private static readonly DONE_BUTTON_LABEL = localize('dialogModalDoneButtonLabel', 'Done');
-	private static readonly CANCEL_BUTTON_LABEL = localize('dialogModalCancelButtonLabel', 'Cancel');
+	private static readonly DONE_BUTTON_LABEL = localize('dialogModalDoneButtonLabel', "Done");
+	private static readonly CANCEL_BUTTON_LABEL = localize('dialogModalCancelButtonLabel', "Cancel");
 
 	public content: string | DialogTab[];
 	public isWide: boolean;

--- a/src/sql/platform/fileBrowser/common/fileBrowserService.ts
+++ b/src/sql/platform/fileBrowser/common/fileBrowserService.ts
@@ -70,8 +70,8 @@ export class FileBrowserService implements IFileBrowserService {
 			let fileTree = this.convertFileTree(null, fileBrowserOpenedParams.fileTree.rootNode, fileBrowserOpenedParams.fileTree.selectedNode.fullPath, fileBrowserOpenedParams.ownerUri);
 			this._onAddFileTree.fire({ rootNode: fileTree.rootNode, selectedNode: fileTree.selectedNode, expandedNodes: fileTree.expandedNodes });
 		} else {
-			let genericErrorMessage = localize('fileBrowserErrorMessage', 'An error occured while loading the file browser.');
-			let errorDialogTitle = localize('fileBrowserErrorDialogTitle', 'File browser error');
+			let genericErrorMessage = localize('fileBrowserErrorMessage', "An error occured while loading the file browser.");
+			let errorDialogTitle = localize('fileBrowserErrorDialogTitle', "File browser error");
 			let errorMessage = strings.isFalsyOrWhitespace(fileBrowserOpenedParams.message) ? genericErrorMessage : fileBrowserOpenedParams.message;
 			this._errorMessageService.showDialog(Severity.Error, errorDialogTitle, errorMessage);
 		}

--- a/src/sql/platform/jobManagement/browser/jobActions.ts
+++ b/src/sql/platform/jobManagement/browser/jobActions.ts
@@ -21,8 +21,8 @@ import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { IErrorMessageService } from 'sql/platform/errorMessage/common/errorMessageService';
 import { JobManagementView } from 'sql/workbench/parts/jobManagement/browser/jobManagementView';
 
-export const successLabel: string = nls.localize('jobaction.successLabel', 'Success');
-export const errorLabel: string = nls.localize('jobaction.faillabel', 'Error');
+export const successLabel: string = nls.localize('jobaction.successLabel', "Success");
+export const errorLabel: string = nls.localize('jobaction.faillabel', "Error");
 
 export enum JobActions {
 	Run = 'run',
@@ -104,7 +104,7 @@ export class RunJobAction extends Action {
 		return new Promise<boolean>((resolve, reject) => {
 			this.jobManagementService.jobAction(ownerUri, jobName, JobActions.Run).then(async (result) => {
 				if (result.success) {
-					let startMsg = nls.localize('jobSuccessfullyStarted', ': The job was successfully started.');
+					let startMsg = nls.localize('jobSuccessfullyStarted', ": The job was successfully started.");
 					this.notificationService.info(jobName + startMsg);
 					await refreshAction.run(context);
 					resolve(true);
@@ -140,7 +140,7 @@ export class StopJobAction extends Action {
 			this.jobManagementService.jobAction(ownerUri, jobName, JobActions.Stop).then(async (result) => {
 				if (result.success) {
 					await refreshAction.run(context);
-					let stopMsg = nls.localize('jobSuccessfullyStopped', ': The job was successfully stopped.');
+					let stopMsg = nls.localize('jobSuccessfullyStopped', ": The job was successfully stopped.");
 					this.notificationService.info(jobName + stopMsg);
 					resolve(true);
 				} else {
@@ -200,7 +200,7 @@ export class DeleteJobAction extends Action {
 								job.name, result.errorMessage ? result.errorMessage : 'Unknown error');
 							self._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
 						} else {
-							let successMessage = nls.localize('jobaction.deletedJob', 'The job was successfully deleted');
+							let successMessage = nls.localize('jobaction.deletedJob', "The job was successfully deleted");
 							self._notificationService.info(successMessage);
 						}
 					});
@@ -268,7 +268,7 @@ export class DeleteStepAction extends Action {
 							self._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
 							await refreshAction.run(actionInfo);
 						} else {
-							let successMessage = nls.localize('jobaction.deletedStep', 'The job step was successfully deleted');
+							let successMessage = nls.localize('jobaction.deletedStep', "The job step was successfully deleted");
 							self._notificationService.info(successMessage);
 						}
 					});
@@ -357,7 +357,7 @@ export class DeleteAlertAction extends Action {
 								alert.name, result.errorMessage ? result.errorMessage : 'Unknown error');
 							self._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
 						} else {
-							let successMessage = nls.localize('jobaction.deletedAlert', 'The alert was successfully deleted');
+							let successMessage = nls.localize('jobaction.deletedAlert', "The alert was successfully deleted");
 							self._notificationService.info(successMessage);
 						}
 					});
@@ -443,7 +443,7 @@ export class DeleteOperatorAction extends Action {
 								operator.name, result.errorMessage ? result.errorMessage : 'Unknown error');
 							self._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
 						} else {
-							let successMessage = nls.localize('joaction.deletedOperator', 'The operator was deleted successfully');
+							let successMessage = nls.localize('joaction.deletedOperator', "The operator was deleted successfully");
 							self._notificationService.info(successMessage);
 						}
 					});
@@ -538,7 +538,7 @@ export class DeleteProxyAction extends Action {
 								proxy.accountName, result.errorMessage ? result.errorMessage : 'Unknown error');
 							self._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
 						} else {
-							let successMessage = nls.localize('jobaction.deletedProxy', 'The proxy was deleted successfully');
+							let successMessage = nls.localize('jobaction.deletedProxy', "The proxy was deleted successfully");
 							self._notificationService.info(successMessage);
 						}
 					});

--- a/src/sql/platform/jobManagement/common/jobManagementUtilities.ts
+++ b/src/sql/platform/jobManagement/common/jobManagementUtilities.ts
@@ -13,36 +13,36 @@ export class JobManagementUtilities {
 
 	public static convertToStatusString(status: number): string {
 		switch (status) {
-			case (0): return nls.localize('agentUtilities.failed', 'Failed');
-			case (1): return nls.localize('agentUtilities.succeeded', 'Succeeded');
-			case (2): return nls.localize('agentUtilities.retry', 'Retry');
-			case (3): return nls.localize('agentUtilities.canceled', 'Cancelled');
-			case (4): return nls.localize('agentUtilities.inProgress', 'In Progress');
-			case (5): return nls.localize('agentUtilities.statusUnknown', 'Status Unknown');
-			default: return nls.localize('agentUtilities.statusUnknown', 'Status Unknown');
+			case (0): return nls.localize('agentUtilities.failed', "Failed");
+			case (1): return nls.localize('agentUtilities.succeeded', "Succeeded");
+			case (2): return nls.localize('agentUtilities.retry', "Retry");
+			case (3): return nls.localize('agentUtilities.canceled', "Cancelled");
+			case (4): return nls.localize('agentUtilities.inProgress', "In Progress");
+			case (5): return nls.localize('agentUtilities.statusUnknown', "Status Unknown");
+			default: return nls.localize('agentUtilities.statusUnknown', "Status Unknown");
 		}
 	}
 
 	public static convertToExecutionStatusString(status: number): string {
 		switch (status) {
-			case (1): return nls.localize('agentUtilities.executing', 'Executing');
-			case (2): return nls.localize('agentUtilities.waitingForThread', 'Waiting for Thread');
-			case (3): return nls.localize('agentUtilities.betweenRetries', 'Between Retries');
-			case (4): return nls.localize('agentUtilities.idle', 'Idle');
-			case (5): return nls.localize('agentUtilities.suspended', 'Suspended');
-			case (6): return nls.localize('agentUtilities.obsolete', '[Obsolete]');
+			case (1): return nls.localize('agentUtilities.executing', "Executing");
+			case (2): return nls.localize('agentUtilities.waitingForThread', "Waiting for Thread");
+			case (3): return nls.localize('agentUtilities.betweenRetries', "Between Retries");
+			case (4): return nls.localize('agentUtilities.idle', "Idle");
+			case (5): return nls.localize('agentUtilities.suspended', "Suspended");
+			case (6): return nls.localize('agentUtilities.obsolete', "[Obsolete]");
 			case (7): return 'PerformingCompletionActions';
-			default: return nls.localize('agentUtilities.statusUnknown', 'Status Unknown');
+			default: return nls.localize('agentUtilities.statusUnknown', "Status Unknown");
 		}
 	}
 
 	public static convertToResponse(bool: boolean) {
-		return bool ? nls.localize('agentUtilities.yes', 'Yes') : nls.localize('agentUtilities.no', 'No');
+		return bool ? nls.localize('agentUtilities.yes', "Yes") : nls.localize('agentUtilities.no', "No");
 	}
 
 	public static convertToNextRun(date: string) {
 		if (date.includes('1/1/0001')) {
-			return nls.localize('agentUtilities.notScheduled', 'Not Scheduled');
+			return nls.localize('agentUtilities.notScheduled', "Not Scheduled");
 		} else {
 			return date;
 		}
@@ -50,7 +50,7 @@ export class JobManagementUtilities {
 
 	public static convertToLastRun(date: string) {
 		if (date.includes('1/1/0001')) {
-			return nls.localize('agentUtilities.neverRun', 'Never Run');
+			return nls.localize('agentUtilities.neverRun', "Never Run");
 		} else {
 			return date;
 		}

--- a/src/sql/platform/query/common/queryModelService.ts
+++ b/src/sql/platform/query/common/queryModelService.ts
@@ -164,7 +164,7 @@ export class QueryModelService implements IQueryModelService {
 	public showCommitError(error: string): void {
 		this._notificationService.notify({
 			severity: Severity.Error,
-			message: nls.localize('commitEditFailed', 'Commit row failed: ') + error
+			message: nls.localize('commitEditFailed', "Commit row failed: ") + error
 		});
 	}
 
@@ -480,7 +480,7 @@ export class QueryModelService implements IQueryModelService {
 			return queryRunner.updateCell(ownerUri, rowId, columnId, newValue).then((result) => result, error => {
 				this._notificationService.notify({
 					severity: Severity.Error,
-					message: nls.localize('updateCellFailed', 'Update cell failed: ') + error.message
+					message: nls.localize('updateCellFailed', "Update cell failed: ") + error.message
 				});
 				return Promise.reject(error);
 			});
@@ -495,7 +495,7 @@ export class QueryModelService implements IQueryModelService {
 			return queryRunner.commitEdit(ownerUri).then(() => { }, error => {
 				this._notificationService.notify({
 					severity: Severity.Error,
-					message: nls.localize('commitEditFailed', 'Commit row failed: ') + error.message
+					message: nls.localize('commitEditFailed', "Commit row failed: ") + error.message
 				});
 				return Promise.reject(error);
 			});

--- a/src/sql/platform/query/common/queryRunner.ts
+++ b/src/sql/platform/query/common/queryRunner.ts
@@ -467,7 +467,7 @@ export default class QueryRunner extends Disposable {
 				}
 				resolve(result);
 			}, error => {
-				// let errorMessage = nls.localize('query.moreRowsFailedError', 'Something went wrong getting more rows:');
+				// let errorMessage = nls.localize('query.moreRowsFailedError', "Something went wrong getting more rows:");
 				// self._notificationService.notify({
 				// 	severity: Severity.Error,
 				// 	message: `${errorMessage} ${error}`

--- a/src/sql/platform/tasks/common/tasksService.ts
+++ b/src/sql/platform/tasks/common/tasksService.ts
@@ -150,7 +150,7 @@ export class TaskService implements ITaskService {
 	}
 
 	public beforeShutdown(): Promise<boolean> {
-		const message = localize('InProgressWarning', '1 or more tasks are in progress. Are you sure you want to quit?');
+		const message = localize('InProgressWarning', "1 or more tasks are in progress. Are you sure you want to quit?");
 		const options = [
 			localize('taskService.yes', "Yes"),
 			localize('taskService.no', "No")

--- a/src/sql/platform/theme/common/colors.ts
+++ b/src/sql/platform/theme/common/colors.ts
@@ -7,8 +7,8 @@ import { registerColor, foreground } from 'vs/platform/theme/common/colorRegistr
 import { Color, RGBA } from 'vs/base/common/color';
 import * as nls from 'vs/nls';
 
-export const tableHeaderBackground = registerColor('table.headerBackground', { dark: new Color(new RGBA(51, 51, 52)), light: new Color(new RGBA(245, 245, 245)), hc: '#333334' }, nls.localize('tableHeaderBackground', 'Table header background color'));
-export const tableHeaderForeground = registerColor('table.headerForeground', { dark: new Color(new RGBA(229, 229, 229)), light: new Color(new RGBA(16, 16, 16)), hc: '#e5e5e5' }, nls.localize('tableHeaderForeground', 'Table header foreground color'));
+export const tableHeaderBackground = registerColor('table.headerBackground', { dark: new Color(new RGBA(51, 51, 52)), light: new Color(new RGBA(245, 245, 245)), hc: '#333334' }, nls.localize('tableHeaderBackground', "Table header background color"));
+export const tableHeaderForeground = registerColor('table.headerForeground', { dark: new Color(new RGBA(229, 229, 229)), light: new Color(new RGBA(16, 16, 16)), hc: '#e5e5e5' }, nls.localize('tableHeaderForeground', "Table header foreground color"));
 export const disabledInputBackground = registerColor('input.disabled.background', { dark: '#444444', light: '#dcdcdc', hc: Color.black }, nls.localize('disabledInputBoxBackground', "Disabled Input box background."));
 export const disabledInputForeground = registerColor('input.disabled.foreground', { dark: '#888888', light: '#888888', hc: foreground }, nls.localize('disabledInputBoxForeground', "Disabled Input box foreground."));
 export const buttonFocusOutline = registerColor('button.focusOutline', { dark: '#eaeaea', light: '#666666', hc: null }, nls.localize('buttonFocusOutline', "Button outline color when focused."));

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -578,7 +578,7 @@ class ComponentWrapper implements azdata.Component {
 	public addItem(item: azdata.Component, itemLayout?: any, index?: number): void {
 		let itemImpl = item as ComponentWrapper;
 		if (!itemImpl) {
-			throw new Error(nls.localize('unknownComponentType', 'Unkown component type. Must use ModelBuilder to create objects'));
+			throw new Error(nls.localize('unknownComponentType', "Unkown component type. Must use ModelBuilder to create objects"));
 		}
 		let config = new InternalItemConfig(itemImpl, itemLayout);
 		if (index !== undefined && index >= 0 && index < this.items.length) {
@@ -586,7 +586,7 @@ class ComponentWrapper implements azdata.Component {
 		} else if (!index) {
 			this.itemConfigs.push(config);
 		} else {
-			throw new Error(nls.localize('invalidIndex', 'The index is invalid.'));
+			throw new Error(nls.localize('invalidIndex', "The index is invalid."));
 		}
 		this._proxy.$addToContainer(this._handle, this.id, config.toIItemConfig(), index).then(undefined, (err) => this.handleError(err));
 	}
@@ -1458,7 +1458,7 @@ class ModelViewImpl implements azdata.ModelView {
 		this._component = component;
 		let componentImpl = <any>component as ComponentWrapper;
 		if (!componentImpl) {
-			return Promise.reject(nls.localize('unknownConfig', 'Unkown component configuration, must use ModelBuilder to create a configuration object'));
+			return Promise.reject(nls.localize('unknownConfig', "Unkown component configuration, must use ModelBuilder to create a configuration object"));
 		}
 		return this._proxy.$initializeModel(this._handle, componentImpl.toComponentShape());
 	}

--- a/src/sql/workbench/api/common/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/common/extHostModelViewDialog.ts
@@ -14,11 +14,11 @@ import * as azdata from 'azdata';
 import { SqlMainContext, ExtHostModelViewDialogShape, MainThreadModelViewDialogShape, ExtHostModelViewShape, ExtHostBackgroundTaskManagementShape } from 'sql/workbench/api/common/sqlExtHost.protocol';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 
-const DONE_LABEL = nls.localize('dialogDoneLabel', 'Done');
-const CANCEL_LABEL = nls.localize('dialogCancelLabel', 'Cancel');
-const GENERATE_SCRIPT_LABEL = nls.localize('generateScriptLabel', 'Generate script');
-const NEXT_LABEL = nls.localize('dialogNextLabel', 'Next');
-const PREVIOUS_LABEL = nls.localize('dialogPreviousLabel', 'Previous');
+const DONE_LABEL = nls.localize('dialogDoneLabel', "Done");
+const CANCEL_LABEL = nls.localize('dialogCancelLabel', "Cancel");
+const GENERATE_SCRIPT_LABEL = nls.localize('generateScriptLabel', "Generate script");
+const NEXT_LABEL = nls.localize('dialogNextLabel', "Next");
+const PREVIOUS_LABEL = nls.localize('dialogPreviousLabel', "Previous");
 
 class ModelViewPanelImpl implements azdata.window.ModelViewPanel {
 	private _modelView: azdata.ModelView;

--- a/src/sql/workbench/api/common/extHostNotebook.ts
+++ b/src/sql/workbench/api/common/extHostNotebook.ts
@@ -212,7 +212,7 @@ export class ExtHostNotebook implements ExtHostNotebookShape {
 	//#region APIs called by extensions
 	registerNotebookProvider(provider: azdata.nb.NotebookProvider): vscode.Disposable {
 		if (!provider || !provider.providerId) {
-			throw new Error(localize('providerRequired', 'A NotebookProvider with valid providerId must be passed to this method'));
+			throw new Error(localize('providerRequired', "A NotebookProvider with valid providerId must be passed to this method"));
 		}
 		const handle = this._addNewAdapter(provider);
 		this._proxy.$registerNotebookProvider(provider.providerId, handle);
@@ -263,7 +263,7 @@ export class ExtHostNotebook implements ExtHostNotebookShape {
 	private _withProvider<R>(handle: number, callback: (provider: azdata.nb.NotebookProvider) => R | PromiseLike<R>): Promise<R> {
 		let provider = this._adapters.get(handle) as azdata.nb.NotebookProvider;
 		if (provider === undefined) {
-			return Promise.reject(new Error(localize('errNoProvider', 'no notebook provider found')));
+			return Promise.reject(new Error(localize('errNoProvider', "no notebook provider found")));
 		}
 		return Promise.resolve(callback(provider));
 	}
@@ -271,7 +271,7 @@ export class ExtHostNotebook implements ExtHostNotebookShape {
 	private _withNotebookManager<R>(handle: number, callback: (manager: NotebookManagerAdapter) => R | PromiseLike<R>): Promise<R> {
 		let manager = this._adapters.get(handle) as NotebookManagerAdapter;
 		if (manager === undefined) {
-			return Promise.reject(new Error(localize('errNoManager', 'No Manager found')));
+			return Promise.reject(new Error(localize('errNoManager', "No Manager found")));
 		}
 		return this.callbackWithErrorWrap<R>(callback, manager);
 	}

--- a/src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/common/extHostNotebookDocumentsAndEditors.ts
@@ -247,7 +247,7 @@ export class ExtHostNotebookDocumentsAndEditors implements ExtHostNotebookDocume
 
 	registerNavigationProvider(provider: azdata.nb.NavigationProvider): vscode.Disposable {
 		if (!provider || !provider.providerId) {
-			throw new Error(localize('providerRequired', 'A NotebookProvider with valid providerId must be passed to this method'));
+			throw new Error(localize('providerRequired', "A NotebookProvider with valid providerId must be passed to this method"));
 		}
 		const handle = this._addNewAdapter(provider);
 		this._proxy.$registerNavigationProvider(provider.providerId, handle);

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -28,12 +28,12 @@ import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/la
 
 export const MODAL_SHOWING_KEY = 'modalShowing';
 export const MODAL_SHOWING_CONTEXT = new RawContextKey<Array<string>>(MODAL_SHOWING_KEY, []);
-const INFO_ALT_TEXT = localize('infoAltText', 'Information');
-const WARNING_ALT_TEXT = localize('warningAltText', 'Warning');
-const ERROR_ALT_TEXT = localize('errorAltText', 'Error');
-const SHOW_DETAILS_TEXT = localize('showMessageDetails', 'Show Details');
-const COPY_TEXT = localize('copyMessage', 'Copy');
-const CLOSE_TEXT = localize('closeMessage', 'Close');
+const INFO_ALT_TEXT = localize('infoAltText', "Information");
+const WARNING_ALT_TEXT = localize('warningAltText', "Warning");
+const ERROR_ALT_TEXT = localize('errorAltText', "Error");
+const SHOW_DETAILS_TEXT = localize('showMessageDetails', "Show Details");
+const COPY_TEXT = localize('copyMessage', "Copy");
+const CLOSE_TEXT = localize('closeMessage', "Close");
 const MESSAGE_EXPANDED_MODE_CLASS = 'expanded';
 
 export interface IModalDialogStyles {
@@ -300,7 +300,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	private toggleMessageDetail() {
 		const isExpanded = DOM.hasClass(this._messageSummary, MESSAGE_EXPANDED_MODE_CLASS);
 		DOM.toggleClass(this._messageSummary, MESSAGE_EXPANDED_MODE_CLASS, !isExpanded);
-		this._toggleMessageDetailButton.label = isExpanded ? SHOW_DETAILS_TEXT : localize('hideMessageDetails', 'Hide Details');
+		this._toggleMessageDetailButton.label = isExpanded ? SHOW_DETAILS_TEXT : localize('hideMessageDetails', "Hide Details");
 
 		if (this._messageDetailText) {
 			if (isExpanded) {

--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -106,8 +106,8 @@ export class OptionsDialog extends Modal {
 			this.backButton.onDidClick(() => this.cancel());
 			attachButtonStyler(this.backButton, this._themeService, { buttonBackground: SIDE_BAR_BACKGROUND, buttonHoverBackground: SIDE_BAR_BACKGROUND });
 		}
-		let okButton = this.addFooterButton(localize('optionsDialog.ok', 'OK'), () => this.ok());
-		let closeButton = this.addFooterButton(this.options.cancelLabel || localize('optionsDialog.cancel', 'Cancel'), () => this.cancel());
+		let okButton = this.addFooterButton(localize('optionsDialog.ok', "OK"), () => this.ok());
+		let closeButton = this.addFooterButton(this.options.cancelLabel || localize('optionsDialog.cancel', "Cancel"), () => this.cancel());
 		// Theme styler
 		attachButtonStyler(okButton, this._themeService);
 		attachButtonStyler(closeButton, this._themeService);

--- a/src/sql/workbench/browser/modal/optionsDialogHelper.ts
+++ b/src/sql/workbench/browser/modal/optionsDialogHelper.ts
@@ -25,8 +25,8 @@ export function createOptionElement(option: azdata.ServiceOption, rowContainer: 
 	let optionValue = getOptionValueAndCategoryValues(option, options, possibleInputs);
 	let optionWidget: any;
 	let inputElement: HTMLElement;
-	let missingErrorMessage = localize('optionsDialog.missingRequireField', ' is required.');
-	let invalidInputMessage = localize('optionsDialog.invalidInput', 'Invalid input.  Numeric value expected.');
+	let missingErrorMessage = localize('optionsDialog.missingRequireField', " is required.");
+	let invalidInputMessage = localize('optionsDialog.invalidInput', "Invalid input.  Numeric value expected.");
 
 	if (option.valueType === ServiceOptionType.number) {
 		optionWidget = new InputBox(rowContainer, contextViewService, {

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -279,7 +279,7 @@ export abstract class ContainerBase<T> extends ComponentBase {
 		} else if (!index) {
 			this.items.push(new ItemDescriptor(componentDescriptor, config));
 		} else {
-			throw new Error(nls.localize('invalidIndex', 'The index is invalid.'));
+			throw new Error(nls.localize('invalidIndex', "The index is invalid."));
 		}
 		this.modelStore.eventuallyRunOnComponent(componentDescriptor.id, component => component.registerEventHandler(event => {
 			if (event.eventType === ComponentEventType.validityChanged) {

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -62,7 +62,7 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 						return undefined;
 					} else {
 						return {
-							content: this.inputElement.inputElement.validationMessage || nls.localize('invalidValueError', 'Invalid value'),
+							content: this.inputElement.inputElement.validationMessage || nls.localize('invalidValueError', "Invalid value"),
 							type: MessageType.ERROR
 						};
 					}

--- a/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
+++ b/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
@@ -25,7 +25,7 @@ import * as nls from 'vs/nls';
 	`
 })
 export default class LoadingComponent extends ComponentBase implements IComponent, OnDestroy, AfterViewInit {
-	private readonly _loadingTitle = nls.localize('loadingMessage', 'Loading');
+	private readonly _loadingTitle = nls.localize('loadingMessage', "Loading");
 	private _component: IComponentDescriptor;
 
 	@Input() descriptor: IComponentDescriptor;

--- a/src/sql/workbench/browser/modelComponents/loadingSpinner.component.ts
+++ b/src/sql/workbench/browser/modelComponents/loadingSpinner.component.ts
@@ -17,7 +17,7 @@ import * as nls from 'vs/nls';
 	`
 })
 export default class LoadingSpinner {
-	private readonly _loadingTitle = nls.localize('loadingMessage', 'Loading');
+	private readonly _loadingTitle = nls.localize('loadingMessage', "Loading");
 
 	@Input() loading: boolean;
 }

--- a/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
@@ -101,7 +101,7 @@ export class QueryTextEditor extends BaseTextEditor {
 	}
 
 	protected getAriaLabel(): string {
-		return nls.localize('queryTextEditorAriaLabel', 'modelview code editor for view model.');
+		return nls.localize('queryTextEditorAriaLabel', "modelview code editor for view model.");
 	}
 
 	public layout(dimension?: DOM.Dimension) {

--- a/src/sql/workbench/common/actions.contribution.ts
+++ b/src/sql/workbench/common/actions.contribution.ts
@@ -24,26 +24,26 @@ Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions)
 
 Registry.as<IConfigurationRegistry>(ConfigExtensions.Configuration).registerConfiguration({
 	'id': 'previewFeatures',
-	'title': nls.localize('previewFeatures.configTitle', 'Preview Features'),
+	'title': nls.localize('previewFeatures.configTitle', "Preview Features"),
 	'type': 'object',
 	'properties': {
 		'workbench.enablePreviewFeatures': {
 			'type': 'boolean',
 			'default': undefined,
-			'description': nls.localize('previewFeatures.configEnable', 'Enable unreleased preview features')
+			'description': nls.localize('previewFeatures.configEnable', "Enable unreleased preview features")
 		}
 	}
 });
 
 Registry.as<IConfigurationRegistry>(ConfigExtensions.Configuration).registerConfiguration({
 	'id': 'showConnectDialogOnStartup',
-	'title': nls.localize('showConnectDialogOnStartup', 'Show connect dialog on startup'),
+	'title': nls.localize('showConnectDialogOnStartup', "Show connect dialog on startup"),
 	'type': 'object',
 	'properties': {
 		'workbench.showConnectDialogOnStartup': {
 			'type': 'boolean',
 			'default': true,
-			'description': nls.localize('showConnectDialogOnStartup', 'Show connect dialog on startup')
+			'description': nls.localize('showConnectDialogOnStartup', "Show connect dialog on startup")
 		}
 	}
 });

--- a/src/sql/workbench/common/actions.ts
+++ b/src/sql/workbench/common/actions.ts
@@ -44,7 +44,7 @@ export interface ManageActionContext extends BaseActionContext {
 // --- actions
 export class NewQueryAction extends Task {
 	public static ID = 'newQuery';
-	public static LABEL = nls.localize('newQueryAction.newQuery', 'New Query');
+	public static LABEL = nls.localize('newQueryAction.newQuery', "New Query");
 	public static ICON = 'new-query';
 
 	constructor() {
@@ -69,7 +69,7 @@ export class NewQueryAction extends Task {
 
 export class ScriptSelectAction extends Action {
 	public static ID = 'selectTop';
-	public static LABEL = nls.localize('scriptSelect', 'Select Top 1000');
+	public static LABEL = nls.localize('scriptSelect', "Select Top 1000");
 
 	constructor(
 		id: string, label: string,
@@ -93,7 +93,7 @@ export class ScriptSelectAction extends Action {
 
 export class ScriptExecuteAction extends Action {
 	public static ID = 'scriptExecute';
-	public static LABEL = nls.localize('scriptExecute', 'Script as Execute');
+	public static LABEL = nls.localize('scriptExecute', "Script as Execute");
 
 	constructor(
 		id: string, label: string,
@@ -120,7 +120,7 @@ export class ScriptExecuteAction extends Action {
 
 export class ScriptAlterAction extends Action {
 	public static ID = 'scriptAlter';
-	public static LABEL = nls.localize('scriptAlter', 'Script as Alter');
+	public static LABEL = nls.localize('scriptAlter', "Script as Alter");
 
 	constructor(
 		id: string, label: string,
@@ -147,7 +147,7 @@ export class ScriptAlterAction extends Action {
 
 export class EditDataAction extends Action {
 	public static ID = 'editData';
-	public static LABEL = nls.localize('editData', 'Edit Data');
+	public static LABEL = nls.localize('editData', "Edit Data");
 
 	constructor(
 		id: string, label: string,
@@ -198,7 +198,7 @@ export class ScriptCreateAction extends Action {
 
 export class ScriptDeleteAction extends Action {
 	public static ID = 'scriptDelete';
-	public static LABEL = nls.localize('scriptDelete', 'Script as Drop');
+	public static LABEL = nls.localize('scriptDelete', "Script as Drop");
 
 	constructor(
 		id: string, label: string,
@@ -227,7 +227,7 @@ export const BackupFeatureName = 'backup';
 
 export class BackupAction extends Task {
 	public static readonly ID = BackupFeatureName;
-	public static readonly LABEL = nls.localize('backupAction.backup', 'Backup');
+	public static readonly LABEL = nls.localize('backupAction.backup', "Backup");
 	public static readonly ICON = BackupFeatureName;
 
 	constructor() {
@@ -243,7 +243,7 @@ export class BackupAction extends Task {
 		const configurationService = accessor.get<IConfigurationService>(IConfigurationService);
 		const previewFeaturesEnabled: boolean = configurationService.getValue('workbench')['enablePreviewFeatures'];
 		if (!previewFeaturesEnabled) {
-			return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.isPreviewFeature', 'You must enable preview features in order to use backup'));
+			return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.isPreviewFeature', "You must enable preview features in order to use backup"));
 		}
 
 		const connectionManagementService = accessor.get<IConnectionManagementService>(IConnectionManagementService);
@@ -255,11 +255,11 @@ export class BackupAction extends Task {
 		if (profile) {
 			const serverInfo = connectionManagementService.getServerInfo(profile.id);
 			if (serverInfo && serverInfo.isCloud && profile.providerName === mssqlProviderName) {
-				return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.commandNotSupported', 'Backup command is not supported for Azure SQL databases.'));
+				return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.commandNotSupported', "Backup command is not supported for Azure SQL databases."));
 			}
 
 			if (!profile.databaseName && profile.providerName === mssqlProviderName) {
-				return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.commandNotSupportedForServer', 'Backup command is not supported in Server Context. Please select a Database and try again.'));
+				return accessor.get<INotificationService>(INotificationService).info(nls.localize('backup.commandNotSupportedForServer', "Backup command is not supported in Server Context. Please select a Database and try again."));
 			}
 		}
 
@@ -274,7 +274,7 @@ export const RestoreFeatureName = 'restore';
 
 export class RestoreAction extends Task {
 	public static readonly ID = RestoreFeatureName;
-	public static readonly LABEL = nls.localize('restoreAction.restore', 'Restore');
+	public static readonly LABEL = nls.localize('restoreAction.restore', "Restore");
 	public static readonly ICON = RestoreFeatureName;
 
 	constructor() {
@@ -290,7 +290,7 @@ export class RestoreAction extends Task {
 		const configurationService = accessor.get<IConfigurationService>(IConfigurationService);
 		const previewFeaturesEnabled: boolean = configurationService.getValue('workbench')['enablePreviewFeatures'];
 		if (!previewFeaturesEnabled) {
-			return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.isPreviewFeature', 'You must enable preview features in order to use restore'));
+			return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.isPreviewFeature', "You must enable preview features in order to use restore"));
 		}
 
 		let connectionManagementService = accessor.get<IConnectionManagementService>(IConnectionManagementService);
@@ -302,11 +302,11 @@ export class RestoreAction extends Task {
 		if (profile) {
 			const serverInfo = connectionManagementService.getServerInfo(profile.id);
 			if (serverInfo && serverInfo.isCloud && profile.providerName === mssqlProviderName) {
-				return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.commandNotSupported', 'Restore command is not supported for Azure SQL databases.'));
+				return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.commandNotSupported', "Restore command is not supported for Azure SQL databases."));
 			}
 
 			if (!profile.databaseName && profile.providerName === mssqlProviderName) {
-				return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.commandNotSupportedForServer', 'Restore command is not supported in Server Context. Please select a Database and try again.'));
+				return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.commandNotSupportedForServer', "Restore command is not supported in Server Context. Please select a Database and try again."));
 			}
 		}
 
@@ -319,7 +319,7 @@ export class RestoreAction extends Task {
 
 export class ManageAction extends Action {
 	public static ID = 'manage';
-	public static LABEL = nls.localize('manage', 'Manage');
+	public static LABEL = nls.localize('manage', "Manage");
 
 	constructor(
 		id: string, label: string,
@@ -341,7 +341,7 @@ export class ManageAction extends Action {
 
 export class InsightAction extends Action {
 	public static ID = 'showInsight';
-	public static LABEL = nls.localize('showDetails', 'Show Details');
+	public static LABEL = nls.localize('showDetails', "Show Details");
 
 	constructor(
 		id: string, label: string,
@@ -358,7 +358,7 @@ export class InsightAction extends Action {
 
 export class ConfigureDashboardAction extends Task {
 	public static readonly ID = 'configureDashboard';
-	public static readonly LABEL = nls.localize('configureDashboard', 'Learn How To Configure The Dashboard');
+	public static readonly LABEL = nls.localize('configureDashboard', "Learn How To Configure The Dashboard");
 	public static readonly ICON = 'configure-dashboard';
 	private static readonly configHelpUri = 'https://aka.ms/sqldashboardconfig';
 

--- a/src/sql/workbench/common/taskUtilities.ts
+++ b/src/sql/workbench/common/taskUtilities.ts
@@ -69,15 +69,15 @@ export function GetScriptOperationName(operation: ScriptOperation) {
 	let defaultName: string = ScriptOperation[operation];
 	switch (operation) {
 		case ScriptOperation.Select:
-			return nls.localize('selectOperationName', 'Select');
+			return nls.localize('selectOperationName', "Select");
 		case ScriptOperation.Create:
-			return nls.localize('createOperationName', 'Create');
+			return nls.localize('createOperationName', "Create");
 		case ScriptOperation.Insert:
-			return nls.localize('insertOperationName', 'Insert');
+			return nls.localize('insertOperationName', "Insert");
 		case ScriptOperation.Update:
-			return nls.localize('updateOperationName', 'Update');
+			return nls.localize('updateOperationName', "Update");
 		case ScriptOperation.Delete:
-			return nls.localize('deleteOperationName', 'Delete');
+			return nls.localize('deleteOperationName', "Delete");
 		default:
 			// return the raw, non-localized string name
 			return defaultName;
@@ -109,7 +109,7 @@ export function scriptSelect(connectionProfile: IConnectionProfile, metadata: az
 						reject(editorError);
 					});
 				} else {
-					let errMsg: string = nls.localize('scriptSelectNotFound', 'No script was returned when calling select script on object ');
+					let errMsg: string = nls.localize('scriptSelectNotFound', "No script was returned when calling select script on object ");
 					reject(errMsg.concat(metadata.metadataTypeName));
 				}
 			}, scriptError => {
@@ -144,7 +144,7 @@ export function scriptEditSelect(connectionProfile: IConnectionProfile, metadata
 						reject(editorError);
 					});
 				} else {
-					let errMsg: string = nls.localize('scriptSelectNotFound', 'No script was returned when calling select script on object ');
+					let errMsg: string = nls.localize('scriptSelectNotFound', "No script was returned when calling select script on object ");
 					reject(errMsg.concat(metadata.metadataTypeName));
 				}
 			}, scriptError => {
@@ -197,7 +197,7 @@ export function script(connectionProfile: IConnectionProfile, metadata: azdata.O
 							messageDetail = operationResult.errorDetails;
 						}
 						if (errorMessageService) {
-							let title = nls.localize('scriptingFailed', 'Scripting Failed');
+							let title = nls.localize('scriptingFailed', "Scripting Failed");
 							errorMessageService.showDialog(Severity.Error, title, scriptNotFoundMsg, messageDetail);
 						}
 						reject(scriptNotFoundMsg);

--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -76,7 +76,8 @@ export default () => `
 				<div class="section learn">
 					<h2 class="caption">${escape(localize('welcomePage.learn', "Learn"))}</h2>
 					<div class="list">
-						<div class="item showCommands"><button data-href="command:workbench.action.showCommands"><h3 class="caption">${escape(localize('welcomePage.showCommands', "Find and run all commands"))}</h3> <span class="detail">${escape(localize('welcomePage.showCommandsDescription', "Rapidly access and search commands from the Command Palette ({0})")).replace('{0}', '<span class="shortcut" data-command="workbench.action.showCommands"></span>')}</span></button></div>
+						<div class="item showCommands"><button data-href="command:workbench.action.showCommands"><h3 class="caption">${escape(localize('welcomePage.showCommands', "Find and run all commands"))}</h3> <span class="detail">${escape(localize('welcomePage.showCommandsDescription', "Rapidly access and search commands from the Command Palette ({0})"))
+		.replace('{0}', '<span class="shortcut" data-command="workbench.action.showCommands"></span>')}</span></button></div>
 						<div class="item showInterfaceOverview"><button data-href="https://aka.ms/azdata-blog"><h3 class="caption">${escape(localize('welcomePage.azdataBlog', "Discover what's new in the latest release"))}</h3> <span class="detail">${escape(localize('welcomePage.azdataBlogDescription', "New monthly blog posts each month showcasing our new features"))}</span></button></div>
 						<div class="item showInteractivePlayground"><button data-href="https://twitter.com/azuredatastudio"><h3 class="caption">${escape(localize('welcomePage.followTwitter', "Follow us on Twitter"))}</h3> <span class="detail">${escape(localize('welcomePage.followTwitterDescription', "Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers."))}</span></button></div>
 					</div>

--- a/src/sql/workbench/parts/backup/browser/backup.component.ts
+++ b/src/sql/workbench/parts/backup/browser/backup.component.ts
@@ -79,34 +79,34 @@ interface MssqlBackupInfo {
 }
 
 const LocalizedStrings = {
-	BACKUP_NAME: localize('backup.backupName', 'Backup name'),
-	RECOVERY_MODEL: localize('backup.recoveryModel', 'Recovery model'),
-	BACKUP_TYPE: localize('backup.backupType', 'Backup type'),
-	BACKUP_DEVICE: localize('backup.backupDevice', 'Backup files'),
-	ALGORITHM: localize('backup.algorithm', 'Algorithm'),
-	CERTIFICATE_OR_ASYMMETRIC_KEY: localize('backup.certificateOrAsymmetricKey', 'Certificate or Asymmetric key'),
-	MEDIA: localize('backup.media', 'Media'),
-	MEDIA_OPTION: localize('backup.mediaOption', 'Backup to the existing media set'),
-	MEDIA_OPTION_FORMAT: localize('backup.mediaOptionFormat', 'Backup to a new media set'),
-	EXISTING_MEDIA_APPEND: localize('backup.existingMediaAppend', 'Append to the existing backup set'),
-	EXISTING_MEDIA_OVERWRITE: localize('backup.existingMediaOverwrite', 'Overwrite all existing backup sets'),
-	NEW_MEDIA_SET_NAME: localize('backup.newMediaSetName', 'New media set name'),
-	NEW_MEDIA_SET_DESCRIPTION: localize('backup.newMediaSetDescription', 'New media set description'),
-	CHECKSUM_CONTAINER: localize('backup.checksumContainer', 'Perform checksum before writing to media'),
-	VERIFY_CONTAINER: localize('backup.verifyContainer', 'Verify backup when finished'),
-	CONTINUE_ON_ERROR_CONTAINER: localize('backup.continueOnErrorContainer', 'Continue on error'),
-	EXPIRATION: localize('backup.expiration', 'Expiration'),
-	SET_BACKUP_RETAIN_DAYS: localize('backup.setBackupRetainDays', 'Set backup retain days'),
-	COPY_ONLY: localize('backup.copyOnly', 'Copy-only backup'),
-	ADVANCED_CONFIGURATION: localize('backup.advancedConfiguration', 'Advanced Configuration'),
-	COMPRESSION: localize('backup.compression', 'Compression'),
-	SET_BACKUP_COMPRESSION: localize('backup.setBackupCompression', 'Set backup compression'),
-	ENCRYPTION: localize('backup.encryption', 'Encryption'),
-	TRANSACTION_LOG: localize('backup.transactionLog', 'Transaction log'),
-	TRUNCATE_TRANSACTION_LOG: localize('backup.truncateTransactionLog', 'Truncate the transaction log'),
-	BACKUP_TAIL: localize('backup.backupTail', 'Backup the tail of the log'),
-	RELIABILITY: localize('backup.reliability', 'Reliability'),
-	MEDIA_NAME_REQUIRED_ERROR: localize('backup.mediaNameRequired', 'Media name is required'),
+	BACKUP_NAME: localize('backup.backupName', "Backup name"),
+	RECOVERY_MODEL: localize('backup.recoveryModel', "Recovery model"),
+	BACKUP_TYPE: localize('backup.backupType', "Backup type"),
+	BACKUP_DEVICE: localize('backup.backupDevice', "Backup files"),
+	ALGORITHM: localize('backup.algorithm', "Algorithm"),
+	CERTIFICATE_OR_ASYMMETRIC_KEY: localize('backup.certificateOrAsymmetricKey', "Certificate or Asymmetric key"),
+	MEDIA: localize('backup.media', "Media"),
+	MEDIA_OPTION: localize('backup.mediaOption', "Backup to the existing media set"),
+	MEDIA_OPTION_FORMAT: localize('backup.mediaOptionFormat', "Backup to a new media set"),
+	EXISTING_MEDIA_APPEND: localize('backup.existingMediaAppend', "Append to the existing backup set"),
+	EXISTING_MEDIA_OVERWRITE: localize('backup.existingMediaOverwrite', "Overwrite all existing backup sets"),
+	NEW_MEDIA_SET_NAME: localize('backup.newMediaSetName', "New media set name"),
+	NEW_MEDIA_SET_DESCRIPTION: localize('backup.newMediaSetDescription', "New media set description"),
+	CHECKSUM_CONTAINER: localize('backup.checksumContainer', "Perform checksum before writing to media"),
+	VERIFY_CONTAINER: localize('backup.verifyContainer', "Verify backup when finished"),
+	CONTINUE_ON_ERROR_CONTAINER: localize('backup.continueOnErrorContainer', "Continue on error"),
+	EXPIRATION: localize('backup.expiration', "Expiration"),
+	SET_BACKUP_RETAIN_DAYS: localize('backup.setBackupRetainDays', "Set backup retain days"),
+	COPY_ONLY: localize('backup.copyOnly', "Copy-only backup"),
+	ADVANCED_CONFIGURATION: localize('backup.advancedConfiguration', "Advanced Configuration"),
+	COMPRESSION: localize('backup.compression', "Compression"),
+	SET_BACKUP_COMPRESSION: localize('backup.setBackupCompression', "Set backup compression"),
+	ENCRYPTION: localize('backup.encryption', "Encryption"),
+	TRANSACTION_LOG: localize('backup.transactionLog', "Transaction log"),
+	TRUNCATE_TRANSACTION_LOG: localize('backup.truncateTransactionLog', "Truncate the transaction log"),
+	BACKUP_TAIL: localize('backup.backupTail', "Backup the tail of the log"),
+	RELIABILITY: localize('backup.reliability', "Reliability"),
+	MEDIA_NAME_REQUIRED_ERROR: localize('backup.mediaNameRequired', "Media name is required"),
 	NO_ENCRYPTOR_WARNING: localize('backup.noEncryptorWarning', "No certificate or asymmetric key is available")
 };
 
@@ -293,11 +293,11 @@ export class BackupComponent {
 		// Set backup path add/remove buttons
 		this.addPathButton = new Button(this.addPathElement.nativeElement);
 		this.addPathButton.label = '+';
-		this.addPathButton.title = localize('addFile', 'Add a file');
+		this.addPathButton.title = localize('addFile', "Add a file");
 
 		this.removePathButton = new Button(this.removePathElement.nativeElement);
 		this.removePathButton.label = '-';
-		this.removePathButton.title = localize('removeFile', 'Remove files');
+		this.removePathButton.title = localize('removeFile', "Remove files");
 
 		// Set compression
 		this.compressionSelectBox = new SelectBox(this.compressionOptions, this.compressionOptions[0], this.contextViewService, undefined, { ariaLabel: this.localizedStrings.SET_BACKUP_COMPRESSION });
@@ -325,7 +325,7 @@ export class BackupComponent {
 		});
 
 		// Set backup retain days
-		let invalidInputMessage = localize('backupComponent.invalidInput', 'Invalid input. Value must be greater than or equal 0.');
+		let invalidInputMessage = localize('backupComponent.invalidInput', "Invalid input. Value must be greater than or equal 0.");
 		this.backupRetainDaysBox = new InputBox(this.backupDaysElement.nativeElement,
 			this.contextViewService,
 			{
@@ -401,21 +401,21 @@ export class BackupComponent {
 	private addFooterButtons(): void {
 		// Set script footer button
 		this.scriptButton = new Button(this.scriptButtonElement.nativeElement);
-		this.scriptButton.label = localize('backupComponent.script', 'Script');
+		this.scriptButton.label = localize('backupComponent.script', "Script");
 		this.addButtonClickHandler(this.scriptButton, () => this.onScript());
 		this._toDispose.push(attachButtonStyler(this.scriptButton, this.themeService));
 		this.scriptButton.enabled = false;
 
 		// Set backup footer button
 		this.backupButton = new Button(this.backupButtonElement.nativeElement);
-		this.backupButton.label = localize('backupComponent.backup', 'Backup');
+		this.backupButton.label = localize('backupComponent.backup', "Backup");
 		this.addButtonClickHandler(this.backupButton, () => this.onOk());
 		this._toDispose.push(attachButtonStyler(this.backupButton, this.themeService));
 		this.backupEnabled = false;
 
 		// Set cancel footer button
 		this.cancelButton = new Button(this.cancelButtonElement.nativeElement);
-		this.cancelButton.label = localize('backupComponent.cancel', 'Cancel');
+		this.cancelButton.label = localize('backupComponent.cancel', "Cancel");
 		this.addButtonClickHandler(this.cancelButton, () => this.onCancel());
 		this._toDispose.push(attachButtonStyler(this.cancelButton, this.themeService));
 	}
@@ -481,7 +481,7 @@ export class BackupComponent {
 
 			// show warning message if latest backup file path contains url
 			if (this.containsBackupToUrl) {
-				this.pathListBox.setValidation(false, { content: localize('backup.containsBackupToUrlError', 'Only backup to file is supported'), type: MessageType.WARNING });
+				this.pathListBox.setValidation(false, { content: localize('backup.containsBackupToUrlError', "Only backup to file is supported"), type: MessageType.WARNING });
 				this.pathListBox.focus();
 			}
 		}
@@ -695,7 +695,7 @@ export class BackupComponent {
 			this.backupEnabled = false;
 
 			// show input validation error
-			this.pathListBox.setValidation(false, { content: localize('backup.backupFileRequired', 'Backup file path is required'), type: MessageType.ERROR });
+			this.pathListBox.setValidation(false, { content: localize('backup.backupFileRequired', "Backup file path is required"), type: MessageType.ERROR });
 			this.pathListBox.focus();
 		}
 

--- a/src/sql/workbench/parts/backup/common/constants.ts
+++ b/src/sql/workbench/parts/backup/common/constants.ts
@@ -23,17 +23,17 @@ export const recoveryModelSimple = 'Simple';
 export const recoveryModelFull = 'Full';
 
 // Constants for UI strings
-export const labelDatabase = localize('backup.labelDatabase', 'Database');
-export const labelFilegroup = localize('backup.labelFilegroup', 'Files and filegroups');
-export const labelFull = localize('backup.labelFull', 'Full');
-export const labelDifferential = localize('backup.labelDifferential', 'Differential');
-export const labelLog = localize('backup.labelLog', 'Transaction Log');
-export const labelDisk = localize('backup.labelDisk', 'Disk');
-export const labelUrl = localize('backup.labelUrl', 'Url');
+export const labelDatabase = localize('backup.labelDatabase', "Database");
+export const labelFilegroup = localize('backup.labelFilegroup', "Files and filegroups");
+export const labelFull = localize('backup.labelFull', "Full");
+export const labelDifferential = localize('backup.labelDifferential', "Differential");
+export const labelLog = localize('backup.labelLog', "Transaction Log");
+export const labelDisk = localize('backup.labelDisk', "Disk");
+export const labelUrl = localize('backup.labelUrl', "Url");
 
-export const defaultCompression = localize('backup.defaultCompression', 'Use the default server setting');
-export const compressionOn = localize('backup.compressBackup', 'Compress backup');
-export const compressionOff = localize('backup.doNotCompress', 'Do not compress backup');
+export const defaultCompression = localize('backup.defaultCompression', "Use the default server setting");
+export const compressionOn = localize('backup.compressBackup', "Compress backup");
+export const compressionOff = localize('backup.doNotCompress', "Do not compress backup");
 
 export const aes128 = 'AES 128';
 export const aes192 = 'AES 192';

--- a/src/sql/workbench/parts/charts/browser/actions.ts
+++ b/src/sql/workbench/parts/charts/browser/actions.ts
@@ -43,7 +43,7 @@ export class CreateInsightAction extends Action {
 	public run(context: IChartActionContext): Promise<boolean> {
 		let uriString: string = this.getActiveUriString();
 		if (!uriString) {
-			this.showError(localize('createInsightNoEditor', 'Cannot create insight as the active editor is not a SQL Editor'));
+			this.showError(localize('createInsightNoEditor', "Cannot create insight as the active editor is not a SQL Editor"));
 			return Promise.resolve(false);
 		}
 
@@ -62,7 +62,7 @@ export class CreateInsightAction extends Action {
 		};
 
 		let widgetConfig = {
-			name: localize('myWidgetName', 'My-Widget'),
+			name: localize('myWidgetName', "My-Widget"),
 			gridItemConfig: {
 				sizex: 2,
 				sizey: 1
@@ -119,7 +119,7 @@ export class CopyAction extends Action {
 		if (context.insight instanceof Graph) {
 			let data = context.insight.getCanvasData();
 			if (!data) {
-				this.showError(localize('chartNotFound', 'Could not find chart to save'));
+				this.showError(localize('chartNotFound', "Could not find chart to save"));
 				return Promise.resolve(false);
 			}
 
@@ -157,7 +157,7 @@ export class SaveImageAction extends Action {
 			return this.promptForFilepath().then(filePath => {
 				let data = (<Graph>context.insight).getCanvasData();
 				if (!data) {
-					this.showError(localize('chartNotFound', 'Could not find chart to save'));
+					this.showError(localize('chartNotFound', "Could not find chart to save"));
 					return false;
 				}
 				if (filePath) {
@@ -190,7 +190,7 @@ export class SaveImageAction extends Action {
 		let filepathPlaceHolder = resolveCurrentDirectory(this.getActiveUriString(), getRootPath(this.workspaceContextService));
 		filepathPlaceHolder = join(filepathPlaceHolder, 'chart.png');
 		return this.windowService.showSaveDialog({
-			title: localize('chartViewer.saveAsFileTitle', 'Choose Results File'),
+			title: localize('chartViewer.saveAsFileTitle', "Choose Results File"),
 			defaultPath: normalize(filepathPlaceHolder)
 		});
 	}

--- a/src/sql/workbench/parts/charts/browser/chartOptions.ts
+++ b/src/sql/workbench/parts/charts/browser/chartOptions.ts
@@ -35,16 +35,16 @@ export interface IChartOptions {
 }
 
 const dataDirectionOption: IChartOption = {
-	label: localize('dataDirectionLabel', 'Data Direction'),
+	label: localize('dataDirectionLabel', "Data Direction"),
 	type: ControlType.combo,
-	displayableOptions: [localize('verticalLabel', 'Vertical'), localize('horizontalLabel', 'Horizontal')],
+	displayableOptions: [localize('verticalLabel', "Vertical"), localize('horizontalLabel', "Horizontal")],
 	options: [DataDirection.Vertical, DataDirection.Horizontal],
 	configEntry: 'dataDirection',
 	default: DataDirection.Horizontal
 };
 
 const columnsAsLabelsInput: IChartOption = {
-	label: localize('columnsAsLabelsLabel', 'Use column names as labels'),
+	label: localize('columnsAsLabelsLabel', "Use column names as labels"),
 	type: ControlType.checkbox,
 	configEntry: 'columnsAsLabels',
 	default: true,
@@ -54,7 +54,7 @@ const columnsAsLabelsInput: IChartOption = {
 };
 
 const labelFirstColumnInput: IChartOption = {
-	label: localize('labelFirstColumnLabel', 'Use first column as row label'),
+	label: localize('labelFirstColumnLabel', "Use first column as row label"),
 	type: ControlType.checkbox,
 	configEntry: 'labelFirstColumn',
 	default: false,
@@ -64,7 +64,7 @@ const labelFirstColumnInput: IChartOption = {
 };
 
 const legendInput: IChartOption = {
-	label: localize('legendLabel', 'Legend Position'),
+	label: localize('legendLabel', "Legend Position"),
 	type: ControlType.combo,
 	options: Object.values(LegendPosition),
 	configEntry: 'legendPosition',
@@ -72,66 +72,66 @@ const legendInput: IChartOption = {
 };
 
 const yAxisLabelInput: IChartOption = {
-	label: localize('yAxisLabel', 'Y Axis Label'),
+	label: localize('yAxisLabel', "Y Axis Label"),
 	type: ControlType.input,
 	configEntry: 'yAxisLabel',
 	default: undefined
 };
 
 const yAxisMinInput: IChartOption = {
-	label: localize('yAxisMinVal', 'Y Axis Minimum Value'),
+	label: localize('yAxisMinVal', "Y Axis Minimum Value"),
 	type: ControlType.numberInput,
 	configEntry: 'yAxisMin',
 	default: undefined
 };
 
 const yAxisMaxInput: IChartOption = {
-	label: localize('yAxisMaxVal', 'Y Axis Maximum Value'),
+	label: localize('yAxisMaxVal', "Y Axis Maximum Value"),
 	type: ControlType.numberInput,
 	configEntry: 'yAxisMax',
 	default: undefined
 };
 
 const xAxisLabelInput: IChartOption = {
-	label: localize('xAxisLabel', 'X Axis Label'),
+	label: localize('xAxisLabel', "X Axis Label"),
 	type: ControlType.input,
 	configEntry: 'xAxisLabel',
 	default: undefined
 };
 
 const xAxisMinInput: IChartOption = {
-	label: localize('xAxisMinVal', 'X Axis Minimum Value'),
+	label: localize('xAxisMinVal', "X Axis Minimum Value"),
 	type: ControlType.numberInput,
 	configEntry: 'xAxisMin',
 	default: undefined
 };
 
 const xAxisMaxInput: IChartOption = {
-	label: localize('xAxisMaxVal', 'X Axis Maximum Value'),
+	label: localize('xAxisMaxVal', "X Axis Maximum Value"),
 	type: ControlType.numberInput,
 	configEntry: 'xAxisMax',
 	default: undefined
 };
 
 const xAxisMinDateInput: IChartOption = {
-	label: localize('xAxisMinDate', 'X Axis Minimum Date'),
+	label: localize('xAxisMinDate', "X Axis Minimum Date"),
 	type: ControlType.dateInput,
 	configEntry: 'xAxisMin',
 	default: undefined
 };
 
 const xAxisMaxDateInput: IChartOption = {
-	label: localize('xAxisMaxDate', 'X Axis Maximum Date'),
+	label: localize('xAxisMaxDate', "X Axis Maximum Date"),
 	type: ControlType.dateInput,
 	configEntry: 'xAxisMax',
 	default: undefined
 };
 
 const dataTypeInput: IChartOption = {
-	label: localize('dataTypeLabel', 'Data Type'),
+	label: localize('dataTypeLabel', "Data Type"),
 	type: ControlType.combo,
 	options: [DataType.Number, DataType.Point],
-	displayableOptions: [localize('numberLabel', 'Number'), localize('pointLabel', 'Point')],
+	displayableOptions: [localize('numberLabel', "Number"), localize('pointLabel', "Point")],
 	configEntry: 'dataType',
 	default: DataType.Number
 };
@@ -139,7 +139,7 @@ const dataTypeInput: IChartOption = {
 export const ChartOptions: IChartOptions = {
 	general: [
 		{
-			label: localize('chartTypeLabel', 'Chart Type'),
+			label: localize('chartTypeLabel', "Chart Type"),
 			type: ControlType.combo,
 			options: insightRegistry.getAllIds(),
 			configEntry: 'type',
@@ -205,13 +205,13 @@ export const ChartOptions: IChartOptions = {
 	[InsightType.Image]: [
 		{
 			configEntry: 'encoding',
-			label: localize('encodingOption', 'Encoding'),
+			label: localize('encodingOption', "Encoding"),
 			type: ControlType.input,
 			default: 'hex'
 		},
 		{
 			configEntry: 'imageFormat',
-			label: localize('imageFormatOption', 'Image Format'),
+			label: localize('imageFormatOption', "Image Format"),
 			type: ControlType.input,
 			default: 'jpeg'
 		}

--- a/src/sql/workbench/parts/charts/browser/chartTab.ts
+++ b/src/sql/workbench/parts/charts/browser/chartTab.ts
@@ -11,7 +11,7 @@ import { localize } from 'vs/nls';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 export class ChartTab implements IPanelTab {
-	public readonly title = localize('chartTabTitle', 'Chart');
+	public readonly title = localize('chartTabTitle', "Chart");
 	public readonly identifier = 'ChartTab';
 	public readonly view: ChartView;
 

--- a/src/sql/workbench/parts/connection/browser/advancedPropertiesController.ts
+++ b/src/sql/workbench/parts/connection/browser/advancedPropertiesController.ts
@@ -32,7 +32,7 @@ export class AdvancedPropertiesController {
 	public get advancedDialog() {
 		if (!this._advancedDialog) {
 			this._advancedDialog = this._instantiationService.createInstance(
-				OptionsDialog, localize('connectionAdvancedProperties', 'Advanced Properties'), TelemetryKeys.ConnectionAdvancedProperties, { hasBackButton: true, cancelLabel: localize('advancedProperties.discard', 'Discard') });
+				OptionsDialog, localize('connectionAdvancedProperties', "Advanced Properties"), TelemetryKeys.ConnectionAdvancedProperties, { hasBackButton: true, cancelLabel: localize('advancedProperties.discard', "Discard") });
 			this._advancedDialog.onCloseEvent(() => this._onCloseAdvancedProperties());
 			this._advancedDialog.onOk(() => this.handleOnOk());
 			this._advancedDialog.render();

--- a/src/sql/workbench/parts/connection/browser/connection.contribution.ts
+++ b/src/sql/workbench/parts/connection/browser/connection.contribution.ts
@@ -119,17 +119,17 @@ configurationRegistry.registerConfiguration({
 		'sql.maxRecentConnections': {
 			'type': 'number',
 			'default': 25,
-			'description': localize('sql.maxRecentConnectionsDescription', 'The maximum number of recently used connections to store in the connection list.')
+			'description': localize('sql.maxRecentConnectionsDescription', "The maximum number of recently used connections to store in the connection list.")
 		},
 		'sql.defaultEngine': {
 			'type': 'string',
-			'description': localize('sql.defaultEngineDescription', 'Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection. Valid option is currently MSSQL'),
+			'description': localize('sql.defaultEngineDescription', "Default SQL Engine to use. This drives default language provider in .sql files and the default to use when creating a new connection. Valid option is currently MSSQL"),
 			'default': 'MSSQL'
 		},
 		'connection.parseClipboardForConnectionString': {
 			'type': 'boolean',
 			'default': true,
-			'description': localize('connection.parseClipboardForConnectionStringDescription', 'Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.')
+			'description': localize('connection.parseClipboardForConnectionStringDescription', "Attempt to parse the contents of the clipboard when the connection dialog is opened or a paste is performed.")
 		}
 	}
 });

--- a/src/sql/workbench/parts/connection/common/connectionActions.ts
+++ b/src/sql/workbench/parts/connection/common/connectionActions.ts
@@ -25,7 +25,7 @@ import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/co
 export class ClearRecentConnectionsAction extends Action {
 
 	public static ID = 'clearRecentConnectionsAction';
-	public static LABEL = nls.localize('ClearRecentlyUsedLabel', 'Clear List');
+	public static LABEL = nls.localize('ClearRecentlyUsedLabel', "Clear List");
 	public static ICON = 'search-action clear-search-results';
 
 	private _onRecentConnectionsRemoved = new Emitter<void>();
@@ -65,7 +65,7 @@ export class ClearRecentConnectionsAction extends Action {
 					const actions: INotificationActions = { primary: [] };
 					this._notificationService.notify({
 						severity: Severity.Info,
-						message: nls.localize('ClearedRecentConnections', 'Recent connections list cleared'),
+						message: nls.localize('ClearedRecentConnections', "Recent connections list cleared"),
 						actions
 					});
 					this._onRecentConnectionsRemoved.fire();
@@ -78,11 +78,11 @@ export class ClearRecentConnectionsAction extends Action {
 		const self = this;
 		return new Promise<boolean>((resolve, reject) => {
 			let choices: { key, value }[] = [
-				{ key: nls.localize('connectionAction.yes', 'Yes'), value: true },
-				{ key: nls.localize('connectionAction.no', 'No'), value: false }
+				{ key: nls.localize('connectionAction.yes', "Yes"), value: true },
+				{ key: nls.localize('connectionAction.no', "No"), value: false }
 			];
 
-			self._quickInputService.pick(choices.map(x => x.key), { placeHolder: nls.localize('ClearRecentlyUsedLabel', 'Clear List'), ignoreFocusLost: true }).then((choice) => {
+			self._quickInputService.pick(choices.map(x => x.key), { placeHolder: nls.localize('ClearRecentlyUsedLabel', "Clear List"), ignoreFocusLost: true }).then((choice) => {
 				let confirm = choices.find(x => x.key === choice);
 				resolve(confirm && confirm.value);
 			});
@@ -91,9 +91,9 @@ export class ClearRecentConnectionsAction extends Action {
 
 	private promptConfirmationMessage(): Promise<IConfirmationResult> {
 		let confirm: IConfirmation = {
-			message: nls.localize('clearRecentConnectionMessage', 'Are you sure you want to delete all the connections from the list?'),
-			primaryButton: nls.localize('connectionDialog.yes', 'Yes'),
-			secondaryButton: nls.localize('connectionDialog.no', 'No'),
+			message: nls.localize('clearRecentConnectionMessage', "Are you sure you want to delete all the connections from the list?"),
+			primaryButton: nls.localize('connectionDialog.yes', "Yes"),
+			secondaryButton: nls.localize('connectionDialog.no', "No"),
 			type: 'question'
 		};
 
@@ -111,7 +111,7 @@ export class ClearRecentConnectionsAction extends Action {
 export class ClearSingleRecentConnectionAction extends Action {
 
 	public static ID = 'clearSingleRecentConnectionAction';
-	public static LABEL = nls.localize('delete', 'Delete');
+	public static LABEL = nls.localize('delete', "Delete");
 	private _onRecentConnectionRemoved = new Emitter<void>();
 	public onRecentConnectionRemoved: Event<void> = this._onRecentConnectionRemoved.event;
 

--- a/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
@@ -69,7 +69,7 @@ const ConnectionProviderContrib: IJSONSchema = {
 			description: localize('schema.displayName', "Display Name for the provider")
 		},
 		iconPath: {
-			description: localize('schema.iconPath', 'Icon path for the server type'),
+			description: localize('schema.iconPath', "Icon path for the server type"),
 			oneOf: [
 				{
 					type: 'array',

--- a/src/sql/workbench/parts/connection/common/localizedConstants.ts
+++ b/src/sql/workbench/parts/connection/common/localizedConstants.ts
@@ -5,6 +5,6 @@
 
 import { localize } from 'vs/nls';
 
-export const onDidConnectMessage = localize('onDidConnectMessage', 'Connected to');
-export const onDidDisconnectMessage = localize('onDidDisconnectMessage', 'Disconnected');
-export const unsavedGroupLabel = localize('unsavedGroupLabel', 'Unsaved Connections');
+export const onDidConnectMessage = localize('onDidConnectMessage', "Connected to");
+export const onDidDisconnectMessage = localize('onDidDisconnectMessage', "Disconnected");
+export const unsavedGroupLabel = localize('unsavedGroupLabel', "Unsaved Connections");

--- a/src/sql/workbench/parts/dashboard/browser/containers/dashboardContainer.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/containers/dashboardContainer.contribution.ts
@@ -58,16 +58,16 @@ ExtensionsRegistry.registerExtensionPoint<IDashboardContainerContrib | IDashboar
 	function handleCommand(dashboardContainer: IDashboardContainerContrib, extension: IExtensionPointUser<any>) {
 		const { id, container } = dashboardContainer;
 		if (!id) {
-			extension.collector.error(localize('dashboardContainer.contribution.noIdError', 'No id in dashboard container specified for extension.'));
+			extension.collector.error(localize('dashboardContainer.contribution.noIdError', "No id in dashboard container specified for extension."));
 			return;
 		}
 
 		if (!container) {
-			extension.collector.error(localize('dashboardContainer.contribution.noContainerError', 'No container in dashboard container specified for extension.'));
+			extension.collector.error(localize('dashboardContainer.contribution.noContainerError', "No container in dashboard container specified for extension."));
 			return;
 		}
 		if (Object.keys(container).length !== 1) {
-			extension.collector.error(localize('dashboardContainer.contribution.moreThanOneDashboardContainersError', 'Exactly 1 dashboard container must be defined per space.'));
+			extension.collector.error(localize('dashboardContainer.contribution.moreThanOneDashboardContainersError', "Exactly 1 dashboard container must be defined per space."));
 			return;
 		}
 
@@ -77,7 +77,7 @@ ExtensionsRegistry.registerExtensionPoint<IDashboardContainerContrib | IDashboar
 
 		const containerTypeFound = containerTypes.find(c => (c === containerkey));
 		if (!containerTypeFound) {
-			extension.collector.error(localize('dashboardTab.contribution.unKnownContainerType', 'Unknown container type defines in dashboard container for extension.'));
+			extension.collector.error(localize('dashboardTab.contribution.unKnownContainerType', "Unknown container type defines in dashboard container for extension."));
 			return;
 		}
 

--- a/src/sql/workbench/parts/dashboard/browser/containers/dashboardGridContainer.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/containers/dashboardGridContainer.contribution.ts
@@ -28,7 +28,7 @@ export function validateGridContainerContribution(extension: IExtensionPointUser
 		const widgetOrWebviewKey = allKeys.find(key => key === 'widget' || key === 'webview');
 		if (!widgetOrWebviewKey) {
 			result = false;
-			extension.collector.error(nls.localize('gridContainer.invalidInputs', 'widgets or webviews are expected inside widgets-container for extension.'));
+			extension.collector.error(nls.localize('gridContainer.invalidInputs', "widgets or webviews are expected inside widgets-container for extension."));
 			return;
 		}
 	});

--- a/src/sql/workbench/parts/dashboard/browser/containers/dashboardNavSection.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/containers/dashboardNavSection.contribution.ts
@@ -26,7 +26,7 @@ const navSectionContainerSchema: IJSONSchema = {
 			description: nls.localize('dashboard.container.left-nav-bar.id', "Unique identifier for this nav section. Will be passed to the extension for any requests.")
 		},
 		icon: {
-			description: nls.localize('dashboard.container.left-nav-bar.icon', '(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration'),
+			description: nls.localize('dashboard.container.left-nav-bar.icon', "(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration"),
 			anyOf: [{
 				type: 'string'
 			},
@@ -34,11 +34,11 @@ const navSectionContainerSchema: IJSONSchema = {
 				type: 'object',
 				properties: {
 					light: {
-						description: nls.localize('dashboard.container.left-nav-bar.icon.light', 'Icon path when a light theme is used'),
+						description: nls.localize('dashboard.container.left-nav-bar.icon.light', "Icon path when a light theme is used"),
 						type: 'string'
 					},
 					dark: {
-						description: nls.localize('dashboard.container.left-nav-bar.icon.dark', 'Icon path when a dark theme is used'),
+						description: nls.localize('dashboard.container.left-nav-bar.icon.dark', "Icon path when a dark theme is used"),
 						type: 'string'
 					}
 				}
@@ -101,17 +101,17 @@ export function validateNavSectionContributionAndRegisterIcon(extension: IExtens
 	navSectionConfigs.forEach(section => {
 		if (!section.title) {
 			result = false;
-			extension.collector.error(nls.localize('navSection.missingTitle_error', 'No title in nav section specified for extension.'));
+			extension.collector.error(nls.localize('navSection.missingTitle_error', "No title in nav section specified for extension."));
 		}
 
 		if (!section.container) {
 			result = false;
-			extension.collector.error(nls.localize('navSection.missingContainer_error', 'No container in nav section specified for extension.'));
+			extension.collector.error(nls.localize('navSection.missingContainer_error', "No container in nav section specified for extension."));
 		}
 
 		if (Object.keys(section.container).length !== 1) {
 			result = false;
-			extension.collector.error(nls.localize('navSection.moreThanOneDashboardContainersError', 'Exactly 1 dashboard container must be defined per space.'));
+			extension.collector.error(nls.localize('navSection.moreThanOneDashboardContainersError', "Exactly 1 dashboard container must be defined per space."));
 		}
 
 		if (isValidIcon(section.icon, extension)) {
@@ -130,7 +130,7 @@ export function validateNavSectionContributionAndRegisterIcon(extension: IExtens
 				break;
 			case NAV_SECTION:
 				result = false;
-				extension.collector.error(nls.localize('navSection.invalidContainer_error', 'NAV_SECTION within NAV_SECTION is an invalid container for extension.'));
+				extension.collector.error(nls.localize('navSection.invalidContainer_error', "NAV_SECTION within NAV_SECTION is an invalid container for extension."));
 				break;
 		}
 

--- a/src/sql/workbench/parts/dashboard/browser/containers/dashboardWidgetContainer.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/containers/dashboardWidgetContainer.contribution.ts
@@ -28,7 +28,7 @@ export function validateWidgetContainerContribution(extension: IExtensionPointUs
 		const widgetKey = allKeys.find(key => key === 'widget');
 		if (!widgetKey) {
 			result = false;
-			extension.collector.error(nls.localize('widgetContainer.invalidInputs', 'The list of widgets is expected inside widgets-container for extension.'));
+			extension.collector.error(nls.localize('widgetContainer.invalidInputs', "The list of widgets is expected inside widgets-container for extension."));
 		}
 	});
 	return result;

--- a/src/sql/workbench/parts/dashboard/browser/core/actions.ts
+++ b/src/sql/workbench/parts/dashboard/browser/core/actions.ts
@@ -54,7 +54,7 @@ export class EditDashboardAction extends Action {
 export class RefreshWidgetAction extends Action {
 
 	private static readonly ID = 'refreshWidget';
-	private static readonly LABEL = nls.localize('refreshWidget', 'Refresh');
+	private static readonly LABEL = nls.localize('refreshWidget', "Refresh");
 	private static readonly ICON = 'refresh';
 
 	constructor(
@@ -77,7 +77,7 @@ export class RefreshWidgetAction extends Action {
 export class ToggleMoreWidgetAction extends Action {
 
 	private static readonly ID = 'toggleMore';
-	private static readonly LABEL = nls.localize('toggleMore', 'Toggle More');
+	private static readonly LABEL = nls.localize('toggleMore', "Toggle More");
 	private static readonly ICON = 'toggle-more';
 
 	constructor(

--- a/src/sql/workbench/parts/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/parts/dashboard/browser/core/dashboardPage.component.ts
@@ -64,7 +64,7 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 	public readonly editEnabled: Event<boolean> = this._editEnabled.event;
 
 	// tslint:disable:no-unused-variable
-	private readonly homeTabTitle: string = nls.localize('home', 'Home');
+	private readonly homeTabTitle: string = nls.localize('home', "Home");
 
 	// a set of config modifiers
 	private readonly _configModifiers: Array<(item: Array<WidgetConfig>, collection: IConfigModifierCollection, context: string) => Array<WidgetConfig>> = [
@@ -109,7 +109,7 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		if (!this.dashboardService.connectionManagementService.connectionInfo) {
 			this.notificationService.notify({
 				severity: Severity.Error,
-				message: nls.localize('missingConnectionInfo', 'No connection information could be found for this dashboard')
+				message: nls.localize('missingConnectionInfo', "No connection information could be found for this dashboard")
 			});
 		} else {
 			let tempWidgets = this.dashboardService.getSettings<Array<WidgetConfig>>([this.context, 'widgets'].join('.'));

--- a/src/sql/workbench/parts/dashboard/browser/core/dashboardTab.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/core/dashboardTab.contribution.ts
@@ -42,11 +42,11 @@ const tabSchema: IJSONSchema = {
 			type: 'string'
 		},
 		when: {
-			description: localize('azdata.extension.contributes.tab.when', 'Condition which must be true to show this item'),
+			description: localize('azdata.extension.contributes.tab.when', "Condition which must be true to show this item"),
 			type: 'string'
 		},
 		provider: {
-			description: localize('azdata.extension.contributes.tab.provider', 'Defines the connection types this tab is compatible with. Defaults to "MSSQL" if not set'),
+			description: localize('azdata.extension.contributes.tab.provider', "Defines the connection types this tab is compatible with. Defaults to "MSSQL" if not set"),
 			type: ['string', 'array']
 
 		},
@@ -88,16 +88,16 @@ ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabCo
 		}
 		const publisher = extension.description.publisher;
 		if (!title) {
-			extension.collector.error(localize('dashboardTab.contribution.noTitleError', 'No title specified for extension.'));
+			extension.collector.error(localize('dashboardTab.contribution.noTitleError', "No title specified for extension."));
 			return;
 		}
 
 		if (!description) {
-			extension.collector.warn(localize('dashboardTab.contribution.noDescriptionWarning', 'No description specified to show.'));
+			extension.collector.warn(localize('dashboardTab.contribution.noDescriptionWarning', "No description specified to show."));
 		}
 
 		if (!container) {
-			extension.collector.error(localize('dashboardTab.contribution.noContainerError', 'No container specified for extension.'));
+			extension.collector.error(localize('dashboardTab.contribution.noContainerError', "No container specified for extension."));
 			return;
 		}
 
@@ -109,7 +109,7 @@ ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabCo
 		}
 
 		if (Object.keys(container).length !== 1) {
-			extension.collector.error(localize('dashboardTab.contribution.moreThanOneDashboardContainersError', 'Exactly 1 dashboard container must be defined per space'));
+			extension.collector.error(localize('dashboardTab.contribution.moreThanOneDashboardContainersError', "Exactly 1 dashboard container must be defined per space"));
 			return;
 		}
 

--- a/src/sql/workbench/parts/dashboard/browser/core/dashboardTab.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/core/dashboardTab.contribution.ts
@@ -46,7 +46,7 @@ const tabSchema: IJSONSchema = {
 			type: 'string'
 		},
 		provider: {
-			description: localize('azdata.extension.contributes.tab.provider', "Defines the connection types this tab is compatible with. Defaults to "MSSQL" if not set"),
+			description: localize('azdata.extension.contributes.tab.provider', "Defines the connection types this tab is compatible with. Defaults to 'MSSQL' if not set"),
 			type: ['string', 'array']
 
 		},

--- a/src/sql/workbench/parts/dashboard/browser/pages/dashboardPageContribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/pages/dashboardPageContribution.ts
@@ -32,7 +32,7 @@ export function generateDashboardWidgetSchema(type?: 'database' | 'server', exte
 				type: 'string'
 			},
 			when: {
-				description: localize('azdata.extension.contributes.widget.when', 'Condition which must be true to show this item'),
+				description: localize('azdata.extension.contributes.widget.when', "Condition which must be true to show this item"),
 				type: 'string'
 			},
 			gridItemConfig: {
@@ -118,7 +118,7 @@ export function generateDashboardGridLayoutSchema(type?: 'database' | 'server', 
 				]
 			},
 			when: {
-				description: localize('azdata.extension.contributes.widget.when', 'Condition which must be true to show this item'),
+				description: localize('azdata.extension.contributes.widget.when', "Condition which must be true to show this item"),
 				type: 'string'
 			}
 		}

--- a/src/sql/workbench/parts/dashboard/browser/pages/databaseDashboardPage.component.ts
+++ b/src/sql/workbench/parts/dashboard/browser/pages/databaseDashboardPage.component.ts
@@ -22,7 +22,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 
 export class DatabaseDashboardPage extends DashboardPage implements OnInit {
 	protected propertiesWidget: WidgetConfig = {
-		name: nls.localize('databasePageName', 'DATABASE DASHBOARD'),
+		name: nls.localize('databasePageName', "DATABASE DASHBOARD"),
 		widget: {
 			'properties-widget': undefined
 		},

--- a/src/sql/workbench/parts/dashboard/browser/pages/databaseDashboardPage.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/pages/databaseDashboardPage.contribution.ts
@@ -8,7 +8,7 @@ import * as nls from 'vs/nls';
 import { generateDashboardWidgetSchema, generateDashboardTabSchema } from './dashboardPageContribution';
 
 export const databaseDashboardPropertiesSchema: IJSONSchema = {
-	description: nls.localize('dashboardDatabaseProperties', 'Enable or disable the properties widget'),
+	description: nls.localize('dashboardDatabaseProperties', "Enable or disable the properties widget"),
 	default: true,
 	oneOf: <IJSONSchema[]>[
 		{ type: 'boolean' },
@@ -28,51 +28,51 @@ export const databaseDashboardPropertiesSchema: IJSONSchema = {
 						type: 'number'
 					},
 					properties: {
-						description: nls.localize('dashboard.databaseproperties', 'Property values to show'),
+						description: nls.localize('dashboard.databaseproperties', "Property values to show"),
 						type: 'array',
 						items: {
 							type: 'object',
 							properties: {
 								displayName: {
 									type: 'string',
-									description: nls.localize('dashboard.databaseproperties.displayName', 'Display name of the property')
+									description: nls.localize('dashboard.databaseproperties.displayName', "Display name of the property")
 								},
 								value: {
 									type: 'string',
-									description: nls.localize('dashboard.databaseproperties.value', 'Value in the Database Info Object')
+									description: nls.localize('dashboard.databaseproperties.value', "Value in the Database Info Object")
 								},
 								ignore: {
 									type: 'array',
-									description: nls.localize('dashboard.databaseproperties.ignore', 'Specify specific values to ignore'),
+									description: nls.localize('dashboard.databaseproperties.ignore', "Specify specific values to ignore"),
 									items: 'string'
 								}
 							}
 						},
 						default: [
 							{
-								displayName: nls.localize('recoveryModel', 'Recovery Model'),
+								displayName: nls.localize('recoveryModel', "Recovery Model"),
 								value: 'recoveryModel'
 							},
 							{
-								displayName: nls.localize('lastDatabaseBackup', 'Last Database Backup'),
+								displayName: nls.localize('lastDatabaseBackup', "Last Database Backup"),
 								value: 'lastBackupDate',
 								ignore: [
 									'1/1/0001 12:00:00 AM'
 								]
 							},
 							{
-								displayName: nls.localize('lastLogBackup', 'Last Log Backup'),
+								displayName: nls.localize('lastLogBackup', "Last Log Backup"),
 								value: 'lastLogBackupDate',
 								ignore: [
 									'1/1/0001 12:00:00 AM'
 								]
 							},
 							{
-								displayName: nls.localize('compatibilityLevel', 'Compatibility Level'),
+								displayName: nls.localize('compatibilityLevel', "Compatibility Level"),
 								value: 'compatibilityLevel'
 							},
 							{
-								displayName: nls.localize('owner', 'Owner'),
+								displayName: nls.localize('owner', "Owner"),
 								value: 'owner'
 							}
 						]
@@ -85,7 +85,7 @@ export const databaseDashboardPropertiesSchema: IJSONSchema = {
 
 export const databaseDashboardSettingSchema: IJSONSchema = {
 	type: ['array'],
-	description: nls.localize('dashboardDatabase', 'Customizes the database dashboard page'),
+	description: nls.localize('dashboardDatabase', "Customizes the database dashboard page"),
 	items: generateDashboardWidgetSchema('database'),
 	default: [
 		{
@@ -119,7 +119,7 @@ export const databaseDashboardSettingSchema: IJSONSchema = {
 
 export const databaseDashboardTabsSchema: IJSONSchema = {
 	type: ['array'],
-	description: nls.localize('dashboardDatabaseTabs', 'Customizes the database dashboard tabs'),
+	description: nls.localize('dashboardDatabaseTabs', "Customizes the database dashboard tabs"),
 	items: generateDashboardTabSchema('database'),
 	default: [
 	]

--- a/src/sql/workbench/parts/dashboard/browser/pages/serverDashboardPage.component.ts
+++ b/src/sql/workbench/parts/dashboard/browser/pages/serverDashboardPage.component.ts
@@ -23,7 +23,7 @@ import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 export class ServerDashboardPage extends DashboardPage implements OnInit {
 	protected propertiesWidget: WidgetConfig = {
-		name: nls.localize('serverPageName', 'SERVER DASHBOARD'),
+		name: nls.localize('serverPageName', "SERVER DASHBOARD"),
 		widget: {
 			'properties-widget': undefined
 		},

--- a/src/sql/workbench/parts/dashboard/browser/pages/serverDashboardPage.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/pages/serverDashboardPage.contribution.ts
@@ -17,7 +17,7 @@ export interface IPropertiesConfig {
 }
 
 export const serverDashboardPropertiesSchema: IJSONSchema = {
-	description: nls.localize('dashboardServerProperties', 'Enable or disable the properties widget'),
+	description: nls.localize('dashboardServerProperties', "Enable or disable the properties widget"),
 	default: true,
 	oneOf: [
 		{ type: 'boolean' },
@@ -35,36 +35,36 @@ export const serverDashboardPropertiesSchema: IJSONSchema = {
 					type: 'number'
 				},
 				properties: {
-					description: nls.localize('dashboard.serverproperties', 'Property values to show'),
+					description: nls.localize('dashboard.serverproperties', "Property values to show"),
 					type: 'array',
 					items: {
 						type: 'object',
 						properties: {
 							displayName: {
 								type: 'string',
-								description: nls.localize('dashboard.serverproperties.displayName', 'Display name of the property')
+								description: nls.localize('dashboard.serverproperties.displayName', "Display name of the property")
 							},
 							value: {
 								type: 'string',
-								description: nls.localize('dashboard.serverproperties.value', 'Value in the Server Info Object')
+								description: nls.localize('dashboard.serverproperties.value', "Value in the Server Info Object")
 							}
 						}
 					},
 					default: [
 						{
-							displayName: nls.localize('version', 'Version'),
+							displayName: nls.localize('version', "Version"),
 							value: 'serverVersion'
 						},
 						{
-							displayName: nls.localize('edition', 'Edition'),
+							displayName: nls.localize('edition', "Edition"),
 							value: 'serverEdition'
 						},
 						{
-							displayName: nls.localize('computerName', 'Computer Name'),
+							displayName: nls.localize('computerName', "Computer Name"),
 							value: 'machineName'
 						},
 						{
-							displayName: nls.localize('osVersion', 'OS Version'),
+							displayName: nls.localize('osVersion', "OS Version"),
 							value: 'osVersion'
 						}
 					]
@@ -109,14 +109,14 @@ const defaultVal = [
 
 export const serverDashboardSettingSchema: IJSONSchema = {
 	type: ['array'],
-	description: nls.localize('dashboardServer', 'Customizes the server dashboard page'),
+	description: nls.localize('dashboardServer', "Customizes the server dashboard page"),
 	items: generateDashboardWidgetSchema('server'),
 	default: defaultVal
 };
 
 export const serverDashboardTabsSchema: IJSONSchema = {
 	type: ['array'],
-	description: nls.localize('dashboardServerTabs', 'Customizes the Server dashboard tabs'),
+	description: nls.localize('dashboardServerTabs', "Customizes the Server dashboard tabs"),
 	items: generateDashboardTabSchema('server'),
 	default: []
 };

--- a/src/sql/workbench/parts/dashboard/browser/services/breadcrumb.service.ts
+++ b/src/sql/workbench/parts/dashboard/browser/services/breadcrumb.service.ts
@@ -41,7 +41,7 @@ export class BreadcrumbService implements IBreadcrumbService {
 	private getBreadcrumbsLink(page: BreadcrumbClass): MenuItem[] {
 		this.itemBreadcrums = [];
 		const profile = this.commonService.connectionManagementService.connectionInfo.connectionProfile;
-		this.itemBreadcrums.push({ label: nls.localize('homeCrumb', 'Home') });
+		this.itemBreadcrums.push({ label: nls.localize('homeCrumb', "Home") });
 		switch (page) {
 			case BreadcrumbClass.DatabasePage:
 				this.itemBreadcrums.push(this.getServerBreadcrumb(profile));

--- a/src/sql/workbench/parts/dashboard/browser/widgets/explorer/explorerWidget.component.ts
+++ b/src/sql/workbench/parts/dashboard/browser/widgets/explorer/explorerWidget.component.ts
@@ -74,7 +74,7 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 	ngOnInit() {
 		this._inited = true;
 
-		const placeholderLabel = this._config.context === 'database' ? nls.localize('seachObjects', 'Search by name of type (a:, t:, v:, f:, or sp:)') : nls.localize('searchDatabases', 'Search databases');
+		const placeholderLabel = this._config.context === 'database' ? nls.localize('seachObjects', "Search by name of type (a:, t:, v:, f:, or sp:)") : nls.localize('searchDatabases', "Search databases");
 
 		const inputOptions: IInputOptions = {
 			placeholder: placeholderLabel,

--- a/src/sql/workbench/parts/dashboard/browser/widgets/insights/insightsWidget.component.ts
+++ b/src/sql/workbench/parts/dashboard/browser/widgets/insights/insightsWidget.component.ts
@@ -229,7 +229,7 @@ export class InsightsWidget extends DashboardWidget implements IDashboardWidget,
 		this._cd.detectChanges();
 
 		if (result.rowCount === 0) {
-			this.showError(nls.localize('noResults', 'No results to show'));
+			this.showError(nls.localize('noResults', "No results to show"));
 			return;
 		}
 

--- a/src/sql/workbench/parts/dashboard/browser/widgets/insights/insightsWidgetSchemas.ts
+++ b/src/sql/workbench/parts/dashboard/browser/widgets/insights/insightsWidgetSchemas.ts
@@ -12,11 +12,11 @@ const insightRegistry = Registry.as<IInsightRegistry>(InsightExtensions.InsightC
 
 export const insightsSchema: IJSONSchema = {
 	type: 'object',
-	description: nls.localize('insightWidgetDescription', 'Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more'),
+	description: nls.localize('insightWidgetDescription', "Adds a widget that can query a server or database and display the results in multiple ways - as a chart, summarized count, and more"),
 	properties: {
 		cacheId: {
 			type: 'string',
-			description: nls.localize('insightIdDescription', 'Unique Identifier used for cacheing the results of the insight.')
+			description: nls.localize('insightIdDescription', "Unique Identifier used for caching the results of the insight.")
 		},
 		type: {
 			type: 'object',
@@ -26,15 +26,15 @@ export const insightsSchema: IJSONSchema = {
 		},
 		query: {
 			type: ['string', 'array'],
-			description: nls.localize('insightQueryDescription', 'SQL query to run. This should return exactly 1 resultset.')
+			description: nls.localize('insightQueryDescription', "SQL query to run. This should return exactly 1 resultset.")
 		},
 		queryFile: {
 			type: 'string',
-			description: nls.localize('insightQueryFileDescription', '[Optional] path to a file that contains a query. Use if "query" is not set')
+			description: nls.localize('insightQueryFileDescription', "[Optional] path to a file that contains a query. Use if 'query' is not set")
 		},
 		autoRefreshInterval: {
 			type: 'number',
-			description: nls.localize('insightAutoRefreshIntervalDescription', '[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh')
+			description: nls.localize('insightAutoRefreshIntervalDescription', "[Optional] Auto refresh interval in minutes, if not set, there will be no auto refresh")
 		},
 		details: {
 			type: 'object',
@@ -97,15 +97,15 @@ export const insightsSchema: IJSONSchema = {
 						},
 						database: {
 							type: 'string',
-							description: nls.localize('actionDatabaseDescription', 'Target database for the action; can use the format "${columnName}" to use a data driven column name.')
+							description: nls.localize('actionDatabaseDescription', "Target database for the action; can use the format '${ columnName }' to use a data driven column name.")
 						},
 						server: {
 							type: 'string',
-							description: nls.localize('actionServerDescription', 'Target server for the action; can use the format "${columnName}" to use a data driven column name.')
+							description: nls.localize('actionServerDescription', "Target server for the action; can use the format '${ columnName }' to use a data driven column name.")
 						},
 						user: {
 							type: 'string',
-							description: nls.localize('actionUserDescription', 'Target user for the action; can use the format "${columnName}" to use a data driven column name.')
+							description: nls.localize('actionUserDescription', "Target user for the action; can use the format '${ columnName }' to use a data driven column name.")
 						}
 					}
 				}
@@ -118,7 +118,7 @@ const insightType: IJSONSchema = {
 	type: 'object',
 	properties: {
 		id: {
-			description: nls.localize('carbon.extension.contributes.insightType.id', 'Identifier of the insight'),
+			description: nls.localize('carbon.extension.contributes.insightType.id', "Identifier of the insight"),
 			type: 'string'
 		},
 		contrib: insightsSchema

--- a/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/charts/chartInsight.component.ts
+++ b/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/charts/chartInsight.component.ts
@@ -49,7 +49,7 @@ export abstract class ChartInsight extends Disposable implements IInsightsView {
 	protected _config: IChartConfig;
 	protected _data: IInsightData;
 
-	protected readonly CHART_ERROR_MESSAGE = nls.localize('chartErrorMessage', 'Chart cannot be displayed with the given data');
+	protected readonly CHART_ERROR_MESSAGE = nls.localize('chartErrorMessage', "Chart cannot be displayed with the given data");
 
 	protected abstract get chartType(): ChartType;
 

--- a/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/charts/chartInsight.contribution.ts
@@ -8,38 +8,38 @@ import * as nls from 'vs/nls';
 
 export const chartInsightSchema: IJSONSchema = {
 	type: 'object',
-	description: nls.localize('chartInsightDescription', 'Displays results of a query as a chart on the dashboard'),
+	description: nls.localize('chartInsightDescription', "Displays results of a query as a chart on the dashboard"),
 	properties: {
 		colorMap: {
 			type: 'object',
-			description: nls.localize('colorMapDescription', 'Maps "column name" -> color. for example add "column1": red to ensure this column uses a red color ')
+			description: nls.localize('colorMapDescription', "Maps 'column name' -> color. for example add 'column1': red to ensure this column uses a red color ")
 		},
 		legendPosition: {
 			type: 'string',
-			description: nls.localize('legendDescription', 'Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry'),
+			description: nls.localize('legendDescription', "Indicates preferred position and visibility of the chart legend. These are the column names from your query, and map to the label of each chart entry"),
 			default: 'none',
 			enum: ['top', 'bottom', 'left', 'right', 'none']
 		},
 		labelFirstColumn: {
 			type: 'boolean',
-			description: nls.localize('labelFirstColumnDescription', 'If dataDirection is horizontal, setting this to true uses the first columns value for the legend.'),
+			description: nls.localize('labelFirstColumnDescription', "If dataDirection is horizontal, setting this to true uses the first columns value for the legend."),
 			default: false
 		},
 		columnsAsLabels: {
 			type: 'boolean',
-			description: nls.localize('columnsAsLabels', 'If dataDirection is vertical, setting this to true will use the columns names for the legend.'),
+			description: nls.localize('columnsAsLabels', "If dataDirection is vertical, setting this to true will use the columns names for the legend."),
 			default: false
 		},
 		dataDirection: {
 			type: 'string',
-			description: nls.localize('dataDirectionDescription', 'Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical.'),
+			description: nls.localize('dataDirectionDescription', "Defines whether the data is read from a column (vertical) or a row (horizontal). For time series this is ignored as direction must be vertical."),
 			default: 'vertical',
 			enum: ['vertical', 'horizontal'],
 			enumDescriptions: ['When vertical, the first column is used to define the x-axis labels, with other columns expected to be numerical.', 'When horizontal, the column names are used as the x-axis labels.']
 		},
 		showTopNData: {
 			type: 'number',
-			description: nls.localize('showTopNData', 'If showTopNData is set, showing only top N data in the chart.')
+			description: nls.localize('showTopNData', "If showTopNData is set, showing only top N data in the chart.")
 		}
 	}
 };

--- a/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/charts/types/lineChart.contribution.ts
@@ -16,7 +16,7 @@ const properties: IJSONSchema = {
 	properties: {
 		dataType: {
 			type: 'string',
-			description: nls.localize('dataTypeDescription', 'Indicates data property of a data set for a chart.'),
+			description: nls.localize('dataTypeDescription', "Indicates data property of a data set for a chart."),
 			default: 'number',
 			enum: ['number', 'point'],
 			enumDescriptions: ['Set "number" if the data values are contained in 1 column.', 'Set "point" if the data is an {x,y} combination requiring 2 columns for each value.']

--- a/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/countInsight.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/countInsight.contribution.ts
@@ -12,7 +12,7 @@ import * as nls from 'vs/nls';
 
 const countInsightSchema: IJSONSchema = {
 	type: 'null',
-	description: nls.localize('countInsightDescription', 'For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports "1 Healthy", "3 Unhealthy" for example, where "Healthy" is the column name and 1 is the value in row 1 cell 1')
+	description: nls.localize('countInsightDescription', "For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports "1 Healthy", "3 Unhealthy" for example, where "Healthy" is the column name and 1 is the value in row 1 cell 1")
 };
 
 registerInsight('count', '', countInsightSchema, CountInsight);

--- a/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/countInsight.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/countInsight.contribution.ts
@@ -12,7 +12,7 @@ import * as nls from 'vs/nls';
 
 const countInsightSchema: IJSONSchema = {
 	type: 'null',
-	description: nls.localize('countInsightDescription', "For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports "1 Healthy", "3 Unhealthy" for example, where "Healthy" is the column name and 1 is the value in row 1 cell 1")
+	description: nls.localize('countInsightDescription', "For each column in a resultset, displays the value in row 0 as a count followed by the column name. Supports '1 Healthy', '3 Unhealthy' for example, where 'Healthy' is the column name and 1 is the value in row 1 cell 1")
 };
 
 registerInsight('count', '', countInsightSchema, CountInsight);

--- a/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/imageInsight.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/imageInsight.contribution.ts
@@ -12,17 +12,17 @@ import * as nls from 'vs/nls';
 
 const imageInsightSchema: IJSONSchema = {
 	type: 'object',
-	description: nls.localize('imageInsightDescription', 'Displays an image, for example one returned by an R query using ggplot2'),
+	description: nls.localize('imageInsightDescription', "Displays an image, for example one returned by an R query using ggplot2"),
 	properties: {
 		imageFormat: {
 			type: 'string',
-			description: nls.localize('imageFormatDescription', 'What format is expected - is this a JPEG, PNG or other format?'),
+			description: nls.localize('imageFormatDescription', "What format is expected - is this a JPEG, PNG or other format?"),
 			default: 'jpeg',
 			enum: ['jpeg', 'png']
 		},
 		encoding: {
 			type: 'string',
-			description: nls.localize('encodingDescription', 'Is this encoded as hex, base64 or some other format?'),
+			description: nls.localize('encodingDescription', "Is this encoded as hex, base64 or some other format?"),
 			default: 'hex',
 			enum: ['hex', 'base64']
 		},

--- a/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/tableInsight.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/widgets/insights/views/tableInsight.contribution.ts
@@ -12,7 +12,7 @@ import * as nls from 'vs/nls';
 
 const tableInsightSchema: IJSONSchema = {
 	type: 'null',
-	description: nls.localize('tableInsightDescription', 'Displays the results in a simple table')
+	description: nls.localize('tableInsightDescription', "Displays the results in a simple table")
 };
 
 registerInsight('table', '', tableInsightSchema, TableInsight);

--- a/src/sql/workbench/parts/dashboard/browser/widgets/properties/propertiesJson.ts
+++ b/src/sql/workbench/parts/dashboard/browser/widgets/properties/propertiesJson.ts
@@ -7,8 +7,8 @@ import { ProviderProperties } from './propertiesWidget.component';
 import * as nls from 'vs/nls';
 import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
-const azureEditionDisplayName = nls.localize('azureEdition', 'Edition');
-const azureType = nls.localize('azureType', 'Type');
+const azureEditionDisplayName = nls.localize('azureEdition', "Edition");
+const azureType = nls.localize('azureType', "Type");
 
 export const properties: Array<ProviderProperties> = [
 	{
@@ -23,47 +23,47 @@ export const properties: Array<ProviderProperties> = [
 				},
 				databaseProperties: [
 					{
-						displayName: nls.localize('recoveryModel', 'Recovery Model'),
+						displayName: nls.localize('recoveryModel', "Recovery Model"),
 						value: 'recoveryModel'
 					},
 					{
-						displayName: nls.localize('lastDatabaseBackup', 'Last Database Backup'),
+						displayName: nls.localize('lastDatabaseBackup', "Last Database Backup"),
 						value: 'lastBackupDate',
 						ignore: [
 							'1/1/0001 12:00:00 AM'
 						]
 					},
 					{
-						displayName: nls.localize('lastLogBackup', 'Last Log Backup'),
+						displayName: nls.localize('lastLogBackup', "Last Log Backup"),
 						value: 'lastLogBackupDate',
 						ignore: [
 							'1/1/0001 12:00:00 AM'
 						]
 					},
 					{
-						displayName: nls.localize('compatibilityLevel', 'Compatibility Level'),
+						displayName: nls.localize('compatibilityLevel', "Compatibility Level"),
 						value: 'compatibilityLevel'
 					},
 					{
-						displayName: nls.localize('owner', 'Owner'),
+						displayName: nls.localize('owner', "Owner"),
 						value: 'owner'
 					}
 				],
 				serverProperties: [
 					{
-						displayName: nls.localize('version', 'Version'),
+						displayName: nls.localize('version', "Version"),
 						value: 'serverVersion'
 					},
 					{
-						displayName: nls.localize('edition', 'Edition'),
+						displayName: nls.localize('edition', "Edition"),
 						value: 'serverEdition'
 					},
 					{
-						displayName: nls.localize('computerName', 'Computer Name'),
+						displayName: nls.localize('computerName', "Computer Name"),
 						value: 'machineName'
 					},
 					{
-						displayName: nls.localize('osVersion', 'OS Version'),
+						displayName: nls.localize('osVersion', "OS Version"),
 						value: 'osVersion'
 					}
 				]
@@ -81,21 +81,21 @@ export const properties: Array<ProviderProperties> = [
 						value: 'azureEdition'
 					},
 					{
-						displayName: nls.localize('serviceLevelObjective', 'Pricing Tier'),
+						displayName: nls.localize('serviceLevelObjective', "Pricing Tier"),
 						value: 'serviceLevelObjective'
 					},
 					{
-						displayName: nls.localize('compatibilityLevel', 'Compatibility Level'),
+						displayName: nls.localize('compatibilityLevel', "Compatibility Level"),
 						value: 'compatibilityLevel'
 					},
 					{
-						displayName: nls.localize('owner', 'Owner'),
+						displayName: nls.localize('owner', "Owner"),
 						value: 'owner'
 					}
 				],
 				serverProperties: [
 					{
-						displayName: nls.localize('version', 'Version'),
+						displayName: nls.localize('version', "Version"),
 						value: 'serverVersion'
 					},
 					{

--- a/src/sql/workbench/parts/dataExplorer/browser/dataExplorerExtensionPoint.ts
+++ b/src/sql/workbench/parts/dataExplorer/browser/dataExplorerExtensionPoint.ts
@@ -31,15 +31,15 @@ const viewDescriptor: IJSONSchema = {
 	type: 'object',
 	properties: {
 		id: {
-			description: localize('vscode.extension.contributes.view.id', 'Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`.'),
+			description: localize('vscode.extension.contributes.view.id', "Identifier of the view. Use this to register a data provider through `vscode.window.registerTreeDataProviderForView` API. Also to trigger activating your extension by registering `onView:${id}` event to `activationEvents`."),
 			type: 'string'
 		},
 		name: {
-			description: localize('vscode.extension.contributes.view.name', 'The human-readable name of the view. Will be shown'),
+			description: localize('vscode.extension.contributes.view.name', "The human-readable name of the view. Will be shown"),
 			type: 'string'
 		},
 		when: {
-			description: localize('vscode.extension.contributes.view.when', 'Condition which must be true to show this view'),
+			description: localize('vscode.extension.contributes.view.when', "Condition which must be true to show this view"),
 			type: 'string'
 		},
 	}
@@ -133,15 +133,15 @@ class DataExplorerContainerExtensionHandler implements IWorkbenchContribution {
 
 		for (let descriptor of viewDescriptors) {
 			if (typeof descriptor.id !== 'string') {
-				collector.error(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", 'id'));
+				collector.error(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", "id"));
 				return false;
 			}
 			if (typeof descriptor.name !== 'string') {
-				collector.error(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", 'name'));
+				collector.error(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", "name"));
 				return false;
 			}
 			if (descriptor.when && typeof descriptor.when !== 'string') {
-				collector.error(localize('optstring', "property `{0}` can be omitted or must be of type `string`", 'when'));
+				collector.error(localize('optstring', "property `{0}` can be omitted or must be of type `string`", "when"));
 				return false;
 			}
 		}

--- a/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
+++ b/src/sql/workbench/parts/dataExplorer/electron-browser/nodeActions.contribution.ts
@@ -28,7 +28,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 4,
 	command: {
 		id: DISCONNECT_COMMAND_ID,
-		title: localize('disconnect', 'Disconnect')
+		title: localize('disconnect', "Disconnect")
 	},
 	when: ContextKeyExpr.and(NodeContextKey.IsConnected,
 		new ContextKeyNotEqualsExpr('nodeType', NodeType.Folder))
@@ -39,7 +39,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 3,
 	command: {
 		id: DISCONNECT_COMMAND_ID,
-		title: localize('disconnect', 'Disconnect')
+		title: localize('disconnect', "Disconnect")
 	},
 	when: ContextKeyExpr.and(NodeContextKey.IsConnected,
 		MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
@@ -52,7 +52,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 2,
 	command: {
 		id: NEW_QUERY_COMMAND_ID,
-		title: localize('newQuery', 'New Query')
+		title: localize('newQuery', "New Query")
 	},
 	when: MssqlNodeContext.IsDatabaseOrServer
 });
@@ -63,7 +63,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 1,
 	command: {
 		id: MANAGE_COMMAND_ID,
-		title: localize('manage', 'Manage')
+		title: localize('manage', "Manage")
 	},
 	when: MssqlNodeContext.IsDatabaseOrServer
 });
@@ -75,7 +75,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 6,
 	command: {
 		id: REFRESH_COMMAND_ID,
-		title: localize('refresh', 'Refresh')
+		title: localize('refresh', "Refresh")
 	},
 	when: NodeContextKey.IsConnectable
 });
@@ -87,7 +87,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 3,
 	command: {
 		id: NEW_NOTEBOOK_COMMAND_ID,
-		title: localize('newNotebook', 'New Notebook')
+		title: localize('newNotebook', "New Notebook")
 	},
 	when: ContextKeyExpr.and(NodeContextKey.IsConnectable,
 		MssqlNodeContext.IsDatabaseOrServer,
@@ -100,7 +100,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 7,
 	command: {
 		id: DATA_TIER_WIZARD_COMMAND_ID,
-		title: localize('dacFx', 'Data-tier Application Wizard')
+		title: localize('dacFx', "Data-tier Application Wizard")
 	},
 	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
 		MssqlNodeContext.IsDatabaseOrServer)
@@ -112,7 +112,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 7,
 	command: {
 		id: DATA_TIER_WIZARD_COMMAND_ID,
-		title: localize('dacFx', 'Data-tier Application Wizard')
+		title: localize('dacFx', "Data-tier Application Wizard")
 	},
 	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
 		MssqlNodeContext.NodeType.isEqualTo(NodeType.Folder),
@@ -125,7 +125,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 8,
 	command: {
 		id: PROFILER_COMMAND_ID,
-		title: localize('profiler', 'Launch Profiler')
+		title: localize('profiler', "Launch Profiler")
 	},
 	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
 		MssqlNodeContext.NodeType.isEqualTo(NodeType.Server))
@@ -137,7 +137,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 10,
 	command: {
 		id: IMPORT_COMMAND_ID,
-		title: localize('flatFileImport', 'Import Wizard')
+		title: localize('flatFileImport', "Import Wizard")
 	},
 	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
 		MssqlNodeContext.NodeType.isEqualTo(NodeType.Database))
@@ -149,7 +149,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 9,
 	command: {
 		id: SCHEMA_COMPARE_COMMAND_ID,
-		title: localize('schemaCompare', 'Schema Compare')
+		title: localize('schemaCompare', "Schema Compare")
 	},
 	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
 		MssqlNodeContext.NodeType.isEqualTo(NodeType.Database))
@@ -161,7 +161,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 4,
 	command: {
 		id: BACKUP_COMMAND_ID,
-		title: localize('backup', 'Backup')
+		title: localize('backup', "Backup")
 	},
 	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
 		MssqlNodeContext.NodeType.isEqualTo(NodeType.Database))
@@ -173,7 +173,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 5,
 	command: {
 		id: RESTORE_COMMAND_ID,
-		title: localize('restore', 'Restore')
+		title: localize('restore', "Restore")
 	},
 	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
 		MssqlNodeContext.NodeType.isEqualTo(NodeType.Database))
@@ -185,7 +185,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 11,
 	command: {
 		id: GENERATE_SCRIPTS_COMMAND_ID,
-		title: localize('generateScripts', 'Generate Scripts...')
+		title: localize('generateScripts', "Generate Scripts...")
 	},
 	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
 		MssqlNodeContext.NodeType.isEqualTo(NodeType.Database),
@@ -198,7 +198,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 12,
 	command: {
 		id: PROPERTIES_COMMAND_ID,
-		title: localize('properties', 'Properties')
+		title: localize('properties', "Properties")
 	},
 	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
 		MssqlNodeContext.NodeType.isEqualTo(NodeType.Server), ContextKeyExpr.not('isCloud'),
@@ -210,7 +210,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 12,
 	command: {
 		id: PROPERTIES_COMMAND_ID,
-		title: localize('properties', 'Properties')
+		title: localize('properties', "Properties")
 	},
 	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
 		MssqlNodeContext.IsWindows,
@@ -225,7 +225,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 3,
 	command: {
 		id: SCRIPT_AS_CREATE_COMMAND_ID,
-		title: localize('scriptAsCreate', 'Script as Create')
+		title: localize('scriptAsCreate', "Script as Create")
 	},
 	when: MssqlNodeContext.CanScriptAsCreateOrDelete
 });
@@ -236,7 +236,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 4,
 	command: {
 		id: SCRIPT_AS_DELETE_COMMAND_ID,
-		title: localize('scriptAsDelete', 'Script as Drop')
+		title: localize('scriptAsDelete', "Script as Drop")
 	},
 	when: MssqlNodeContext.CanScriptAsCreateOrDelete
 });
@@ -247,7 +247,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 1,
 	command: {
 		id: SCRIPT_AS_SELECT_COMMAND_ID,
-		title: localize('scriptAsSelect', 'Select Top 1000')
+		title: localize('scriptAsSelect', "Select Top 1000")
 	},
 	when: MssqlNodeContext.CanScriptAsSelect
 });
@@ -258,7 +258,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 5,
 	command: {
 		id: SCRIPT_AS_EXECUTE_COMMAND_ID,
-		title: localize('scriptAsExecute', 'Script as Execute')
+		title: localize('scriptAsExecute', "Script as Execute")
 	},
 	when: MssqlNodeContext.CanScriptAsExecute
 });
@@ -269,7 +269,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 5,
 	command: {
 		id: SCRIPT_AS_ALTER_COMMAND_ID,
-		title: localize('scriptAsAlter', 'Script as Alter')
+		title: localize('scriptAsAlter', "Script as Alter")
 	},
 	when: MssqlNodeContext.CanScriptAsAlter
 });
@@ -280,7 +280,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	order: 2,
 	command: {
 		id: EDIT_DATA_COMMAND_ID,
-		title: localize('editData', 'Edit Data')
+		title: localize('editData', "Edit Data")
 	},
 	when: MssqlNodeContext.CanEditData
 });

--- a/src/sql/workbench/parts/editData/browser/editDataActions.ts
+++ b/src/sql/workbench/parts/editData/browser/editDataActions.ts
@@ -70,7 +70,7 @@ export class RefreshTableAction extends EditDataAction {
 		@INotificationService private _notificationService: INotificationService,
 	) {
 		super(editor, RefreshTableAction.ID, RefreshTableAction.EnabledClass, _connectionManagementService);
-		this.label = nls.localize('editData.run', 'Run');
+		this.label = nls.localize('editData.run', "Run");
 	}
 
 	public run(): Promise<void> {
@@ -91,7 +91,7 @@ export class RefreshTableAction extends EditDataAction {
 			}, error => {
 				this._notificationService.notify({
 					severity: Severity.Error,
-					message: nls.localize('disposeEditFailure', 'Dispose Edit Failed With Error: ') + error
+					message: nls.localize('disposeEditFailure', "Dispose Edit Failed With Error: ") + error
 				});
 			});
 		}
@@ -113,7 +113,7 @@ export class StopRefreshTableAction extends EditDataAction {
 	) {
 		super(editor, StopRefreshTableAction.ID, StopRefreshTableAction.EnabledClass, _connectionManagementService);
 		this.enabled = false;
-		this.label = nls.localize('editData.stop', 'Stop');
+		this.label = nls.localize('editData.stop', "Stop");
 	}
 
 	public run(): Promise<void> {
@@ -235,8 +235,8 @@ export class ShowQueryPaneAction extends EditDataAction {
 
 	private static EnabledClass = 'filterLabel';
 	public static ID = 'showQueryPaneAction';
-	private readonly showSqlLabel = nls.localize('editData.showSql', 'Show SQL Pane');
-	private readonly closeSqlLabel = nls.localize('editData.closeSql', 'Close SQL Pane');
+	private readonly showSqlLabel = nls.localize('editData.showSql', "Show SQL Pane");
+	private readonly closeSqlLabel = nls.localize('editData.closeSql', "Close SQL Pane");
 
 	constructor(editor: EditDataEditor,
 		@IQueryModelService private _queryModelService: IQueryModelService,

--- a/src/sql/workbench/parts/editData/browser/editDataEditor.ts
+++ b/src/sql/workbench/parts/editData/browser/editDataEditor.ts
@@ -323,7 +323,7 @@ export class EditDataEditor extends BaseEditor {
 
 		// Create HTML Elements for the taskbar
 		let separator = Taskbar.createTaskbarSeparator();
-		let textSeparator = Taskbar.createTaskbarText(nls.localize('maxRowTaskbar', 'Max Rows:'));
+		let textSeparator = Taskbar.createTaskbarText(nls.localize('maxRowTaskbar', "Max Rows:"));
 
 		this._spinnerElement = Taskbar.createTaskbarSpinner();
 

--- a/src/sql/workbench/parts/editData/common/editDataInput.ts
+++ b/src/sql/workbench/parts/editData/common/editDataInput.ts
@@ -166,7 +166,7 @@ export class EditDataInput extends EditorInput implements IConnectableInput {
 
 			this.notificationService.notify({
 				severity: Severity.Error,
-				message: nls.localize('connectionFailure', 'Edit Data Session Failed To Connect')
+				message: nls.localize('connectionFailure', "Edit Data Session Failed To Connect")
 			});
 		}
 	}

--- a/src/sql/workbench/parts/grid/views/editData/editDataGridActions.ts
+++ b/src/sql/workbench/parts/grid/views/editData/editDataGridActions.ts
@@ -33,7 +33,7 @@ export class EditDataGridActionProvider extends GridActionProvider {
 
 export class DeleteRowAction extends Action {
 	public static ID = 'grid.deleteRow';
-	public static LABEL = localize('deleteRow', 'Delete Row');
+	public static LABEL = localize('deleteRow', "Delete Row");
 
 	constructor(
 		id: string,
@@ -51,7 +51,7 @@ export class DeleteRowAction extends Action {
 
 export class RevertRowAction extends Action {
 	public static ID = 'grid.revertRow';
-	public static LABEL = localize('revertRow', 'Revert Current Row');
+	public static LABEL = localize('revertRow', "Revert Current Row");
 
 	constructor(
 		id: string,

--- a/src/sql/workbench/parts/jobManagement/browser/alertsView.component.ts
+++ b/src/sql/workbench/parts/jobManagement/browser/alertsView.component.ts
@@ -37,16 +37,16 @@ export class AlertsViewComponent extends JobManagementView implements OnInit, On
 
 	private columns: Array<Slick.Column<any>> = [
 		{
-			name: nls.localize('jobAlertColumns.name', 'Name'),
+			name: nls.localize('jobAlertColumns.name', "Name"),
 			field: 'name',
 			formatter: (row, cell, value, columnDef, dataContext) => this.renderName(row, cell, value, columnDef, dataContext),
 			width: 500,
 			id: 'name'
 		},
-		{ name: nls.localize('jobAlertColumns.lastOccurrenceDate', 'Last Occurrence'), field: 'lastOccurrenceDate', width: 150, id: 'lastOccurrenceDate' },
-		{ name: nls.localize('jobAlertColumns.enabled', 'Enabled'), field: 'enabled', width: 80, id: 'enabled' },
-		{ name: nls.localize('jobAlertColumns.delayBetweenResponses', 'Delay Between Responses (in secs)'), field: 'delayBetweenResponses', width: 200, id: 'delayBetweenResponses' },
-		{ name: nls.localize('jobAlertColumns.categoryName', 'Category Name'), field: 'categoryName', width: 250, id: 'categoryName' },
+		{ name: nls.localize('jobAlertColumns.lastOccurrenceDate', "Last Occurrence"), field: 'lastOccurrenceDate', width: 150, id: 'lastOccurrenceDate' },
+		{ name: nls.localize('jobAlertColumns.enabled', "Enabled"), field: 'enabled', width: 80, id: 'enabled' },
+		{ name: nls.localize('jobAlertColumns.delayBetweenResponses', "Delay Between Responses (in secs)"), field: 'delayBetweenResponses', width: 200, id: 'delayBetweenResponses' },
+		{ name: nls.localize('jobAlertColumns.categoryName', "Category Name"), field: 'categoryName', width: 250, id: 'categoryName' },
 	];
 
 	private options: Slick.GridOptions<any> = {

--- a/src/sql/workbench/parts/jobManagement/browser/jobHistory.component.ts
+++ b/src/sql/workbench/parts/jobManagement/browser/jobHistory.component.ts
@@ -222,9 +222,9 @@ export class JobHistoryComponent extends JobManagementView implements OnInit {
 				});
 				self._stepRows.unshift(new JobStepsViewRow());
 				self._stepRows[0].rowID = 'stepsColumn' + self._agentJobInfo.jobId;
-				self._stepRows[0].stepId = nls.localize('stepRow.stepID', 'Step ID');
-				self._stepRows[0].stepName = nls.localize('stepRow.stepName', 'Step Name');
-				self._stepRows[0].message = nls.localize('stepRow.message', 'Message');
+				self._stepRows[0].stepId = nls.localize('stepRow.stepID', "Step ID");
+				self._stepRows[0].stepName = nls.localize('stepRow.stepName', "Step Name");
+				self._stepRows[0].message = nls.localize('stepRow.message', "Message");
 				this._showSteps = self._stepRows.length > 1;
 			} else {
 				self._showSteps = false;

--- a/src/sql/workbench/parts/jobManagement/browser/jobStepsView.component.ts
+++ b/src/sql/workbench/parts/jobManagement/browser/jobStepsView.component.ts
@@ -105,7 +105,7 @@ export class JobStepsViewComponent extends JobManagementView implements OnInit, 
 			renderer: this._treeRenderer
 		}, { verticalScrollMode: ScrollbarVisibility.Visible, horizontalScrollMode: ScrollbarVisibility.Visible });
 		this._register(attachListStyler(this._tree, this.themeService));
-		const stepsTooltip = nls.localize('agent.steps', 'Steps');
+		const stepsTooltip = nls.localize('agent.steps', "Steps");
 		jQuery('.steps-header > .steps-icon').attr('title', stepsTooltip);
 		this._telemetryService.publicLog(TelemetryKeys.JobStepsView);
 	}

--- a/src/sql/workbench/parts/jobManagement/browser/jobsView.component.ts
+++ b/src/sql/workbench/parts/jobManagement/browser/jobsView.component.ts
@@ -52,22 +52,22 @@ export class JobsViewComponent extends JobManagementView implements OnInit, OnDe
 
 	private columns: Array<Slick.Column<any>> = [
 		{
-			name: nls.localize('jobColumns.name', 'Name'),
+			name: nls.localize('jobColumns.name', "Name"),
 			field: 'name',
 			formatter: (row, cell, value, columnDef, dataContext) => this.renderName(row, cell, value, columnDef, dataContext),
 			width: 150,
 			id: 'name'
 		},
-		{ name: nls.localize('jobColumns.lastRun', 'Last Run'), field: 'lastRun', width: 80, id: 'lastRun' },
-		{ name: nls.localize('jobColumns.nextRun', 'Next Run'), field: 'nextRun', width: 80, id: 'nextRun' },
-		{ name: nls.localize('jobColumns.enabled', 'Enabled'), field: 'enabled', width: 60, id: 'enabled' },
-		{ name: nls.localize('jobColumns.status', 'Status'), field: 'currentExecutionStatus', width: 50, id: 'currentExecutionStatus' },
-		{ name: nls.localize('jobColumns.category', 'Category'), field: 'category', width: 100, id: 'category' },
-		{ name: nls.localize('jobColumns.runnable', 'Runnable'), field: 'runnable', width: 70, id: 'runnable' },
-		{ name: nls.localize('jobColumns.schedule', 'Schedule'), field: 'hasSchedule', width: 60, id: 'hasSchedule' },
-		{ name: nls.localize('jobColumns.lastRunOutcome', 'Last Run Outcome'), field: 'lastRunOutcome', width: 100, id: 'lastRunOutcome' },
+		{ name: nls.localize('jobColumns.lastRun', "Last Run"), field: 'lastRun', width: 80, id: 'lastRun' },
+		{ name: nls.localize('jobColumns.nextRun', "Next Run"), field: 'nextRun', width: 80, id: 'nextRun' },
+		{ name: nls.localize('jobColumns.enabled', "Enabled"), field: 'enabled', width: 60, id: 'enabled' },
+		{ name: nls.localize('jobColumns.status', "Status"), field: 'currentExecutionStatus', width: 50, id: 'currentExecutionStatus' },
+		{ name: nls.localize('jobColumns.category', "Category"), field: 'category', width: 100, id: 'category' },
+		{ name: nls.localize('jobColumns.runnable', "Runnable"), field: 'runnable', width: 70, id: 'runnable' },
+		{ name: nls.localize('jobColumns.schedule', "Schedule"), field: 'hasSchedule', width: 60, id: 'hasSchedule' },
+		{ name: nls.localize('jobColumns.lastRunOutcome', "Last Run Outcome"), field: 'lastRunOutcome', width: 100, id: 'lastRunOutcome' },
 		{
-			name: nls.localize('jobColumns.previousRuns', 'Previous Runs'),
+			name: nls.localize('jobColumns.previousRuns', "Previous Runs"),
 			formatter: (row, cell, value, columnDef, dataContext) => this.renderChartsPostHistory(row, cell, value, columnDef, dataContext),
 			field: 'previousRuns',
 			width: 100,
@@ -610,10 +610,10 @@ export class JobsViewComponent extends JobManagementView implements OnInit, OnDe
 				if (self._agentViewComponent.expanded.has(job.jobId)) {
 					let lastJobHistory = jobHistories[jobHistories.length - 1];
 					let item = self.dataView.getItemById(job.jobId + '.error');
-					let noStepsMessage = nls.localize('jobsView.noSteps', 'No Steps available for this job.');
+					let noStepsMessage = nls.localize('jobsView.noSteps', "No Steps available for this job.");
 					let errorMessage = lastJobHistory ? lastJobHistory.message : noStepsMessage;
 					if (item) {
-						item['name'] = nls.localize('jobsView.error', 'Error: ') + errorMessage;
+						item['name'] = nls.localize('jobsView.error', "Error: ") + errorMessage;
 						self._agentViewComponent.setExpanded(job.jobId, item['name']);
 						self.dataView.updateItem(job.jobId + '.error', item);
 					}

--- a/src/sql/workbench/parts/jobManagement/browser/operatorsView.component.ts
+++ b/src/sql/workbench/parts/jobManagement/browser/operatorsView.component.ts
@@ -38,14 +38,14 @@ export class OperatorsViewComponent extends JobManagementView implements OnInit,
 
 	private columns: Array<Slick.Column<any>> = [
 		{
-			name: nls.localize('jobOperatorsView.name', 'Name'),
+			name: nls.localize('jobOperatorsView.name', "Name"),
 			field: 'name',
 			formatter: (row, cell, value, columnDef, dataContext) => this.renderName(row, cell, value, columnDef, dataContext),
 			width: 200,
 			id: 'name'
 		},
-		{ name: nls.localize('jobOperatorsView.emailAddress', 'Email Address'), field: 'emailAddress', width: 200, id: 'emailAddress' },
-		{ name: nls.localize('jobOperatorsView.enabled', 'Enabled'), field: 'enabled', width: 200, id: 'enabled' },
+		{ name: nls.localize('jobOperatorsView.emailAddress', "Email Address"), field: 'emailAddress', width: 200, id: 'emailAddress' },
+		{ name: nls.localize('jobOperatorsView.enabled', "Enabled"), field: 'enabled', width: 200, id: 'enabled' },
 	];
 
 	private options: Slick.GridOptions<any> = {

--- a/src/sql/workbench/parts/jobManagement/browser/proxiesView.component.ts
+++ b/src/sql/workbench/parts/jobManagement/browser/proxiesView.component.ts
@@ -41,15 +41,15 @@ export class ProxiesViewComponent extends JobManagementView implements OnInit, O
 
 	private columns: Array<Slick.Column<any>> = [
 		{
-			name: nls.localize('jobProxiesView.accountName', 'Account Name'),
+			name: nls.localize('jobProxiesView.accountName', "Account Name"),
 			field: 'accountName',
 			formatter: (row, cell, value, columnDef, dataContext) => this.renderName(row, cell, value, columnDef, dataContext),
 			width: 200,
 			id: 'accountName'
 		},
-		{ name: nls.localize('jobProxiesView.credentialName', 'Credential Name'), field: 'credentialName', width: 200, id: 'credentialName' },
-		{ name: nls.localize('jobProxiesView.description', 'Description'), field: 'description', width: 200, id: 'description' },
-		{ name: nls.localize('jobProxiesView.isEnabled', 'Enabled'), field: 'isEnabled', width: 200, id: 'isEnabled' }
+		{ name: nls.localize('jobProxiesView.credentialName', "Credential Name"), field: 'credentialName', width: 200, id: 'credentialName' },
+		{ name: nls.localize('jobProxiesView.description', "Description"), field: 'description', width: 200, id: 'description' },
+		{ name: nls.localize('jobProxiesView.isEnabled', "Enabled"), field: 'isEnabled', width: 200, id: 'isEnabled' }
 	];
 
 	private options: Slick.GridOptions<any> = {

--- a/src/sql/workbench/parts/notebook/common/models/notebookConnection.ts
+++ b/src/sql/workbench/parts/notebook/common/models/notebookConnection.ts
@@ -26,7 +26,7 @@ export class NotebookConnection {
 
 	constructor(private _connectionProfile: IConnectionProfile) {
 		if (!this._connectionProfile) {
-			throw new Error(localize('connectionInfoMissing', 'connectionInfo is required'));
+			throw new Error(localize('connectionInfoMissing', "connectionInfo is required"));
 		}
 	}
 

--- a/src/sql/workbench/parts/notebook/electron-browser/cellToggleMoreActions.ts
+++ b/src/sql/workbench/parts/notebook/electron-browser/cellToggleMoreActions.ts
@@ -29,14 +29,14 @@ export class CellToggleMoreActions {
 	constructor(
 		@IInstantiationService private instantiationService: IInstantiationService) {
 		this._actions.push(
-			instantiationService.createInstance(DeleteCellAction, 'delete', localize('delete', 'Delete')),
-			instantiationService.createInstance(AddCellFromContextAction, 'codeBefore', localize('codeBefore', 'Insert Code Before'), CellTypes.Code, false),
-			instantiationService.createInstance(AddCellFromContextAction, 'codeAfter', localize('codeAfter', 'Insert Code After'), CellTypes.Code, true),
-			instantiationService.createInstance(AddCellFromContextAction, 'markdownBefore', localize('markdownBefore', 'Insert Text Before'), CellTypes.Markdown, false),
-			instantiationService.createInstance(AddCellFromContextAction, 'markdownAfter', localize('markdownAfter', 'Insert Text After'), CellTypes.Markdown, true),
+			instantiationService.createInstance(DeleteCellAction, 'delete', localize('delete', "Delete")),
+			instantiationService.createInstance(AddCellFromContextAction, 'codeBefore', localize('codeBefore', "Insert Code Before"), CellTypes.Code, false),
+			instantiationService.createInstance(AddCellFromContextAction, 'codeAfter', localize('codeAfter', "Insert Code After"), CellTypes.Code, true),
+			instantiationService.createInstance(AddCellFromContextAction, 'markdownBefore', localize('markdownBefore', "Insert Text Before"), CellTypes.Markdown, false),
+			instantiationService.createInstance(AddCellFromContextAction, 'markdownAfter', localize('markdownAfter', "Insert Text After"), CellTypes.Markdown, true),
 			instantiationService.createInstance(RunCellsAction, 'runAllBefore', localize('runAllBefore', "Run Cells Before"), false),
 			instantiationService.createInstance(RunCellsAction, 'runAllAfter', localize('runAllAfter', "Run Cells After"), true),
-			instantiationService.createInstance(ClearCellOutputAction, 'clear', localize('clear', 'Clear Output'))
+			instantiationService.createInstance(ClearCellOutputAction, 'clear', localize('clear', "Clear Output"))
 		);
 	}
 

--- a/src/sql/workbench/parts/notebook/electron-browser/cellViews/output.component.ts
+++ b/src/sql/workbench/parts/notebook/electron-browser/cellViews/output.component.ts
@@ -151,7 +151,7 @@ export class OutputComponent extends AngularDisposable implements OnInit, AfterV
 		this.errorText = undefined;
 		if (!mimeType) {
 			this.errorText = localize('noMimeTypeFound', "No {0}renderer could be found for output. It has the following MIME types: {1}",
-				options.trusted ? '' : localize('safe', 'safe '),
+				options.trusted ? '' : localize('safe', "safe "),
 				Object.keys(options.data).join(', '));
 			return;
 		}

--- a/src/sql/workbench/parts/notebook/electron-browser/cellViews/placeholderCell.component.ts
+++ b/src/sql/workbench/parts/notebook/electron-browser/cellViews/placeholderCell.component.ts
@@ -49,23 +49,23 @@ export class PlaceholderCellComponent extends CellView implements OnInit, OnChan
 	}
 
 	get clickOn(): string {
-		return localize('clickOn', 'Click on');
+		return localize('clickOn', "Click on");
 	}
 
 	get plusCode(): string {
-		return localize('plusCode', '+ Code');
+		return localize('plusCode', "+ Code");
 	}
 
 	get or(): string {
-		return localize('or', 'or');
+		return localize('or', "or");
 	}
 
 	get plusText(): string {
-		return localize('plusText', '+ Text');
+		return localize('plusText', "+ Text");
 	}
 
 	get toAddCell(): string {
-		return localize('toAddCell', 'to add a code or text cell');
+		return localize('toAddCell', "to add a code or text cell");
 	}
 
 	public addCell(cellType: string, event?: Event): void {

--- a/src/sql/workbench/parts/notebook/electron-browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/parts/notebook/electron-browser/cellViews/textCell.component.ts
@@ -169,7 +169,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		if (trustedChanged || contentChanged) {
 			this._lastTrustedMode = this.cellModel.trustedMode;
 			if (!this.cellModel.source && !this.isEditMode) {
-				this._content = localize('doubleClickEdit', 'Double-click to edit');
+				this._content = localize('doubleClickEdit', "Double-click to edit");
 			} else {
 				this._content = this.cellModel.source;
 			}

--- a/src/sql/workbench/parts/notebook/electron-browser/notebook.contribution.ts
+++ b/src/sql/workbench/parts/notebook/electron-browser/notebook.contribution.ts
@@ -82,7 +82,7 @@ configurationRegistry.registerConfiguration({
 		'notebook.useInProcMarkdown': {
 			'type': 'boolean',
 			'default': true,
-			'description': localize('notebook.inProcMarkdown', 'Use in-process markdown viewer to render text cells more quickly (Experimental).')
+			'description': localize('notebook.inProcMarkdown', "Use in-process markdown viewer to render text cells more quickly (Experimental).")
 		}
 	}
 });

--- a/src/sql/workbench/parts/notebook/electron-browser/notebookActions.ts
+++ b/src/sql/workbench/parts/notebook/electron-browser/notebookActions.ts
@@ -199,9 +199,9 @@ export abstract class MultiStateAction<T> extends Action {
 
 export class TrustedAction extends ToggleableAction {
 	// Constants
-	private static readonly trustedLabel = localize('trustLabel', 'Trusted');
-	private static readonly notTrustedLabel = localize('untrustLabel', 'Not Trusted');
-	private static readonly alreadyTrustedMsg = localize('alreadyTrustedMsg', 'Notebook is already trusted.');
+	private static readonly trustedLabel = localize('trustLabel', "Trusted");
+	private static readonly notTrustedLabel = localize('untrustLabel', "Not Trusted");
+	private static readonly alreadyTrustedMsg = localize('alreadyTrustedMsg', "Notebook is already trusted.");
 	private static readonly baseClass = 'notebook-button';
 	private static readonly trustedCssClass = 'icon-trusted';
 	private static readonly notTrustedCssClass = 'icon-notTrusted';

--- a/src/sql/workbench/parts/notebook/node/models/cell.ts
+++ b/src/sql/workbench/parts/notebook/node/models/cell.ts
@@ -287,7 +287,7 @@ export class CellModel implements ICellModel {
 		} catch (error) {
 			let message: string;
 			if (error.message === 'Canceled') {
-				message = localize('executionCanceled', 'Query execution was canceled');
+				message = localize('executionCanceled', "Query execution was canceled");
 			} else {
 				message = getErrorMessage(error);
 			}
@@ -306,17 +306,17 @@ export class CellModel implements ICellModel {
 		let model = this.options.notebook;
 		let clientSession = model && model.clientSession;
 		if (!clientSession) {
-			this.sendNotification(notificationService, Severity.Error, localize('notebookNotReady', 'The session for this notebook is not yet ready'));
+			this.sendNotification(notificationService, Severity.Error, localize('notebookNotReady', "The session for this notebook is not yet ready"));
 			return undefined;
 		} else if (!clientSession.isReady || clientSession.status === 'dead') {
 
-			this.sendNotification(notificationService, Severity.Info, localize('sessionNotReady', 'The session for this notebook will start momentarily'));
+			this.sendNotification(notificationService, Severity.Info, localize('sessionNotReady', "The session for this notebook will start momentarily"));
 			await clientSession.kernelChangeCompleted;
 		}
 		if (!clientSession.kernel) {
 			let defaultKernel = model && model.defaultKernel && model.defaultKernel.name;
 			if (!defaultKernel) {
-				this.sendNotification(notificationService, Severity.Error, localize('noDefaultKernel', 'No kernel is available for this notebook'));
+				this.sendNotification(notificationService, Severity.Error, localize('noDefaultKernel', "No kernel is available for this notebook"));
 				return undefined;
 			}
 			await clientSession.changeKernel({

--- a/src/sql/workbench/parts/notebook/node/models/modelInterfaces.ts
+++ b/src/sql/workbench/parts/notebook/node/models/modelInterfaces.ts
@@ -526,7 +526,7 @@ export interface ICellMagicMapper {
 export namespace notebookConstants {
 	export const SQL = 'SQL';
 	export const SQL_CONNECTION_PROVIDER = mssqlProviderName;
-	export const sqlKernel: string = localize('sqlKernel', 'SQL');
+	export const sqlKernel: string = localize('sqlKernel', "SQL");
 	export const sqlKernelSpec: nb.IKernelSpec = ({
 		name: sqlKernel,
 		language: 'sql',

--- a/src/sql/workbench/parts/notebook/node/models/notebookContexts.ts
+++ b/src/sql/workbench/parts/notebook/node/models/notebookContexts.ts
@@ -18,7 +18,7 @@ export class NotebookContexts {
 		let defaultConnection: ConnectionProfile = <any>{
 			providerName: mssqlProviderName,
 			id: '-1',
-			serverName: localize('selectConnection', 'Select Connection')
+			serverName: localize('selectConnection', "Select Connection")
 		};
 
 		return {
@@ -32,7 +32,7 @@ export class NotebookContexts {
 		let localConnection: ConnectionProfile = <any>{
 			providerName: mssqlProviderName,
 			id: '-1',
-			serverName: localize('localhost', 'localhost')
+			serverName: localize('localhost', "localhost")
 		};
 
 		return {
@@ -107,7 +107,7 @@ export class NotebookContexts {
 			let newConnection = <ConnectionProfile><any>{
 				providerName: 'SQL',
 				id: '-2',
-				serverName: localize('addConnection', 'Add New Connection')
+				serverName: localize('addConnection', "Add New Connection")
 			};
 			activeConnections.push(newConnection);
 		}

--- a/src/sql/workbench/parts/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/parts/objectExplorer/browser/connectionTreeAction.ts
@@ -25,7 +25,7 @@ import { UNSAVED_GROUP_ID } from 'sql/platform/connection/common/constants';
 export class RefreshAction extends Action {
 
 	public static ID = 'objectExplorer.refresh';
-	public static LABEL = localize('connectionTree.refresh', 'Refresh');
+	public static LABEL = localize('connectionTree.refresh', "Refresh");
 	private _tree: ITree;
 
 	constructor(
@@ -85,7 +85,7 @@ export class RefreshAction extends Action {
 
 export class DisconnectConnectionAction extends Action {
 	public static ID = 'objectExplorer.disconnect';
-	public static LABEL = localize('DisconnectAction', 'Disconnect');
+	public static LABEL = localize('DisconnectAction', "Disconnect");
 
 	constructor(
 		id: string,
@@ -129,7 +129,7 @@ export class DisconnectConnectionAction extends Action {
  */
 export class AddServerAction extends Action {
 	public static ID = 'registeredServers.addConnection';
-	public static LABEL = localize('connectionTree.addConnection', 'New Connection');
+	public static LABEL = localize('connectionTree.addConnection', "New Connection");
 
 	constructor(
 		id: string,
@@ -168,7 +168,7 @@ export class AddServerAction extends Action {
  */
 export class AddServerGroupAction extends Action {
 	public static ID = 'registeredServers.addServerGroup';
-	public static LABEL = localize('connectionTree.addServerGroup', 'New Server Group');
+	public static LABEL = localize('connectionTree.addServerGroup', "New Server Group");
 
 	constructor(
 		id: string,
@@ -190,7 +190,7 @@ export class AddServerGroupAction extends Action {
  */
 export class EditServerGroupAction extends Action {
 	public static ID = 'registeredServers.editServerGroup';
-	public static LABEL = localize('connectionTree.editServerGroup', 'Edit Server Group');
+	public static LABEL = localize('connectionTree.editServerGroup', "Edit Server Group");
 
 	constructor(
 		id: string,
@@ -213,10 +213,10 @@ export class EditServerGroupAction extends Action {
  */
 export class ActiveConnectionsFilterAction extends Action {
 	public static ID = 'registeredServers.recentConnections';
-	public static LABEL = localize('activeConnections', 'Show Active Connections');
+	public static LABEL = localize('activeConnections', "Show Active Connections");
 	private static enabledClass = 'active-connections-action';
 	private static disabledClass = 'icon server-page';
-	private static showAllConnectionsLabel = localize('showAllConnections', 'Show All Connections');
+	private static showAllConnectionsLabel = localize('showAllConnections', "Show All Connections");
 	private _isSet: boolean;
 	public static readonly ACTIVE = 'active';
 	public get isSet(): boolean {
@@ -263,7 +263,7 @@ export class ActiveConnectionsFilterAction extends Action {
  */
 export class RecentConnectionsFilterAction extends Action {
 	public static ID = 'registeredServers.recentConnections';
-	public static LABEL = localize('recentConnections', 'Recent Connections');
+	public static LABEL = localize('recentConnections', "Recent Connections");
 	private static enabledClass = 'recent-connections-action';
 	private static disabledClass = 'recent-connections-action-set';
 	private _isSet: boolean;
@@ -306,7 +306,7 @@ export class RecentConnectionsFilterAction extends Action {
 
 export class NewQueryAction extends Action {
 	public static ID = 'registeredServers.newQuery';
-	public static LABEL = localize('registeredServers.newQuery', 'New Query');
+	public static LABEL = localize('registeredServers.newQuery', "New Query");
 	private _connectionProfile: IConnectionProfile;
 	get connectionProfile(): IConnectionProfile {
 		return this._connectionProfile;
@@ -343,8 +343,8 @@ export class NewQueryAction extends Action {
  */
 export class DeleteConnectionAction extends Action {
 	public static ID = 'registeredServers.deleteConnection';
-	public static DELETE_CONNECTION_LABEL = localize('deleteConnection', 'Delete Connection');
-	public static DELETE_CONNECTION_GROUP_LABEL = localize('deleteConnectionGroup', 'Delete Group');
+	public static DELETE_CONNECTION_LABEL = localize('deleteConnection', "Delete Connection");
+	public static DELETE_CONNECTION_GROUP_LABEL = localize('deleteConnectionGroup', "Delete Group");
 
 	constructor(
 		id: string,

--- a/src/sql/workbench/parts/objectExplorer/browser/objectExplorerActions.ts
+++ b/src/sql/workbench/parts/objectExplorer/browser/objectExplorerActions.ts
@@ -81,7 +81,7 @@ export class OEAction extends ExecuteCommandAction {
 
 export class ManageConnectionAction extends Action {
 	public static ID = 'objectExplorer.manage';
-	public static LABEL = localize('ManageAction', 'Manage');
+	public static LABEL = localize('ManageAction', "Manage");
 
 	private _treeSelectionHandler: TreeSelectionHandler;
 

--- a/src/sql/workbench/parts/objectExplorer/browser/serverGroupDialog.ts
+++ b/src/sql/workbench/parts/objectExplorer/browser/serverGroupDialog.ts
@@ -57,7 +57,7 @@ export class ServerGroupDialog extends Modal {
 		@IClipboardService clipboardService: IClipboardService,
 		@ILogService logService: ILogService
 	) {
-		super(localize('ServerGroupsDialogTitle', 'Server Groups'), TelemetryKeys.ServerGroups, telemetryService, layoutService, clipboardService, themeService, logService, contextKeyService);
+		super(localize('ServerGroupsDialogTitle', "Server Groups"), TelemetryKeys.ServerGroups, telemetryService, layoutService, clipboardService, themeService, logService, contextKeyService);
 	}
 
 	public render() {

--- a/src/sql/workbench/parts/objectExplorer/browser/serverTreeRenderer.ts
+++ b/src/sql/workbench/parts/objectExplorer/browser/serverTreeRenderer.ts
@@ -225,7 +225,7 @@ export class ServerTreeRenderer implements IRenderer {
 
 		let label = connection.title;
 		if (!connection.isConnectionOptionsValid) {
-			label = localize('loading', 'Loading...');
+			label = localize('loading', "Loading...");
 		}
 
 		templateData.label.textContent = label;

--- a/src/sql/workbench/parts/objectExplorer/common/objectExplorerViewTreeShim.ts
+++ b/src/sql/workbench/parts/objectExplorer/common/objectExplorerViewTreeShim.ts
@@ -90,7 +90,7 @@ export class OEShimService extends Disposable implements IOEShimService {
 					resolve(connProfile);
 				},
 				onConnectCanceled: () => {
-					reject(new Error(localize('loginCanceled', 'User canceled')));
+					reject(new Error(localize('loginCanceled', "User canceled")));
 				},
 				onConnectReject: undefined,
 				onConnectStart: undefined,

--- a/src/sql/workbench/parts/objectExplorer/common/serverGroup.contribution.ts
+++ b/src/sql/workbench/parts/objectExplorer/common/serverGroup.contribution.ts
@@ -21,7 +21,7 @@ const serverGroupConfig: IConfigurationNode = {
 		[SERVER_GROUP_CONFIG + '.' + SERVER_GROUP_COLORS_CONFIG]: <IJSONSchema>{
 			type: 'array',
 			items: 'string',
-			'description': localize('serverGroup.colors', 'Server Group color palette used in the Object Explorer viewlet.'),
+			'description': localize('serverGroup.colors', "Server Group color palette used in the Object Explorer viewlet."),
 			default: [
 				'#A1634D',
 				'#7F0000',
@@ -35,7 +35,7 @@ const serverGroupConfig: IConfigurationNode = {
 		},
 		[SERVER_GROUP_CONFIG + '.' + SERVER_GROUP_AUTOEXPAND_CONFIG]: {
 			'type': 'boolean',
-			'description': localize('serverGroup.autoExpand', 'Auto-expand Server Groups in the Object Explorer viewlet.'),
+			'description': localize('serverGroup.autoExpand', "Auto-expand Server Groups in the Object Explorer viewlet."),
 			'default': 'true'
 		},
 	}

--- a/src/sql/workbench/parts/objectExplorer/common/serverGroupViewModel.ts
+++ b/src/sql/workbench/parts/objectExplorer/common/serverGroupViewModel.ts
@@ -17,8 +17,8 @@ export class ServerGroupViewModel {
 
 	private _domainModel: IConnectionProfileGroup;
 	private _editMode: boolean;
-	private readonly _addServerGroupTitle: string = localize('serverGroup.addServerGroup', 'Add server group');
-	private readonly _editServerGroupTitle: string = localize('serverGroup.editServerGroup', 'Edit server group');
+	private readonly _addServerGroupTitle: string = localize('serverGroup.addServerGroup', "Add server group");
+	private readonly _editServerGroupTitle: string = localize('serverGroup.editServerGroup', "Edit server group");
 	private readonly _defaultColor: string = '#515151';
 
 	constructor(domainModel?: IConnectionProfileGroup, colors?: string[]) {

--- a/src/sql/workbench/parts/profiler/browser/profilerActions.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerActions.ts
@@ -20,8 +20,8 @@ import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiati
 import { INotificationService } from 'vs/platform/notification/common/notification';
 
 export class ProfilerConnect extends Action {
-	private static readonly ConnectText = nls.localize('profilerAction.connect', 'Connect');
-	private static readonly DisconnectText = nls.localize('profilerAction.disconnect', 'Disconnect');
+	private static readonly ConnectText = nls.localize('profilerAction.connect', "Connect");
+	private static readonly DisconnectText = nls.localize('profilerAction.disconnect', "Disconnect");
 
 	public static ID = 'profiler.connect';
 	public static LABEL = ProfilerConnect.ConnectText;
@@ -103,8 +103,8 @@ export class ProfilerCreate extends Action {
 }
 
 export class ProfilerPause extends Action {
-	private static readonly PauseText = nls.localize('profilerAction.pauseCapture', 'Pause');
-	private static readonly ResumeText = nls.localize('profilerAction.resumeCapture', 'Resume');
+	private static readonly PauseText = nls.localize('profilerAction.pauseCapture', "Pause");
+	private static readonly ResumeText = nls.localize('profilerAction.resumeCapture', "Resume");
 	private static readonly PauseCssClass = 'sql pause';
 	private static readonly ResumeCssClass = 'sql continue';
 
@@ -170,8 +170,8 @@ export class ProfilerClear extends Action {
 }
 
 export class ProfilerAutoScroll extends Action {
-	private static readonly AutoScrollOnText = nls.localize('profilerAction.autoscrollOn', 'Auto Scroll: On');
-	private static readonly AutoScrollOffText = nls.localize('profilerAction.autoscrollOff', 'Auto Scroll: Off');
+	private static readonly AutoScrollOnText = nls.localize('profilerAction.autoscrollOn', "Auto Scroll: On");
+	private static readonly AutoScrollOffText = nls.localize('profilerAction.autoscrollOff', "Auto Scroll: Off");
 	private static readonly CheckedCssClass = 'sql checked';
 
 	public static ID = 'profiler.autoscroll';
@@ -268,7 +268,7 @@ export class ProfilerFindPrevious implements IEditorAction {
 
 export class NewProfilerAction extends Task {
 	public static readonly ID = 'profiler.newProfiler';
-	public static readonly LABEL = nls.localize('profilerAction.newProfiler', 'Launch Profiler');
+	public static readonly LABEL = nls.localize('profilerAction.newProfiler', "Launch Profiler");
 	public static readonly ICON = 'profile';
 
 	private _connectionProfile: ConnectionProfile;

--- a/src/sql/workbench/parts/profiler/browser/profilerColumnEditorDialog.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerColumnEditorDialog.ts
@@ -318,7 +318,7 @@ export class ProfilerColumnEditorDialog extends Modal {
 		@IClipboardService clipboardService: IClipboardService,
 		@ILogService logService: ILogService
 	) {
-		super(nls.localize('profilerColumnDialog.profiler', 'Profiler'), TelemetryKeys.Profiler, telemetryService, layoutService, clipboardService, themeService, logService, contextKeyService);
+		super(nls.localize('profilerColumnDialog.profiler', "Profiler"), TelemetryKeys.Profiler, telemetryService, layoutService, clipboardService, themeService, logService, contextKeyService);
 	}
 
 	public render(): void {

--- a/src/sql/workbench/parts/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerEditor.ts
@@ -228,7 +228,7 @@ export class ProfilerEditor extends BaseEditor {
 		this._clearFilterAction.enabled = true;
 		this._viewTemplates = this._profilerService.getViewTemplates();
 		this._viewTemplateSelector = new SelectBox(this._viewTemplates.map(i => i.name), 'Standard View', this._contextViewService);
-		this._viewTemplateSelector.setAriaLabel(nls.localize('profiler.viewSelectAccessibleName', 'Select View'));
+		this._viewTemplateSelector.setAriaLabel(nls.localize('profiler.viewSelectAccessibleName', "Select View"));
 		this._register(this._viewTemplateSelector.onDidSelect(e => {
 			if (this.input) {
 				this.input.viewTemplate = this._viewTemplates.find(i => i.name === e.selected);
@@ -241,7 +241,7 @@ export class ProfilerEditor extends BaseEditor {
 
 		this._sessionsList = [''];
 		this._sessionSelector = new SelectBox(this._sessionsList, '', this._contextViewService);
-		this._sessionSelector.setAriaLabel(nls.localize('profiler.sessionSelectAccessibleName', 'Select Session'));
+		this._sessionSelector.setAriaLabel(nls.localize('profiler.sessionSelectAccessibleName', "Select Session"));
 		this._register(this._sessionSelector.onDidSelect(e => {
 			if (this.input) {
 				this.input.sessionName = e.selected;
@@ -259,7 +259,7 @@ export class ProfilerEditor extends BaseEditor {
 		this._actionBar.setContent([
 			{ action: this._createAction },
 			{ element: Taskbar.createTaskbarSeparator() },
-			{ element: this._createTextElement(nls.localize('profiler.sessionSelectLabel', 'Select Session:')) },
+			{ element: this._createTextElement(nls.localize('profiler.sessionSelectLabel', "Select Session:")) },
 			{ element: sessionsContainer },
 			{ action: this._startAction },
 			{ action: this._stopAction },
@@ -268,7 +268,7 @@ export class ProfilerEditor extends BaseEditor {
 			{ action: this._filterAction },
 			{ action: this._clearFilterAction },
 			{ element: Taskbar.createTaskbarSeparator() },
-			{ element: this._createTextElement(nls.localize('profiler.viewSelectLabel', 'Select View:')) },
+			{ element: this._createTextElement(nls.localize('profiler.viewSelectLabel', "Select View:")) },
 			{ element: viewTemplateContainer },
 			{ action: this._autoscrollAction },
 			{ action: this._instantiationService.createInstance(Actions.ProfilerClear, Actions.ProfilerClear.ID, Actions.ProfilerClear.LABEL) }

--- a/src/sql/workbench/parts/profiler/browser/profilerInput.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerInput.ts
@@ -127,7 +127,7 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 	}
 
 	public getName(): string {
-		let name: string = nls.localize('profilerInput.profiler', 'Profiler');
+		let name: string = nls.localize('profilerInput.profiler', "Profiler");
 		if (!this.connection) {
 			return name;
 		}
@@ -287,9 +287,9 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 			return this._dialogService.show(Severity.Warning,
 				nls.localize('confirmStopProfilerSession', "Would you like to stop the running XEvent session?"),
 				[
-					nls.localize('profilerClosingActions.yes', 'Yes'),
-					nls.localize('profilerClosingActions.no', 'No'),
-					nls.localize('profilerClosingActions.cancel', 'Cancel')
+					nls.localize('profilerClosingActions.yes', "Yes"),
+					nls.localize('profilerClosingActions.no', "No"),
+					nls.localize('profilerClosingActions.cancel', "Cancel")
 				]).then((selection: number) => {
 					if (selection === 0) {
 						this._profilerService.stopSession(this.id);

--- a/src/sql/workbench/parts/profiler/browser/profilerResourceEditor.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerResourceEditor.ts
@@ -87,7 +87,7 @@ export class ProfilerResourceEditor extends BaseTextEditor {
 	}
 
 	protected getAriaLabel(): string {
-		return nls.localize('profilerTextEditorAriaLabel', 'Profiler editor for event text. Readonly');
+		return nls.localize('profilerTextEditorAriaLabel', "Profiler editor for event text. Readonly");
 	}
 
 	public layout(dimension: DOM.Dimension) {

--- a/src/sql/workbench/parts/query/browser/actions.ts
+++ b/src/sql/workbench/parts/query/browser/actions.ts
@@ -45,19 +45,19 @@ function mapForNumberColumn(ranges: Slick.Range[]): Slick.Range[] {
 
 export class SaveResultAction extends Action {
 	public static SAVECSV_ID = 'grid.saveAsCsv';
-	public static SAVECSV_LABEL = localize('saveAsCsv', 'Save As CSV');
+	public static SAVECSV_LABEL = localize('saveAsCsv', "Save As CSV");
 	public static SAVECSV_ICON = 'saveCsv';
 
 	public static SAVEJSON_ID = 'grid.saveAsJson';
-	public static SAVEJSON_LABEL = localize('saveAsJson', 'Save As JSON');
+	public static SAVEJSON_LABEL = localize('saveAsJson', "Save As JSON");
 	public static SAVEJSON_ICON = 'saveJson';
 
 	public static SAVEEXCEL_ID = 'grid.saveAsExcel';
-	public static SAVEEXCEL_LABEL = localize('saveAsExcel', 'Save As Excel');
+	public static SAVEEXCEL_LABEL = localize('saveAsExcel', "Save As Excel");
 	public static SAVEEXCEL_ICON = 'saveExcel';
 
 	public static SAVEXML_ID = 'grid.saveAsXml';
-	public static SAVEXML_LABEL = localize('saveAsXml', 'Save As XML');
+	public static SAVEXML_LABEL = localize('saveAsXml', "Save As XML");
 	public static SAVEXML_ICON = 'saveXml';
 
 	constructor(
@@ -81,10 +81,10 @@ export class SaveResultAction extends Action {
 
 export class CopyResultAction extends Action {
 	public static COPY_ID = 'grid.copySelection';
-	public static COPY_LABEL = localize('copySelection', 'Copy');
+	public static COPY_LABEL = localize('copySelection', "Copy");
 
 	public static COPYWITHHEADERS_ID = 'grid.copyWithHeaders';
-	public static COPYWITHHEADERS_LABEL = localize('copyWithHeaders', 'Copy With Headers');
+	public static COPYWITHHEADERS_LABEL = localize('copyWithHeaders', "Copy With Headers");
 
 	constructor(
 		id: string,
@@ -109,7 +109,7 @@ export class CopyResultAction extends Action {
 
 export class SelectAllGridAction extends Action {
 	public static ID = 'grid.selectAll';
-	public static LABEL = localize('selectAll', 'Select All');
+	public static LABEL = localize('selectAll', "Select All");
 
 	constructor() {
 		super(SelectAllGridAction.ID, SelectAllGridAction.LABEL);
@@ -123,7 +123,7 @@ export class SelectAllGridAction extends Action {
 
 export class CopyMessagesAction extends Action {
 	public static ID = 'grid.messages.copy';
-	public static LABEL = localize('copyMessages', 'Copy');
+	public static LABEL = localize('copyMessages', "Copy");
 
 	constructor(
 		@IClipboardService private clipboardService: IClipboardService
@@ -166,7 +166,7 @@ export class CopyAllMessagesAction extends Action {
 
 export class MaximizeTableAction extends Action {
 	public static ID = 'grid.maximize';
-	public static LABEL = localize('maximize', 'Maximize');
+	public static LABEL = localize('maximize', "Maximize");
 	public static ICON = 'extendFullScreen';
 
 	constructor() {
@@ -181,7 +181,7 @@ export class MaximizeTableAction extends Action {
 
 export class RestoreTableAction extends Action {
 	public static ID = 'grid.restore';
-	public static LABEL = localize('restore', 'Restore');
+	public static LABEL = localize('restore', "Restore");
 	public static ICON = 'exitFullScreen';
 
 	constructor() {
@@ -196,7 +196,7 @@ export class RestoreTableAction extends Action {
 
 export class ChartDataAction extends Action {
 	public static ID = 'grid.chart';
-	public static LABEL = localize('chart', 'Chart');
+	public static LABEL = localize('chart', "Chart");
 	public static ICON = 'viewChart';
 
 	constructor(@IEditorService private editorService: IEditorService) {

--- a/src/sql/workbench/parts/query/browser/flavorStatus.ts
+++ b/src/sql/workbench/parts/query/browser/flavorStatus.ts
@@ -52,7 +52,7 @@ class SqlProviderEntry implements ISqlProviderEntry {
 	}
 
 	public static getDefaultLabel(): string {
-		return nls.localize('chooseSqlLang', 'Choose SQL Language');
+		return nls.localize('chooseSqlLang', "Choose SQL Language");
 	}
 }
 

--- a/src/sql/workbench/parts/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/parts/query/browser/keyboardQueryActions.ts
@@ -60,7 +60,7 @@ function escapeSqlString(input: string, escapeChar: string) {
 export class FocusOnCurrentQueryKeyboardAction extends Action {
 
 	public static ID = 'focusOnCurrentQueryKeyboardAction';
-	public static LABEL = nls.localize('focusOnCurrentQueryKeyboardAction', 'Focus on Current Query');
+	public static LABEL = nls.localize('focusOnCurrentQueryKeyboardAction', "Focus on Current Query");
 
 	constructor(
 		id: string,
@@ -86,7 +86,7 @@ export class FocusOnCurrentQueryKeyboardAction extends Action {
 export class RunQueryKeyboardAction extends Action {
 
 	public static ID = 'runQueryKeyboardAction';
-	public static LABEL = nls.localize('runQueryKeyboardAction', 'Run Query');
+	public static LABEL = nls.localize('runQueryKeyboardAction', "Run Query");
 
 	constructor(
 		id: string,
@@ -111,7 +111,7 @@ export class RunQueryKeyboardAction extends Action {
  */
 export class RunCurrentQueryKeyboardAction extends Action {
 	public static ID = 'runCurrentQueryKeyboardAction';
-	public static LABEL = nls.localize('runCurrentQueryKeyboardAction', 'Run Current Query');
+	public static LABEL = nls.localize('runCurrentQueryKeyboardAction', "Run Current Query");
 
 	constructor(
 		id: string,
@@ -133,7 +133,7 @@ export class RunCurrentQueryKeyboardAction extends Action {
 
 export class RunCurrentQueryWithActualPlanKeyboardAction extends Action {
 	public static ID = 'runCurrentQueryWithActualPlanKeyboardAction';
-	public static LABEL = nls.localize('runCurrentQueryWithActualPlanKeyboardAction', 'Run Current Query with Actual Plan');
+	public static LABEL = nls.localize('runCurrentQueryWithActualPlanKeyboardAction', "Run Current Query with Actual Plan");
 
 	constructor(
 		id: string,
@@ -159,7 +159,7 @@ export class RunCurrentQueryWithActualPlanKeyboardAction extends Action {
 export class CancelQueryKeyboardAction extends Action {
 
 	public static ID = 'cancelQueryKeyboardAction';
-	public static LABEL = nls.localize('cancelQueryKeyboardAction', 'Cancel Query');
+	public static LABEL = nls.localize('cancelQueryKeyboardAction', "Cancel Query");
 
 	constructor(
 		id: string,
@@ -184,7 +184,7 @@ export class CancelQueryKeyboardAction extends Action {
  */
 export class RefreshIntellisenseKeyboardAction extends Action {
 	public static ID = 'refreshIntellisenseKeyboardAction';
-	public static LABEL = nls.localize('refreshIntellisenseKeyboardAction', 'Refresh IntelliSense Cache');
+	public static LABEL = nls.localize('refreshIntellisenseKeyboardAction', "Refresh IntelliSense Cache");
 
 	constructor(
 		id: string,
@@ -211,7 +211,7 @@ export class RefreshIntellisenseKeyboardAction extends Action {
  */
 export class ToggleQueryResultsKeyboardAction extends Action {
 	public static ID = 'toggleQueryResultsKeyboardAction';
-	public static LABEL = nls.localize('toggleQueryResultsKeyboardAction', 'Toggle Query Results');
+	public static LABEL = nls.localize('toggleQueryResultsKeyboardAction', "Toggle Query Results");
 
 	constructor(
 		id: string,
@@ -265,7 +265,7 @@ export class RunQueryShortcutAction extends Action {
 	 */
 	public runQueryShortcut(editor: QueryEditor, shortcutIndex: number): Thenable<void> {
 		if (!editor) {
-			throw new Error(nls.localize('queryShortcutNoEditor', 'Editor parameter is required for a shortcut to be executed'));
+			throw new Error(nls.localize('queryShortcutNoEditor', "Editor parameter is required for a shortcut to be executed"));
 		}
 
 		if (isConnected(editor, this.connectionManagementService)) {
@@ -388,7 +388,7 @@ export class RunQueryShortcutAction extends Action {
 export class ParseSyntaxAction extends Action {
 
 	public static ID = 'parseQueryAction';
-	public static LABEL = nls.localize('parseSyntaxLabel', 'Parse Query');
+	public static LABEL = nls.localize('parseSyntaxLabel', "Parse Query");
 
 	constructor(
 		id: string,
@@ -415,10 +415,10 @@ export class ParseSyntaxAction extends Action {
 						if (result && result.parseable) {
 							this.notificationService.notify({
 								severity: Severity.Info,
-								message: nls.localize('queryActions.parseSyntaxSuccess', 'Commands completed successfully')
+								message: nls.localize('queryActions.parseSyntaxSuccess', "Commands completed successfully")
 							});
 						} else if (result && result.errors.length > 0) {
-							let errorMessage = nls.localize('queryActions.parseSyntaxFailure', 'Command failed: ');
+							let errorMessage = nls.localize('queryActions.parseSyntaxFailure', "Command failed: ");
 							this.notificationService.error(`${errorMessage}${result.errors[0]}`);
 
 						}
@@ -426,7 +426,7 @@ export class ParseSyntaxAction extends Action {
 				} else {
 					this.notificationService.notify({
 						severity: Severity.Error,
-						message: nls.localize('queryActions.notConnected', 'Please connect to a server')
+						message: nls.localize('queryActions.notConnected', "Please connect to a server")
 					});
 				}
 			}

--- a/src/sql/workbench/parts/query/browser/query.contribution.ts
+++ b/src/sql/workbench/parts/query/browser/query.contribution.ts
@@ -263,57 +263,57 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 let registryProperties = {
 	'sql.saveAsCsv.includeHeaders': {
 		'type': 'boolean',
-		'description': localize('sql.saveAsCsv.includeHeaders', '[Optional] When true, column headers are included when saving results as CSV'),
+		'description': localize('sql.saveAsCsv.includeHeaders', "[Optional] When true, column headers are included when saving results as CSV"),
 		'default': true
 	},
 	'sql.saveAsCsv.delimiter': {
 		'type': 'string',
-		'description': localize('sql.saveAsCsv.delimiter', '[Optional] The custom delimiter to use between values when saving as CSV'),
+		'description': localize('sql.saveAsCsv.delimiter', "[Optional] The custom delimiter to use between values when saving as CSV"),
 		'default': ','
 	},
 	'sql.saveAsCsv.lineSeperator': {
 		'type': '',
-		'description': localize('sql.saveAsCsv.lineSeperator', '[Optional] Character(s) used for seperating rows when saving results as CSV'),
+		'description': localize('sql.saveAsCsv.lineSeperator', "[Optional] Character(s) used for seperating rows when saving results as CSV"),
 		'default': null
 	},
 	'sql.saveAsCsv.textIdentifier': {
 		'type': 'string',
-		'description': localize('sql.saveAsCsv.textIdentifier', '[Optional] Character used for enclosing text fields when saving results as CSV'),
+		'description': localize('sql.saveAsCsv.textIdentifier', "[Optional] Character used for enclosing text fields when saving results as CSV"),
 		'default': '\"'
 	},
 	'sql.saveAsCsv.encoding': {
 		'type': 'string',
-		'description': localize('sql.saveAsCsv.encoding', '[Optional] File encoding used when saving results as CSV'),
+		'description': localize('sql.saveAsCsv.encoding', "[Optional] File encoding used when saving results as CSV"),
 		'default': 'utf-8'
 	},
 	'sql.results.streaming': {
 		'type': 'boolean',
-		'description': localize('sql.results.streaming', 'Enable results streaming; contains few minor visual issues'),
+		'description': localize('sql.results.streaming', "Enable results streaming; contains few minor visual issues"),
 		'default': true
 	},
 	'sql.saveAsXml.formatted': {
 		'type': 'string',
-		'description': localize('sql.saveAsXml.formatted', '[Optional] When true, XML output will be formatted when saving results as XML'),
+		'description': localize('sql.saveAsXml.formatted', "[Optional] When true, XML output will be formatted when saving results as XML"),
 		'default': true
 	},
 	'sql.saveAsXml.encoding': {
 		'type': 'string',
-		'description': localize('sql.saveAsXml.encoding', '[Optional] File encoding used when saving results as XML'),
+		'description': localize('sql.saveAsXml.encoding', "[Optional] File encoding used when saving results as XML"),
 		'default': 'utf-8'
 	},
 	'sql.copyIncludeHeaders': {
 		'type': 'boolean',
-		'description': localize('sql.copyIncludeHeaders', '[Optional] Configuration options for copying results from the Results View'),
+		'description': localize('sql.copyIncludeHeaders', "[Optional] Configuration options for copying results from the Results View"),
 		'default': false
 	},
 	'sql.copyRemoveNewLine': {
 		'type': 'boolean',
-		'description': localize('sql.copyRemoveNewLine', '[Optional] Configuration options for copying multi-line results from the Results View'),
+		'description': localize('sql.copyRemoveNewLine', "[Optional] Configuration options for copying multi-line results from the Results View"),
 		'default': true
 	},
 	'sql.showBatchTime': {
 		'type': 'boolean',
-		'description': localize('sql.showBatchTime', '[Optional] Should execution time be shown for individual batches'),
+		'description': localize('sql.showBatchTime', "[Optional] Should execution time be shown for individual batches"),
 		'default': false
 	},
 	'sql.chart.defaultChartType': {
@@ -340,142 +340,142 @@ let registryProperties = {
 	'sql.promptToSaveGeneratedFiles': {
 		'type': 'boolean',
 		'default': false,
-		'description': localize('sql.promptToSaveGeneratedFiles', 'Prompt to save generated SQL files')
+		'description': localize('sql.promptToSaveGeneratedFiles', "Prompt to save generated SQL files")
 	},
 	'mssql.intelliSense.enableIntelliSense': {
 		'type': 'boolean',
 		'default': true,
-		'description': localize('mssql.intelliSense.enableIntelliSense', 'Should IntelliSense be enabled')
+		'description': localize('mssql.intelliSense.enableIntelliSense', "Should IntelliSense be enabled")
 	},
 	'mssql.intelliSense.enableErrorChecking': {
 		'type': 'boolean',
 		'default': true,
-		'description': localize('mssql.intelliSense.enableErrorChecking', 'Should IntelliSense error checking be enabled')
+		'description': localize('mssql.intelliSense.enableErrorChecking', "Should IntelliSense error checking be enabled")
 	},
 	'mssql.intelliSense.enableSuggestions': {
 		'type': 'boolean',
 		'default': true,
-		'description': localize('mssql.intelliSense.enableSuggestions', 'Should IntelliSense suggestions be enabled')
+		'description': localize('mssql.intelliSense.enableSuggestions', "Should IntelliSense suggestions be enabled")
 	},
 	'mssql.intelliSense.enableQuickInfo': {
 		'type': 'boolean',
 		'default': true,
-		'description': localize('mssql.intelliSense.enableQuickInfo', 'Should IntelliSense quick info be enabled')
+		'description': localize('mssql.intelliSense.enableQuickInfo', "Should IntelliSense quick info be enabled")
 	},
 	'mssql.intelliSense.lowerCaseSuggestions': {
 		'type': 'boolean',
 		'default': false,
-		'description': localize('mssql.intelliSense.lowerCaseSuggestions', 'Should IntelliSense suggestions be lowercase')
+		'description': localize('mssql.intelliSense.lowerCaseSuggestions', "Should IntelliSense suggestions be lowercase")
 	},
 	'mssql.query.rowCount': {
 		'type': 'number',
 		'default': 0,
-		'description': localize('mssql.query.setRowCount', 'Maximum number of rows to return before the server stops processing your query.')
+		'description': localize('mssql.query.setRowCount', "Maximum number of rows to return before the server stops processing your query.")
 	},
 	'mssql.query.textSize': {
 		'type': 'number',
 		'default': 2147483647,
-		'description': localize('mssql.query.textSize', 'Maximum size of text and ntext data returned from a SELECT statement')
+		'description': localize('mssql.query.textSize', "Maximum size of text and ntext data returned from a SELECT statement")
 	},
 	'mssql.query.executionTimeout': {
 		'type': 'number',
 		'default': 0,
-		'description': localize('mssql.query.executionTimeout', 'An execution time-out of 0 indicates an unlimited wait (no time-out)')
+		'description': localize('mssql.query.executionTimeout', "An execution time-out of 0 indicates an unlimited wait (no time-out)")
 	},
 	'mssql.query.noCount': {
 		'type': 'boolean',
 		'default': false,
-		'description': localize('mssql.query.noCount', 'Enable SET NOCOUNT option')
+		'description': localize('mssql.query.noCount', "Enable SET NOCOUNT option")
 	},
 	'mssql.query.noExec': {
 		'type': 'boolean',
 		'default': false,
-		'description': localize('mssql.query.noExec', 'Enable SET NOEXEC option')
+		'description': localize('mssql.query.noExec', "Enable SET NOEXEC option")
 	},
 	'mssql.query.parseOnly': {
 		'type': 'boolean',
 		'default': false,
-		'description': localize('mssql.query.parseOnly', 'Enable SET PARSEONLY option')
+		'description': localize('mssql.query.parseOnly', "Enable SET PARSEONLY option")
 	},
 	'mssql.query.arithAbort': {
 		'type': 'boolean',
 		'default': true,
-		'description': localize('mssql.query.arithAbort', 'Enable SET ARITHABORT option')
+		'description': localize('mssql.query.arithAbort', "Enable SET ARITHABORT option")
 	},
 	'mssql.query.statisticsTime': {
 		'type': 'boolean',
 		'default': false,
-		'description': localize('mssql.query.statisticsTime', 'Enable SET STATISTICS TIME option')
+		'description': localize('mssql.query.statisticsTime', "Enable SET STATISTICS TIME option")
 	},
 	'mssql.query.statisticsIO': {
 		'type': 'boolean',
 		'default': false,
-		'description': localize('mssql.query.statisticsIO', 'Enable SET STATISTICS IO option')
+		'description': localize('mssql.query.statisticsIO', "Enable SET STATISTICS IO option")
 	},
 	'mssql.query.xactAbortOn': {
 		'type': 'boolean',
 		'default': false,
-		'description': localize('mssql.query.xactAbortOn', 'Enable SET XACT_ABORT ON option')
+		'description': localize('mssql.query.xactAbortOn', "Enable SET XACT_ABORT ON option")
 	},
 	'mssql.query.transactionIsolationLevel': {
 		'enum': ['READ COMMITTED', 'READ UNCOMMITTED', 'REPEATABLE READ', 'SERIALIZABLE'],
 		'default': 'READ COMMITTED',
-		'description': localize('mssql.query.transactionIsolationLevel', 'Enable SET TRANSACTION ISOLATION LEVEL option')
+		'description': localize('mssql.query.transactionIsolationLevel', "Enable SET TRANSACTION ISOLATION LEVEL option")
 	},
 	'mssql.query.deadlockPriority': {
 		'enum': ['Normal', 'Low'],
 		'default': 'Normal',
-		'description': localize('mssql.query.deadlockPriority', 'Enable SET DEADLOCK_PRIORITY option')
+		'description': localize('mssql.query.deadlockPriority', "Enable SET DEADLOCK_PRIORITY option")
 	},
 	'mssql.query.lockTimeout': {
 		'type': 'number',
 		'default': -1,
-		'description': localize('mssql.query.lockTimeout', 'Enable SET LOCK TIMEOUT option (in milliseconds)')
+		'description': localize('mssql.query.lockTimeout', "Enable SET LOCK TIMEOUT option (in milliseconds)")
 	},
 	'mssql.query.queryGovernorCostLimit': {
 		'type': 'number',
 		'default': -1,
-		'description': localize('mssql.query.queryGovernorCostLimit', 'Enable SET QUERY_GOVERNOR_COST_LIMIT')
+		'description': localize('mssql.query.queryGovernorCostLimit', "Enable SET QUERY_GOVERNOR_COST_LIMIT")
 	},
 	'mssql.query.ansiDefaults': {
 		'type': 'boolean',
 		'default': false,
-		'description': localize('mssql.query.ansiDefaults', 'Enable SET ANSI_DEFAULTS')
+		'description': localize('mssql.query.ansiDefaults', "Enable SET ANSI_DEFAULTS")
 	},
 	'mssql.query.quotedIdentifier': {
 		'type': 'boolean',
 		'default': true,
-		'description': localize('mssql.query.quotedIdentifier', 'Enable SET QUOTED_IDENTIFIER')
+		'description': localize('mssql.query.quotedIdentifier', "Enable SET QUOTED_IDENTIFIER")
 	},
 	'mssql.query.ansiNullDefaultOn': {
 		'type': 'boolean',
 		'default': true,
-		'description': localize('mssql.query.ansiNullDefaultOn', 'Enable SET ANSI_NULL_DFLT_ON')
+		'description': localize('mssql.query.ansiNullDefaultOn', "Enable SET ANSI_NULL_DFLT_ON")
 	},
 	'mssql.query.implicitTransactions': {
 		'type': 'boolean',
 		'default': false,
-		'description': localize('mssql.query.implicitTransactions', 'Enable SET IMPLICIT_TRANSACTIONS')
+		'description': localize('mssql.query.implicitTransactions', "Enable SET IMPLICIT_TRANSACTIONS")
 	},
 	'mssql.query.cursorCloseOnCommit': {
 		'type': 'boolean',
 		'default': false,
-		'description': localize('mssql.query.cursorCloseOnCommit', 'Enable SET CURSOR_CLOSE_ON_COMMIT')
+		'description': localize('mssql.query.cursorCloseOnCommit', "Enable SET CURSOR_CLOSE_ON_COMMIT")
 	},
 	'mssql.query.ansiPadding': {
 		'type': 'boolean',
 		'default': true,
-		'description': localize('mssql.query.ansiPadding', 'Enable SET ANSI_PADDING')
+		'description': localize('mssql.query.ansiPadding', "Enable SET ANSI_PADDING")
 	},
 	'mssql.query.ansiWarnings': {
 		'type': 'boolean',
 		'default': true,
-		'description': localize('mssql.query.ansiWarnings', 'Enable SET ANSI_WARNINGS')
+		'description': localize('mssql.query.ansiWarnings', "Enable SET ANSI_WARNINGS")
 	},
 	'mssql.query.ansiNulls': {
 		'type': 'boolean',
 		'default': true,
-		'description': localize('mssql.query.ansiNulls', 'Enable SET ANSI_NULLS')
+		'description': localize('mssql.query.ansiNulls', "Enable SET ANSI_NULLS")
 	}
 };
 

--- a/src/sql/workbench/parts/query/browser/queryActions.ts
+++ b/src/sql/workbench/parts/query/browser/queryActions.ts
@@ -110,7 +110,7 @@ export class RunQueryAction extends QueryTaskbarAction {
 		@IConnectionManagementService connectionManagementService: IConnectionManagementService
 	) {
 		super(connectionManagementService, editor, RunQueryAction.ID, RunQueryAction.EnabledClass);
-		this.label = nls.localize('runQueryLabel', 'Run');
+		this.label = nls.localize('runQueryLabel', "Run");
 	}
 
 	public run(): Promise<void> {
@@ -181,7 +181,7 @@ export class CancelQueryAction extends QueryTaskbarAction {
 	) {
 		super(connectionManagementService, editor, CancelQueryAction.ID, CancelQueryAction.EnabledClass);
 		this.enabled = false;
-		this.label = nls.localize('cancelQueryLabel', 'Cancel');
+		this.label = nls.localize('cancelQueryLabel', "Cancel");
 	}
 
 	public run(): Promise<void> {
@@ -205,7 +205,7 @@ export class EstimatedQueryPlanAction extends QueryTaskbarAction {
 		@IConnectionManagementService connectionManagementService: IConnectionManagementService
 	) {
 		super(connectionManagementService, editor, EstimatedQueryPlanAction.ID, EstimatedQueryPlanAction.EnabledClass);
-		this.label = nls.localize('estimatedQueryPlan', 'Explain');
+		this.label = nls.localize('estimatedQueryPlan', "Explain");
 	}
 
 	public run(): Promise<void> {
@@ -291,7 +291,7 @@ export class DisconnectDatabaseAction extends QueryTaskbarAction {
 		@IConnectionManagementService connectionManagementService: IConnectionManagementService
 	) {
 		super(connectionManagementService, editor, DisconnectDatabaseAction.ID, DisconnectDatabaseAction.EnabledClass);
-		this.label = nls.localize('disconnectDatabaseLabel', 'Disconnect');
+		this.label = nls.localize('disconnectDatabaseLabel', "Disconnect");
 	}
 
 	public run(): Promise<void> {
@@ -321,10 +321,10 @@ export class ConnectDatabaseAction extends QueryTaskbarAction {
 
 		if (isChangeConnectionAction) {
 			enabledClass = ConnectDatabaseAction.EnabledChangeClass;
-			label = nls.localize('changeConnectionDatabaseLabel', 'Change Connection');
+			label = nls.localize('changeConnectionDatabaseLabel', "Change Connection");
 		} else {
 			enabledClass = ConnectDatabaseAction.EnabledDefaultClass;
-			label = nls.localize('connectDatabaseLabel', 'Connect');
+			label = nls.localize('connectDatabaseLabel', "Connect");
 		}
 
 		super(connectionManagementService, editor, ConnectDatabaseAction.ID, enabledClass);
@@ -348,8 +348,8 @@ export class ToggleConnectDatabaseAction extends QueryTaskbarAction {
 	public static DisconnectClass = 'disconnect';
 	public static ID = 'toggleConnectDatabaseAction';
 
-	private _connectLabel = nls.localize('connectDatabaseLabel', 'Connect');
-	private _disconnectLabel = nls.localize('disconnectDatabaseLabel', 'Disconnect');
+	private _connectLabel = nls.localize('connectDatabaseLabel', "Connect");
+	private _disconnectLabel = nls.localize('disconnectDatabaseLabel', "Disconnect");
 	constructor(
 		editor: QueryEditor,
 		private _connected: boolean,
@@ -454,7 +454,7 @@ export class ListDatabasesActionItem implements IActionViewItem {
 				strictSelection: true,
 				placeholder: this._selectDatabaseString,
 				ariaLabel: this._selectDatabaseString,
-				actionLabel: nls.localize('listDatabases.toggleDatabaseNameDropdown', 'Select Database Toggle Dropdown')
+				actionLabel: nls.localize('listDatabases.toggleDatabaseNameDropdown', "Select Database Toggle Dropdown")
 			});
 			this._dropdown.onValueChange(s => this.databaseSelected(s));
 			this._toDispose.push(this._dropdown.onFocus(() => this.onDropdownFocus()));

--- a/src/sql/workbench/parts/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/parts/query/browser/queryResultsView.ts
@@ -121,7 +121,7 @@ class ResultsView extends Disposable implements IPanelView {
 }
 
 class ResultsTab implements IPanelTab {
-	public readonly title = nls.localize('resultsTabTitle', 'Results');
+	public readonly title = nls.localize('resultsTabTitle', "Results");
 	public readonly identifier = 'resultsTab';
 	public readonly view: ResultsView;
 
@@ -143,7 +143,7 @@ class ResultsTab implements IPanelTab {
 }
 
 class MessagesTab implements IPanelTab {
-	public readonly title = nls.localize('messagesTabTitle', 'Messages');
+	public readonly title = nls.localize('messagesTabTitle', "Messages");
 	public readonly identifier = 'messagesTab';
 	public readonly view: MessagesView;
 

--- a/src/sql/workbench/parts/query/browser/statusBarItems.ts
+++ b/src/sql/workbench/parts/query/browser/statusBarItems.ts
@@ -202,7 +202,7 @@ export class QueryStatusStatusBarContributions extends Disposable implements IWo
 		super();
 		this._register(
 			this.statusbarService.addEntry({
-				text: localize('query.status.executing', 'Executing query...'),
+				text: localize('query.status.executing', "Executing query..."),
 			},
 				QueryStatusStatusBarContributions.ID,
 				localize('status.query.status', "Execution Status"),

--- a/src/sql/workbench/parts/query/common/localizedConstants.ts
+++ b/src/sql/workbench/parts/query/common/localizedConstants.ts
@@ -7,32 +7,32 @@ import { localize } from 'vs/nls';
 
 // localizable strings
 
-export const runQueryBatchStartMessage = localize('runQueryBatchStartMessage', 'Started executing query at ');
-export const runQueryBatchStartLine = localize('runQueryBatchStartLine', 'Line {0}');
+export const runQueryBatchStartMessage = localize('runQueryBatchStartMessage', "Started executing query at ");
+export const runQueryBatchStartLine = localize('runQueryBatchStartLine', "Line {0}");
 
-export const msgCancelQueryFailed = localize('msgCancelQueryFailed', 'Canceling the query failed: {0}');
+export const msgCancelQueryFailed = localize('msgCancelQueryFailed', "Canceling the query failed: {0}");
 
-export const msgSaveStarted = localize('msgSaveStarted', 'Started saving results to ');
-export const msgSaveFailed = localize('msgSaveFailed', 'Failed to save results. ');
-export const msgSaveSucceeded = localize('msgSaveSucceeded', 'Successfully saved results to ');
+export const msgSaveStarted = localize('msgSaveStarted', "Started saving results to ");
+export const msgSaveFailed = localize('msgSaveFailed', "Failed to save results. ");
+export const msgSaveSucceeded = localize('msgSaveSucceeded', "Successfully saved results to ");
 
-export const msgStatusRunQueryInProgress = localize('msgStatusRunQueryInProgress', 'Executing query...');
+export const msgStatusRunQueryInProgress = localize('msgStatusRunQueryInProgress', "Executing query...");
 
 // /** Results Pane Labels */
-export const maximizeLabel = localize('maximizeLabel', 'Maximize');
-export const restoreLabel = localize('resultsPane.restoreLabel', 'Restore');
-export const saveCSVLabel = localize('saveCSVLabel', 'Save as CSV');
-export const saveJSONLabel = localize('saveJSONLabel', 'Save as JSON');
-export const saveExcelLabel = localize('saveExcelLabel', 'Save as Excel');
-export const saveXMLLabel = localize('saveXMLLabel', 'Save as XML');
-export const viewChartLabel = localize('viewChartLabel', 'View as Chart');
+export const maximizeLabel = localize('maximizeLabel', "Maximize");
+export const restoreLabel = localize('resultsPane.restoreLabel', "Restore");
+export const saveCSVLabel = localize('saveCSVLabel', "Save as CSV");
+export const saveJSONLabel = localize('saveJSONLabel', "Save as JSON");
+export const saveExcelLabel = localize('saveExcelLabel', "Save as Excel");
+export const saveXMLLabel = localize('saveXMLLabel', "Save as XML");
+export const viewChartLabel = localize('viewChartLabel', "View as Chart");
 
-export const resultPaneLabel = localize('resultPaneLabel', 'Results');
-export const executeQueryLabel = localize('executeQueryLabel', 'Executing query ');
+export const resultPaneLabel = localize('resultPaneLabel', "Results");
+export const executeQueryLabel = localize('executeQueryLabel', "Executing query ");
 
 /** Messages Pane Labels */
-export const messagePaneLabel = localize('messagePaneLabel', 'Messages');
-export const elapsedTimeLabel = localize('elapsedTimeLabel', 'Total execution time: {0}');
+export const messagePaneLabel = localize('messagePaneLabel', "Messages");
+export const elapsedTimeLabel = localize('elapsedTimeLabel', "Total execution time: {0}");
 
 /** Warning message for save icons */
-export const msgCannotSaveMultipleSelections = localize('msgCannotSaveMultipleSelections', 'Save results command cannot be used with multiple selections.');
+export const msgCannotSaveMultipleSelections = localize('msgCannotSaveMultipleSelections', "Save results command cannot be used with multiple selections.");

--- a/src/sql/workbench/parts/query/common/queryInput.ts
+++ b/src/sql/workbench/parts/query/common/queryInput.ts
@@ -232,7 +232,7 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 					title += `${profile.serverName}.${profile.databaseName} (${profile.authenticationType})`;
 				}
 			} else {
-				title += localize('disconnected', 'disconnected');
+				title += localize('disconnected', "disconnected");
 			}
 			return this._sql.getName() + (longForm ? (' - ' + title) : ` - ${trimTitle(title)}`);
 		} else {

--- a/src/sql/workbench/parts/query/common/queryResultsInput.ts
+++ b/src/sql/workbench/parts/query/common/queryResultsInput.ts
@@ -79,7 +79,7 @@ export class QueryResultsInput extends EditorInput {
 	}
 
 	getName(): string {
-		return localize('extensionsInputName', 'Extension');
+		return localize('extensionsInputName', "Extension");
 	}
 
 	matches(other: any): boolean {

--- a/src/sql/workbench/parts/query/common/resultSerializer.ts
+++ b/src/sql/workbench/parts/query/common/resultSerializer.ts
@@ -95,7 +95,7 @@ export class ResultSerializer {
 		}
 
 		return this.fileDialogService.showSaveDialog({
-			title: nls.localize('resultsSerializer.saveAsFileTitle', 'Choose Results File'),
+			title: nls.localize('resultsSerializer.saveAsFileTitle', "Choose Results File"),
 			defaultUri: filepathPlaceHolder ? URI.file(filepathPlaceHolder) : undefined,
 			filters: this.getResultsFileExtension(saveRequest)
 		}).then(filePath => {
@@ -131,23 +131,23 @@ export class ResultSerializer {
 
 		switch (saveRequest.format) {
 			case SaveFormat.CSV:
-				fileFilter.name = nls.localize('resultsSerializer.saveAsFileExtensionCSVTitle', 'CSV (Comma delimited)');
+				fileFilter.name = nls.localize('resultsSerializer.saveAsFileExtensionCSVTitle', "CSV (Comma delimited)");
 				fileFilter.extensions = ['csv'];
 				break;
 			case SaveFormat.JSON:
-				fileFilter.name = nls.localize('resultsSerializer.saveAsFileExtensionJSONTitle', 'JSON');
+				fileFilter.name = nls.localize('resultsSerializer.saveAsFileExtensionJSONTitle', "JSON");
 				fileFilter.extensions = ['json'];
 				break;
 			case SaveFormat.EXCEL:
-				fileFilter.name = nls.localize('resultsSerializer.saveAsFileExtensionExcelTitle', 'Excel Workbook');
+				fileFilter.name = nls.localize('resultsSerializer.saveAsFileExtensionExcelTitle', "Excel Workbook");
 				fileFilter.extensions = ['xlsx'];
 				break;
 			case SaveFormat.XML:
-				fileFilter.name = nls.localize('resultsSerializer.saveAsFileExtensionXMLTitle', 'XML');
+				fileFilter.name = nls.localize('resultsSerializer.saveAsFileExtensionXMLTitle', "XML");
 				fileFilter.extensions = ['xml'];
 				break;
 			default:
-				fileFilter.name = nls.localize('resultsSerializer.saveAsFileExtensionTXTTitle', 'Plain Text');
+				fileFilter.name = nls.localize('resultsSerializer.saveAsFileExtensionTXTTitle', "Plain Text");
 				fileFilter.extensions = ['txt'];
 		}
 

--- a/src/sql/workbench/parts/queryPlan/browser/queryPlan.ts
+++ b/src/sql/workbench/parts/queryPlan/browser/queryPlan.ts
@@ -13,7 +13,7 @@ import { dispose } from 'vs/base/common/lifecycle';
 import { QueryPlanState } from 'sql/workbench/parts/queryPlan/common/queryPlanState';
 
 export class QueryPlanTab implements IPanelTab {
-	public readonly title = localize('queryPlanTitle', 'Query Plan');
+	public readonly title = localize('queryPlanTitle', "Query Plan");
 	public readonly identifier = 'QueryPlanTab';
 	public readonly view: QueryPlanView;
 

--- a/src/sql/workbench/parts/queryPlan/browser/topOperations.ts
+++ b/src/sql/workbench/parts/queryPlan/browser/topOperations.ts
@@ -17,25 +17,25 @@ import { TableDataView } from 'sql/base/browser/ui/table/tableDataView';
 import { TopOperationsState } from 'sql/workbench/parts/queryPlan/common/topOperationsState';
 
 const topOperationColumns: Array<Slick.Column<any>> = [
-	{ name: localize('topOperations.operation', 'Operation'), field: 'operation', sortable: true },
-	{ name: localize('topOperations.object', 'Object'), field: 'object', sortable: true },
-	{ name: localize('topOperations.estCost', 'Est Cost'), field: 'estCost', sortable: true },
-	{ name: localize('topOperations.estSubtreeCost', 'Est Subtree Cost'), field: 'estSubtreeCost', sortable: true },
-	{ name: localize('topOperations.actualRows', 'Actual Rows'), field: 'actualRows', sortable: true },
-	{ name: localize('topOperations.estRows', 'Est Rows'), field: 'estRows', sortable: true },
-	{ name: localize('topOperations.actualExecutions', 'Actual Executions'), field: 'actualExecutions', sortable: true },
-	{ name: localize('topOperations.estCPUCost', 'Est CPU Cost'), field: 'estCPUCost', sortable: true },
-	{ name: localize('topOperations.estIOCost', 'Est IO Cost'), field: 'estIOCost', sortable: true },
-	{ name: localize('topOperations.parallel', 'Parallel'), field: 'parallel', sortable: true },
-	{ name: localize('topOperations.actualRebinds', 'Actual Rebinds'), field: 'actualRebinds', sortable: true },
-	{ name: localize('topOperations.estRebinds', 'Est Rebinds'), field: 'estRebinds', sortable: true },
-	{ name: localize('topOperations.actualRewinds', 'Actual Rewinds'), field: 'actualRewinds', sortable: true },
-	{ name: localize('topOperations.estRewinds', 'Est Rewinds'), field: 'estRewinds', sortable: true },
-	{ name: localize('topOperations.partitioned', 'Partitioned'), field: 'partitioned', sortable: true }
+	{ name: localize('topOperations.operation', "Operation"), field: 'operation', sortable: true },
+	{ name: localize('topOperations.object', "Object"), field: 'object', sortable: true },
+	{ name: localize('topOperations.estCost', "Est Cost"), field: 'estCost', sortable: true },
+	{ name: localize('topOperations.estSubtreeCost', "Est Subtree Cost"), field: 'estSubtreeCost', sortable: true },
+	{ name: localize('topOperations.actualRows', "Actual Rows"), field: 'actualRows', sortable: true },
+	{ name: localize('topOperations.estRows', "Est Rows"), field: 'estRows', sortable: true },
+	{ name: localize('topOperations.actualExecutions', "Actual Executions"), field: 'actualExecutions', sortable: true },
+	{ name: localize('topOperations.estCPUCost', "Est CPU Cost"), field: 'estCPUCost', sortable: true },
+	{ name: localize('topOperations.estIOCost', "Est IO Cost"), field: 'estIOCost', sortable: true },
+	{ name: localize('topOperations.parallel', "Parallel"), field: 'parallel', sortable: true },
+	{ name: localize('topOperations.actualRebinds', "Actual Rebinds"), field: 'actualRebinds', sortable: true },
+	{ name: localize('topOperations.estRebinds', "Est Rebinds"), field: 'estRebinds', sortable: true },
+	{ name: localize('topOperations.actualRewinds', "Actual Rewinds"), field: 'actualRewinds', sortable: true },
+	{ name: localize('topOperations.estRewinds', "Est Rewinds"), field: 'estRewinds', sortable: true },
+	{ name: localize('topOperations.partitioned', "Partitioned"), field: 'partitioned', sortable: true }
 ];
 
 export class TopOperationsTab implements IPanelTab {
-	public readonly title = localize('topOperationsTitle', 'Top Operations');
+	public readonly title = localize('topOperationsTitle', "Top Operations");
 	public readonly identifier = 'TopOperationsTab';
 	public readonly view: TopOperationsView;
 

--- a/src/sql/workbench/parts/restore/browser/restoreDialog.ts
+++ b/src/sql/workbench/parts/restore/browser/restoreDialog.ts
@@ -53,7 +53,7 @@ interface FileListElement {
 
 const LocalizedStrings = {
 	BACKFILEPATH: localize('backupFilePath', "Backup file path"),
-	TARGETDATABASE: localize('targetDatabase', 'Target database')
+	TARGETDATABASE: localize('targetDatabase', "Target database")
 };
 
 export class RestoreDialog extends Modal {
@@ -161,8 +161,8 @@ export class RestoreDialog extends Modal {
 	public render() {
 		super.render();
 		attachModalDialogStyler(this, this._themeService);
-		let cancelLabel = localize('restoreDialog.cancel', 'Cancel');
-		this._scriptButton = this.addFooterButton(localize('restoreDialog.script', 'Script'), () => this.restore(true));
+		let cancelLabel = localize('restoreDialog.cancel', "Cancel");
+		this._scriptButton = this.addFooterButton(localize('restoreDialog.script', "Script"), () => this.restore(true));
 		this._restoreButton = this.addFooterButton(this._restoreLabel, () => this.restore(false));
 		this._closeButton = this.addFooterButton(cancelLabel, () => this.cancel());
 		this.registerListeners();
@@ -217,7 +217,7 @@ export class RestoreDialog extends Modal {
 			{
 				strictSelection: false,
 				ariaLabel: LocalizedStrings.TARGETDATABASE,
-				actionLabel: localize('restoreDialog.toggleDatabaseNameDropdown', 'Select Database Toggle Dropdown')
+				actionLabel: localize('restoreDialog.toggleDatabaseNameDropdown', "Select Database Toggle Dropdown")
 			}
 		);
 		this._databaseDropdown.onValueChange(s => {
@@ -331,7 +331,7 @@ export class RestoreDialog extends Modal {
 		attachTabbedPanelStyler(this._panel, this._themeService);
 		this._generalTabId = this._panel.pushTab({
 			identifier: 'general',
-			title: localize('generalTitle', 'General'),
+			title: localize('generalTitle', "General"),
 			view: {
 				render: c => {
 					DOM.append(c, generalTab);
@@ -343,7 +343,7 @@ export class RestoreDialog extends Modal {
 
 		const fileTab = this._panel.pushTab({
 			identifier: 'fileContent',
-			title: localize('filesTitle', 'Files'),
+			title: localize('filesTitle', "Files"),
 			view: {
 				layout: () => { },
 				render: c => {
@@ -355,7 +355,7 @@ export class RestoreDialog extends Modal {
 
 		this._panel.pushTab({
 			identifier: 'options',
-			title: localize('optionsTitle', 'Options'),
+			title: localize('optionsTitle', "Options"),
 			view: {
 				layout: () => { },
 				render: c => {

--- a/src/sql/workbench/parts/tasks/browser/tasksView.ts
+++ b/src/sql/workbench/parts/tasks/browser/tasksView.ts
@@ -53,7 +53,7 @@ export class TaskHistoryView {
 		if (taskNode && taskNode.hasChildren) {
 			hide(this._messages);
 		}
-		let noTaskMessage = localize('noTaskMessage', 'No task history to display.');
+		let noTaskMessage = localize('noTaskMessage', "No task history to display.");
 		append(this._messages, $('span')).innerText = noTaskMessage;
 
 		this._tree = this.createTaskHistoryTree(container, this._instantiationService);
@@ -143,7 +143,7 @@ export class TaskHistoryView {
 			if (isDoubleClick) {
 				if (task.status === TaskStatus.Failed) {
 					let err = task.taskName + ': ' + task.message;
-					this._errorMessageService.showDialog(Severity.Error, localize('taskError', 'Task error'), err);
+					this._errorMessageService.showDialog(Severity.Error, localize('taskError', "Task error"), err);
 				}
 			}
 		}

--- a/src/sql/workbench/parts/tasks/common/tasksAction.ts
+++ b/src/sql/workbench/parts/tasks/common/tasksAction.ts
@@ -13,7 +13,7 @@ import { IErrorMessageService } from 'sql/platform/errorMessage/common/errorMess
 
 export class CancelAction extends Action {
 	public static ID = 'taskHistory.cancel';
-	public static LABEL = localize('cancelTask.cancel', 'Cancel');
+	public static LABEL = localize('cancelTask.cancel', "Cancel");
 
 	constructor(
 		id: string,
@@ -27,7 +27,7 @@ export class CancelAction extends Action {
 		if (element instanceof TaskNode) {
 			this._taskService.cancelTask(element.providerName, element.id).then((result) => {
 				if (!result) {
-					let error = localize('errorMsgFromCancelTask', 'The task is failed to cancel.');
+					let error = localize('errorMsgFromCancelTask', "The task is failed to cancel.");
 					this.showError(error);
 				}
 			}, error => {
@@ -47,7 +47,7 @@ export class CancelAction extends Action {
 
 export class ScriptAction extends Action {
 	public static ID = 'taskHistory.script';
-	public static LABEL = localize('taskAction.script', 'Script');
+	public static LABEL = localize('taskAction.script', "Script");
 
 	constructor(
 		id: string,

--- a/src/sql/workbench/parts/webview/electron-browser/webViewDialog.ts
+++ b/src/sql/workbench/parts/webview/electron-browser/webViewDialog.ts
@@ -48,8 +48,8 @@ export class WebViewDialog extends Modal {
 		@IInstantiationService private _instantiationService: IInstantiationService
 	) {
 		super('', TelemetryKeys.WebView, telemetryService, layoutService, clipboardService, themeService, logService, contextKeyService, { isFlyout: false, hasTitleIcon: true });
-		this._okLabel = localize('webViewDialog.ok', 'OK');
-		this._closeLabel = localize('webViewDialog.close', 'Close');
+		this._okLabel = localize('webViewDialog.ok', "OK");
+		this._closeLabel = localize('webViewDialog.close', "Close");
 	}
 
 	public set html(value: string) {

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -151,7 +151,7 @@ export class AccountManagementService implements IAccountManagementService {
 			let refreshedAccount = await provider.provider.refresh(account);
 			if (self.isCanceledResult(refreshedAccount)) {
 				// Pattern here is to throw if this fails. Handled upstream.
-				throw new Error(localize('refreshFailed', 'Refresh account was canceled by the user'));
+				throw new Error(localize('refreshFailed', "Refresh account was canceled by the user"));
 			} else {
 				account = refreshedAccount;
 			}

--- a/src/sql/workbench/services/admin/common/adminService.ts
+++ b/src/sql/workbench/services/admin/common/adminService.ts
@@ -38,13 +38,13 @@ export class AdminService implements IAdminService {
 		let providerId: string = this._connectionService.getProviderIdFromUri(uri);
 
 		if (!providerId) {
-			return Promise.reject(new Error(localize('adminService.providerIdNotValidError', 'Connection is required in order to interact with adminservice')));
+			return Promise.reject(new Error(localize('adminService.providerIdNotValidError', "Connection is required in order to interact with adminservice")));
 		}
 		let handler = this._providers[providerId];
 		if (handler) {
 			return action(handler);
 		} else {
-			return Promise.reject(new Error(localize('adminService.noHandlerRegistered', 'No Handler Registered')));
+			return Promise.reject(new Error(localize('adminService.noHandlerRegistered', "No Handler Registered")));
 		}
 	}
 

--- a/src/sql/workbench/services/commandLine/common/commandLineService.ts
+++ b/src/sql/workbench/services/commandLine/common/commandLineService.ts
@@ -151,7 +151,7 @@ export class CommandLineService implements ICommandLineProcessing {
 					showFirewallRuleOnError: warnOnConnectFailure
 				};
 				if (this._notificationService) {
-					this._notificationService.status(localize('connectingQueryLabel', 'Connecting query file'), { hideAfter: 2500 });
+					this._notificationService.status(localize('connectingQueryLabel', "Connecting query file"), { hideAfter: 2500 });
 				}
 				await this._connectionManagementService.connect(profile, uriString, options);
 			}

--- a/src/sql/workbench/services/connection/browser/cmsConnectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/cmsConnectionWidget.ts
@@ -118,7 +118,7 @@ export class CmsConnectionWidget extends ConnectionWidget {
 		// Registered Server Description
 		let serverDescriptionOption = this._optionsMaps['serverDescription'];
 		if (serverDescriptionOption) {
-			serverDescriptionOption.displayName = localize('serverDescription', 'Server Description (optional)');
+			serverDescriptionOption.displayName = localize('serverDescription', "Server Description (optional)");
 			let serverDescriptionBuilder = DialogHelper.appendRow(this._tableContainer, serverDescriptionOption.displayName, 'connection-label', 'connection-input', 'server-description-input');
 			this._serverDescriptionInputBox = new InputBox(serverDescriptionBuilder, this._contextViewService, { type: 'textarea', flexibleHeight: true });
 			this._serverDescriptionInputBox.setHeight('75px');

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -70,7 +70,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	private _providerDisplayNames: string[] = [];
 	private _currentProviderType: string = Constants.mssqlProviderName;
 	private _connecting: boolean = false;
-	private _connectionErrorTitle = localize('connectionError', 'Connection error');
+	private _connectionErrorTitle = localize('connectionError', "Connection error");
 	private _dialogDeferredPromise: Deferred<IConnectionProfile>;
 
 	/**

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -46,7 +46,7 @@ export class ConnectionWidget {
 	private _azureAccountDropdown: SelectBox;
 	private _azureTenantDropdown: SelectBox;
 	private _refreshCredentialsLink: HTMLLinkElement;
-	private _addAzureAccountMessage: string = localize('connectionWidget.AddAzureAccount', 'Add an account...');
+	private _addAzureAccountMessage: string = localize('connectionWidget.AddAzureAccount', "Add an account...");
 	private readonly _azureProviderId = 'azurePublicCloud';
 	private _azureTenantId: string;
 	private _azureAccountList: azdata.Account[];
@@ -54,9 +54,9 @@ export class ConnectionWidget {
 	private _focusedBeforeHandleOnConnection: HTMLElement;
 	private _saveProfile: boolean;
 	private _databaseDropdownExpanded: boolean = false;
-	private _defaultDatabaseName: string = localize('defaultDatabaseOption', '<Default>');
-	private _loadingDatabaseName: string = localize('loadingDatabaseOption', 'Loading...');
-	private _serverGroupDisplayString: string = localize('serverGroup', 'Server group');
+	private _defaultDatabaseName: string = localize('defaultDatabaseOption', "<Default>");
+	private _loadingDatabaseName: string = localize('loadingDatabaseOption', "Loading...");
+	private _serverGroupDisplayString: string = localize('serverGroup', "Server group");
 	protected _container: HTMLElement;
 	protected _serverGroupSelectBox: SelectBox;
 	protected _authTypeSelectBox: SelectBox;
@@ -72,7 +72,7 @@ export class ConnectionWidget {
 	protected _advancedButton: Button;
 	public DefaultServerGroup: IConnectionProfileGroup = {
 		id: '',
-		name: localize('defaultServerGroup', '<Default>'),
+		name: localize('defaultServerGroup', "<Default>"),
 		parentId: undefined,
 		color: undefined,
 		description: undefined,
@@ -80,14 +80,14 @@ export class ConnectionWidget {
 
 	private _addNewServerGroup = {
 		id: '',
-		name: localize('addNewServerGroup', 'Add new group...'),
+		name: localize('addNewServerGroup', "Add new group..."),
 		parentId: undefined,
 		color: undefined,
 		description: undefined,
 	};
 	public NoneServerGroup: IConnectionProfileGroup = {
 		id: '',
-		name: localize('noneServerGroup', '<Do not save>'),
+		name: localize('noneServerGroup', "<Do not save>"),
 		parentId: undefined,
 		color: undefined,
 		description: undefined,
@@ -223,20 +223,20 @@ export class ConnectionWidget {
 		this._password = '';
 
 		// Remember password
-		let rememberPasswordLabel = localize('rememberPassword', 'Remember password');
+		let rememberPasswordLabel = localize('rememberPassword', "Remember password");
 		this._rememberPasswordCheckBox = this.appendCheckbox(this._tableContainer, rememberPasswordLabel, 'connection-input', 'username-password-row', false);
 
 		// Azure account picker
-		let accountLabel = localize('connection.azureAccountDropdownLabel', 'Account');
+		let accountLabel = localize('connection.azureAccountDropdownLabel', "Account");
 		let accountDropdown = DialogHelper.appendRow(this._tableContainer, accountLabel, 'connection-label', 'connection-input', 'azure-account-row');
 		this._azureAccountDropdown = new SelectBox([], undefined, this._contextViewService, accountDropdown, { ariaLabel: accountLabel });
 		DialogHelper.appendInputSelectBox(accountDropdown, this._azureAccountDropdown);
 		let refreshCredentials = DialogHelper.appendRow(this._tableContainer, '', 'connection-label', 'connection-input', ['azure-account-row', 'refresh-credentials-link']);
 		this._refreshCredentialsLink = DOM.append(refreshCredentials, DOM.$('a'));
 		this._refreshCredentialsLink.href = '#';
-		this._refreshCredentialsLink.innerText = localize('connectionWidget.refreshAzureCredentials', 'Refresh account credentials');
+		this._refreshCredentialsLink.innerText = localize('connectionWidget.refreshAzureCredentials', "Refresh account credentials");
 		// Azure tenant picker
-		let tenantLabel = localize('connection.azureTenantDropdownLabel', 'Azure AD tenant');
+		let tenantLabel = localize('connection.azureTenantDropdownLabel', "Azure AD tenant");
 		let tenantDropdown = DialogHelper.appendRow(this._tableContainer, tenantLabel, 'connection-label', 'connection-input', ['azure-account-row', 'azure-tenant-row']);
 		this._azureTenantDropdown = new SelectBox([], undefined, this._contextViewService, tenantDropdown, { ariaLabel: tenantLabel });
 		DialogHelper.appendInputSelectBox(tenantDropdown, this._azureTenantDropdown);
@@ -253,7 +253,7 @@ export class ConnectionWidget {
 				placeholder: this._defaultDatabaseName,
 				maxHeight: 125,
 				ariaLabel: databaseOption.displayName,
-				actionLabel: localize('connectionWidget.toggleDatabaseNameDropdown', 'Select Database Toggle Dropdown')
+				actionLabel: localize('connectionWidget.toggleDatabaseNameDropdown', "Select Database Toggle Dropdown")
 			});
 		}
 	}
@@ -269,13 +269,13 @@ export class ConnectionWidget {
 	protected addConnectionNameOptions(): void {
 		// Connection name
 		let connectionNameOption = this._optionsMaps[ConnectionOptionSpecialType.connectionName];
-		connectionNameOption.displayName = localize('connectionName', 'Name (optional)');
+		connectionNameOption.displayName = localize('connectionName', "Name (optional)");
 		let connectionNameBuilder = DialogHelper.appendRow(this._tableContainer, connectionNameOption.displayName, 'connection-label', 'connection-input');
 		this._connectionNameInputBox = new InputBox(connectionNameBuilder, this._contextViewService, { ariaLabel: connectionNameOption.displayName });
 	}
 
 	protected addAdvancedOptions(): void {
-		let AdvancedLabel = localize('advanced', 'Advanced...');
+		let AdvancedLabel = localize('advanced', "Advanced...");
 		this._advancedButton = this.createAdvancedButton(this._tableContainer, AdvancedLabel);
 	}
 
@@ -754,7 +754,7 @@ export class ConnectionWidget {
 		if (selected === '' || selected === this._addAzureAccountMessage) {
 			if (showMessage) {
 				this._azureAccountDropdown.showMessage({
-					content: localize('connectionWidget.invalidAzureAccount', 'You must select an account'),
+					content: localize('connectionWidget.invalidAzureAccount', "You must select an account"),
 					type: MessageType.ERROR
 				});
 			}

--- a/src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl.ts
+++ b/src/sql/workbench/services/dashboard/browser/newDashboardTabDialogImpl.ts
@@ -115,7 +115,7 @@ export class NewDashboardTabDialog extends Modal {
 		@ILogService logService: ILogService
 	) {
 		super(
-			localize('newDashboardTab.openDashboardExtensions', 'Open dashboard extensions'),
+			localize('newDashboardTab.openDashboardExtensions', "Open dashboard extensions"),
 			TelemetryKeys.AddNewDashboardTab,
 			telemetryService,
 			layoutService,
@@ -143,8 +143,8 @@ export class NewDashboardTabDialog extends Modal {
 		super.render();
 		attachModalDialogStyler(this, this._themeService);
 
-		this._addNewTabButton = this.addFooterButton(localize('newDashboardTab.ok', 'OK'), () => this.addNewTabs());
-		this._cancelButton = this.addFooterButton(localize('newDashboardTab.cancel', 'Cancel'), () => this.cancel());
+		this._addNewTabButton = this.addFooterButton(localize('newDashboardTab.ok', "OK"), () => this.addNewTabs());
+		this._cancelButton = this.addFooterButton(localize('newDashboardTab.cancel', "Cancel"), () => this.cancel());
 		this.registerListeners();
 	}
 
@@ -155,7 +155,7 @@ export class NewDashboardTabDialog extends Modal {
 		this.createExtensionList(this._extensionViewContainer);
 		this._noExtensionViewContainer = DOM.$('.no-extension-view');
 		let noExtensionTitle = DOM.append(this._noExtensionViewContainer, DOM.$('.no-extensionTab-label'));
-		let noExtensionLabel = localize('newdashboardTabDialog.noExtensionLabel', 'No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.');
+		let noExtensionLabel = localize('newdashboardTabDialog.noExtensionLabel', "No dashboard extensions are installed at this time. Go to Extension Manager to explore recommended extensions.");
 		noExtensionTitle.textContent = noExtensionLabel;
 
 		DOM.append(container, this._noExtensionViewContainer);

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -50,8 +50,8 @@ export class ErrorMessageDialog extends Modal {
 		@ILogService logService: ILogService
 	) {
 		super('', TelemetryKeys.ErrorMessage, telemetryService, layoutService, clipboardService, themeService, logService, contextKeyService, { isFlyout: false, hasTitleIcon: true });
-		this._okLabel = localize('errorMessageDialog.ok', 'OK');
-		this._closeLabel = localize('errorMessageDialog.close', 'Close');
+		this._okLabel = localize('errorMessageDialog.ok', "OK");
+		this._closeLabel = localize('errorMessageDialog.close', "Close");
 	}
 
 	protected renderBody(container: HTMLElement) {
@@ -71,7 +71,7 @@ export class ErrorMessageDialog extends Modal {
 	}
 
 	private createCopyButton() {
-		let copyButtonLabel = localize('copyDetails', 'Copy details');
+		let copyButtonLabel = localize('copyDetails', "Copy details");
 		this._copyButton = this.addFooterButton(copyButtonLabel, () => this._clipboardService.writeText(this._messageDetails), 'left');
 		this._copyButton.icon = 'icon scriptToClipboard';
 		this._copyButton.element.title = copyButtonLabel;

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageService.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageService.ts
@@ -43,13 +43,13 @@ export class ErrorMessageService implements IErrorMessageService {
 		let defaultTitle: string;
 		switch (severity) {
 			case Severity.Error:
-				defaultTitle = localize('error', 'Error');
+				defaultTitle = localize('error', "Error");
 				break;
 			case Severity.Warning:
-				defaultTitle = localize('warning', 'Warning');
+				defaultTitle = localize('warning', "Warning");
 				break;
 			case Severity.Info:
-				defaultTitle = localize('info', 'Info');
+				defaultTitle = localize('info', "Info");
 		}
 		return defaultTitle;
 	}

--- a/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
+++ b/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
@@ -86,20 +86,20 @@ export class FileBrowserDialog extends Modal {
 		this._treeContainer = DOM.append(this._body, DOM.$('.tree-view'));
 
 		let tableContainer: HTMLElement = DOM.append(DOM.append(this._body, DOM.$('.option-section')), DOM.$('table.file-table-content'));
-		let pathLabel = localize('filebrowser.filepath', 'Selected path');
+		let pathLabel = localize('filebrowser.filepath', "Selected path");
 		let pathBuilder = DialogHelper.appendRow(tableContainer, pathLabel, 'file-input-label', 'file-input-box');
 		this._filePathInputBox = new InputBox(pathBuilder, this._contextViewService, {
 			ariaLabel: pathLabel
 		});
 
 		this._fileFilterSelectBox = new SelectBox(['*'], '*', this._contextViewService);
-		let filterLabel = localize('fileFilter', 'Files of type');
+		let filterLabel = localize('fileFilter', "Files of type");
 		let filterBuilder = DialogHelper.appendRow(tableContainer, filterLabel, 'file-input-label', 'file-input-box');
 		DialogHelper.appendInputSelectBox(filterBuilder, this._fileFilterSelectBox);
 
-		this._okButton = this.addFooterButton(localize('fileBrowser.ok', 'OK'), () => this.ok());
+		this._okButton = this.addFooterButton(localize('fileBrowser.ok', "OK"), () => this.ok());
 		this._okButton.enabled = false;
-		this._cancelButton = this.addFooterButton(localize('fileBrowser.discard', 'Discard'), () => this.close());
+		this._cancelButton = this.addFooterButton(localize('fileBrowser.discard', "Discard"), () => this.close());
 
 		this.registerListeners();
 		this.updateTheme();

--- a/src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel.ts
+++ b/src/sql/workbench/services/fileBrowser/common/fileBrowserViewModel.ts
@@ -37,7 +37,7 @@ export class FileBrowserViewModel {
 		this._fileValidationServiceType = fileValidationServiceType;
 
 		if (!fileFilters) {
-			this._fileFilters = [{ label: localize('allFiles', 'All files'), filters: ['*'] }];
+			this._fileFilters = [{ label: localize('allFiles', "All files"), filters: ['*'] }];
 		} else {
 			this._fileFilters = fileFilters;
 		}

--- a/src/sql/workbench/services/insights/common/insightsUtils.ts
+++ b/src/sql/workbench/services/insights/common/insightsUtils.ts
@@ -41,5 +41,5 @@ export async function resolveQueryFilePath(services: ServicesAccessor, filePath:
 		}
 	}
 
-	throw Error(localize('insightsDidNotFindResolvedFile', 'Could not find query file at any of the following paths :\n {0}', resolvedFilePaths.join('\n')));
+	throw Error(localize('insightsDidNotFindResolvedFile', "Could not find query file at any of the following paths :\n {0}", resolvedFilePaths.join('\n')));
 }

--- a/src/sql/workbench/services/notebook/common/notebookRegistry.ts
+++ b/src/sql/workbench/services/notebook/common/notebookRegistry.ts
@@ -26,11 +26,11 @@ let notebookProviderType: IJSONSchema = {
 	default: { provider: '', fileExtensions: [], standardKernels: [] },
 	properties: {
 		provider: {
-			description: localize('carbon.extension.contributes.notebook.provider', 'Identifier of the notebook provider.'),
+			description: localize('carbon.extension.contributes.notebook.provider', "Identifier of the notebook provider."),
 			type: 'string'
 		},
 		fileExtensions: {
-			description: localize('carbon.extension.contributes.notebook.fileExtensions', 'What file extensions should be registered to this notebook provider'),
+			description: localize('carbon.extension.contributes.notebook.fileExtensions', "What file extensions should be registered to this notebook provider"),
 			oneOf: [
 				{ type: 'string' },
 				{
@@ -42,7 +42,7 @@ let notebookProviderType: IJSONSchema = {
 			]
 		},
 		standardKernels: {
-			description: localize('carbon.extension.contributes.notebook.standardKernels', 'What kernels should be standard with this notebook provider'),
+			description: localize('carbon.extension.contributes.notebook.standardKernels', "What kernels should be standard with this notebook provider"),
 			oneOf: [
 				{
 					type: 'object',
@@ -101,19 +101,19 @@ let notebookLanguageMagicType: IJSONSchema = {
 	default: { magic: '', language: '', kernels: [], executionTarget: null },
 	properties: {
 		magic: {
-			description: localize('carbon.extension.contributes.notebook.magic', 'Name of the cell magic, such as "%%sql".'),
+			description: localize('carbon.extension.contributes.notebook.magic', "Name of the cell magic, such as '%%sql'."),
 			type: 'string'
 		},
 		language: {
-			description: localize('carbon.extension.contributes.notebook.language', 'The cell language to be used if this cell magic is included in the cell'),
+			description: localize('carbon.extension.contributes.notebook.language', "The cell language to be used if this cell magic is included in the cell"),
 			type: 'string'
 		},
 		executionTarget: {
-			description: localize('carbon.extension.contributes.notebook.executionTarget', 'Optional execution target this magic indicates, for example Spark vs SQL'),
+			description: localize('carbon.extension.contributes.notebook.executionTarget', "Optional execution target this magic indicates, for example Spark vs SQL"),
 			type: 'string'
 		},
 		kernels: {
-			description: localize('carbon.extension.contributes.notebook.kernels', 'Optional set of kernels this is valid for, e.g. python3, pyspark3, sql'),
+			description: localize('carbon.extension.contributes.notebook.kernels', "Optional set of kernels this is valid for, e.g. python3, pyspark3, sql"),
 			oneOf: [
 				{ type: 'string' },
 				{

--- a/src/sql/workbench/services/notebook/common/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/common/notebookServiceImpl.ts
@@ -348,7 +348,7 @@ export class NotebookService extends Disposable implements INotebookService {
 
 	async getOrCreateNotebookManager(providerId: string, uri: URI): Promise<INotebookManager> {
 		if (!uri) {
-			throw new Error(localize('notebookUriNotDefined', 'No URI was passed when creating a notebook manager'));
+			throw new Error(localize('notebookUriNotDefined', "No URI was passed when creating a notebook manager"));
 		}
 		let uriString = uri.toString();
 		let managers: INotebookManager[] = this._managersMap.get(uriString);
@@ -472,7 +472,7 @@ export class NotebookService extends Disposable implements INotebookService {
 
 		// Should never happen, but if default wasn't registered we should throw
 		if (!instance) {
-			throw new Error(localize('notebookServiceNoProvider', 'Notebook provider does not exist'));
+			throw new Error(localize('notebookServiceNoProvider', "Notebook provider does not exist"));
 		}
 		return instance;
 	}

--- a/src/sql/workbench/services/notebook/common/sessionManager.ts
+++ b/src/sql/workbench/services/notebook/common/sessionManager.ts
@@ -8,8 +8,8 @@ import { localize } from 'vs/nls';
 import { FutureInternal } from 'sql/workbench/parts/notebook/node/models/modelInterfaces';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 
-export const noKernel: string = localize('noKernel', 'No Kernel');
-const runNotebookDisabled = localize('runNotebookDisabled', 'Cannot run cells as no kernel has been configured');
+export const noKernel: string = localize('noKernel', "No Kernel");
+const runNotebookDisabled = localize('runNotebookDisabled', "Cannot run cells as no kernel has been configured");
 
 let noKernelSpec: nb.IKernelSpec = ({
 	name: noKernel,
@@ -210,7 +210,7 @@ export class EmptyFuture implements FutureInternal {
 					msg_type: 'error'
 				},
 				content: <nb.IErrorResult>{
-					ename: localize('errorName', 'Error'),
+					ename: localize('errorName', "Error"),
 					evalue: runNotebookDisabled,
 					output_type: 'error'
 				},

--- a/src/sql/workbench/services/notebook/node/localContentManager.ts
+++ b/src/sql/workbench/services/notebook/node/localContentManager.ts
@@ -39,7 +39,7 @@ export class LocalContentManager implements nb.ContentManager {
 		}
 
 		// else, fallthrough condition
-		throw new TypeError(localize('nbNotSupported', 'This file does not have a valid notebook format'));
+		throw new TypeError(localize('nbNotSupported', "This file does not have a valid notebook format"));
 
 	}
 
@@ -69,7 +69,7 @@ export class LocalContentManager implements nb.ContentManager {
 		}
 
 		// else, fallthrough condition
-		throw new TypeError(localize('nbNotSupported', 'This file does not have a valid notebook format'));
+		throw new TypeError(localize('nbNotSupported', "This file does not have a valid notebook format"));
 
 	}
 

--- a/src/sql/workbench/services/objectExplorer/common/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/common/objectExplorerService.ts
@@ -232,7 +232,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 			this.handleSessionCreated(session);
 		} else {
 			let errorMessage = session && session.errorMessage ? session.errorMessage :
-				nls.localize('OeSessionFailedError', 'Failed to create Object Explorer session');
+				nls.localize('OeSessionFailedError', "Failed to create Object Explorer session");
 			this.logService.error(errorMessage);
 		}
 	}
@@ -252,7 +252,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 				}
 				else {
 					errorMessage = session && session.errorMessage ? session.errorMessage :
-						nls.localize('OeSessionFailedError', 'Failed to create Object Explorer session');
+						nls.localize('OeSessionFailedError', "Failed to create Object Explorer session");
 					this.logService.error(errorMessage);
 				}
 				// Send on session created about the session to all node providers so they can prepare for node expansion
@@ -472,7 +472,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		if (finalResult) {
 			if (errorMessages.length > 0) {
 				if (errorMessages.length > 1) {
-					errorMessages.unshift(nls.localize('nodeExpansionError', 'Multiple errors:'));
+					errorMessages.unshift(nls.localize('nodeExpansionError', "Multiple errors:"));
 				}
 				errorNode.errorMessage = errorMessages.join('\n');
 				errorNode.label = errorNode.errorMessage;
@@ -772,7 +772,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 	private getUpdatedTreeNode(treeNode: TreeNode): Promise<TreeNode> {
 		return this.getTreeNode(treeNode.getConnectionProfile().id, treeNode.nodePath).then(treeNode => {
 			if (!treeNode) {
-				// throw new Error(nls.localize('treeNodeNoLongerExists', 'The given tree node no longer exists'));
+				// throw new Error(nls.localize('treeNodeNoLongerExists', "The given tree node no longer exists"));
 				return undefined;
 			}
 			return treeNode;


### PR DESCRIPTION
Add hygiene check for ensuring that calls to the localize function have the message param in double quotes. Currently only enabled for files under src/sql - but I plan on expanding this to the extensions folders as well. 

The regex likely isn't perfect so may have missed some but this is a good start and should catch the majority of these so we can stop needing to call them out in PRs. 