### PR TITLE
Fix #6771: Dacfx wizard summary page has wrong page number

### DIFF
--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -66,6 +66,16 @@ export enum ExportOperationPath {
 	summary
 }
 
+export enum PageName {
+	selectOperation = 'selectOperation',
+	deployConfig = 'deployConfig',
+	deployPlan = 'deployPlan',
+	extractConfig = 'extractConfig',
+	importConfig = 'importConfig',
+	exportConfig = 'exportConfig',
+	summary = 'summary'
+}
+
 export class DataTierApplicationWizard {
 	public wizard: azdata.window.Wizard;
 	private connection: azdata.connection.ConnectionProfile;
@@ -107,13 +117,13 @@ export class DataTierApplicationWizard {
 		let importConfigWizardPage = azdata.window.createWizardPage(localize('dacFx.importConfigPageName', 'Select Import Bacpac Settings'));
 		let exportConfigWizardPage = azdata.window.createWizardPage(localize('dacFx.exportConfigPageName', 'Select Export Bacpac Settings'));
 
-		this.pages.set('selectOperation', new Page(selectOperationWizardPage));
-		this.pages.set('deployConfig', new Page(deployConfigWizardPage));
-		this.pages.set('deployPlan', new Page(deployPlanWizardPage));
-		this.pages.set('extractConfig', new Page(extractConfigWizardPage));
-		this.pages.set('importConfig', new Page(importConfigWizardPage));
-		this.pages.set('exportConfig', new Page(exportConfigWizardPage));
-		this.pages.set('summary', new Page(summaryWizardPage));
+		this.pages.set(PageName.selectOperation, new Page(selectOperationWizardPage));
+		this.pages.set(PageName.deployConfig, new Page(deployConfigWizardPage));
+		this.pages.set(PageName.deployPlan, new Page(deployPlanWizardPage));
+		this.pages.set(PageName.extractConfig, new Page(extractConfigWizardPage));
+		this.pages.set(PageName.importConfig, new Page(importConfigWizardPage));
+		this.pages.set(PageName.exportConfig, new Page(exportConfigWizardPage));
+		this.pages.set(PageName.summary, new Page(summaryWizardPage));
 
 		selectOperationWizardPage.registerContent(async (view) => {
 			let selectOperationDacFxPage = new SelectOperationPage(this, selectOperationWizardPage, this.model, view);
@@ -126,37 +136,37 @@ export class DataTierApplicationWizard {
 
 		deployConfigWizardPage.registerContent(async (view) => {
 			let deployConfigDacFxPage = new DeployConfigPage(this, deployConfigWizardPage, this.model, view);
-			this.pages.get('deployConfig').dacFxPage = deployConfigDacFxPage;
+			this.pages.get(PageName.deployConfig).dacFxPage = deployConfigDacFxPage;
 			await deployConfigDacFxPage.start();
 		});
 
 		deployPlanWizardPage.registerContent(async (view) => {
 			let deployPlanDacFxPage = new DeployPlanPage(this, deployPlanWizardPage, this.model, view);
-			this.pages.get('deployPlan').dacFxPage = deployPlanDacFxPage;
+			this.pages.get(PageName.deployPlan).dacFxPage = deployPlanDacFxPage;
 			await deployPlanDacFxPage.start();
 		});
 
 		extractConfigWizardPage.registerContent(async (view) => {
 			let extractConfigDacFxPage = new ExtractConfigPage(this, extractConfigWizardPage, this.model, view);
-			this.pages.get('extractConfig').dacFxPage = extractConfigDacFxPage;
+			this.pages.get(PageName.extractConfig).dacFxPage = extractConfigDacFxPage;
 			await extractConfigDacFxPage.start();
 		});
 
 		importConfigWizardPage.registerContent(async (view) => {
 			let importConfigDacFxPage = new ImportConfigPage(this, importConfigWizardPage, this.model, view);
-			this.pages.get('importConfig').dacFxPage = importConfigDacFxPage;
+			this.pages.get(PageName.importConfig).dacFxPage = importConfigDacFxPage;
 			await importConfigDacFxPage.start();
 		});
 
 		exportConfigWizardPage.registerContent(async (view) => {
 			let exportConfigDacFxPage = new ExportConfigPage(this, exportConfigWizardPage, this.model, view);
-			this.pages.get('exportConfig').dacFxPage = exportConfigDacFxPage;
+			this.pages.get(PageName.exportConfig).dacFxPage = exportConfigDacFxPage;
 			await exportConfigDacFxPage.start();
 		});
 
 		summaryWizardPage.registerContent(async (view) => {
 			let summaryDacFxPage = new DacFxSummaryPage(this, summaryWizardPage, this.model, view);
-			this.pages.get('summary').dacFxPage = summaryDacFxPage;
+			this.pages.get(PageName.summary).dacFxPage = summaryDacFxPage;
 			await summaryDacFxPage.start();
 		});
 
@@ -312,26 +322,26 @@ export class DataTierApplicationWizard {
 		if (idx === 1) {
 			switch (this.selectedOperation) {
 				case Operation.deploy: {
-					page = this.pages.get('deployConfig');
+					page = this.pages.get(PageName.deployConfig);
 					break;
 				}
 				case Operation.extract: {
-					page = this.pages.get('extractConfig');
+					page = this.pages.get(PageName.extractConfig);
 					break;
 				}
 				case Operation.import: {
-					page = this.pages.get('importConfig');
+					page = this.pages.get(PageName.importConfig);
 					break;
 				}
 				case Operation.export: {
-					page = this.pages.get('exportConfig');
+					page = this.pages.get(PageName.exportConfig);
 					break;
 				}
 			}
 		} else if (this.isSummaryPage(idx)) {
-			page = this.pages.get('summary');
+			page = this.pages.get(PageName.summary);
 		} else if ((this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.deployPlan) {
-			page = this.pages.get('deployPlan');
+			page = this.pages.get(PageName.deployPlan);
 		}
 
 		return page;

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as os from 'os';
 import { DacFxDataModel } from '../api/models';
-import { DataTierApplicationWizard, DeployOperationPath, Operation, DeployNewOperationPath } from '../dataTierApplicationWizard';
+import { DataTierApplicationWizard, DeployOperationPath, Operation, DeployNewOperationPath, PageName } from '../dataTierApplicationWizard';
 import { DacFxConfigPage } from '../api/dacFxConfigPage';
 import { DacFxSummaryPage } from './dacFxSummaryPage';
 
@@ -126,8 +126,8 @@ export class DeployConfigPage extends DacFxConfigPage {
 
 			// add deploy plan page and remove and re-add summary page so that it has the correct page number
 			this.instance.wizard.removePage(DeployNewOperationPath.summary);
-			let deployPlanPage = this.instance.pages.get('deployPlan');
-			let summaryPage = this.instance.pages.get('summary');
+			let deployPlanPage = this.instance.pages.get(PageName.deployPlan);
+			let summaryPage = this.instance.pages.get(PageName.summary);
 			this.instance.wizard.addPage(deployPlanPage.wizardPage, DeployOperationPath.deployPlan);
 			this.instance.wizard.addPage(summaryPage.wizardPage, DeployOperationPath.summary);
 		});
@@ -142,7 +142,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 			// remove deploy plan page and readd summary page so that it has the correct page number
 			this.instance.wizard.removePage(DeployOperationPath.summary);
 			this.instance.wizard.removePage(DeployOperationPath.deployPlan);
-			let summaryPage = this.instance.pages.get('summary');
+			let summaryPage = this.instance.pages.get(PageName.summary);
 			this.instance.wizard.addPage(summaryPage.wizardPage, DeployNewOperationPath.summary);
 		});
 

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -124,9 +124,12 @@ export class DeployConfigPage extends DacFxConfigPage {
 			this.formBuilder.addFormItem(this.databaseDropdownComponent, { horizontal: true, componentWidth: 400 });
 			this.model.database = (<azdata.CategoryValue>this.databaseDropdown.value).name;
 
-			// add deploy plan page
+			// add deploy plan page and remove and re-add summary page so that it has the correct page number
+			this.instance.wizard.removePage(DeployNewOperationPath.summary);
 			let deployPlanPage = this.instance.pages.get('deployPlan');
+			let summaryPage = this.instance.pages.get('summary');
 			this.instance.wizard.addPage(deployPlanPage.wizardPage, DeployOperationPath.deployPlan);
+			this.instance.wizard.addPage(summaryPage.wizardPage, DeployOperationPath.summary);
 		});
 
 		newRadioButton.onDidClick(() => {

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -10,8 +10,9 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as os from 'os';
 import { DacFxDataModel } from '../api/models';
-import { DataTierApplicationWizard, DeployOperationPath, Operation } from '../dataTierApplicationWizard';
+import { DataTierApplicationWizard, DeployOperationPath, Operation, DeployNewOperationPath } from '../dataTierApplicationWizard';
 import { DacFxConfigPage } from '../api/dacFxConfigPage';
+import { DacFxSummaryPage } from './dacFxSummaryPage';
 
 const localize = nls.loadMessageBundle();
 
@@ -135,8 +136,11 @@ export class DeployConfigPage extends DacFxConfigPage {
 			this.model.database = this.databaseTextBox.value;
 			this.instance.setDoneButton(Operation.deploy);
 
-			// remove deploy plan page
+			// remove deploy plan page and readd summary page so that it has the correct page number
+			this.instance.wizard.removePage(DeployOperationPath.summary);
 			this.instance.wizard.removePage(DeployOperationPath.deployPlan);
+			let summaryPage = this.instance.pages.get('summary');
+			this.instance.wizard.addPage(summaryPage.wizardPage, DeployNewOperationPath.summary);
 		});
 
 		//Initialize with upgrade existing true

--- a/extensions/dacpac/src/wizard/pages/selectOperationpage.ts
+++ b/extensions/dacpac/src/wizard/pages/selectOperationpage.ts
@@ -7,7 +7,7 @@
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
 import { DacFxDataModel } from '../api/models';
-import { DataTierApplicationWizard, Operation, DeployOperationPath, ExtractOperationPath, ImportOperationPath, ExportOperationPath } from '../dataTierApplicationWizard';
+import { DataTierApplicationWizard, Operation, DeployOperationPath, ExtractOperationPath, ImportOperationPath, ExportOperationPath, PageName } from '../dataTierApplicationWizard';
 import { BasePage } from '../api/basePage';
 
 const localize = nls.loadMessageBundle();
@@ -72,9 +72,9 @@ export class SelectOperationPage extends BasePage {
 			this.removePages();
 
 			//add deploy pages
-			let configPage = this.instance.pages.get('deployConfig');
+			let configPage = this.instance.pages.get(PageName.deployConfig);
 			this.instance.wizard.addPage(configPage.wizardPage, DeployOperationPath.deployOptions);
-			let deployPlanPage = this.instance.pages.get('deployPlan');
+			let deployPlanPage = this.instance.pages.get(PageName.deployPlan);
 			this.instance.wizard.addPage(deployPlanPage.wizardPage, DeployOperationPath.deployPlan);
 			this.addSummaryPage(DeployOperationPath.summary);
 
@@ -99,7 +99,7 @@ export class SelectOperationPage extends BasePage {
 			this.removePages();
 
 			// add the extract page
-			let page = this.instance.pages.get('extractConfig');
+			let page = this.instance.pages.get(PageName.extractConfig);
 			this.instance.wizard.addPage(page.wizardPage, ExtractOperationPath.options);
 			this.addSummaryPage(ExtractOperationPath.summary);
 
@@ -124,7 +124,7 @@ export class SelectOperationPage extends BasePage {
 			this.removePages();
 
 			// add the import page
-			let page = this.instance.pages.get('importConfig');
+			let page = this.instance.pages.get(PageName.importConfig);
 			this.instance.wizard.addPage(page.wizardPage, ImportOperationPath.options);
 			this.addSummaryPage(ImportOperationPath.summary);
 
@@ -149,7 +149,7 @@ export class SelectOperationPage extends BasePage {
 			this.removePages();
 
 			// add the export pages
-			let page = this.instance.pages.get('exportConfig');
+			let page = this.instance.pages.get(PageName.exportConfig);
 			this.instance.wizard.addPage(page.wizardPage, ExportOperationPath.options);
 			this.addSummaryPage(ExportOperationPath.summary);
 
@@ -171,7 +171,7 @@ export class SelectOperationPage extends BasePage {
 	}
 
 	private addSummaryPage(index: number) {
-		let summaryPage = this.instance.pages.get('summary');
+		let summaryPage = this.instance.pages.get(PageName.summary);
 		this.instance.wizard.addPage(summaryPage.wizardPage, index);
 	}
 


### PR DESCRIPTION
Fixes #6771. The summary page had the wrong page number for deploy to new database. This fixes that by removing both the summary and deploy plan pages, then adding the summary page back so that it will have the correct page number.

![image](https://user-images.githubusercontent.com/31145923/63136246-eaa8d700-bf85-11e9-98af-d31672d8978d.png)