### PR TITLE
Add support for cancelling BDC Add Controller request

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/addControllerDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/addControllerDialog.ts
@@ -5,7 +5,6 @@
 
 'use strict';
 
-import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
 import { IEndPoint, IControllerError, getEndPoints } from '../controller/clusterControllerApi';
@@ -16,6 +15,9 @@ import { showErrorMessage } from '../utils';
 const localize = nls.loadMessageBundle();
 
 export class AddControllerDialogModel {
+
+	private _canceled = false;
+
 	constructor(
 		public treeDataProvider: ControllerTreeDataProvider,
 		public node?: TreeNode,
@@ -33,15 +35,26 @@ export class AddControllerDialogModel {
 	}
 
 	public async onComplete(clusterName: string, url: string, username: string, password: string, rememberPassword: boolean): Promise<void> {
-		let response = await getEndPoints(clusterName, url, username, password, true);
-		if (response && response.endPoints) {
-			let masterInstance: IEndPoint = undefined;
-			if (response.endPoints) {
-				masterInstance = response.endPoints.find(e => e.name && e.name === 'sql-server-master');
+		try {
+			let response = await getEndPoints(clusterName, url, username, password, true);
+			if (response && response.endPoints) {
+				let masterInstance: IEndPoint = undefined;
+				if (response.endPoints) {
+					masterInstance = response.endPoints.find(e => e.name && e.name === 'sql-server-master');
+				}
+				if (this._canceled) {
+					return;
+				}
+				this.treeDataProvider.addController(clusterName, url, username, password, rememberPassword, masterInstance);
+				await this.treeDataProvider.saveControllers();
 			}
-			this.treeDataProvider.addController(clusterName, url, username, password, rememberPassword, masterInstance);
-			await this.treeDataProvider.saveControllers();
+		} catch (error) {
+			// Ignore the error if we cancelled the request since we can't stop the actual request from completing
+			if (!this._canceled) {
+				throw error;
+			}
 		}
+
 	}
 
 	public async onError(error: IControllerError): Promise<void> {
@@ -49,6 +62,7 @@ export class AddControllerDialogModel {
 	}
 
 	public async onCancel(): Promise<void> {
+		this._canceled = true;
 		if (this.node) {
 			this.node.refresh();
 		}

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/addControllerDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/addControllerDialog.ts
@@ -36,6 +36,7 @@ export class AddControllerDialogModel {
 
 	public async onComplete(clusterName: string, url: string, username: string, password: string, rememberPassword: boolean): Promise<void> {
 		try {
+			// We pre-fetch the endpoints here to verify that the information entered is correct (the user is able to connect)
 			let response = await getEndPoints(clusterName, url, username, password, true);
 			if (response && response.endPoints) {
 				let masterInstance: IEndPoint = undefined;


### PR DESCRIPTION
We can't actually stop the endpoints request from completing so just using a flag that will tell us whether to actually add the controller node after completion (and ignore any errors)

Fixes #6400