### PR TITLE
Silences "table" announcement for all UIs built with formContainer

### DIFF
--- a/src/sql/workbench/browser/modelComponents/formContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/formContainer.component.ts
@@ -39,7 +39,7 @@ class FormItem {
 
 @Component({
 	template: `
-		<div #container *ngIf="items" class="form-table" [style.padding]="getFormPadding()" [style.width]="getFormWidth()" [style.height]="getFormHeight()">
+		<div #container *ngIf="items" class="form-table" [style.padding]="getFormPadding()" [style.width]="getFormWidth()" [style.height]="getFormHeight()" role="presentation">
 			<ng-container *ngFor="let item of items">
 			<div class="form-row" *ngIf="isGroupLabel(item)" [style.font-size]="getItemTitleFontSize(item)">
 				<div class="form-item-row form-group-label">


### PR DESCRIPTION
Addresses #6744

formContainer UIs are tables under the hood, so screen readers (unnecessarily) announce them as such.  This adds `role="presentation"` to them by default.  Because dataTables are constructed differently, this change shouldn't impact them.