### PR TITLE
Added unit test for books getChildren() method

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -346,7 +346,6 @@
 	},
 	"dependencies": {
 		"@jupyterlab/services": "^3.2.1",
-		"@types/glob": "^7.1.1",
 		"@types/js-yaml": "^3.12.1",
 		"@types/rimraf": "^2.0.2",
 		"decompress": "^4.2.0",

--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -346,7 +346,9 @@
 	},
 	"dependencies": {
 		"@jupyterlab/services": "^3.2.1",
+		"@types/glob": "^7.1.1",
 		"@types/js-yaml": "^3.12.1",
+		"@types/rimraf": "^2.0.2",
 		"decompress": "^4.2.0",
 		"error-ex": "^1.3.1",
 		"figures": "^2.0.0",

--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -100,6 +100,14 @@ export class BookTreeItem extends vscode.TreeItem {
 		}
 	}
 
+	public get title(): string {
+		return this.book.title;
+	}
+
+	public get uri(): string {
+		return this._uri;
+	}
+
 	public get root(): string {
 		return this.book.root;
 	}

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -33,7 +33,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		this._extensionContext = extensionContext;
 	}
 
-	private getTocFiles(dir: string): string[] {
+	public getTocFiles(dir: string): string[] {
 		let allFiles: string[] = [];
 		let files = fs.readdirSync(dir);
 		for (let i in files) {
@@ -119,7 +119,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		return array.reduce((acc, val) => Array.isArray(val.sections) ? acc.concat(val).concat(this.flattenArray(val.sections)) : acc.concat(val), []);
 	}
 
-	private getBooks(): BookTreeItem[] {
+	public getBooks(): BookTreeItem[] {
 		let books: BookTreeItem[] = [];
 		for (let i in this._tableOfContentsPath) {
 			let root = path.dirname(path.dirname(this._tableOfContentsPath[i]));

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -33,18 +33,21 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		this._extensionContext = extensionContext;
 	}
 
-	public getTocFiles(dir: string): string[] {
-		let allFiles: string[] = [];
-		let files = fs.readdirSync(dir);
-		for (let i in files) {
-			let name = path.join(dir, files[i]);
-			if (fs.statSync(name).isDirectory()) {
-				allFiles = allFiles.concat(this.getTocFiles(name));
-			} else if (files[i] === 'toc.yml') {
-				allFiles.push(name);
-			}
-		}
-		return allFiles;
+	private getTableOfContentFiles(directories: string[]): string[] {
+		let tableOfContentPaths: string[] = [];
+		let paths: string[];
+		directories.forEach(dir => {
+			paths = fs.readdirSync(dir);
+			paths.forEach(filename => {
+				let fullPath = path.join(dir, filename);
+				if (fs.statSync(fullPath).isDirectory()) {
+					tableOfContentPaths = tableOfContentPaths.concat(this.getTableOfContentFiles([fullPath]));
+				} else if (filename === 'toc.yml') {
+					tableOfContentPaths.push(fullPath);
+				}
+			});
+		});
+		return tableOfContentPaths;
 	}
 
 	async openNotebook(resource: string): Promise<void> {

--- a/extensions/notebook/src/test/book/book.test.ts
+++ b/extensions/notebook/src/test/book/book.test.ts
@@ -9,11 +9,12 @@ import * as TypeMoq from 'typemoq';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as rimraf from 'rimraf';
+import * as os from 'os';
 import { BookTreeViewProvider } from '../../book/bookTreeView';
 import { BookTreeItem } from '../../book/bookTreeItem';
 
 describe('BookTreeViewProvider.getChildren', function (): void {
-	const rootFolderPath = path.join(__dirname, 'testBook');
+	const rootFolderPath = path.join(os.tmpdir(), 'testBook');
 	const dataFolderPath = path.join(rootFolderPath, '_data');
 	const contentFolderPath = path.join(rootFolderPath, 'content');
 	const configFile = path.join(rootFolderPath, '_config.yml');
@@ -56,7 +57,7 @@ describe('BookTreeViewProvider.getChildren', function (): void {
 
 	it('should return all book nodes when element is undefined', async function (): Promise<void> {
 		const children = await bookTreeViewProvider.getChildren();
-		should(children).Array();
+		should(children).be.Array();
 		should(children.length).equal(1);
 		book = children[0];
 		should(book.title).equal(expectedBook.title);
@@ -64,7 +65,7 @@ describe('BookTreeViewProvider.getChildren', function (): void {
 
 	it('should return all page nodes when element is a book', async function (): Promise<void> {
 		const children = await bookTreeViewProvider.getChildren(book);
-		should(children).Array();
+		should(children).be.Array();
 		should(children.length).equal(3);
 		const notebook = children[0];
 		const markdown = children[1];

--- a/extensions/notebook/src/test/book/book.test.ts
+++ b/extensions/notebook/src/test/book/book.test.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// import * as should from 'should';
+import * as TypeMoq from 'typemoq';
+import { BookTreeViewProvider } from '../../book/bookTreeView';
+import { BookTreeItem, BookTreeItemType } from '../../book/bookTreeItem';
+// import { IContextKeyService } from '../../../../../src/vs/platform/contextkey/common/contextkey';
+// import { MockContextKeyService } from '../../../../../src/vs/platform/keybinding/test/common/mockKeybindingService';
+
+// const mockTableOfContents = [
+// 	{
+// 		title: '1_Notebook',
+// 		url: '/path/to/notebook'
+// 	},
+// 	{
+// 		title: '2_Markdown',
+// 		url: '/path/to/markdown'
+// 	},
+// 	{
+// 		title: '3_External_Link',
+// 		url: '/path/to/external_link'
+// 	}
+// ];
+
+// const mockConfig = {
+// 	title: 'Title of Book'
+// }
+
+const mockBookTreeItem = new BookTreeItem({
+	title: 'mock_title',
+	root: 'mock/root/path',
+	tableOfContents: [''],
+	page: [''],
+	type: BookTreeItemType.Book
+},
+	{
+		light: 'path/to/book.svg',
+		dark: 'path/to/book_inverse.svg'
+	}
+);
+
+const mockNotebookTreeItem = new BookTreeItem({
+	title: 'mock_title',
+	root: 'mock/root/path',
+	tableOfContents: [''],
+	page: [''],
+	type: BookTreeItemType.Notebook
+},
+	{
+		light: 'path/to/notebook.svg',
+		dark: 'path/to/notebook_inverse.svg'
+	}
+);
+
+const mockMarkdownTreeItem = new BookTreeItem({
+	title: 'mock_title',
+	root: 'mock/root/path',
+	tableOfContents: [''],
+	page: [''],
+	type: BookTreeItemType.Markdown
+},
+	{
+		light: 'path/to/markdown.svg',
+		dark: 'path/to/markdown_inverse.svg'
+	}
+);
+
+const mockExternalLinkTreeItem = new BookTreeItem({
+	title: 'mock_title',
+	root: 'mock/root/path',
+	tableOfContents: [''],
+	page: [''],
+	type: BookTreeItemType.ExternalLink
+},
+	{
+		light: 'path/to/link.svg',
+		dark: 'path/to/link_inverse.svg'
+	}
+);
+
+describe('BookTreeViewProvider', function (): void {
+	let mockBookTreeViewProvider: TypeMoq.IMock<BookTreeViewProvider>;
+	// let mockIContextKeyService: TypeMoq.IMock<IContextKeyService>;
+
+	this.beforeEach(() => {
+		mockBookTreeViewProvider = TypeMoq.Mock.ofType<BookTreeViewProvider>();
+		// mockIContextKeyService = TypeMoq.Mock.ofType<IContextKeyService>();
+	});
+
+	it('bookOpened should be false if there are no toc.yml files in folder', async function (): Promise<void> {
+		mockBookTreeViewProvider.setup(x => x.getTocFiles('')).returns(() => []);
+		// should.equal(mockIContextKeyService.object.getContextKeyValue('bookOpened'), false);
+	});
+
+	it('bookOpened should be true if there are toc.yml files in folder', async function (): Promise<void> {
+		mockBookTreeViewProvider.setup(x => x.getTocFiles('')).returns(() => ['path/to/toc.yml']);
+		// should.equal(mockIContextKeyService.object.getContextKeyValue('bookOpened'), false);
+	});
+
+});
+
+describe('BookTreeViewProvider.getChildren', function (): void {
+	// let mockExtensionContext: TypeMoq.IMock<vscode.ExtensionContext>;
+	let mockBookTreeViewProvider: TypeMoq.IMock<BookTreeViewProvider>;
+
+	this.beforeEach(() => {
+		// mockExtensionContext = TypeMoq.Mock.ofType<vscode.ExtensionContext>();
+		mockBookTreeViewProvider = TypeMoq.Mock.ofType<BookTreeViewProvider>();
+		mockBookTreeViewProvider.setup(x => x.getBooks()).returns(() => [mockBookTreeItem]);
+		mockBookTreeViewProvider.setup(x => x.getChildren(mockBookTreeItem)).returns(() => Promise.resolve([mockNotebookTreeItem, mockMarkdownTreeItem, mockExternalLinkTreeItem]));
+	});
+
+	it('should get all pages in book', async function (): Promise<void> {
+
+	});
+
+
+});

--- a/extensions/notebook/yarn.lock
+++ b/extensions/notebook/yarn.lock
@@ -111,7 +111,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@^7.1.1":
+"@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
   integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -154,6 +154,14 @@
     "@types/form-data" "*"
     "@types/node" "*"
     "@types/tough-cookie" "*"
+
+"@types/rimraf@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-2.0.2.tgz#7f0fc3cf0ff0ad2a99bb723ae1764f30acaf8b6e"
+  integrity sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/temp-write@^3.3.0":
   version "3.3.0"


### PR DESCRIPTION
This unit test creates a simple test book that contains three items (.ipynb, .md, and external link) and checks that getChildren() correctly creates tree nodes for each item. Test book is removed at the end of unit test.