### PR TITLE
Move CMS saved servers to be stored in memento instead of config

### DIFF
--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -68,9 +68,6 @@
 			"type": "object",
 			"title": "%text.sqlServerBigDataClusters%",
 			"properties": {
-				"clusterControllers.controllers": {
-					"type": "array"
-				},
 				"bigDataClusters.enabled": {
 					"type": "boolean",
 					"default": false,

--- a/extensions/cms/package.json
+++ b/extensions/cms/package.json
@@ -2,7 +2,7 @@
 	"name": "cms",
 	"displayName": "%cms.displayName%",
 	"description": "%cms.description%",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"publisher": "Microsoft",
 	"preview": true,
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",

--- a/extensions/cms/src/apiWrapper.ts
+++ b/extensions/cms/src/apiWrapper.ts
@@ -88,19 +88,6 @@ export class ApiWrapper {
 	}
 
 	/**
-	 * Get the configuration for a extensionName
-	 * @param extensionName The string name of the extension to get the configuration for
-	 * @param resource The optional URI, as a URI object or a string, to use to get resource-scoped configurations
-	 */
-	public getConfiguration(): vscode.WorkspaceConfiguration {
-		return vscode.workspace.getConfiguration('centralManagementServers');
-	}
-
-	public async setConfiguration(value: any): Promise<void> {
-		await vscode.workspace.getConfiguration('centralManagementServers').update('servers', value, true);
-	}
-
-	/**
 	 * Parse uri
 	 */
 	public parseUri(uri: string): vscode.Uri {

--- a/extensions/cms/src/appContext.ts
+++ b/extensions/cms/src/appContext.ts
@@ -18,8 +18,5 @@ export class AppContext {
 		public readonly extensionContext: vscode.ExtensionContext,
 		public readonly apiWrapper: ApiWrapper,
 		public readonly cmsUtils: CmsUtils
-	) {
-		this.apiWrapper = apiWrapper || new ApiWrapper();
-		this.cmsUtils = cmsUtils || new CmsUtils();
-	}
+	) { }
 }

--- a/extensions/cms/src/cmsResource/tree/treeProvider.ts
+++ b/extensions/cms/src/cmsResource/tree/treeProvider.ts
@@ -36,10 +36,9 @@ export class CmsResourceTreeProvider implements TreeDataProvider<TreeNode>, ICms
 			try {
 				// Call to collect all locally saved CMS servers
 				// to determine whether the system has been initialized.
-				let cmsConfig = this._appContext.cmsUtils.getConfiguration();
-				let cachedServers = cmsConfig.servers ? cmsConfig.servers : [];
+				const cachedServers = this._appContext.cmsUtils.getSavedServers();
 				if (cachedServers && cachedServers.length > 0) {
-					let servers = [];
+					const servers = [];
 					cachedServers.forEach(async (server) => {
 						servers.push(new CmsResourceTreeNode(
 							server.name,

--- a/extensions/cms/src/cmsUtils.ts
+++ b/extensions/cms/src/cmsUtils.ts
@@ -32,7 +32,9 @@ export interface CreateCmsResult {
  */
 export class CmsUtils {
 
-	constructor(private _memento: vscode.Memento) { }
+	constructor(private _memento: vscode.Memento) {
+		this._registeredCmsServers = this.getSavedServers();
+	}
 
 	private _credentialProvider: azdata.CredentialProvider;
 	private _cmsService: mssql.CmsService;

--- a/extensions/cms/src/cmsUtils.ts
+++ b/extensions/cms/src/cmsUtils.ts
@@ -32,6 +32,8 @@ export interface CreateCmsResult {
  */
 export class CmsUtils {
 
+	constructor(private _memento: vscode.Memento) { }
+
 	private _credentialProvider: azdata.CredentialProvider;
 	private _cmsService: mssql.CmsService;
 	private _registeredCmsServers: ICmsResourceNodeInfo[] = [];
@@ -52,17 +54,12 @@ export class CmsUtils {
 		return vscode.window.showErrorMessage(message, ...items);
 	}
 
-	/**
-	 * Get the configuration for a extensionName
-	 * @param extensionName The string name of the extension to get the configuration for
-	 * @param resource The optional URI, as a URI object or a string, to use to get resource-scoped configurations
-	 */
-	public getConfiguration(): vscode.WorkspaceConfiguration {
-		return vscode.workspace.getConfiguration('centralManagementServers');
+	public getSavedServers(): ICmsResourceNodeInfo[] {
+		return this._memento.get('centralManagementServers') || [];
 	}
 
-	public async setConfiguration(value: any): Promise<void> {
-		await vscode.workspace.getConfiguration('centralManagementServers').update('servers', value, true);
+	public async saveServers(servers: ICmsResourceNodeInfo[]): Promise<void> {
+		await this._memento.update('centralManagementServers', servers);
 	}
 
 	// Connection APIs
@@ -128,12 +125,12 @@ export class CmsUtils {
 	}
 
 	public async deleteCmsServer(cmsServerName: string, connection: azdata.connection.Connection): Promise<void> {
-		let config = this.getConfiguration();
-		if (config && config.servers) {
-			let newServers = config.servers.filter((cachedServer) => {
+		const servers: ICmsResourceNodeInfo[] = this._memento.get('servers');
+		if (servers) {
+			const newServers: ICmsResourceNodeInfo[] = servers.filter((cachedServer) => {
 				return cachedServer.name !== cmsServerName;
 			});
-			await this.setConfiguration(newServers);
+			await this.saveServers(newServers);
 			this._registeredCmsServers = this._registeredCmsServers.filter((cachedServer) => {
 				return cachedServer.name !== cmsServerName;
 			});
@@ -164,7 +161,7 @@ export class CmsUtils {
 			// don't save password in config
 			server.connection.options.password = '';
 		});
-		await this.setConfiguration(toSaveCmsServers);
+		await this.saveServers(toSaveCmsServers);
 	}
 
 	public async addRegisteredServer(relativePath: string, ownerUri: string,

--- a/extensions/cms/src/extension.ts
+++ b/extensions/cms/src/extension.ts
@@ -18,7 +18,7 @@ let controllers: ControllerBase[] = [];
 // your extension is activated the very first time the command is executed
 export function activate(extensionContext: vscode.ExtensionContext) {
 	const apiWrapper = new ApiWrapper();
-	const cmsUtils = new CmsUtils();
+	const cmsUtils = new CmsUtils(extensionContext.globalState);
 	let appContext = new AppContext(extensionContext, apiWrapper, cmsUtils);
 	let activations: Thenable<boolean>[] = [];
 

--- a/extensions/cms/src/extension.ts
+++ b/extensions/cms/src/extension.ts
@@ -11,16 +11,19 @@ import { AppContext } from './appContext';
 import ControllerBase from './controllers/controllerBase';
 import { ApiWrapper } from './apiWrapper';
 import { CmsUtils } from './cmsUtils';
+import { ICmsResourceNodeInfo } from './cmsResource/tree/baseTreeNodes';
 
 let controllers: ControllerBase[] = [];
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
-export function activate(extensionContext: vscode.ExtensionContext) {
+export async function activate(extensionContext: vscode.ExtensionContext): Promise<void> {
 	const apiWrapper = new ApiWrapper();
 	const cmsUtils = new CmsUtils(extensionContext.globalState);
-	let appContext = new AppContext(extensionContext, apiWrapper, cmsUtils);
-	let activations: Thenable<boolean>[] = [];
+	const appContext = new AppContext(extensionContext, apiWrapper, cmsUtils);
+	const activations: Thenable<boolean>[] = [];
+
+	await portSavedConfigServers(appContext);
 
 	const cmsResourceController = new CmsResourceController(appContext);
 	controllers.push(cmsResourceController);
@@ -29,8 +32,25 @@ export function activate(extensionContext: vscode.ExtensionContext) {
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {
+export function deactivate(): void {
 	for (let controller of controllers) {
 		controller.deactivate();
+	}
+}
+
+/**
+ * Helper method to port over servers that were previously saved in the configuration (in versions <= 0.3.0 of the extension)
+ * @param appContext The context to use to store the new saved servers
+ */
+async function portSavedConfigServers(appContext: AppContext): Promise<void> {
+	const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('centralManagementServers');
+	if (config) {
+		const oldServers = config.get<ICmsResourceNodeInfo[]>('servers');
+		if (oldServers) {
+			oldServers.forEach(s => appContext.cmsUtils.cacheRegisteredCmsServer(s.name, s.description, s.ownerUri, s.connection));
+			// Now delete the config value since we don't need it anymore
+			await config.update('servers', undefined, true);
+		}
+
 	}
 }


### PR DESCRIPTION
This way we aren't cluttering up the config more than we have to.

On extension startup it will see if any servers exist in the config and if so store them into the memento storage so that users don't lose existing saved servers. 

Also removed unused config from BDC extension - the servers aren't stored in the config anymore so that setting isn't necessary. 