### PR TITLE
Enable restore from server context only backup should be blocked

### DIFF
--- a/src/sql/workbench/common/actions.ts
+++ b/src/sql/workbench/common/actions.ts
@@ -148,10 +148,6 @@ export class RestoreAction extends Task {
 			if (serverInfo && serverInfo.isCloud && profile.providerName === mssqlProviderName) {
 				return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.commandNotSupported', "Restore command is not supported for Azure SQL databases."));
 			}
-
-			if (!profile.databaseName && profile.providerName === mssqlProviderName) {
-				return accessor.get<INotificationService>(INotificationService).info(nls.localize('restore.commandNotSupportedForServer', "Restore command is not supported in Server Context. Please select a Database and try again."));
-			}
 		}
 
 		TaskUtilities.showRestore(


### PR DESCRIPTION
Restore was mistakenly blocked from server context when blocking backup for this bug https://github.com/microsoft/azuredatastudio/issues/5797

Reverting the change for restore. Fixes https://github.com/microsoft/azuredatastudio/issues/6608 https://github.com/microsoft/azuredatastudio/issues/6493