### PR TITLE
Fix file URI input

### DIFF
--- a/src/sql/workbench/common/customInputConverter.ts
+++ b/src/sql/workbench/common/customInputConverter.ts
@@ -43,7 +43,7 @@ export function convertEditorInput(input: EditorInput, options: IQueryEditorOpti
 			//QueryInput
 			uri = getQueryEditorFileUri(input);
 			if (uri) {
-				const queryResultsInput: QueryResultsInput = instantiationService.createInstance(QueryResultsInput, uri.toString());
+				const queryResultsInput: QueryResultsInput = instantiationService.createInstance(QueryResultsInput, uri.toString(true));
 				let queryInput: QueryInput = instantiationService.createInstance(QueryInput, '', input, queryResultsInput, undefined);
 				return queryInput;
 			}

--- a/src/sql/workbench/parts/query/common/queryInput.ts
+++ b/src/sql/workbench/parts/query/common/queryInput.ts
@@ -194,7 +194,7 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 	}
 
 	// Getters for private properties
-	public get uri(): string { return this.getResource().toString(); }
+	public get uri(): string { return this.getResource().toString(true); }
 	public get sql(): UntitledEditorInput { return this._sql; }
 	public get results(): QueryResultsInput { return this._results; }
 	public updateSelection(selection: ISelectionData): void { this._updateSelection.fire(selection); }


### PR DESCRIPTION
Recent VS Code merge made it so the URI is always passed through the transformer - so to preserve the normal connection URIs (which had | in them) 6fd4b5eaf26c75c45ad0ecf9af6df2faeae87ce3 was done to not encode the URIs. This broke the file URIs though as we weren't doing that everywhere so as a result the Input objects were storing the encoded URI which didn't match the URI stored by the connection services. 

Fixes #6829 - and I also did some basic testing to verify that this didn't regress behavior for normal untitled queries. 