### PR TITLE
Added Delete Database extension

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -2493,7 +2493,7 @@
 					"flags": "preview"
 				},
 				{
-					"extensionId": "27",
+					"extensionId": "53",
 					"extensionName": "delete-database",
 					"displayName": "Delete database",
 					"shortDescription": "Adds 'Delete' option when right clicking on a database",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -2491,6 +2491,63 @@
 					],
 					"statistics": [],
 					"flags": "preview"
+				},
+				{
+					"extensionId": "27",
+					"extensionName": "delete-database",
+					"displayName": "Delete database",
+					"shortDescription": "Adds 'Delete' option when right clicking on a database",
+					"publisher": {
+						"displayName": "AlexP",
+						"publisherId": "alx-ppv",
+						"publisherName": "alx-ppv"
+					},
+					"versions": [
+						{
+							"version": "0.0.3",
+							"lastUpdated": "08/14/2019",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.SQLOps.DownloadPage",
+									"source": "https://github.com/alx-ppv/ADS-delete-database/releases/tag/0.0.3"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/logo.png"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/LICENSE"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+									"value": ""
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/alx-ppv/ADS-delete-database"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": "*"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": "preview"
 				}
 			],
 			"resultMetadata": [


### PR DESCRIPTION
Extension that adds a 'Delete' option when right-clicking on a database. It prompts the user to confirm the deletion and refreshes the database tree after.