### PR TITLE
Benjind/schema compare add aria label

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -814,7 +814,8 @@ export class SchemaCompareMainWindow {
 	private createSourceAndTargetButtons(view: azdata.ModelView): void {
 		this.selectSourceButton = view.modelBuilder.button().withProperties({
 			label: '•••',
-			title: localize('schemaCompare.sourceButtonTitle', 'Select Source')
+			title: localize('schemaCompare.sourceButtonTitle', 'Select Source'),
+			ariaLabel: localize('schemaCompare.sourceButtonTitle', 'Select Source')
 		}).component();
 
 		this.selectSourceButton.onDidClick(() => {
@@ -825,7 +826,8 @@ export class SchemaCompareMainWindow {
 
 		this.selectTargetButton = view.modelBuilder.button().withProperties({
 			label: '•••',
-			title: localize('schemaCompare.targetButtonTitle', 'Select Target')
+			title: localize('schemaCompare.targetButtonTitle', 'Select Target'),
+			ariaLabel: localize('schemaCompare.targetButtonTitle', 'Select Target')
 		}).component();
 
 		this.selectTargetButton.onDidClick(() => {

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -814,8 +814,8 @@ export class SchemaCompareMainWindow {
 	private createSourceAndTargetButtons(view: azdata.ModelView): void {
 		this.selectSourceButton = view.modelBuilder.button().withProperties({
 			label: '•••',
-			title: localize('schemaCompare.sourceButtonTitle', 'Select Source'),
-			ariaLabel: localize('schemaCompare.sourceButtonTitle', 'Select Source')
+			title: localize('schemaCompare.sourceButtonTitle', "Select Source"),
+			ariaLabel: localize('schemaCompare.sourceButtonTitle', "Select Source")
 		}).component();
 
 		this.selectSourceButton.onDidClick(() => {
@@ -826,8 +826,8 @@ export class SchemaCompareMainWindow {
 
 		this.selectTargetButton = view.modelBuilder.button().withProperties({
 			label: '•••',
-			title: localize('schemaCompare.targetButtonTitle', 'Select Target'),
-			ariaLabel: localize('schemaCompare.targetButtonTitle', 'Select Target')
+			title: localize('schemaCompare.targetButtonTitle', "Select Target"),
+			ariaLabel: localize('schemaCompare.targetButtonTitle', "Select Target")
 		}).component();
 
 		this.selectTargetButton.onDidClick(() => {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3356,6 +3356,7 @@ declare module 'azdata' {
 		isFile?: boolean;
 		fileContent?: string;
 		title?: string;
+		ariaLabel?: string;
 	}
 
 	export interface LoadingComponentProperties {

--- a/src/sql/base/browser/ui/button/button.ts
+++ b/src/sql/base/browser/ui/button/button.ts
@@ -43,6 +43,14 @@ export class Button extends vsButton {
 		this.element.title = value;
 	}
 
+	public set ariaLabel(value: string) {
+		this.element.setAttribute('aria-label', value);
+	}
+
+	public get ariaLabel() {
+		return this.element.getAttribute('aria-label');
+	}
+
 	public setHeight(value: string) {
 		this.element.style.height = value;
 	}

--- a/src/sql/base/browser/ui/button/button.ts
+++ b/src/sql/base/browser/ui/button/button.ts
@@ -47,7 +47,7 @@ export class Button extends vsButton {
 		this.element.setAttribute('aria-label', value);
 	}
 
-	public get ariaLabel() {
+	public get ariaLabel(): string {
 		return this.element.getAttribute('aria-label');
 	}
 

--- a/src/sql/base/browser/ui/button/button.ts
+++ b/src/sql/base/browser/ui/button/button.ts
@@ -47,10 +47,6 @@ export class Button extends vsButton {
 		this.element.setAttribute('aria-label', value);
 	}
 
-	public get ariaLabel(): string {
-		return this.element.getAttribute('aria-label');
-	}
-
 	public setHeight(value: string) {
 		this.element.style.height = value;
 	}

--- a/src/sql/workbench/browser/modelComponents/button.component.ts
+++ b/src/sql/workbench/browser/modelComponents/button.component.ts
@@ -102,6 +102,13 @@ export default class ButtonComponent extends ComponentWithIconBase implements IC
 		this._button.enabled = this.enabled;
 		this._button.label = this.label;
 		this._button.title = this.title;
+
+		// Button's ariaLabel gets set to the label by default.
+		// We only want to override that if buttonComponent's ariaLabel is set explicitly.
+		if (this.ariaLabel) {
+			this._button.ariaLabel = this.ariaLabel;
+		}
+
 		if (this.width) {
 			this._button.setWidth(this.convertSize(this.width.toString()));
 		}
@@ -175,4 +182,11 @@ export default class ButtonComponent extends ComponentWithIconBase implements IC
 		this.setPropertyFromUI<azdata.ButtonProperties, string>((properties, title) => { properties.title = title; }, newValue);
 	}
 
+	private get ariaLabel(): string {
+		return this.getPropertyOrDefault<azdata.ButtonProperties, string>((properties) => properties.ariaLabel, '');
+	}
+
+	private set ariaLabel(newValue: string) {
+		this.setPropertyFromUI<azdata.ButtonProperties, string>((properties, ariaLabel) => { properties.ariaLabel = ariaLabel; }, newValue);
+	}
 }


### PR DESCRIPTION
Adds the ability to explicitly set the `aria-label` property of a button, which is used by screen-readers.
Sets `aria-label` for the ellipsis buttons in the SchemaCompare pane, as "..." is not accessible.

Addresses #6730 (not linking so that Accessibility testing team can be the ones to validate and close)