### PR TITLE
Add server-level actions to master SQL node in BDC view

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/tree/controllerTreeNode.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/tree/controllerTreeNode.ts
@@ -333,7 +333,7 @@ export class SqlMasterNode extends ControllerTreeNode {
 		let item = super.getTreeItem();
 		let connectionProfile: azdata.IConnectionProfile = {
 			id: this.id,
-			connectionName: this.id,
+			connectionName: '',
 			serverName: this._endPointAddress,
 			databaseName: '',
 			userName: this._username,
@@ -346,7 +346,11 @@ export class SqlMasterNode extends ControllerTreeNode {
 			saveProfile: false,
 			options: {}
 		};
-		return Object.assign(item, { payload: connectionProfile, childProvider: 'MSSQL' });
+		return Object.assign(item, {
+			payload: connectionProfile,
+			childProvider: 'MSSQL',
+			type: 'Server'
+		});
 	}
 
 	public get role() {


### PR DESCRIPTION
Adds the contributed server-level actions to the BDC SQL Master node. 

Removed the connection name value since it isn't used for anything as far as I know and was causing the dashboard to have a title which included the random GUID that we generate for each node. Leaving it blank makes the dashboard generate the title from the connection info itself (this is what we normally do elsewhere such as OE)

![image](https://user-images.githubusercontent.com/28519865/61897202-7077bc00-aecb-11e9-9fd6-fb673de70f2b.png)

Fixes #6402
