### PR TITLE
Improve narration for backup and dacpac UIs

### DIFF
--- a/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
@@ -134,4 +134,3 @@ export class DacFxSummaryPage extends BasePage {
 		});
 	}
 }
-

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3240,6 +3240,8 @@ declare module 'azdata' {
 		selectedRows?: number[];
 		forceFitColumns?: ColumnSizingMode;
 		title?: string;
+		ariaRowCount?: number;
+		ariaColumnCount?: number;
 	}
 
 	export interface FileBrowserTreeProperties extends ComponentProperties {

--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -343,4 +343,20 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 	public setTableTitle(title: string): void {
 		this._tableContainer.title = title;
 	}
+
+	public removeAriaRowCount(): void {
+		this._tableContainer.removeAttribute('aria-rowcount');
+	}
+
+	public set ariaRowCount(value: number) {
+		this._tableContainer.setAttribute('aria-rowcount', value.toString());
+	}
+
+	public removeAriaColumnCount(): void {
+		this._tableContainer.removeAttribute('aria-colcount');
+	}
+
+	public set ariaColumnCount(value: number) {
+		this._tableContainer.setAttribute('aria-colcount', value.toString());
+	}
 }

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -217,6 +217,20 @@ export default class TableComponent extends ComponentBase implements IComponent,
 			this.registerCheckboxPlugin(this._checkboxColumns[col]);
 		}
 
+		if (this.ariaRowCount === -1) {
+			this._table.removeAriaRowCount();
+		}
+		else {
+			this._table.ariaRowCount = this.ariaRowCount;
+		}
+
+		if (this.ariaColumnCount === -1) {
+			this._table.removeAriaColumnCount();
+		}
+		else {
+			this._table.ariaColumnCount = this.ariaColumnCount;
+		}
+
 		this.layoutTable();
 		this.validate();
 	}
@@ -290,5 +304,13 @@ export default class TableComponent extends ComponentBase implements IComponent,
 
 	public get title() {
 		return this.getPropertyOrDefault<azdata.TableComponentProperties, string>((props) => props.title, '');
+	}
+
+	public get ariaRowCount(): number {
+		return this.getPropertyOrDefault<azdata.TableComponentProperties, number>((props) => props.ariaRowCount, -1);
+	}
+
+	public get ariaColumnCount(): number {
+		return this.getPropertyOrDefault<azdata.TableComponentProperties, number>((props) => props.ariaColumnCount, -1);
 	}
 }

--- a/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
+++ b/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
@@ -88,6 +88,8 @@ export class FileBrowserDialog extends Modal {
 		this._treeContainer = DOM.append(this._body, DOM.$('.tree-view'));
 
 		let tableContainer: HTMLElement = DOM.append(DOM.append(this._body, DOM.$('.option-section')), DOM.$('table.file-table-content'));
+		tableContainer.setAttribute('role', 'presentation');
+
 		let pathLabel = localize('filebrowser.filepath', "Selected path");
 		let pathBuilder = DialogHelper.appendRow(tableContainer, pathLabel, 'file-input-label', 'file-input-box');
 		this._filePathInputBox = new InputBox(pathBuilder, this._contextViewService, {


### PR DESCRIPTION
Addresses #6694 

The `aria-rowcount` and `aria-colcount` properties are intended to indicate to a screen-reader how many total, non-DOM rows and columns there are for a virtualized table.  Electron seems to automatically add these properties when the table's first initialized (before we add data), but aria documentation recommends to only include these if there are any non-DOM rows or columns.

As most tables do not have virtualized cells, this change defaults to removing the aria properties, but if you specify the number of cells in the virtualized dataset, they'll be added with the correct values.

Also addresses #6749 by adding `role="presentation"` to the element so screen readers don't announce it.