### PR TITLE
QueryExecutionOptions Fix

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -771,9 +771,7 @@ declare module 'azdata' {
 		flavor: string;
 	}
 
-	export interface QueryExecutionOptions {
-		options: Map<string, any>;
-	}
+	type QueryExecutionOptions = { [key: string]: any };
 
 	export interface QueryProvider extends DataProvider {
 		cancelQuery(ownerUri: string): Thenable<QueryCancelResult>;
@@ -4026,7 +4024,7 @@ declare module 'azdata' {
 			uri: string;
 
 			// set the document's execution options
-			setExecutionOptions(options: Map<string, any>): Thenable<void>;
+			setExecutionOptions(options: QueryExecutionOptions): Thenable<void>;
 
 			// tab content is build using the modelview UI builder APIs
 			// probably should rename DialogTab class since it is useful outside dialogs

--- a/src/sql/workbench/api/common/extHostQueryEditor.ts
+++ b/src/sql/workbench/api/common/extHostQueryEditor.ts
@@ -16,10 +16,8 @@ class ExtHostQueryDocument implements azdata.queryeditor.QueryDocument {
 		private _proxy: MainThreadQueryEditorShape) {
 	}
 
-	public setExecutionOptions(options: Map<string, any>): Thenable<void> {
-		let executionOptions: azdata.QueryExecutionOptions = {
-			options: options
-		};
+	public setExecutionOptions(options: azdata.QueryExecutionOptions): Thenable<void> {
+		let executionOptions: azdata.QueryExecutionOptions = options;
 		return this._proxy.$setQueryExecutionOptions(this.uri, executionOptions);
 	}
 


### PR DESCRIPTION
This is a breaking change to the extensibility endpoints. However, this extensibility point seems to be broken without this change anyway... so I'm not sure if anyone is actually using it.


Maybe keeping this as a deprecated method would be ideal, but I'm not sure what the protocol here is.