### PR TITLE
Add result grid selection extensibility API

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -4000,6 +4000,18 @@ declare module 'azdata' {
 			// tab content is build using the modelview UI builder APIs
 			// probably should rename DialogTab class since it is useful outside dialogs
 			createQueryTab(tab: window.DialogTab): void;
+
+			readonly selections: Thenable<GridSelection[]>;
+		}
+
+		export interface GridSelection {
+			startRow: number;
+
+			startColumn: number;
+
+			endRow: number;
+
+			endColumn: number;
 		}
 
 		/**

--- a/src/sql/workbench/api/common/extHostQueryEditor.ts
+++ b/src/sql/workbench/api/common/extHostQueryEditor.ts
@@ -26,6 +26,10 @@ class ExtHostQueryDocument implements azdata.queryeditor.QueryDocument {
 	public createQueryTab(tab: azdata.window.DialogTab): void {
 		this._proxy.$createQueryTab(this.uri, tab.title, tab.content);
 	}
+
+	public get selections(): Thenable<azdata.queryeditor.GridSelection[]> {
+		return this._proxy.$getQueryGridSelections(this.uri);
+	}
 }
 
 export class ExtHostQueryEditor implements ExtHostQueryEditorShape {

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -180,6 +180,8 @@ export abstract class ExtHostDataProtocolShape {
 	 */
 	$setQueryExecutionOptions(handle: number, ownerUri: string, options: azdata.QueryExecutionOptions): Thenable<void> { throw ni(); }
 
+	$getQueryGridSelections(fileUri: string): Thenable<azdata.queryeditor.GridSelection[]> { throw ni(); }
+
 	/**
 	 * Disposes the cached information regarding a query
 	 */
@@ -819,6 +821,7 @@ export interface MainThreadQueryEditorShape extends IDisposable {
 	$runQuery(fileUri: string): void;
 	$createQueryTab(fileUri: string, title: string, content: string): void;
 	$setQueryExecutionOptions(fileUri: string, options: azdata.QueryExecutionOptions): Thenable<void>;
+	$getQueryGridSelections(fileUri: string): Thenable<azdata.queryeditor.GridSelection[]>;
 	$registerQueryInfoListener(handle: number, providerId: string): void;
 }
 


### PR DESCRIPTION
This is the change from our mob programming session 1.  Below is an API usage example.

```TypeScript
 	// usage example
	azdata.queryeditor.getQueryDocument(uri).then(document => {
		document.selections.then(selection => {
			console.log(selection.toString());
		});
	});

```