### PR TITLE
Add Manage action to BDC controller node

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -219,13 +219,6 @@
 				"Launch azuredatastudio",
 				"Attach to Extension Host"
 			]
-		},
-		{
-			"name": "Attach Main and Extension Host",
-			"configurations": [
-				"Attach to azuredatastudio",
-				"Attach to Extension Host"
-			]
 		}
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -219,6 +219,13 @@
 				"Launch azuredatastudio",
 				"Attach to Extension Host"
 			]
+		},
+		{
+			"name": "Attach Main and Extension Host",
+			"configurations": [
+				"Attach to azuredatastudio",
+				"Attach to Extension Host"
+			]
 		}
 	]
 }

--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -39,6 +39,10 @@
 					"when": "false"
 				},
 				{
+					"command": "bigDataClusters.command.manage",
+					"when": "false"
+				},
+				{
 					"command": "bigDataClusters.command.refreshController",
 					"when": "false"
 				}
@@ -52,14 +56,19 @@
 			],
 			"view/item/context": [
 				{
-					"command": "bigDataClusters.command.deleteController",
+					"command": "bigDataClusters.command.manage",
 					"when": "viewItem == bigDataClusters.itemType.controllerNode",
 					"group": "navigation@1"
 				},
 				{
+					"command": "bigDataClusters.command.deleteController",
+					"when": "viewItem == bigDataClusters.itemType.controllerNode",
+					"group": "navigation@2"
+				},
+				{
 					"command": "bigDataClusters.command.refreshController",
 					"when": "viewItem == bigDataClusters.itemType.controllerNode",
-					"group": "navigation@1"
+					"group": "navigation@3"
 				}
 			]
 		},
@@ -83,8 +92,11 @@
 			},
 			{
 				"command": "bigDataClusters.command.deleteController",
-				"title": "%command.deleteController.title%",
-				"when": "viewItem == bigDataClusters.itemType.controllerNode"
+				"title": "%command.deleteController.title%"
+			},
+			{
+				"command": "bigDataClusters.command.manage",
+				"title": "%command.manage.title%"
 			},
 			{
 				"command": "bigDataClusters.command.refreshController",

--- a/extensions/big-data-cluster/package.nls.json
+++ b/extensions/big-data-cluster/package.nls.json
@@ -3,5 +3,6 @@
 	"text.sqlServerBigDataClusters": "SQL Server big data clusters",
 	"command.addController.title": "Connect to Controller",
 	"command.deleteController.title" : "Delete",
-	"command.refreshController.title" : "Refresh"
+	"command.refreshController.title" : "Refresh",
+	"command.manage.title" : "Manage"
 }

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/addControllerDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/addControllerDialog.ts
@@ -33,15 +33,8 @@ export class AddControllerDialogModel {
 	}
 
 	public async onComplete(clusterName: string, url: string, username: string, password: string, rememberPassword: boolean): Promise<void> {
-		let response = await getEndPoints(clusterName, url, username, password, true);
-		if (response && response.endPoints) {
-			let masterInstance: IEndPoint = undefined;
-			if (response.endPoints) {
-				masterInstance = response.endPoints.find(e => e.name && e.name === 'sql-server-master');
-			}
-			this.treeDataProvider.addController(clusterName, url, username, password, rememberPassword, masterInstance);
-			await this.treeDataProvider.saveControllers();
-		}
+		this.treeDataProvider.addController(clusterName, url, username, password, rememberPassword);
+		await this.treeDataProvider.saveControllers();
 	}
 
 	public async onError(error: IControllerError): Promise<void> {

--- a/extensions/big-data-cluster/src/bigDataCluster/tree/controllerTreeDataProvider.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/tree/controllerTreeDataProvider.ts
@@ -62,11 +62,10 @@ export class ControllerTreeDataProvider implements vscode.TreeDataProvider<TreeN
 		url: string,
 		username: string,
 		password: string,
-		rememberPassword: boolean,
-		masterInstance?: IEndPoint
+		rememberPassword: boolean
 	): void {
 		this.removeNonControllerNodes();
-		this.root.addControllerNode(clusterName, url, username, password, rememberPassword, masterInstance);
+		this.root.addControllerNode(clusterName, url, username, password, rememberPassword);
 		this.notifyNodeChanged();
 	}
 

--- a/extensions/big-data-cluster/src/bigDataCluster/tree/controllerTreeDataProvider.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/tree/controllerTreeDataProvider.ts
@@ -11,7 +11,6 @@ import { TreeNode } from './treeNode';
 import { IControllerTreeChangeHandler } from './controllerTreeChangeHandler';
 import { AddControllerNode } from './addControllerNode';
 import { ControllerRootNode, ControllerNode } from './controllerTreeNode';
-import { IEndPoint } from '../controller/clusterControllerApi';
 import { showErrorMessage } from '../utils';
 import { LoadingControllerNode } from './loadingControllerNode';
 

--- a/extensions/big-data-cluster/src/bigDataCluster/tree/controllerTreeNode.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/tree/controllerTreeNode.ts
@@ -11,8 +11,7 @@ import * as nls from 'vscode-nls';
 import { IControllerTreeChangeHandler } from './controllerTreeChangeHandler';
 import { TreeNode } from './treeNode';
 import { IconPath, BdcItemType } from '../constants';
-import { IEndPoint, IControllerError, getEndPoints } from '../controller/clusterControllerApi';
-import { showErrorMessage } from '../utils';
+import { getEndPoints } from '../controller/clusterControllerApi';
 
 const localize = nls.loadMessageBundle();
 
@@ -177,6 +176,10 @@ export class ControllerNode extends ControllerTreeNode {
 			}
 			reject(new Error(localize('noEndpointsError', "Did not receive valid response when fetching endpoints.")));
 		});
+
+		this._sqlMasterNodePromise.then((sqlMasterNode) => {
+			this._endPointFolderNode.addChild(sqlMasterNode);
+		});
 	}
 
 	public async getChildren(): Promise<ControllerTreeNode[]> {
@@ -191,14 +194,7 @@ export class ControllerNode extends ControllerTreeNode {
 
 		this.addChild(this._endPointFolderNode);
 
-		try {
-			const masterNode = await this.getSqlMasterNode();
-			this._endPointFolderNode.addChild(masterNode);
-			return this.children as ControllerTreeNode[];
-		} catch (error) {
-			showErrorMessage(error);
-			return this.children as ControllerTreeNode[];
-		}
+		return this.children as ControllerTreeNode[];
 	}
 
 	private static toIpAndPort(url: string): string {

--- a/extensions/big-data-cluster/src/extension.ts
+++ b/extensions/big-data-cluster/src/extension.ts
@@ -56,7 +56,6 @@ function registerCommands(treeDataProvider: ControllerTreeDataProvider): void {
 
 	vscode.commands.registerCommand(ManageCommand, async (node: TreeNode) => {
 		if (node instanceof ControllerNode) {
-			// await node.getChildren();
 			const sqlMasterNode: SqlMasterNode = await node.getSqlMasterNode();
 
 			const connectionProfile: azdata.IConnectionProfile = {

--- a/extensions/big-data-cluster/src/extension.ts
+++ b/extensions/big-data-cluster/src/extension.ts
@@ -51,7 +51,7 @@ function registerCommands(treeDataProvider: ControllerTreeDataProvider): void {
 		if (!node) {
 			return;
 		}
-		treeDataProvider.notifyNodeChanged(node);
+		node.refresh();
 	});
 
 	vscode.commands.registerCommand(ManageCommand, async (node: TreeNode) => {

--- a/extensions/big-data-cluster/src/extension.ts
+++ b/extensions/big-data-cluster/src/extension.ts
@@ -55,9 +55,6 @@ function registerCommands(treeDataProvider: ControllerTreeDataProvider): void {
 	});
 
 	vscode.commands.registerCommand(ManageCommand, async (node: TreeNode) => {
-		if (!node) {
-			return;
-		}
 		if (node instanceof ControllerNode) {
 			// await node.getChildren();
 			const sqlMasterNode: SqlMasterNode = await node.getSqlMasterNode();


### PR DESCRIPTION
Closes #6403

This adds the **Manage** action to the context menu for BDC controllers - which will open the Dashboard for the SQL master instance. 

Currently this just opens the dashboard to the normal default SQL tab - #6519 has been created to address this.

Along the way did some refactoring of how the nodes to clean up how the nodes are added/created. As a perf improvement made it so that we only query the endpoint data once when we create the controller node - although I may need to change this if it's expected that the master SQL instance can change after the cluster is created. 