### PR TITLE
DacFx server dropdown fixes

### DIFF
--- a/extensions/dacpac/src/wizard/api/basePage.ts
+++ b/extensions/dacpac/src/wizard/api/basePage.ts
@@ -90,6 +90,18 @@ export abstract class BasePage {
 			this.deleteServerValues();
 		}
 
+		// only leave unique server connections
+		values = values.reduce((uniqueValues, conn) => {
+			let exists = uniqueValues.find(x => x.displayName === conn.displayName);
+			if (!exists) {
+				uniqueValues.push(conn);
+			}
+			return uniqueValues;
+		}, []);
+
+		// reverse list so that most recent connections show first
+		values.reverse();
+
 		return values;
 	}
 


### PR DESCRIPTION
This makes two changes to the DacFx wizard server dropdowns:

1. Remove duplicate server connections. Fixes #6562
2. Sort the dropdown values so that the most recent connections are at the top

These are the same changes that were made to the Schema Compare server dropdowns in this PR #5552