### PR TITLE
Revert "Remove references to query model service in query code"

### DIFF
--- a/src/sql/workbench/common/customInputConverter.ts
+++ b/src/sql/workbench/common/customInputConverter.ts
@@ -43,7 +43,9 @@ export function convertEditorInput(input: EditorInput, options: IQueryEditorOpti
 			//QueryInput
 			uri = getQueryEditorFileUri(input);
 			if (uri) {
-				return instantiationService.createInstance(QueryInput, '', input, undefined);
+				const queryResultsInput: QueryResultsInput = instantiationService.createInstance(QueryResultsInput, uri.toString());
+				let queryInput: QueryInput = instantiationService.createInstance(QueryInput, '', input, queryResultsInput, undefined);
+				return queryInput;
 			}
 
 			//QueryPlanInput

--- a/src/sql/workbench/parts/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/parts/commandLine/test/electron-browser/commandLine.test.ts
@@ -26,9 +26,6 @@ import { QueryInput, QueryEditorState } from 'sql/workbench/parts/query/common/q
 import { URI } from 'vs/base/common/uri';
 import { ILogService, NullLogService } from 'vs/platform/log/common/log';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
-import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
-import { TestEditorInput } from 'vs/workbench/services/editor/test/browser/editorGroupsService.test';
-import { Schemas } from 'vs/base/common/network';
 
 class TestParsedArgs implements ParsedArgs {
 	[arg: string]: any;
@@ -375,9 +372,7 @@ suite('commandLineService tests', () => {
 			}).verifiable(TypeMoq.Times.once());
 		connectionManagementService.setup(c => c.getConnectionProfileById(TypeMoq.It.isAnyString())).returns(() => originalProfile);
 		const configurationService = getConfigurationServiceMock(true);
-		const instantiationService = new TestInstantiationService();
-		const fileInput = new TestEditorInput(URI.from({ scheme: Schemas.untitled }));
-		const queryInput: TypeMoq.Mock<QueryInput> = TypeMoq.Mock.ofType<QueryInput>(QueryInput, TypeMoq.MockBehavior.Loose, undefined, fileInput, undefined, undefined, undefined, instantiationService);
+		const queryInput: TypeMoq.Mock<QueryInput> = TypeMoq.Mock.ofType<QueryInput>(QueryInput);
 		let uri = URI.file(args._[0]);
 		const queryState = new QueryEditorState();
 		queryState.connected = true;

--- a/src/sql/workbench/parts/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/parts/query/browser/keyboardQueryActions.ts
@@ -13,6 +13,7 @@ import * as azdata from 'azdata';
 import { IQueryManagementService } from 'sql/platform/query/common/queryManagement';
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 import { QueryEditor } from 'sql/workbench/parts/query/browser/queryEditor';
+import { IQueryModelService } from 'sql/platform/query/common/queryModel';
 import * as WorkbenchUtils from 'sql/workbench/common/sqlWorkbenchUtils';
 import * as Constants from 'sql/workbench/parts/query/common/constants';
 import * as ConnectionConstants from 'sql/platform/connection/common/constants';
@@ -238,6 +239,7 @@ export class RunQueryShortcutAction extends Action {
 
 	constructor(
 		@IEditorService private readonly editorService: IEditorService,
+		@IQueryModelService protected readonly queryModelService: IQueryModelService,
 		@IQueryManagementService private readonly queryManagementService: IQueryManagementService,
 		@IConnectionManagementService private readonly connectionManagementService: IConnectionManagementService,
 		@IConfigurationService private readonly configurationService: IConfigurationService

--- a/src/sql/workbench/parts/query/browser/queryActions.ts
+++ b/src/sql/workbench/parts/query/browser/queryActions.ts
@@ -24,6 +24,7 @@ import {
 	RunQueryOnConnectionMode
 } from 'sql/platform/connection/common/connectionManagement';
 import { QueryEditor } from 'sql/workbench/parts/query/browser/queryEditor';
+import { IQueryModelService } from 'sql/platform/query/common/queryModel';
 import { SelectBox } from 'sql/base/browser/ui/selectBox/selectBox';
 import { attachEditableDropdownStyler, attachSelectBoxStyler } from 'sql/platform/theme/common/styler';
 import { Dropdown } from 'sql/base/parts/editableDropdown/browser/dropdown';
@@ -106,7 +107,9 @@ export class RunQueryAction extends QueryTaskbarAction {
 
 	constructor(
 		editor: QueryEditor,
-		@IConnectionManagementService connectionManagementService: IConnectionManagementService
+		@IQueryModelService protected readonly queryModelService: IQueryModelService,
+		@IConnectionManagementService connectionManagementService: IConnectionManagementService,
+		@IExtensionTipsService private readonly extensionTipsService: IExtensionTipsService
 	) {
 		super(connectionManagementService, editor, RunQueryAction.ID, RunQueryAction.EnabledClass);
 		this.label = nls.localize('runQueryLabel', "Run");
@@ -175,7 +178,8 @@ export class CancelQueryAction extends QueryTaskbarAction {
 
 	constructor(
 		editor: QueryEditor,
-		@IConnectionManagementService connectionManagementService: IConnectionManagementService,
+		@IQueryModelService private readonly queryModelService: IQueryModelService,
+		@IConnectionManagementService connectionManagementService: IConnectionManagementService
 	) {
 		super(connectionManagementService, editor, CancelQueryAction.ID, CancelQueryAction.EnabledClass);
 		this.enabled = false;
@@ -184,7 +188,7 @@ export class CancelQueryAction extends QueryTaskbarAction {
 
 	public run(): Promise<void> {
 		if (this.isConnected(this.editor)) {
-			this.editor.input.runner.cancelQuery();
+			this.queryModelService.cancelQuery(this.editor.input.uri);
 		}
 		return Promise.resolve(null);
 	}

--- a/src/sql/workbench/parts/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/parts/query/browser/queryResultsView.ts
@@ -5,6 +5,7 @@
 
 import { QueryResultsInput } from 'sql/workbench/parts/query/common/queryResultsInput';
 import { TabbedPanel, IPanelTab, IPanelView } from 'sql/base/browser/ui/panel/panel';
+import { IQueryModelService } from 'sql/platform/query/common/queryModel';
 import QueryRunner from 'sql/platform/query/common/queryRunner';
 import { MessagePanel } from 'sql/workbench/parts/query/browser/messagePanel';
 import { GridPanel } from 'sql/workbench/parts/query/browser/gridPanel';
@@ -178,6 +179,7 @@ export class QueryResultsView extends Disposable {
 		container: HTMLElement,
 		@IThemeService themeService: IThemeService,
 		@IInstantiationService private instantiationService: IInstantiationService,
+		@IQueryModelService private queryModelService: IQueryModelService
 	) {
 		super();
 		this.resultsTab = this._register(new ResultsTab(instantiationService));
@@ -307,7 +309,19 @@ export class QueryResultsView extends Disposable {
 			dynamicTab.captureState(this.input.state.dynamicModelViewTabsState);
 		});
 
-		this.setQueryRunner(input.runner);
+		let info = this.queryModelService._getQueryInfo(input.uri);
+		if (info) {
+			this.setQueryRunner(info.queryRunner);
+		} else {
+			let disposable = this.queryModelService.onRunQueryStart(c => {
+				if (c === input.uri) {
+					let info = this.queryModelService._getQueryInfo(input.uri);
+					this.setQueryRunner(info.queryRunner);
+					disposable.dispose();
+				}
+			});
+			this.runnerDisposables.push(disposable);
+		}
 	}
 
 	clearInput() {

--- a/src/sql/workbench/parts/query/common/queryInput.ts
+++ b/src/sql/workbench/parts/query/common/queryInput.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
+import { IDisposable, dispose, Disposable } from 'vs/base/common/lifecycle';
 import { Event, Emitter } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
@@ -13,13 +13,11 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 
 import { IConnectionManagementService, IConnectableInput, INewConnectionParams, RunQueryOnConnectionMode } from 'sql/platform/connection/common/connectionManagement';
 import { QueryResultsInput } from 'sql/workbench/parts/query/common/queryResultsInput';
+import { IQueryModelService } from 'sql/platform/query/common/queryModel';
 
 import { ISelectionData, ExecutionPlanOptions } from 'azdata';
 import { UntitledEditorModel } from 'vs/workbench/common/editor/untitledEditorModel';
 import { IResolvedTextEditorModel } from 'vs/editor/common/services/resolverService';
-import { IQueryManagementService } from 'sql/platform/query/common/queryManagement';
-import QueryRunner from 'sql/platform/query/common/queryRunner';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 const MAX_SIZE = 13;
 
@@ -112,56 +110,63 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 
 	private _updateSelection: Emitter<ISelectionData>;
 
-	private _runner: QueryRunner;
-	public get runner(): QueryRunner {
-		return this._runner;
-	}
-
-	private _results: QueryResultsInput;
-
 	constructor(
 		private _description: string,
 		private _sql: UntitledEditorInput,
+		private _results: QueryResultsInput,
 		private _connectionProviderName: string,
-		@IConnectionManagementService private readonly connectionManagementService: IConnectionManagementService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IInstantiationService instantiationService: IInstantiationService
+		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
+		@IQueryModelService private _queryModelService: IQueryModelService,
+		@IConfigurationService private _configurationService: IConfigurationService
 	) {
 		super();
 		this._updateSelection = new Emitter<ISelectionData>();
 
-		this._runner = this._register(instantiationService.createInstance(QueryRunner, this.uri));
-		this._results = this._register(instantiationService.createInstance(QueryResultsInput, this.uri, this.runner));
-
 		this._register(this._sql);
+		this._register(this._results);
 
 		// re-emit sql editor events through this editor if it exists
 		if (this._sql) {
 			this._register(this._sql.onDidChangeDirty(() => this._onDidChangeDirty.fire()));
 		}
 
-		// Register callbacks for the Actions
-		this.runner.onQueryStart(() => this.onRunQuery());
+		// Attach to event callbacks
+		if (this._queryModelService) {
+			// Register callbacks for the Actions
+			this._register(
+				this._queryModelService.onRunQueryStart(uri => {
+					if (this.uri === uri) {
+						this.onRunQuery();
+					}
+				})
+			);
 
-		this.runner.onQueryEnd(() => this.onQueryComplete());
+			this._register(
+				this._queryModelService.onRunQueryComplete(uri => {
+					if (this.uri === uri) {
+						this.onQueryComplete();
+					}
+				})
+			);
+		}
 
-		if (this.connectionManagementService) {
-			this._register(this.connectionManagementService.onDisconnect(result => {
+		if (this._connectionManagementService) {
+			this._register(this._connectionManagementService.onDisconnect(result => {
 				if (result.connectionUri === this.uri) {
 					this.onDisconnect();
 				}
 			}));
 			if (this.uri) {
 				if (this._connectionProviderName) {
-					this.connectionManagementService.doChangeLanguageFlavor(this.uri, 'sql', this._connectionProviderName);
+					this._connectionManagementService.doChangeLanguageFlavor(this.uri, 'sql', this._connectionProviderName);
 				} else {
-					this.connectionManagementService.ensureDefaultLanguageFlavor(this.uri);
+					this._connectionManagementService.ensureDefaultLanguageFlavor(this.uri);
 				}
 			}
 		}
 
-		if (this.configurationService) {
-			this._register(this.configurationService.onDidChangeConfiguration(e => {
+		if (this._configurationService) {
+			this._register(this._configurationService.onDidChangeConfiguration(e => {
 				if (e.affectedKeys.includes('sql.showConnectionInfoInTitle')) {
 					this._onDidChangeLabel.fire();
 				}
@@ -214,8 +219,8 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 	}
 
 	public getName(longForm?: boolean): string {
-		if (this.configurationService.getValue('sql.showConnectionInfoInTitle')) {
-			let profile = this.connectionManagementService.getConnectionProfile(this.uri);
+		if (this._configurationService.getValue('sql.showConnectionInfoInTitle')) {
+			let profile = this._connectionManagementService.getConnectionProfile(this.uri);
 			let title = '';
 			if (this._description && this._description !== '') {
 				title = this._description + ' ';
@@ -248,17 +253,17 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 
 	// State update funtions
 	public runQuery(selection: ISelectionData, executePlanOptions?: ExecutionPlanOptions): void {
-		this.runner.runQuery(selection, executePlanOptions);
+		this._queryModelService.runQuery(this.uri, selection, this, executePlanOptions);
 		this.state.executing = true;
 	}
 
 	public runQueryStatement(selection: ISelectionData): void {
-		this.runner.runQueryStatement(selection);
+		this._queryModelService.runQueryStatement(this.uri, selection, this);
 		this.state.executing = true;
 	}
 
 	public runQueryString(text: string): void {
-		this.runner.runQuery(text);
+		this._queryModelService.runQueryString(this.uri, text, this);
 		this.state.executing = true;
 	}
 
@@ -281,7 +286,7 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 		this.state.connected = true;
 		this.state.connecting = false;
 
-		let isRunningQuery = this.runner.isExecuting;
+		let isRunningQuery = this._queryModelService.isRunningQuery(this.uri);
 		if (!isRunningQuery && params && params.runQueryOnCompletion) {
 			let selection: ISelectionData = params ? params.querySelection : undefined;
 			if (params.runQueryOnCompletion === RunQueryOnConnectionMode.executeCurrentQuery) {
@@ -312,7 +317,8 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 	}
 
 	public close(): void {
-		this.connectionManagementService.disconnectEditor(this, true);
+		this._queryModelService.disposeQuery(this.uri);
+		this._connectionManagementService.disconnectEditor(this, true);
 
 		this._sql.close();
 		this._results.close();
@@ -323,6 +329,6 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 	 * Get the color that should be displayed
 	 */
 	public get tabColor(): string {
-		return this.connectionManagementService.getTabColorForUri(this.uri);
+		return this._connectionManagementService.getTabColorForUri(this.uri);
 	}
 }

--- a/src/sql/workbench/parts/query/common/queryResultsInput.ts
+++ b/src/sql/workbench/parts/query/common/queryResultsInput.ts
@@ -13,7 +13,6 @@ import { QueryPlanState } from 'sql/workbench/parts/queryPlan/common/queryPlanSt
 import { MessagePanelState } from 'sql/workbench/parts/query/common/messagePanelState';
 import { GridPanelState } from 'sql/workbench/parts/query/common/gridPanelState';
 import { QueryModelViewState } from 'sql/workbench/parts/query/common/modelViewTab/modelViewState';
-import QueryRunner from 'sql/platform/query/common/queryRunner';
 
 export class ResultsViewState {
 	public gridPanelState: GridPanelState = new GridPanelState();
@@ -63,11 +62,7 @@ export class QueryResultsInput extends EditorInput {
 		return this._state;
 	}
 
-	public get runner(): QueryRunner {
-		return this._runner;
-	}
-
-	constructor(private _uri: string, private _runner: QueryRunner) {
+	constructor(private _uri: string) {
 		super();
 		this._visible = false;
 		this._hasBootstrapped = false;

--- a/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
@@ -12,6 +12,7 @@ import { QueryPlanInput } from 'sql/workbench/parts/queryPlan/common/queryPlanIn
 import { sqlModeId, untitledFilePrefix, getSupportedInputResource } from 'sql/workbench/common/customInputConverter';
 import * as TaskUtilities from 'sql/workbench/browser/taskUtilities';
 
+import { IMode } from 'vs/editor/common/modes';
 import { ITextModel } from 'vs/editor/common/model';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
 import { IEditorService, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
@@ -90,9 +91,10 @@ export class QueryEditorService implements IQueryEditorService {
 					}
 				}
 
-				let input = this._instantiationService.createInstance(QueryInput, objectName, fileInput, connectionProviderName);
+				const queryResultsInput: QueryResultsInput = this._instantiationService.createInstance(QueryResultsInput, docUri.toString());
+				let queryInput: QueryInput = this._instantiationService.createInstance(QueryInput, objectName, fileInput, queryResultsInput, connectionProviderName);
 
-				this._editorService.openEditor(input, { pinned: true })
+				this._editorService.openEditor(queryInput, { pinned: true })
 					.then((editor) => {
 						let params = <QueryInput>editor.input;
 						resolve(params);
@@ -286,7 +288,8 @@ export class QueryEditorService implements IQueryEditorService {
 
 		let newEditorInput: IEditorInput = undefined;
 		if (changingToSql) {
-			let queryInput: QueryInput = QueryEditorService.instantiationService.createInstance(QueryInput, '', input, undefined);
+			const queryResultsInput: QueryResultsInput = QueryEditorService.instantiationService.createInstance(QueryResultsInput, uri.toString());
+			let queryInput: QueryInput = QueryEditorService.instantiationService.createInstance(QueryInput, '', input, queryResultsInput, undefined);
 			newEditorInput = queryInput;
 		} else {
 			let uriCopy: URI = URI.from({ scheme: uri.scheme, authority: uri.authority, path: uri.path, query: uri.query, fragment: uri.fragment });

--- a/src/sql/workbench/test/common/taskUtilities.test.ts
+++ b/src/sql/workbench/test/common/taskUtilities.test.ts
@@ -14,7 +14,6 @@ import { URI } from 'vs/base/common/uri';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
 import { QueryInput } from 'sql/workbench/parts/query/common/queryInput';
 import { TestEditorService } from 'vs/workbench/test/workbenchTestServices';
-import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 
 suite('TaskUtilities', function () {
 	test('getCurrentGlobalConnection returns the selected OE server if a server or one of its children is selected', () => {
@@ -77,8 +76,7 @@ suite('TaskUtilities', function () {
 		// Mock the workbench service to return the active tab connection
 		let tabConnectionUri = 'file://test_uri';
 		let editorInput = new UntitledEditorInput(URI.parse(tabConnectionUri), false, undefined, undefined, undefined, undefined, undefined, undefined);
-		const instantiationService = new TestInstantiationService();
-		let queryInput = new QueryInput(undefined, editorInput, undefined, undefined, undefined, instantiationService);
+		let queryInput = new QueryInput(undefined, editorInput, undefined, undefined, undefined, undefined, undefined);
 		mockConnectionManagementService.setup(x => x.getConnectionProfile(tabConnectionUri)).returns(() => tabProfile);
 
 		// If I call getCurrentGlobalConnection, it should return the expected profile from the active tab


### PR DESCRIPTION
Reverts microsoft/azuredatastudio#6513

Reverting since it breaks some other features.

This will halt progress in other feature areas, but I'm not sure how long it will take to redesign this area.