### PR TITLE
Fix #6709: default DacFx connection not always being correct

### DIFF
--- a/extensions/dacpac/src/wizard/api/basePage.ts
+++ b/extensions/dacpac/src/wizard/api/basePage.ts
@@ -52,6 +52,9 @@ export abstract class BasePage {
 			return undefined;
 		}
 
+		// reverse list so that most recent connections are first
+		cons.reverse();
+
 		let count = -1;
 		let idx = -1;
 
@@ -98,9 +101,6 @@ export abstract class BasePage {
 			}
 			return uniqueValues;
 		}, []);
-
-		// reverse list so that most recent connections show first
-		values.reverse();
 
 		return values;
 	}


### PR DESCRIPTION
Fixes regression from #6565. The connections list needs to be reversed before the default connection is set.