### PR TITLE
Close editor on disconnect

### DIFF
--- a/src/sql/platform/connection/common/connectionManagementService.ts
+++ b/src/sql/platform/connection/common/connectionManagementService.ts
@@ -630,7 +630,18 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	}
 
 	public closeDashboard(uri: string): void {
+		let profile = this.getConnectionProfile(uri);
 
+		this._editorService.editors.forEach(editor => {
+			if (editor instanceof DashboardInput) {
+				if (DashboardInput.profileMatches(profile, editor.connectionProfile)) {
+					if (!this._editorService.isOpen(editor)) {
+						return;
+					}
+					this._editorService.closeEditor(editor);
+				}
+			}
+		});
 	}
 
 	public getConnectionGroups(providers?: string[]): ConnectionProfileGroup[] {
@@ -1088,6 +1099,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		return new Promise<boolean>((resolve, reject) => {
 			let disconnectParams = new ConnectionContracts.DisconnectParams();
 			disconnectParams.ownerUri = fileUri;
+			this.closeDashboard(fileUri);
 
 			// Send a disconnection request for the input URI
 			self.sendDisconnectRequest(fileUri).then((result) => {

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -218,6 +218,14 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 
 	//#endregion
 
+	// {{SQL CARBON EDIT}}
+	//#region closeEditor()
+	closeEditor(editor: IEditorInput) {
+		const targetGroup = this.findTargetGroup(editor);
+		targetGroup.closeEditor(editor);
+	}
+	//#endregion
+
 	//#region openEditor()
 
 	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<IEditor | null>;

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -108,6 +108,8 @@ export interface IEditorService {
 	 */
 	readonly editors: ReadonlyArray<IEditorInput>;
 
+	closeEditor(editor: IEditorInput);
+
 	/**
 	 * Open an editor in an editor group.
 	 *

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -867,6 +867,10 @@ export class TestEditorService implements EditorServiceImpl {
 		return toDisposable(() => undefined);
 	}
 
+	closeEditor(_editor: IEditorInput) {
+		throw new Error('not implemented');
+	}
+
 	openEditor(_editor: any, _options?: any, _group?: any): Promise<any> {
 		throw new Error('not implemented');
 	}


### PR DESCRIPTION
This might have unintended consequences that @anthonydresser or @abist will know better than me.

When we disconnect from a server, we shouldn't leave an active connection from the editor to the server. This can create security problems and issues such as #6017 

I'll try to get the VSCode changes patched on VSCode itself.