### PR TITLE
add valid uri prefix

### DIFF
--- a/src/sql/workbench/parts/profiler/browser/profilerInput.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerInput.ts
@@ -22,6 +22,7 @@ import * as types from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import Severity from 'vs/base/common/severity';
 import { FilterData } from 'sql/workbench/services/profiler/common/profilerFilter';
+import { uriPrefixes } from 'sql/platform/connection/common/utils';
 
 export class ProfilerInput extends EditorInput implements IProfilerSession {
 
@@ -60,7 +61,7 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 			autoscroll: true
 		});
 
-		this._profilerService.registerSession(generateUuid(), connection, this).then((id) => {
+		this._profilerService.registerSession(uriPrefixes.connection + generateUuid(), connection, this).then((id) => {
 			this._id = id;
 			this.state.change({ isConnected: true });
 		});


### PR DESCRIPTION
#6805 

recent uri transformer change caused the issue, now it is required to pass in a valid uri instead of a guid, otherwise a connection not found error would occur when connection is established. fixing the occurrence for the profiler feature. 