### PR TITLE
Fixed telemetry events for visualizer recommendation prompts

### DIFF
--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -50,6 +50,7 @@ export const ProfilerFilter = 'ProfilerFilter';
 export const JobsView = 'JobsViewOpened';
 export const JobHistoryView = 'JobHistoryViewOpened';
 export const JobStepsView = 'JobStepsViewOpened';
+export const ExtensionRecommendationDialog = 'ExtensionRecommendationDialog';
 
 // Actions
 export const RunAgentJob = 'RunAgentJob';
@@ -59,6 +60,7 @@ export const DeleteAgentJobStep = 'DeleteAgentJobStep';
 export const DeleteAgentAlert = 'DeleteAgentAlert';
 export const DeleteAgentOperator = 'DeleteAgentOperator';
 export const DeleteAgentProxy = 'DeleteAgentProxy';
+export const Click = 'Click';
 
 // Notebook Events:
 export const NotebookMarkdownRendered = 'NotebookMarkdownRendered';

--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -51,6 +51,7 @@ export const JobsView = 'JobsViewOpened';
 export const JobHistoryView = 'JobHistoryViewOpened';
 export const JobStepsView = 'JobStepsViewOpened';
 export const ExtensionRecommendationDialog = 'ExtensionRecommendationDialog';
+export const ResultsPanel = 'ResultsPanel';
 
 // Actions
 export const RunAgentJob = 'RunAgentJob';

--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -50,8 +50,6 @@ export const ProfilerFilter = 'ProfilerFilter';
 export const JobsView = 'JobsViewOpened';
 export const JobHistoryView = 'JobHistoryViewOpened';
 export const JobStepsView = 'JobStepsViewOpened';
-export const ExtensionRecommendationDialog = 'ExtensionRecommendationDialog';
-export const ResultsPanel = 'ResultsPanel';
 
 // Actions
 export const RunAgentJob = 'RunAgentJob';
@@ -61,11 +59,16 @@ export const DeleteAgentJobStep = 'DeleteAgentJobStep';
 export const DeleteAgentAlert = 'DeleteAgentAlert';
 export const DeleteAgentOperator = 'DeleteAgentOperator';
 export const DeleteAgentProxy = 'DeleteAgentProxy';
-export const Click = 'Click';
 
 // Notebook Events:
 export const NotebookMarkdownRendered = 'NotebookMarkdownRendered';
 
 export enum TelemetryView {
-	Shell = 'Shell'
+	Shell = 'Shell',
+	ExtensionRecommendationDialog = 'ExtensionRecommendationDialog',
+	ResultsPanel = 'ResultsPanel'
+}
+
+export enum TelemetryAction {
+	Click = 'Click'
 }

--- a/src/sql/workbench/parts/query/browser/actions.ts
+++ b/src/sql/workbench/parts/query/browser/actions.ts
@@ -235,8 +235,8 @@ export class VisualizerDataAction extends Action {
 
 	public run(context: IGridActionContext): Promise<boolean> {
 		this.adsTelemetryService.sendActionEvent(
-			TelemetryKeys.ResultsPanel,
-			TelemetryKeys.Click,
+			TelemetryKeys.TelemetryView.ResultsPanel,
+			TelemetryKeys.TelemetryAction.Click,
 			'VisualizerButton',
 			'VisualizerDataAction'
 		);

--- a/src/sql/workbench/parts/query/browser/actions.ts
+++ b/src/sql/workbench/parts/query/browser/actions.ts
@@ -21,6 +21,8 @@ import QueryRunner from 'sql/platform/query/common/queryRunner';
 import product from 'vs/platform/product/node/product';
 import { GridTableState } from 'sql/workbench/parts/query/common/gridPanelState';
 import * as Constants from 'sql/workbench/contrib/extensions/constants';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/telemetry';
+import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 
 export interface IGridActionContext {
 	gridDataProvider: IGridDataProvider;
@@ -226,13 +228,18 @@ export class VisualizerDataAction extends Action {
 
 	constructor(
 		private runner: QueryRunner,
-		@IEditorService private editorService: IEditorService,
-
+		@IAdsTelemetryService private adsTelemetryService: IAdsTelemetryService
 	) {
 		super(VisualizerDataAction.ID, VisualizerDataAction.LABEL, VisualizerDataAction.ICON);
 	}
 
 	public run(context: IGridActionContext): Promise<boolean> {
+		this.adsTelemetryService.sendActionEvent(
+			TelemetryKeys.ResultsPanel,
+			TelemetryKeys.Click,
+			'VisualizerButton',
+			'VisualizerDataAction'
+		);
 		this.runner.notifyVisualizeRequested(context.batchId, context.resultId);
 		return Promise.resolve(true);
 	}

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionTipsService.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionTipsService.ts
@@ -50,6 +50,8 @@ import { extname } from 'vs/base/common/resources';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { IExeBasedExtensionTip } from 'vs/platform/product/common/product';
 import { timeout } from 'vs/base/common/async';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/telemetry';
+import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 
 const milliSecondsInADay = 1000 * 60 * 60 * 24;
 const choiceNever = localize('neverShowAgain', "Don't Show Again");
@@ -115,7 +117,8 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
 		@IExtensionsWorkbenchService private readonly extensionWorkbenchService: IExtensionsWorkbenchService,
 		@IExperimentService private readonly experimentService: IExperimentService,
-		@ITextFileService private readonly textFileService: ITextFileService
+		@ITextFileService private readonly textFileService: ITextFileService,
+		@IAdsTelemetryService private readonly adsTelemetryService: IAdsTelemetryService
 	) {
 		super();
 
@@ -1181,7 +1184,12 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 						[{
 							label: localize('installAll', "Install All"),
 							run: () => {
-								this.telemetryService.publicLog(scenarioType + 'Recommendations:popup', { userReaction: 'install' });
+								this.adsTelemetryService.sendActionEvent(
+									TelemetryKeys.ExtensionRecommendationDialog,
+									TelemetryKeys.Click,
+									'InstallButton',
+									'VisualizerExtensionNotificationService'
+								);
 								const installAllAction = this.instantiationService.createInstance(InstallRecommendedExtensionsByScenarioAction, scenarioType, recommendations);
 								installAllAction.run();
 								installAllAction.dispose();
@@ -1189,7 +1197,12 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 						}, {
 							label: localize('showRecommendations', "Show Recommendations"),
 							run: () => {
-								this.telemetryService.publicLog(scenarioType + 'Recommendations:popup', { userReaction: 'show' });
+								this.adsTelemetryService.sendActionEvent(
+									TelemetryKeys.ExtensionRecommendationDialog,
+									TelemetryKeys.Click,
+									'ShowRecommendationsButton',
+									'VisualizerExtensionNotificationService'
+								);
 								const showAction = this.instantiationService.createInstance(ShowRecommendedExtensionsByScenarioAction, scenarioType);
 								showAction.run();
 								showAction.dispose();
@@ -1199,7 +1212,12 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 							label: choiceNever,
 							isSecondary: true,
 							run: () => {
-								this.telemetryService.publicLog(scenarioType + 'Recommendations:popup', { userReaction: 'neverShowAgain' });
+								this.adsTelemetryService.sendActionEvent(
+									TelemetryKeys.ExtensionRecommendationDialog,
+									TelemetryKeys.Click,
+									'NeverShowAgainButton',
+									'VisualizerExtensionNotificationService'
+								);
 								this.storageService.store(storageKey, true, StorageScope.GLOBAL);
 								c(undefined);
 							}
@@ -1207,7 +1225,12 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 						{
 							sticky: true,
 							onCancel: () => {
-								this.telemetryService.publicLog(scenarioType + 'Recommendations:popup', { userReaction: 'cancelled' });
+								this.adsTelemetryService.sendActionEvent(
+									TelemetryKeys.ExtensionRecommendationDialog,
+									TelemetryKeys.Click,
+									'CancelButton',
+									'VisualizerExtensionNotificationService'
+								);
 								c(undefined);
 							}
 						}

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionTipsService.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionTipsService.ts
@@ -1170,6 +1170,7 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 		let localExtensions: ILocalExtension[];
 		const getRecommendationPromise = this.getRecommendedExtensionsByScenario(scenarioType).then(recs => { recommendations = recs; });
 		const getLocalExtensionPromise = this.extensionsService.getInstalled(ExtensionType.User).then(local => { localExtensions = local; });
+		const visualizerExtensionNotificationService = 'VisualizerExtensionNotificationService';
 
 		let recommendationMessage = localize('ExtensionsRecommended', "Azure Data Studio has extension recommendations.");
 		if (scenarioType === Constants.visualizerExtensions) {
@@ -1185,10 +1186,10 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 							label: localize('installAll', "Install All"),
 							run: () => {
 								this.adsTelemetryService.sendActionEvent(
-									TelemetryKeys.ExtensionRecommendationDialog,
-									TelemetryKeys.Click,
+									TelemetryKeys.TelemetryView.ExtensionRecommendationDialog,
+									TelemetryKeys.TelemetryAction.Click,
 									'InstallButton',
-									'VisualizerExtensionNotificationService'
+									visualizerExtensionNotificationService
 								);
 								const installAllAction = this.instantiationService.createInstance(InstallRecommendedExtensionsByScenarioAction, scenarioType, recommendations);
 								installAllAction.run();
@@ -1198,10 +1199,10 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 							label: localize('showRecommendations', "Show Recommendations"),
 							run: () => {
 								this.adsTelemetryService.sendActionEvent(
-									TelemetryKeys.ExtensionRecommendationDialog,
-									TelemetryKeys.Click,
+									TelemetryKeys.TelemetryView.ExtensionRecommendationDialog,
+									TelemetryKeys.TelemetryAction.Click,
 									'ShowRecommendationsButton',
-									'VisualizerExtensionNotificationService'
+									visualizerExtensionNotificationService
 								);
 								const showAction = this.instantiationService.createInstance(ShowRecommendedExtensionsByScenarioAction, scenarioType);
 								showAction.run();
@@ -1213,10 +1214,10 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 							isSecondary: true,
 							run: () => {
 								this.adsTelemetryService.sendActionEvent(
-									TelemetryKeys.ExtensionRecommendationDialog,
-									TelemetryKeys.Click,
+									TelemetryKeys.TelemetryView.ExtensionRecommendationDialog,
+									TelemetryKeys.TelemetryAction.Click,
 									'NeverShowAgainButton',
-									'VisualizerExtensionNotificationService'
+									visualizerExtensionNotificationService
 								);
 								this.storageService.store(storageKey, true, StorageScope.GLOBAL);
 								c(undefined);
@@ -1226,10 +1227,10 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 							sticky: true,
 							onCancel: () => {
 								this.adsTelemetryService.sendActionEvent(
-									TelemetryKeys.ExtensionRecommendationDialog,
-									TelemetryKeys.Click,
+									TelemetryKeys.TelemetryView.ExtensionRecommendationDialog,
+									TelemetryKeys.TelemetryAction.Click,
 									'CancelButton',
-									'VisualizerExtensionNotificationService'
+									visualizerExtensionNotificationService
 								);
 								c(undefined);
 							}


### PR DESCRIPTION
Added 'Click' and 'ExtensionRecommendationDialog' telemetry keys and fixed telemetry events for the visualizer recommendation prompt.