### PR TITLE
Fix Schema compare recompare after options reset not using correct options 

### DIFF
--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -2,7 +2,7 @@
 	"name": "schema-compare",
 	"displayName": "%displayName%",
 	"description": "%description%",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"publisher": "Microsoft",
 	"preview": true,
 	"engines": {

--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -448,6 +448,7 @@ export class SchemaCompareOptionsDialog {
 		if (this.optionsChanged) {
 			vscode.window.showWarningMessage(SchemaCompareOptionsDialog.OptionsChangedMessage, SchemaCompareOptionsDialog.YesButtonText, SchemaCompareOptionsDialog.NoButtonText).then((result) => {
 				if (result === SchemaCompareOptionsDialog.YesButtonText) {
+					this.schemaComparison.setDeploymentOptions(this.deploymentOptions);
 					this.schemaComparison.startCompare();
 				}
 			});

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -266,6 +266,10 @@ export class SchemaCompareMainWindow {
 		return this.deploymentOptions;
 	}
 
+	public setDeploymentOptions(deploymentOptions: azdata.DeploymentOptions): void {
+		this.deploymentOptions = deploymentOptions;
+	}
+
 	public async execute(): Promise<void> {
 		Telemetry.sendTelemetryEvent('SchemaComparisonStarted');
 		const service = await SchemaCompareMainWindow.getService(msSqlProvider);
@@ -649,7 +653,6 @@ export class SchemaCompareMainWindow {
 			// create fresh every time
 			this.schemaCompareOptionDialog = new SchemaCompareOptionsDialog(this.deploymentOptions, this);
 			await this.schemaCompareOptionDialog.openDialog();
-			this.deploymentOptions = this.schemaCompareOptionDialog.deploymentOptions;
 		});
 	}
 
@@ -915,7 +918,7 @@ export class SchemaCompareMainWindow {
 			}
 
 			this.updateSourceAndTarget();
-			this.deploymentOptions = result.deploymentOptions;
+			this.setDeploymentOptions(result.deploymentOptions);
 			this.scmpSourceExcludes = result.excludedSourceElements;
 			this.scmpTargetExcludes = result.excludedTargetElements;
 			this.sourceTargetSwitched = result.originalTargetName !== this.targetEndpointInfo.databaseName;
@@ -1014,7 +1017,7 @@ export class SchemaCompareMainWindow {
 		// Same as dacfx default options
 		const service = await SchemaCompareMainWindow.getService(msSqlProvider);
 		let result = await service.schemaCompareGetDefaultOptions();
-		this.deploymentOptions = result.defaultDeploymentOptions;
+		this.setDeploymentOptions(result.defaultDeploymentOptions);
 	}
 }
 


### PR DESCRIPTION
Recomparing from the notification after resetting options wasn't using the correct options because the compare was being started before the options were set to the new values. Fixes #6538.