### PR TITLE
use database drop down via keybinding

### DIFF
--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -289,6 +289,11 @@ export class Dropdown extends Disposable {
 		this._input.focus();
 	}
 
+	public focusAndOpen() {
+		this._input.focus();
+		this._showList();
+	}
+
 	public blur() {
 		this._input.blur();
 		this.contextViewService.hideContextView();

--- a/src/sql/workbench/parts/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/parts/query/browser/keyboardQueryActions.ts
@@ -180,6 +180,32 @@ export class CancelQueryKeyboardAction extends Action {
 }
 
 /**
+ * Change queryeditor database
+ */
+export class ListDatabasesKeyboardAction extends Action {
+	public static ID = 'listDatabasesKeyboardAction';
+	public static LABEL = nls.localize('listDatabasesKeyboardAction', 'Change Database');
+
+	constructor(
+		id: string,
+		label: string,
+		@IConnectionManagementService private connectionManagementService: IConnectionManagementService,
+		@IEditorService private editorService: IEditorService
+	) {
+		super(id, label);
+		this.enabled = true;
+	}
+
+	public run(): Promise<void> {
+		const editor = this.editorService.activeControl;
+		if (editor instanceof QueryEditor) {
+			editor.openDatabaseList();
+		}
+		return Promise.resolve(null);
+	}
+}
+
+/**
  * Refresh the IntelliSense cache
  */
 export class RefreshIntellisenseKeyboardAction extends Action {

--- a/src/sql/workbench/parts/query/browser/query.contribution.ts
+++ b/src/sql/workbench/parts/query/browser/query.contribution.ts
@@ -23,7 +23,7 @@ import * as queryContext from 'sql/workbench/parts/query/common/queryContext';
 import { QueryInput } from 'sql/workbench/parts/query/common/queryInput';
 import {
 	RunQueryKeyboardAction, RunCurrentQueryKeyboardAction, CancelQueryKeyboardAction, RefreshIntellisenseKeyboardAction, ToggleQueryResultsKeyboardAction,
-	RunQueryShortcutAction, RunCurrentQueryWithActualPlanKeyboardAction, FocusOnCurrentQueryKeyboardAction, ParseSyntaxAction
+	RunQueryShortcutAction, RunCurrentQueryWithActualPlanKeyboardAction, FocusOnCurrentQueryKeyboardAction, ParseSyntaxAction, ListDatabasesKeyboardAction
 } from 'sql/workbench/parts/query/browser/keyboardQueryActions';
 import * as gridActions from 'sql/workbench/parts/grid/views/gridActions';
 import * as gridCommands from 'sql/workbench/parts/grid/views/gridCommands';
@@ -121,6 +121,16 @@ actionRegistry.registerWorkbenchAction(
 		RefreshIntellisenseKeyboardAction.LABEL
 	),
 	RefreshIntellisenseKeyboardAction.LABEL
+);
+
+actionRegistry.registerWorkbenchAction(
+	new SyncActionDescriptor(
+		ListDatabasesKeyboardAction,
+		ListDatabasesKeyboardAction.ID,
+		ListDatabasesKeyboardAction.LABEL,
+		{ primary: KeyMod.CtrlCmd | KeyCode.KEY_U },
+	),
+	ListDatabasesKeyboardAction.LABEL
 );
 
 actionRegistry.registerWorkbenchAction(

--- a/src/sql/workbench/parts/query/browser/queryActions.ts
+++ b/src/sql/workbench/parts/query/browser/queryActions.ts
@@ -494,6 +494,15 @@ export class ListDatabasesActionItem implements IActionViewItem {
 		}
 	}
 
+	public focusAndOpen(): void {
+		if (this._isInAccessibilityMode) {
+			this._databaseSelectBox.focus();
+		} else {
+			this._dropdown.focusAndOpen();
+		}
+
+	}
+
 	public blur(): void {
 		if (this._isInAccessibilityMode) {
 			this._databaseSelectBox.blur();

--- a/src/sql/workbench/parts/query/browser/queryEditor.ts
+++ b/src/sql/workbench/parts/query/browser/queryEditor.ts
@@ -597,6 +597,13 @@ export class QueryEditor extends BaseEditor {
 		this._cancelQueryAction.run();
 	}
 
+	/**
+	 * Calls the focusAndOpen method of this editor's list databases action item
+	 */
+	public openDatabaseList(): void {
+		this._listDatabasesActionItem.focusAndOpen();
+	}
+
 	public registerQueryModelViewTab(title: string, componentId: string): void {
 		this.resultsEditor.registerQueryModelViewTab(title, componentId);
 	}


### PR DESCRIPTION
Relative to issue: https://github.com/microsoft/azuredatastudio/issues/1128

Covers the use database dropdown with keyboard action and default keybinding (ctrl+U)