### PR TITLE
Add aria labels to '•••' buttons in dacfx and schema compare

### DIFF
--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -162,6 +162,7 @@ export abstract class DacFxConfigPage extends BasePage {
 		this.fileTextBox.ariaLabel = localize('dacfx.fileLocationAriaLabel', "File Location");
 		this.fileButton = this.view.modelBuilder.button().withProperties({
 			label: '•••',
+			ariaLabel: localize('dacfx.selectFileAriaLabel', "Select file")
 		}).component();
 	}
 

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -162,7 +162,8 @@ export abstract class DacFxConfigPage extends BasePage {
 		this.fileTextBox.ariaLabel = localize('dacfx.fileLocationAriaLabel', "File Location");
 		this.fileButton = this.view.modelBuilder.button().withProperties({
 			label: '•••',
-			ariaLabel: localize('dacfx.selectFileAriaLabel', "Select file")
+			title: localize('dacfx.selectFile', "Select file"),
+			ariaLabel: localize('dacfx.selectFile', "Select file")
 		}).component();
 	}
 

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -288,10 +288,12 @@ export class SchemaCompareDialog {
 		if (isTarget) {
 			this.targetFileButton = view.modelBuilder.button().withProperties({
 				label: '•••',
+				ariaLabel: localize('schemaCompare.selectFileAriaLabel', "Select file")
 			}).component();
 		} else {
 			this.sourceFileButton = view.modelBuilder.button().withProperties({
 				label: '•••',
+				ariaLabel: localize('schemaCompare.selectFileAriaLabel', "Select file")
 			}).component();
 		}
 

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -294,8 +294,8 @@ export class SchemaCompareDialog {
 		} else {
 			this.sourceFileButton = view.modelBuilder.button().withProperties({
 				label: '•••',
-				title: localize('schemaCompare.selectTargetFile', "Select target file"),
-				ariaLabel: localize('schemaCompare.selectTargetFile', "Select target file")
+				title: localize('schemaCompare.selectSourceFile', "Select source file"),
+				ariaLabel: localize('schemaCompare.selectSourceFile', "Select source file")
 			}).component();
 		}
 

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -288,12 +288,14 @@ export class SchemaCompareDialog {
 		if (isTarget) {
 			this.targetFileButton = view.modelBuilder.button().withProperties({
 				label: '•••',
-				ariaLabel: localize('schemaCompare.selectFileAriaLabel', "Select file")
+				title: localize('schemaCompare.selectTargetFile', "Select target file"),
+				ariaLabel: localize('schemaCompare.selectTargetFile', "Select target file")
 			}).component();
 		} else {
 			this.sourceFileButton = view.modelBuilder.button().withProperties({
 				label: '•••',
-				ariaLabel: localize('schemaCompare.selectFileAriaLabel', "Select file")
+				title: localize('schemaCompare.selectTargetFile', "Select target file"),
+				ariaLabel: localize('schemaCompare.selectTargetFile', "Select target file")
 			}).component();
 		}
 


### PR DESCRIPTION
Adding aria labels to the '•••' buttons so that their names show as "Select file". Addresses #6742.

![image](https://user-images.githubusercontent.com/31145923/63306449-6add7e00-c29f-11e9-9a8e-adeeddd159d7.png)

![image](https://user-images.githubusercontent.com/31145923/63306520-c445ad00-c29f-11e9-87e0-689bcff24621.png)
