### PR TITLE
Bug/restore query editor tabs

### DIFF
--- a/src/sql/workbench/parts/query/common/queryInput.ts
+++ b/src/sql/workbench/parts/query/common/queryInput.ts
@@ -18,6 +18,7 @@ import { IQueryModelService } from 'sql/platform/query/common/queryModel';
 import { ISelectionData, ExecutionPlanOptions } from 'azdata';
 import { UntitledEditorModel } from 'vs/workbench/common/editor/untitledEditorModel';
 import { IResolvedTextEditorModel } from 'vs/editor/common/services/resolverService';
+import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
 
 const MAX_SIZE = 13;
 
@@ -216,6 +217,11 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 		}
 
 		return false;
+	}
+
+	// will change this to a better function but needed to know if its file or untitled for now
+	public isFileEditorInput(): boolean {
+		return (this._sql instanceof FileEditorInput);
 	}
 
 	public getName(longForm?: boolean): string {

--- a/src/sql/workbench/parts/query/common/queryInput.ts
+++ b/src/sql/workbench/parts/query/common/queryInput.ts
@@ -219,9 +219,8 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 		return false;
 	}
 
-	// will change this to a better function but needed to know if its file or untitled for now
-	public isFileEditorInput(): boolean {
-		return (this._sql instanceof FileEditorInput);
+	public matchInputInstanceType(inputType: any): boolean {
+		return (this._sql instanceof inputType);
 	}
 
 	public getName(longForm?: boolean): string {

--- a/src/sql/workbench/parts/query/common/queryInput.ts
+++ b/src/sql/workbench/parts/query/common/queryInput.ts
@@ -10,6 +10,7 @@ import { URI } from 'vs/base/common/uri';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
 import { EditorInput, ConfirmResult, EncodingMode, IEncodingSupport } from 'vs/workbench/common/editor';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IFileService } from 'vs/platform/files/common/files';
 
 import { IConnectionManagementService, IConnectableInput, INewConnectionParams, RunQueryOnConnectionMode } from 'sql/platform/connection/common/connectionManagement';
 import { QueryResultsInput } from 'sql/workbench/parts/query/common/queryResultsInput';
@@ -118,7 +119,8 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 		private _connectionProviderName: string,
 		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
 		@IQueryModelService private _queryModelService: IQueryModelService,
-		@IConfigurationService private _configurationService: IConfigurationService
+		@IConfigurationService private _configurationService: IConfigurationService,
+		@IFileService private _fileService: IFileService
 	) {
 		super();
 		this._updateSelection = new Emitter<ISelectionData>();
@@ -221,6 +223,10 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 
 	public matchInputInstanceType(inputType: any): boolean {
 		return (this._sql instanceof inputType);
+	}
+
+	public inputFileExists(): Promise<boolean> {
+		return this._fileService.exists(this.getResource());
 	}
 
 	public getName(longForm?: boolean): string {

--- a/src/sql/workbench/parts/query/test/browser/queryEditor.test.ts
+++ b/src/sql/workbench/parts/query/test/browser/queryEditor.test.ts
@@ -294,6 +294,7 @@ suite('SQL QueryEditor Tests', () => {
 				undefined,
 				connectionManagementService.object,
 				queryModelService.object,
+				undefined,
 				undefined
 			);
 		});

--- a/src/sql/workbench/test/common/taskUtilities.test.ts
+++ b/src/sql/workbench/test/common/taskUtilities.test.ts
@@ -76,7 +76,7 @@ suite('TaskUtilities', function () {
 		// Mock the workbench service to return the active tab connection
 		let tabConnectionUri = 'file://test_uri';
 		let editorInput = new UntitledEditorInput(URI.parse(tabConnectionUri), false, undefined, undefined, undefined, undefined, undefined, undefined);
-		let queryInput = new QueryInput(undefined, editorInput, undefined, undefined, undefined, undefined, undefined);
+		let queryInput = new QueryInput(undefined, editorInput, undefined, undefined, undefined, undefined, undefined, undefined);
 		mockConnectionManagementService.setup(x => x.getConnectionProfile(tabConnectionUri)).returns(() => tabProfile);
 
 		// If I call getCurrentGlobalConnection, it should return the expected profile from the active tab

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -426,9 +426,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 	}
 
 	private async restoreEditors(from: IEditorGroupView | ISerializedEditorGroup): Promise<void> {
+		await this._group.removeNonExitingEditor(); // {{SQL CARBON EDIT}} @udeeshagautam perform async correction for non-existing files
 
-		// doing this here because doing this inside constructor with then was hanging intermittently (not sure why)
-		await this._group.removeNonExitingEditor();
 		if (this._group.count === 0) {
 			return; // nothing to show
 		}

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -426,6 +426,9 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 	}
 
 	private async restoreEditors(from: IEditorGroupView | ISerializedEditorGroup): Promise<void> {
+
+		// doing this here because doing this inside constructor with then was hanging intermittently (not sure why)
+		await this._group.removeNonExitingEditor();
 		if (this._group.count === 0) {
 			return; // nothing to show
 		}

--- a/src/vs/workbench/common/editor/editorGroup.ts
+++ b/src/vs/workbench/common/editor/editorGroup.ts
@@ -19,7 +19,6 @@ import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorIn
 import * as CustomInputConverter from 'sql/workbench/common/customInputConverter';
 import { NotebookInput } from 'sql/workbench/parts/notebook/common/models/notebookInput';
 import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
-import { IFileService } from 'vs/platform/files/common/files';
 
 const EditorOpenPositioning = {
 	LEFT: 'left',
@@ -111,8 +110,7 @@ export class EditorGroup extends Disposable {
 	constructor(
 		labelOrSerializedGroup: ISerializedEditorGroup,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IFileService protected readonly fileService: IFileService,
+		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super();
 
@@ -737,8 +735,7 @@ export class EditorGroup extends Disposable {
 		let n = 0;
 		while (n < this.editors.length) {
 			let editor = this.editors[n];
-			let exist: boolean = await this.fileService.exists(editor.getResource());
-			if (editor instanceof QueryInput && editor.matchInputInstanceType(FileEditorInput) && !editor.isDirty() && exist === false && this.editors.length > 1) {
+			if (editor instanceof QueryInput && editor.matchInputInstanceType(FileEditorInput) && !editor.isDirty() && await editor.inputFileExists() === false && this.editors.length > 1) {
 				// remove from editors list so that they do not get restored
 				this.editors.splice(n, 1);
 				let index = this.mru.findIndex(e => e.matches(editor));

--- a/src/vs/workbench/common/editor/editorGroup.ts
+++ b/src/vs/workbench/common/editor/editorGroup.ts
@@ -732,23 +732,18 @@ export class EditorGroup extends Disposable {
 		}
 	}
 
+	// {{SQL CARBON EDIT}}
 	async removeNonExitingEditor(): Promise<void> {
 		let n = 0;
 		while (n < this.editors.length) {
-			let editor = this.editors[n] as QueryInput;
+			let editor = this.editors[n];
 			let exist: boolean = await this.fileService.exists(editor.getResource());
-			// Explanation of the 5 ifs : do this for
-			// editor !== undefined : only query editors (to check for actual inpput type)
-			// editor.isFileEditorInput() : which have been created from fileEditor input (not untitled)
-			// !editor.isDirty() : do not have changes
-			// exist === false : do not exist
-			// this.editors.length > 1: opened with atleast one more editor because single active editor scenario is handled by VS and if we do it here then welcome page doesn't come
-			if (editor !== undefined && editor.isFileEditorInput() && !editor.isDirty() && exist === false && this.editors.length > 1) {
-				//remove from editors list so that they do not get restored
+			if (editor instanceof QueryInput && editor.matchInputInstanceType(FileEditorInput) && !editor.isDirty() && exist === false && this.editors.length > 1) {
+				// remove from editors list so that they do not get restored
 				this.editors.splice(n, 1);
 				let index = this.mru.findIndex(e => e.matches(editor));
 
-				// remove from MRU list other wise later if we try to close them it leaves a sticky active editor with no data
+				// remove from MRU list otherwise later if we try to close them it leaves a sticky active editor with no data
 				this.mru.splice(index, 1);
 				this.active = this.isActive(editor) ? this.editors[0] : this.active;
 				editor.close();
@@ -756,7 +751,7 @@ export class EditorGroup extends Disposable {
 			else {
 				n++;
 			}
-
 		}
 	}
+	// {{SQL CARBON EDIT}}
 }


### PR DESCRIPTION
Refixing https://github.com/microsoft/azuredatastudio/issues/4051 with correct layering (removed os/path reference). This change ensures that,

1. Any non existing / not edited (non-dirty) SQL file will not reopen at ADS relaunch whether is it active editor or not. The definition files fall under this category.
2. This behavior does not affect other types of files (because vscode by default handles them differently). This is same as previous fix.
3. However if single active editor was open and the file is removed between sessions - VScode shows welcome at relaunch. We do the same for any type of file.
