### PR TITLE
Add names for schema compare dialog

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -190,7 +190,8 @@ export class SchemaCompareDialog {
 		this.schemaCompareTab.registerContent(async view => {
 			this.sourceTextBox = view.modelBuilder.inputBox().withProperties({
 				value: this.schemaCompareResult.sourceEndpointInfo ? this.schemaCompareResult.sourceEndpointInfo.packageFilePath : '',
-				width: 275
+				width: 275,
+				ariaLabel: localize('schemaCompareDialog.sourceTextBox', "Source file")
 			}).component();
 
 			this.sourceTextBox.onTextChanged((e) => {
@@ -199,7 +200,8 @@ export class SchemaCompareDialog {
 
 			this.targetTextBox = view.modelBuilder.inputBox().withProperties({
 				value: this.schemaCompareResult.targetEndpointInfo ? this.schemaCompareResult.targetEndpointInfo.packageFilePath : '',
-				width: 275
+				width: 275,
+				ariaLabel: localize('schemaCompareDialog.targetTextBox', "Target file")
 			}).component();
 
 			this.targetTextBox.onTextChanged(() => {
@@ -464,7 +466,8 @@ export class SchemaCompareDialog {
 		this.sourceServerDropdown = view.modelBuilder.dropDown().withProperties(
 			{
 				editable: true,
-				fireOnTextChange: true
+				fireOnTextChange: true,
+				ariaLabel: localize('schemaCompareDialog.sourceServerDropdown', "Source Server")
 			}
 		).component();
 		this.sourceServerDropdown.onValueChanged(async (value) => {
@@ -489,7 +492,8 @@ export class SchemaCompareDialog {
 		this.targetServerDropdown = view.modelBuilder.dropDown().withProperties(
 			{
 				editable: true,
-				fireOnTextChange: true
+				fireOnTextChange: true,
+				ariaLabel: localize('schemaCompareDialog.targetServerDropdown', "Target Server")
 			}
 		).component();
 		this.targetServerDropdown.onValueChanged(async (value) => {
@@ -586,7 +590,8 @@ export class SchemaCompareDialog {
 		this.sourceDatabaseDropdown = view.modelBuilder.dropDown().withProperties(
 			{
 				editable: true,
-				fireOnTextChange: true
+				fireOnTextChange: true,
+				ariaLabel: localize('schemaCompareDialog.sourceDatabaseDropdown', "Source Database")
 			}
 		).component();
 		this.sourceDatabaseDropdown.onValueChanged((value) => {
@@ -605,6 +610,7 @@ export class SchemaCompareDialog {
 			{
 				editable: true,
 				fireOnTextChange: true,
+				ariaLabel: localize('schemaCompareDialog.targetDatabaseDropdown', "Target Database")
 			}
 		).component();
 		this.targetDatabaseDropdown.onValueChanged((value) => {

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -327,4 +327,8 @@ export class Dropdown extends Disposable {
 	public get enabled(): boolean {
 		return this._input.isEnabled();
 	}
+
+	public set ariaLabel(val: string) {
+		this._input.setAriaLabel(val);
+	}
 }

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -109,6 +109,7 @@ export default class DropDownComponent extends ComponentBase implements ICompone
 
 		if (this.ariaLabel !== '') {
 			this._selectBox.setAriaLabel(this.ariaLabel);
+			this._editableDropdown.ariaLabel = this.ariaLabel;
 		}
 
 		if (this.editable) {


### PR DESCRIPTION
Addresses #6850. Adds names for Server and database editable dropdowns and file location text box. The radio button names were added in #6835

![image](https://user-images.githubusercontent.com/31145923/63467663-d13adb80-c41a-11e9-9e7d-045065e347ef.png)
