### PR TITLE
Fix #6707: deploy filename changing when it shouldn't

### DIFF
--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -9,7 +9,7 @@ import * as nls from 'vscode-nls';
 import * as vscode from 'vscode';
 import * as os from 'os';
 import * as path from 'path';
-import { DataTierApplicationWizard } from '../dataTierApplicationWizard';
+import { DataTierApplicationWizard, Operation } from '../dataTierApplicationWizard';
 import { DacFxDataModel } from './models';
 import { BasePage } from './basePage';
 import { sanitizeStringForFilename, isValidBasename } from './utils';
@@ -128,9 +128,15 @@ export abstract class DacFxConfigPage extends BasePage {
 
 		// only update values and regenerate filepath if this is the first time and database isn't set yet
 		if (this.model.database !== values[0].name) {
-			this.model.database = values[0].name;
-			this.model.filePath = this.generateFilePathFromDatabaseAndTimestamp();
-			this.fileTextBox.value = this.model.filePath;
+			// db should only get set to the dropdown value if it isn't deploy with create database
+			if (!(this.instance.selectedOperation === Operation.deploy && !this.model.upgradeExisting)) {
+				this.model.database = values[0].name;
+			}
+			// filename shouldn't change for deploy because the file exists and isn't being generated like for extract and export
+			if (this.instance.selectedOperation !== Operation.deploy) {
+				this.model.filePath = this.generateFilePathFromDatabaseAndTimestamp();
+				this.fileTextBox.value = this.model.filePath;
+			}
 		}
 
 		this.databaseDropdown.updateProperties({

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -28,7 +28,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 
 	public constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
 		super(instance, wizardPage, model, view);
-		this.fileExtension = '.bacpac';
+		this.fileExtension = '.dacpac';
 	}
 
 	async start(): Promise<boolean> {


### PR DESCRIPTION
Deploy, extract, and export all use the same populateDatabaseDropdown() method. For extract and export, the database dropdown population should result in the generated filepath and selected database to change to the match the top entry in the dropdown. However, for deploy, populating the database dropdown should only update the database if it's updating an existing database(not creating a new db) and the filepath should not be generated because it uses an existing dacpac(not being created like in the other two scenarios).

Fixes #6707.