### PR TITLE
Multiple individual cell selection

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
@@ -38,6 +38,7 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 		this.grid = grid;
 		this._handler.subscribe(this.grid.onActiveCellChanged, (e: Event, args: Slick.OnActiveCellChangedEventArgs<T>) => this.handleActiveCellChange(e, args));
 		this._handler.subscribe(this.grid.onKeyDown, (e: KeyboardEvent) => this.handleKeyDown(e));
+		this._handler.subscribe(this.grid.onClick, (e: MouseEvent, args: Slick.OnClickEventArgs<T>) => this.handleCtrlClick(e, args));
 		this._handler.subscribe(this.grid.onHeaderClick, (e: MouseEvent, args: Slick.OnHeaderClickEventArgs<T>) => this.handleHeaderClick(e, args));
 		this.grid.registerPlugin(this.selector);
 		this._handler.subscribe(this.selector.onCellRangeSelected, (e: Event, range: Slick.Range) => this.handleCellRangeSelected(e, range));
@@ -116,6 +117,21 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 				this.setSelectedRanges(ranges);
 			}
 		}
+	}
+
+	private handleCtrlClick(e: MouseEvent, args: Slick.OnClickEventArgs<T>) {
+		if (!e.ctrlKey) {
+			return;
+		}
+		let ranges: Array<Slick.Range>;
+
+		ranges = this.getSelectedRanges();
+
+		ranges.push(new Slick.Range(args.row, args.cell));
+		this.grid.setActiveCell(args.row, args.cell);
+		this.setSelectedRanges(ranges);
+		e.preventDefault();
+		e.stopImmediatePropagation();
 	}
 
 	private handleKeyDown(e: KeyboardEvent) {

--- a/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
@@ -123,13 +123,31 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 		if (!e.ctrlKey) {
 			return;
 		}
+		const handleRangeInput = (ranges: Array<Slick.Range>, current: Slick.Range) => {
+			let removed: boolean = false;
+			ranges = ranges.filter((r) => {
+				if (r.fromCell === current.fromCell && r.fromRow === current.fromRow && !removed) {
+					removed = true;
+					return false;
+				}
+				return true;
+			});
+
+			if (!removed) {
+				ranges.push(current);
+			}
+
+			return ranges;
+		};
+
 		let ranges: Array<Slick.Range>;
 
 		ranges = this.getSelectedRanges();
+		ranges = handleRangeInput(ranges, new Slick.Range(args.row, args.cell));
 
-		ranges.push(new Slick.Range(args.row, args.cell));
 		this.grid.setActiveCell(args.row, args.cell);
 		this.setSelectedRanges(ranges);
+
 		e.preventDefault();
 		e.stopImmediatePropagation();
 	}

--- a/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
@@ -107,7 +107,7 @@ export class CellSelectionModel<T> implements Slick.SelectionModel<T, Array<Slic
 			let columnIndex = this.grid.getColumnIndex(args.column.id!);
 			if (this.grid.canCellBeSelected(0, columnIndex)) {
 				let ranges: Array<Slick.Range>;
-				if (e.shiftKey) {
+				if (e.shiftKey || e.ctrlKey) {
 					ranges = this.getSelectedRanges();
 					ranges.push(new Slick.Range(0, columnIndex, this.grid.getDataLength() - 1, columnIndex));
 				} else {


### PR DESCRIPTION
Partially handles #2727 

With this and #6509 the copy mechanism performs as a client would expect.

You can ctrl + click specific cells to select them individually.

What this doesn't solve:

Scenario:

- Select cell from column A
- Select cell from column B
- Select cell from column A

When pasting, the two cells from column A will be treated as different cells.

Future work: Handle all the edge cases for selection.