### PR TITLE
Set aria-label for radio buttons

### DIFF
--- a/src/sql/base/browser/ui/radioButton/radioButton.ts
+++ b/src/sql/base/browser/ui/radioButton/radioButton.ts
@@ -81,6 +81,7 @@ export class RadioButton extends Widget {
 
 	public set label(val: string) {
 		this._label.innerText = val;
+		this.inputElement.setAttribute('aria-label', val);
 	}
 
 }


### PR DESCRIPTION
Set the aria-label to the same value as the label for radio buttons so that screenreeders can read it. Addresses  #6825

![image](https://user-images.githubusercontent.com/31145923/63387134-8907b480-c359-11e9-8b04-13a55cf422e7.png)
