### PR TITLE
Add optional title to tables

### DIFF
--- a/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
@@ -32,7 +32,9 @@ export class DacFxSummaryPage extends BasePage {
 	}
 
 	async start(): Promise<boolean> {
-		this.table = this.view.modelBuilder.table().component();
+		this.table = this.view.modelBuilder.table().withProperties({
+			title: 'Summary of settings'
+		}).component();
 		this.loader = this.view.modelBuilder.loadingComponent().withItem(this.table).component();
 		this.form = this.view.modelBuilder.formContainer().withFormItems(
 			[

--- a/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
@@ -33,7 +33,7 @@ export class DacFxSummaryPage extends BasePage {
 
 	async start(): Promise<boolean> {
 		this.table = this.view.modelBuilder.table().withProperties({
-			title: 'Summary of settings'
+			title: localize('dacfx.summaryTableTitle', 'Summary of settings')
 		}).component();
 		this.loader = this.view.modelBuilder.loadingComponent().withItem(this.table).component();
 		this.form = this.view.modelBuilder.formContainer().withFormItems(

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3239,6 +3239,7 @@ declare module 'azdata' {
 		fontSize?: number | string;
 		selectedRows?: number[];
 		forceFitColumns?: ColumnSizingMode;
+		title?: string;
 	}
 
 	export interface FileBrowserTreeProperties extends ComponentProperties {

--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -339,4 +339,8 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 		this._grid.setOptions(newOptions);
 		this._grid.invalidate();
 	}
+
+	public setTableTitle(title: string): void {
+		this._tableContainer.title = title;
+	}
 }

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1133,6 +1133,13 @@ class TableComponentWrapper extends ComponentWrapper implements azdata.TableComp
 		this.setProperty('forceFitColumns', v);
 	}
 
+	public get title(): string {
+		return this.properties['title'];
+	}
+	public set title(v: string) {
+		this.setProperty('title', v);
+	}
+
 	public get onRowSelected(): vscode.Event<any> {
 		let emitter = this._emitterMap.get(ComponentEventType.onSelectedRowChanged);
 		return emitter && emitter.event;

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -208,6 +208,7 @@ export default class TableComponent extends ComponentBase implements IComponent,
 		this._tableColumns = this.transformColumns(this.columns);
 		this._table.columns = this._tableColumns;
 		this._table.setData(this._tableData);
+		this._table.setTableTitle(this.title);
 		if (this.selectedRows) {
 			this._table.setSelectedRows(this.selectedRows);
 		}
@@ -285,5 +286,9 @@ export default class TableComponent extends ComponentBase implements IComponent,
 
 	public get forceFitColumns() {
 		return this.getPropertyOrDefault<azdata.TableComponentProperties, ColumnSizingMode>((props) => props.forceFitColumns, ColumnSizingMode.ForceFit);
+	}
+
+	public get title() {
+		return this.getPropertyOrDefault<azdata.TableComponentProperties, string>((props) => props.title, '');
 	}
 }


### PR DESCRIPTION
This adds the option for tables to have a title attribute and adds a title to the summary tables in the DacFx wizard. Addresses accessibility bug #6660. 

![image](https://user-images.githubusercontent.com/31145923/62985983-87387100-bdee-11e9-9309-7d2d853fccf6.png)
