### PR TITLE
Correctly set focus on new Notebook cells after clicking on inline buttons.

### DIFF
--- a/src/sql/workbench/parts/notebook/browser/notebook.component.html
+++ b/src/sql/workbench/parts/notebook/browser/notebook.component.html
@@ -11,11 +11,11 @@
 		<loading-spinner [loading]="isLoading"></loading-spinner>
 		<div class="hoverButtonsContainer" *ngIf="(cells && cells.length > 0) && !isLoading">
 			<span class="containerBackground"></span>
-			<button class="hoverButton" (click)="addCell('code', 0)">
+			<button class="hoverButton" (click)="addCell('code', 0, $event)">
 				<div class="addCodeIcon"></div>
 				<span>{{addCodeLabel}}</span>
 			</button>
-			<button class="hoverButton" (click)="addCell('markdown', 0)">
+			<button class="hoverButton" (click)="addCell('markdown', 0, $event)">
 				<div class="addTextIcon"></div>
 				<span>{{addTextLabel}}</span>
 			</button>
@@ -29,11 +29,11 @@
 			</div>
 			<div class="hoverButtonsContainer">
 				<span class="containerBackground"></span>
-				<button class="hoverButton" (click)="addCell('code', findCellIndex(cell) + 1)">
+				<button class="hoverButton" (click)="addCell('code', findCellIndex(cell) + 1, $event)">
 					<div class="addCodeIcon"></div>
 					<span>{{addCodeLabel}}</span>
 				</button>
-				<button class="hoverButton" (click)="addCell('markdown', findCellIndex(cell) + 1)">
+				<button class="hoverButton" (click)="addCell('markdown', findCellIndex(cell) + 1, $event)">
 					<div class="addTextIcon"></div>
 					<span>{{addTextLabel}}</span>
 				</button>

--- a/src/sql/workbench/parts/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/parts/notebook/browser/notebook.component.ts
@@ -200,7 +200,10 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	}
 
 	// Add cell based on cell type
-	public addCell(cellType: CellType, index?: number) {
+	public addCell(cellType: CellType, index?: number, event?: Event) {
+		if (event) {
+			event.stopPropagation();
+		}
 		this._model.addCell(cellType, index);
 	}
 


### PR DESCRIPTION
When clicking on an inline notebook button to add a cell, the click would also trigger the unselectActiveCell callback of the notebook container, causing the newly added cell to lose focus. This change stops the mouse event propagation after adding a cell to prevent that unselect callback from being triggered, similar to how we block mouse events in selectCell.

Fixes https://github.com/microsoft/azuredatastudio/issues/6705 https://github.com/microsoft/azuredatastudio/issues/6614