### PR TITLE
Remove hyperlinks from non-management BDC endpoints

### DIFF
--- a/extensions/mssql/src/dashboard/serviceEndpoints.ts
+++ b/extensions/mssql/src/dashboard/serviceEndpoints.ts
@@ -15,7 +15,6 @@ export function registerServiceEndpoints(context: vscode.ExtensionContext): void
 
 		const endpointsArray: Array<Utils.IEndpoint> = Object.assign([], view.serverInfo.options['clusterEndpoints']);
 		endpointsArray.forEach(endpointInfo => {
-			endpointInfo.isHyperlink = true;
 			endpointInfo.hyperlink = 'https://' + endpointInfo.ipAddress + ':' + endpointInfo.port;
 
 		});


### PR DESCRIPTION
Fixes #6401

Having the text be a hyperlink isn't really useful as there's no UI to interact with. Users can use the copy button to copy the endpoint info for using elsewhere (such as BDC tree-view)

![image](https://user-images.githubusercontent.com/28519865/61892456-b0857180-aec0-11e9-9ab9-8f4cb16c823c.png)
