### PR TITLE
Fix #6576 Spark job submit fails from command palette

### DIFF
--- a/extensions/mssql/src/sparkFeature/dialog/dialogCommands.ts
+++ b/extensions/mssql/src/sparkFeature/dialog/dialogCommands.ts
@@ -21,6 +21,12 @@ import * as LocalizedConstants from '../../localizedConstants';
 import * as SqlClusterLookUp from '../../sqlClusterLookUp';
 import { SqlClusterConnection } from '../../objectExplorerNodeProvider/connection';
 
+interface MssqlOptions {
+	server: string;
+}
+
+const timeout = (millis: number) => new Promise(c => setTimeout(c, millis));
+
 export class OpenSparkJobSubmissionDialogCommand extends Command {
 	constructor(appContext: AppContext, private outputChannel: vscode.OutputChannel) {
 		super(constants.mssqlClusterLivySubmitSparkJobCommand, appContext);
@@ -49,23 +55,53 @@ export class OpenSparkJobSubmissionDialogCommand extends Command {
 
 	private async selectConnection(): Promise<SqlClusterConnection> {
 		let connectionList: azdata.connection.Connection[] = await this.apiWrapper.getActiveConnections();
-		let displayList: string[] = new Array();
 		let connectionMap: Map<string, azdata.connection.Connection> = new Map();
+		let selectedHost: string = undefined;
+		let showConnectionDialog = false;
+
+		// Filter invalid connections
 		if (connectionList && connectionList.length > 0) {
-			connectionList.forEach(conn => {
-				if (conn.providerName === constants.sqlProviderName) {
-					displayList.push(conn.options.host);
-					connectionMap.set(conn.options.host, conn);
-				}
+			connectionList = connectionList.filter(conn => conn.providerName === constants.sqlProviderName && (<MssqlOptions><any>conn.options).server);
+		}
+		// Prompt choice if we have active connections
+		if (connectionList && connectionList.length > 0) {
+			let selectConnectionMsg = localize('selectOtherServer', 'Select other SQL Server');
+			let displayList: string[] = [];
+			if (connectionList && connectionList.length > 0) {
+				connectionList.forEach(conn => {
+					let options: MssqlOptions = <any>conn.options;
+					displayList.push(options.server);
+					connectionMap.set(options.server, conn);
+				});
+			}
+			displayList.push(selectConnectionMsg);
+
+			selectedHost = await vscode.window.showQuickPick(displayList, {
+				placeHolder:
+					localize('sparkJobSubmission_PleaseSelectSqlWithCluster',
+						"Please select SQL Server with big data cluster.")
 			});
+			if (selectedHost === selectConnectionMsg) {
+				showConnectionDialog = true;
+				selectedHost = undefined;
+			}
+		} else {
+			showConnectionDialog = true;
 		}
 
-		let selectedHost: string = await vscode.window.showQuickPick(displayList, {
-			placeHolder:
-				localize('sparkJobSubmission_PleaseSelectSqlWithCluster',
-					"Please select SQL Server with big data cluster.")
-		});
-		let errorMsg = localize('sparkJobSubmission_NoSqlSelected', 'No Sql Server is selected.');
+		// Show connection dialog if still don't have a server
+		if (showConnectionDialog) {
+			let connection = await azdata.connection.openConnectionDialog([constants.sqlProviderName]);
+			if (connection) {
+				let options: MssqlOptions = <any>connection.options;
+				connectionMap.set(options.server, connection);
+				selectedHost = options.server;
+				// Wait an appropriate timeout so that the serverInfo object can populate...
+				await timeout(150);
+			}
+		}
+
+		let errorMsg = localize('sparkJobSubmission_NoSqlSelected', 'No SQL Server is selected.');
 		if (!selectedHost) { throw new Error(errorMsg); }
 
 		let sqlConnection = connectionMap.get(selectedHost);
@@ -73,7 +109,7 @@ export class OpenSparkJobSubmissionDialogCommand extends Command {
 
 		let sqlClusterConnection = await SqlClusterLookUp.getSqlClusterConnection(sqlConnection);
 		if (!sqlClusterConnection) {
-			throw new Error(LocalizedConstants.sparkJobSubmissionNoSqlBigDataClusterFound);
+			throw new Error(localize('errorNotSqlBigDataCluster', 'The selected server is not a SQL Server big data cluster'));
 		}
 
 		return new SqlClusterConnection(sqlClusterConnection);

--- a/extensions/mssql/src/sparkFeature/dialog/dialogCommands.ts
+++ b/extensions/mssql/src/sparkFeature/dialog/dialogCommands.ts
@@ -65,15 +65,13 @@ export class OpenSparkJobSubmissionDialogCommand extends Command {
 		}
 		// Prompt choice if we have active connections
 		if (connectionList && connectionList.length > 0) {
-			let selectConnectionMsg = localize('selectOtherServer', 'Select other SQL Server');
+			let selectConnectionMsg = localize('selectOtherServer', "Select other SQL Server");
 			let displayList: string[] = [];
-			if (connectionList && connectionList.length > 0) {
-				connectionList.forEach(conn => {
-					let options: MssqlOptions = <any>conn.options;
-					displayList.push(options.server);
-					connectionMap.set(options.server, conn);
-				});
-			}
+			connectionList.forEach(conn => {
+				let options: MssqlOptions = <any>conn.options;
+				displayList.push(options.server);
+				connectionMap.set(options.server, conn);
+			});
 			displayList.push(selectConnectionMsg);
 
 			selectedHost = await vscode.window.showQuickPick(displayList, {
@@ -109,7 +107,7 @@ export class OpenSparkJobSubmissionDialogCommand extends Command {
 
 		let sqlClusterConnection = await SqlClusterLookUp.getSqlClusterConnection(sqlConnection);
 		if (!sqlClusterConnection) {
-			throw new Error(localize('errorNotSqlBigDataCluster', 'The selected server is not a SQL Server big data cluster'));
+			throw new Error(localize('errorNotSqlBigDataCluster', "The selected server does not belong to a SQL Server big data cluster"));
 		}
 
 		return new SqlClusterConnection(sqlClusterConnection);


### PR DESCRIPTION
- Fix spark job failing when 1 or more servers are connected
and listed in getActiveConnections
- If nothing is connected, prompts to choose a server
- Added option to dropdown when 1 or more server is connected
to support picking a different connection

Root bug was trying to access "host" not "server" in options bag, which no longer exists.

**Screenshot - new option in prompt**
![image](https://user-images.githubusercontent.com/10819925/62404087-a6114a80-b546-11e9-99fb-d157030a3b2a.png)
