### PR TITLE
Change 'Ok' to "OK" in schema compare UI

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -15,7 +15,7 @@ import { Telemetry } from '../telemetry';
 import { getEndpointName } from '../utils';
 
 const localize = nls.loadMessageBundle();
-const OkButtonText: string = localize('schemaCompareDialog.ok', 'Ok');
+const OkButtonText: string = localize('schemaCompareDialog.ok', 'OK');
 const CancelButtonText: string = localize('schemaCompareDialog.cancel', 'Cancel');
 const SourceTitle: string = localize('schemaCompareDialog.SourceTitle', 'Source');
 const TargetTitle: string = localize('schemaCompareDialog.TargetTitle', 'Target');

--- a/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareOptionsDialog.ts
@@ -12,7 +12,7 @@ import { SchemaCompareMainWindow } from '../schemaCompareMainWindow';
 const localize = nls.loadMessageBundle();
 
 export class SchemaCompareOptionsDialog {
-	private static readonly OkButtonText: string = localize('SchemaCompareOptionsDialog.Ok', 'Ok');
+	private static readonly OkButtonText: string = localize('SchemaCompareOptionsDialog.Ok', 'OK');
 	private static readonly CancelButtonText: string = localize('SchemaCompareOptionsDialog.Cancel', 'Cancel');
 	private static readonly ResetButtonText: string = localize('SchemaCompareOptionsDialog.Reset', 'Reset');
 	private static readonly YesButtonText: string = localize('SchemaCompareOptionsDialog.Yes', 'Yes');

--- a/extensions/schema-compare/src/test/schemaCompare.test.ts
+++ b/extensions/schema-compare/src/test/schemaCompare.test.ts
@@ -59,7 +59,7 @@ describe('SchemaCompareDialog.openDialog', function (): void {
 		await dialog.openDialog();
 
 		should(dialog.dialog.title).equal('Schema Compare');
-		should(dialog.dialog.okButton.label).equal('Ok');
+		should(dialog.dialog.okButton.label).equal('OK');
 		should(dialog.dialog.okButton.enabled).equal(false); // Should be false when open
 	});
 });


### PR DESCRIPTION
Typically the string "OK" is used for the submit buttons in windows applications.  For example, the below from SSMS.  This updates for Schema Compare for consistency with other UX.

![image](https://user-images.githubusercontent.com/599935/62505260-c04e6100-b7b0-11e9-9e1b-b88ce16ee1cf.png)

