### PR TITLE
Fix Books Unit Tests

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -26,8 +26,8 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	private _resource: string;
 	private _onReadAllTOCFiles: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
 
-	constructor(private workspaceFolders: vscode.WorkspaceFolder[], extensionContext: vscode.ExtensionContext) {
-		this.getTableOfContentFiles().then(() => undefined, (err) => { console.log(err); });
+	constructor(workspaceFolders: vscode.WorkspaceFolder[], extensionContext: vscode.ExtensionContext) {
+		this.getTableOfContentFiles(workspaceFolders).then(() => undefined, (err) => { console.log(err); });
 		this._extensionContext = extensionContext;
 	}
 
@@ -35,7 +35,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		return this._onReadAllTOCFiles.event;
 	}
 
-	async getTableOfContentFiles(): Promise<void> {
+	async getTableOfContentFiles(workspaceFolders: vscode.WorkspaceFolder[]): Promise<void> {
 		let notebookConfig = vscode.workspace.getConfiguration(notebookConfigKey);
 		let maxDepth = notebookConfig[maxBookSearchDepth];
 		// Use default value if user enters an invalid value
@@ -44,7 +44,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		} else if (maxDepth === 0) { // No limit of search depth if user enters 0
 			maxDepth = undefined;
 		}
-		let workspacePaths: string[] = this.workspaceFolders.map(a => a.uri.fsPath);
+		let workspacePaths: string[] = workspaceFolders.map(a => a.uri.fsPath);
 		for (let path of workspacePaths) {
 			let tableOfContentPaths = await glob([path + '/**/_data/toc.yml'], { deep: maxDepth });
 			this._tableOfContentPaths = this._tableOfContentPaths.concat(tableOfContentPaths);

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -24,10 +24,15 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	private _extensionContext: vscode.ExtensionContext;
 	private _throttleTimer: any;
 	private _resource: string;
+	private _onReadAllTOCFiles: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
 
 	constructor(private workspaceFolders: vscode.WorkspaceFolder[], extensionContext: vscode.ExtensionContext) {
 		this.getTableOfContentFiles().then(() => undefined, (err) => { console.log(err); });
 		this._extensionContext = extensionContext;
+	}
+
+	public get onReadAllTOCFiles(): vscode.Event<void> {
+		return this._onReadAllTOCFiles.event;
 	}
 
 	async getTableOfContentFiles(): Promise<void> {
@@ -49,6 +54,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		});
 		let bookOpened: boolean = this._tableOfContentPaths.length > 0;
 		vscode.commands.executeCommand('setContext', 'bookOpened', bookOpened);
+		this._onReadAllTOCFiles.fire();
 	}
 
 	async openNotebook(resource: string): Promise<void> {

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -49,9 +49,6 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			let tableOfContentPaths = await glob([path + '/**/_data/toc.yml'], { deep: maxDepth });
 			this._tableOfContentPaths = this._tableOfContentPaths.concat(tableOfContentPaths);
 		}
-		this._tableOfContentPaths = this._tableOfContentPaths.filter(function (elem, index, self) {
-			return index === self.indexOf(elem);
-		});
 		let bookOpened: boolean = this._tableOfContentPaths.length > 0;
 		vscode.commands.executeCommand('setContext', 'bookOpened', bookOpened);
 		this._onReadAllTOCFiles.fire();

--- a/extensions/notebook/src/test/book/book.test.ts
+++ b/extensions/notebook/src/test/book/book.test.ts
@@ -73,6 +73,7 @@ describe('BookTreeViewProvider.getChildren', function (): void {
 	});
 
 	it('should return all book nodes when element is undefined', async function (): Promise<void> {
+		await bookTreeViewProvider.getTableOfContentFiles();
 		const children = await bookTreeViewProvider.getChildren();
 		should(children).be.Array();
 		should(children.length).equal(1);

--- a/extensions/notebook/src/test/book/book.test.ts
+++ b/extensions/notebook/src/test/book/book.test.ts
@@ -73,27 +73,30 @@ describe('BookTreeViewProvider.getChildren', function (): void {
 	});
 
 	it('should return all book nodes when element is undefined', async function (): Promise<void> {
-		await bookTreeViewProvider.getTableOfContentFiles();
-		const children = await bookTreeViewProvider.getChildren();
-		should(children).be.Array();
-		should(children.length).equal(1);
-		book = children[0];
-		should(book.title).equal(expectedBook.title);
+		bookTreeViewProvider.onReadAllTOCFiles(async () => {
+			const children = await bookTreeViewProvider.getChildren();
+			should(children).be.Array();
+			should(children.length).equal(1);
+			book = children[0];
+			should(book.title).equal(expectedBook.title);
+		});
 	});
 
 	it('should return all page nodes when element is a book', async function (): Promise<void> {
-		const children = await bookTreeViewProvider.getChildren(book);
-		should(children).be.Array();
-		should(children.length).equal(3);
-		const notebook = children[0];
-		const markdown = children[1];
-		const externalLink = children[2];
-		should(notebook.title).equal(expectedNotebook.title);
-		should(notebook.uri).equal(expectedNotebook.url);
-		should(markdown.title).equal(expectedMarkdown.title);
-		should(markdown.uri).equal(expectedMarkdown.url);
-		should(externalLink.title).equal(expectedExternalLink.title);
-		should(externalLink.uri).equal(expectedExternalLink.url);
+		bookTreeViewProvider.onReadAllTOCFiles(async () => {
+				const children = await bookTreeViewProvider.getChildren(book);
+				should(children).be.Array();
+				should(children.length).equal(3);
+				const notebook = children[0];
+				const markdown = children[1];
+				const externalLink = children[2];
+				should(notebook.title).equal(expectedNotebook.title);
+				should(notebook.uri).equal(expectedNotebook.url);
+				should(markdown.title).equal(expectedMarkdown.title);
+				should(markdown.uri).equal(expectedMarkdown.url);
+				should(externalLink.title).equal(expectedExternalLink.title);
+				should(externalLink.uri).equal(expectedExternalLink.url);
+		});
 	});
 
 	this.afterAll(async function () {


### PR DESCRIPTION
The tests were failing because I moved getTableOfContents() into an async method and getChildren() was being called before the toc.yml files were found. I added an Event to make sure all toc.yml files were found before running the tests.