### PR TITLE
Find all books in workspace with multiple folders

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -25,16 +25,14 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	private _resource: string;
 
 	constructor(workspaceFolders: vscode.WorkspaceFolder[], extensionContext: vscode.ExtensionContext) {
-		if (workspaceFolders !== []) {
-			let workspacePaths: string[] = workspaceFolders.map(a => a.uri.fsPath);
-			this._tableOfContentsPath = this.getTableOfContentFiles(workspacePaths);
-			let bookOpened: boolean = this._tableOfContentsPath && this._tableOfContentsPath.length > 0;
-			vscode.commands.executeCommand('setContext', 'bookOpened', bookOpened);
-		}
+		let workspacePaths: string[] = workspaceFolders.map(a => a.uri.fsPath);
+		this._tableOfContentsPath = this.getTableOfContentFiles(workspacePaths);
+		let bookOpened: boolean = this._tableOfContentsPath && this._tableOfContentsPath.length > 0;
+		vscode.commands.executeCommand('setContext', 'bookOpened', bookOpened);
 		this._extensionContext = extensionContext;
 	}
 
-	private getTableOfContentFiles(directories?: string[]): string[] {
+	private getTableOfContentFiles(directories: string[]): string[] {
 		let tableOfContentPaths: string[] = [];
 		let paths: string[];
 		directories.forEach(dir => {

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -27,8 +27,7 @@ let controller: JupyterController;
 type ChooseCellType = { label: string, id: CellType };
 
 export async function activate(extensionContext: vscode.ExtensionContext): Promise<IExtensionApi> {
-
-	const bookTreeViewProvider = new BookTreeViewProvider(vscode.workspace.rootPath || '', extensionContext);
+	const bookTreeViewProvider = new BookTreeViewProvider(vscode.workspace.workspaceFolders || [], extensionContext);
 	extensionContext.subscriptions.push(vscode.window.registerTreeDataProvider('bookTreeView', bookTreeViewProvider));
 	extensionContext.subscriptions.push(azdata.nb.registerNavigationProvider(bookTreeViewProvider));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('bookTreeView.openNotebook', (resource) => bookTreeViewProvider.openNotebook(resource)));


### PR DESCRIPTION
Fixes #6487 
Previously Book Tree View was only looking at the first folder in a workspace. Now it looks through all folders.

