### PR TITLE
Reinstall pip during python install on Windows to update shebangs in exe files.

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -425,17 +425,19 @@ export class JupyterServerInstallation {
 	}
 
 	private async installOfflinePipDependencies(): Promise<void> {
-		let installJupyterCommand: string;
-		if (process.platform === constants.winPlatform) {
-			let cmdOptions = this._usingExistingPython ? '--user' : '';
-			let requirements = path.join(this._pythonPackageDir, 'requirements.txt');
-			installJupyterCommand = `"${this._pythonExecutable}" -m pip install ${cmdOptions} --no-index -r "${requirements}" --find-links "${this._pythonPackageDir}" --no-warn-script-location`;
-		}
-
-		if (installJupyterCommand) {
+		// Skip this step if using existing python, since this is for our provided package
+		if (!this._usingExistingPython && process.platform === constants.winPlatform) {
 			this.outputChannel.show(true);
 			this.outputChannel.appendLine(localize('msgInstallStart', "Installing required packages to run Notebooks..."));
+
+			let requirements = path.join(this._pythonPackageDir, 'requirements.txt');
+			let installJupyterCommand = `"${this._pythonExecutable}" -m pip install --no-index -r "${requirements}" --find-links "${this._pythonPackageDir}" --no-warn-script-location`;
 			await this.executeStreamedCommand(installJupyterCommand);
+
+			// Force reinstall pip to update shebangs in pip*.exe files
+			installJupyterCommand = `"${this._pythonExecutable}" -m pip install --force-reinstall --no-index pip --find-links "${this._pythonPackageDir}" --no-warn-script-location`;
+			await this.executeStreamedCommand(installJupyterCommand);
+
 			this.outputChannel.appendLine(localize('msgJupyterInstallDone', "... Jupyter installation complete."));
 		} else {
 			return Promise.resolve();


### PR DESCRIPTION
In our provided Windows Python package, the shebangs (lines with #!) in the pip*.exe files are set to a local path picked up when the package was originally built. This is because Windows has no preinstalled version of Python, so we can't use the same portable shebangs that Mac/Linux generally use e.g. "#! /usr/bin/env python3". Thus the Windows shebangs have to updated after the install, since we would have no way of knowing the python install location ahead of time. Otherwise the executable files can't be run by themselves, and have to be run like "python -m pip".

This change reinstalls pip at the end of the installation, so that we pick up the absolute path to the python exe in our package.

Fun fact, apparently the shebang path in the pip*.exe files is currently "#!c:\users\corivera\downloads\0.0.1\python.exe", which causes a lot of confusion in the error message when trying to run pip.exe directly.