### PR TITLE
Change the signature of setQueryExecutionOptions/setExecutionOptions

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -760,9 +760,7 @@ declare module 'azdata' {
 		flavor: string;
 	}
 
-	export interface QueryExecutionOptions {
-		options: Map<string, any>;
-	}
+	export type QueryExecutionOptions = Map<string, any>;
 
 	export interface QueryProvider extends DataProvider {
 		cancelQuery(ownerUri: string): Thenable<QueryCancelResult>;
@@ -4016,7 +4014,7 @@ declare module 'azdata' {
 			uri: string;
 
 			// set the document's execution options
-			setExecutionOptions(options: Map<string, any>): Thenable<void>;
+			setExecutionOptions(options: QueryExecutionOptions): Thenable<void>;
 
 			// tab content is build using the modelview UI builder APIs
 			// probably should rename DialogTab class since it is useful outside dialogs

--- a/src/sql/workbench/api/common/extHostQueryEditor.ts
+++ b/src/sql/workbench/api/common/extHostQueryEditor.ts
@@ -17,9 +17,8 @@ class ExtHostQueryDocument implements azdata.queryeditor.QueryDocument {
 	}
 
 	public setExecutionOptions(options: Map<string, any>): Thenable<void> {
-		let executionOptions: azdata.QueryExecutionOptions = {
-			options: options
-		};
+		let executionOptions = options as azdata.QueryExecutionOptions;
+
 		return this._proxy.$setQueryExecutionOptions(this.uri, executionOptions);
 	}
 


### PR DESCRIPTION
Replaces #6679 

@udeeshagautam Debugging on the server side shows me that with the current double nested options field, nothing gets passed to the sqltoolsservice. Does the current setQueryExecutionOptions work for you?