### PR TITLE
Notebooks: Multiline cell execution fix

### DIFF
--- a/src/sql/workbench/parts/notebook/common/models/cell.ts
+++ b/src/sql/workbench/parts/notebook/common/models/cell.ts
@@ -267,6 +267,8 @@ export class CellModel implements ICellModel {
 				}
 				let content = this.source;
 				if (content) {
+					// requestExecute expects a string for the code parameter
+					content = Array.isArray(content) ? content.join('') : content;
 					let future = await kernel.requestExecute({
 						code: content,
 						stop_on_error: true


### PR DESCRIPTION
Notebooks: Multiline cell execution fix. Fixes regression caused by multiline saving PR.