### PR TITLE
Use VS Code iKey and modify event prefix

### DIFF
--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -7,7 +7,7 @@
 	"preview": true,
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/admin-tool-ext-win/license/Azure%20Data%20Studio%20Extension%20-%20Standalone%20(free)%20Use%20Terms.txt",
 	"icon": "images/sqlserver.png",
-	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+	"aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
 	"engines": {
 		"vscode": "^1.30.1",
 		"azdata": ">=1.8.0"

--- a/extensions/agent/package.json
+++ b/extensions/agent/package.json
@@ -7,7 +7,7 @@
 	"preview": true,
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",
 	"icon": "images/sqlserver.png",
-	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+	"aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
 	"engines": {
 		"vscode": "^1.25.0"
 	},

--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -11,7 +11,7 @@
 	},
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",
 	"icon": "images/sqlserver.png",
-	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+	"aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
 	"activationEvents": [
 		"*"
 	],

--- a/extensions/import/package.json
+++ b/extensions/import/package.json
@@ -11,7 +11,7 @@
 	},
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/import/Microsoft_SQL_Server_Import_Extension_and_Tools_Import_Flat_File_Preview.docx",
 	"icon": "images/sqlserver.png",
-	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+	"aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
 	"activationEvents": [
 		"*"
 	],

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -2,7 +2,7 @@
   "name": "mssql",
   "version": "0.1.0",
   "publisher": "Microsoft",
-  "aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+  "aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
   "activationEvents": [
     "*"
   ],

--- a/extensions/profiler/package.json
+++ b/extensions/profiler/package.json
@@ -7,7 +7,7 @@
 	"preview": true,
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",
 	"icon": "images/sqlserver.png",
-	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+	"aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
 	"engines": {
 		"vscode": "0.10.x"
 	},

--- a/extensions/resource-deployment/package.json
+++ b/extensions/resource-deployment/package.json
@@ -7,7 +7,7 @@
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",
   "icon": "images/sqlserver.png",
-  "aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+  "aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
   "engines": {
     "vscode": "*",
     "azdata": ">=1.6.0"

--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -11,7 +11,7 @@
 	},
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/import/Microsoft_SQL_Server_Import_Extension_and_Tools_Import_Flat_File_Preview.docx",
 	"icon": "images/sqlserver.png",
-	"aiKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412",
+	"aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
 	"activationEvents": [
 		"*"
 	],

--- a/product.json
+++ b/product.json
@@ -25,7 +25,7 @@
 	"urlProtocol": "azuredatastudio",
 	"enableTelemetry": true,
 	"aiConfig": {
-		"asimovKey": "AIF-5574968e-856d-40d2-af67-c89a14e76412"
+		"asimovKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916"
 	},
 	"sendASmile": {
 		"reportIssueUrl": "https://github.com/Microsoft/azuredatastudio/issues/new?labels=customer%20reported%20issue",

--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -72,8 +72,7 @@ interface ISharedProcessInitData {
 	logLevel: LogLevel;
 }
 
-// {{SQL CARBON EDIT}} Use custom event prefix to differentiate from VS Code telemetry events
-const eventPrefix = 'adsworkbench';
+const eventPrefix = 'adsworkbench'; // {{SQL CARBON EDIT}} Use custom event prefix to differentiate from VS Code telemetry events
 
 class MainProcessService implements IMainProcessService {
 	constructor(private server: Server, private mainRouter: StaticRouter) { }

--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -72,7 +72,8 @@ interface ISharedProcessInitData {
 	logLevel: LogLevel;
 }
 
-const eventPrefix = 'monacoworkbench';
+// {{SQL CARBON EDIT}} Use custom event prefix to differentiate from VS Code telemetry events
+const eventPrefix = 'adsworkbench';
 
 class MainProcessService implements IMainProcessService {
 	constructor(private server: Server, private mainRouter: StaticRouter) { }

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -303,7 +303,8 @@ export class Main {
 	}
 }
 
-const eventPrefix = 'monacoworkbench';
+// {{SQL CARBON EDIT}} Use custom event prefix to differentiate from VS Code telemetry events
+const eventPrefix = 'adsworkbench';
 
 export async function main(argv: ParsedArgs): Promise<void> {
 	const services = new ServiceCollection();

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -303,8 +303,7 @@ export class Main {
 	}
 }
 
-// {{SQL CARBON EDIT}} Use custom event prefix to differentiate from VS Code telemetry events
-const eventPrefix = 'adsworkbench';
+const eventPrefix = 'adsworkbench'; // {{SQL CARBON EDIT}} Use custom event prefix to differentiate from VS Code telemetry events
 
 export async function main(argv: ParsedArgs): Promise<void> {
 	const services = new ServiceCollection();

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -101,8 +101,7 @@ export class WebTelemetryAppender implements ITelemetryAppender {
 		data = validateTelemetryData(data);
 		this._logService.trace(`telemetry/${eventName}`, data);
 
-		// {{SQL CARBON EDIT}} Use custom event prefix to differentiate from VS Code telemetry events
-		this._aiClient.trackEvent('adsworkbench/' + eventName, data.properties, data.measurements);
+		this._aiClient.trackEvent('adsworkbench/' + eventName, data.properties, data.measurements); // {{SQL CARBON EDIT}} Use custom event prefix to differentiate from VS Code telemetry events
 	}
 
 	flush(): Promise<any> | undefined {

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -101,7 +101,8 @@ export class WebTelemetryAppender implements ITelemetryAppender {
 		data = validateTelemetryData(data);
 		this._logService.trace(`telemetry/${eventName}`, data);
 
-		this._aiClient.trackEvent('monacoworkbench/' + eventName, data.properties, data.measurements);
+		// {{SQL CARBON EDIT}} Use custom event prefix to differentiate from VS Code telemetry events
+		this._aiClient.trackEvent('adsworkbench/' + eventName, data.properties, data.measurements);
 	}
 
 	flush(): Promise<any> | undefined {


### PR DESCRIPTION
Use VS Code iKey for onboarding into Nova. 

Update event prefix to then differentiate our telemetry from their events. 