### PR TITLE
Notebooks: Use much faster json parser when loading notebook initially

### DIFF
--- a/src/sql/workbench/services/notebook/common/localContentManager.ts
+++ b/src/sql/workbench/services/notebook/common/localContentManager.ts
@@ -7,7 +7,6 @@
 
 import { nb } from 'azdata';
 
-import * as json from 'vs/base/common/json';
 import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { IFileService } from 'vs/platform/files/common/files';
@@ -25,8 +24,12 @@ export class LocalContentManager implements nb.ContentManager {
 	constructor(@IFileService private readonly fileService: IFileService) { }
 
 	public async loadFromContentString(contentString: string): Promise<nb.INotebookContents> {
-		let contents: JSONObject = json.parse(contentString);
-
+		let contents: JSONObject;
+		if (contentString === '' || contentString === undefined) {
+			return v4.createEmptyNotebook();
+		} else {
+			contents = JSON.parse(contentString);
+		}
 		if (contents) {
 			if (contents.nbformat === 4) {
 				return v4.readNotebook(<any>contents);
@@ -36,9 +39,6 @@ export class LocalContentManager implements nb.ContentManager {
 			if (contents.nbformat) {
 				throw new TypeError(localize('nbformatNotRecognized', 'nbformat v{0}.{1} not recognized', contents.nbformat as any, contents.nbformat_minor as any));
 			}
-		} else if (contentString === '' || contentString === undefined) {
-			// Empty?
-			return v4.createEmptyNotebook();
 		}
 
 		// else, fallthrough condition
@@ -53,7 +53,13 @@ export class LocalContentManager implements nb.ContentManager {
 		// Note: intentionally letting caller handle exceptions
 		let notebookFileBuffer = await this.fileService.readFile(notebookUri);
 		let stringContents = notebookFileBuffer.value.toString();
-		let contents: JSONObject = json.parse(stringContents);
+		let contents: JSONObject;
+		if (stringContents === '' || stringContents === undefined) {
+			// Empty?
+			return v4.createEmptyNotebook();
+		} else {
+			contents = JSON.parse(stringContents);
+		}
 
 		if (contents) {
 			if (contents.nbformat === 4) {
@@ -64,9 +70,6 @@ export class LocalContentManager implements nb.ContentManager {
 			if (contents.nbformat) {
 				throw new TypeError(localize('nbformatNotRecognized', 'nbformat v{0}.{1} not recognized', contents.nbformat as any, contents.nbformat_minor as any));
 			}
-		} else if (stringContents === '' || stringContents === undefined) {
-			// Empty?
-			return v4.createEmptyNotebook();
 		}
 
 		// else, fallthrough condition

--- a/src/sql/workbench/services/notebook/common/localContentManager.ts
+++ b/src/sql/workbench/services/notebook/common/localContentManager.ts
@@ -7,6 +7,7 @@
 
 import { nb } from 'azdata';
 
+import * as json from 'vs/base/common/json';
 import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { IFileService } from 'vs/platform/files/common/files';
@@ -28,7 +29,7 @@ export class LocalContentManager implements nb.ContentManager {
 		if (contentString === '' || contentString === undefined) {
 			return v4.createEmptyNotebook();
 		} else {
-			contents = JSON.parse(contentString);
+			contents = this.parseFromJson(contentString);
 		}
 		if (contents) {
 			if (contents.nbformat === 4) {
@@ -58,7 +59,7 @@ export class LocalContentManager implements nb.ContentManager {
 			// Empty?
 			return v4.createEmptyNotebook();
 		} else {
-			contents = JSON.parse(stringContents);
+			contents = this.parseFromJson(stringContents);
 		}
 
 		if (contents) {
@@ -84,6 +85,15 @@ export class LocalContentManager implements nb.ContentManager {
 		return notebook;
 	}
 
+	private parseFromJson(contentString: string): JSONObject {
+		let contents: JSONObject;
+		try {
+			contents = JSON.parse(contentString);
+		} catch {
+			contents = json.parse(contentString);
+		}
+		return contents;
+	}
 }
 
 namespace v4 {


### PR DESCRIPTION
To date, we’ve been leveraging the vscode json parser when opening notebooks. It’s very fault-tolerant (accepts things such as being able to read JSON when it’s not properly formatted JSON [see: extra } at the end of a document]), which has its pros and cons.

However, this comes at a cost: speed. It’s slow. Like, really, _really_ slow.

Since I’ve been doing other perf work lately, I’ve become familiar with the various JSON parsers that we leverage in ADS and immediately spotted an improvement here. @aasimkhan30 may be interested in this 😄.

Here are preliminary results when loading the same ~30MB file on my machine (just for the parsing portion of loading a file)…

Old parser: 10503ms

New parser: 357ms

= 97% faster