### PR TITLE
Adding aria-live label support for input boxes

### DIFF
--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -136,7 +136,7 @@ export abstract class DacFxConfigPage extends BasePage {
 			if (!(this.instance.selectedOperation === Operation.deploy && !this.model.upgradeExisting)) {
 				this.model.database = values[0].name;
 			}
-			// filename shouldn't change for deploy because the file exists and isn't being generated like for extract and export
+			// filename shouldn't change for deploy because the file exists and isn't being generated as for extract and export
 			if (this.instance.selectedOperation !== Operation.deploy) {
 				this.model.filePath = this.generateFilePathFromDatabaseAndTimestamp();
 				this.fileTextBox.value = this.model.filePath;

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -156,7 +156,8 @@ export abstract class DacFxConfigPage extends BasePage {
 			component => isValidBasename(component.value)
 		)
 			.withProperties({
-				required: true
+				required: true,
+				ariaLive: 'polite'
 			}).component();
 
 		this.fileTextBox.ariaLabel = localize('dacfx.fileLocationAriaLabel', "File Location");

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2890,6 +2890,7 @@ declare module 'azdata' {
 	export interface InputBoxProperties extends ComponentProperties {
 		value?: string;
 		ariaLabel?: string;
+		ariaLive?: string;
 		placeHolder?: string;
 		inputType?: InputBoxInputType;
 		required?: boolean;

--- a/src/sql/base/browser/ui/inputBox/inputBox.ts
+++ b/src/sql/base/browser/ui/inputBox/inputBox.ts
@@ -96,6 +96,10 @@ export class InputBox extends vsInputBox {
 		}
 	}
 
+	public set ariaLive(value: string) {
+		this.element.setAttribute('aria-live', value);
+	}
+
 	public isEnabled(): boolean {
 		return !this.inputElement.hasAttribute('disabled');
 	}

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -767,6 +767,13 @@ class InputBoxWrapper extends ComponentWrapper implements azdata.InputBoxCompone
 		this.setProperty('ariaLabel', v);
 	}
 
+	public get ariaLive(): string {
+		return this.properties['ariaLive'];
+	}
+	public set ariaLive(v: string) {
+		this.setProperty('ariaLabel', v);
+	}
+
 	public get placeHolder(): string {
 		return this.properties['placeHolder'];
 	}

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -204,6 +204,9 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 			}
 		}
 
+		if (this.ariaLive) {
+			input.ariaLive = this.ariaLive;
+		}
 
 		input.inputElement.required = this.required;
 	}
@@ -224,6 +227,10 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 
 	public set ariaLabel(newValue: string) {
 		this.setPropertyFromUI<azdata.InputBoxProperties, string>((props, value) => props.ariaLabel = value, newValue);
+	}
+
+	public get ariaLive() {
+		return this.getPropertyOrDefault<azdata.InputBoxProperties, string>((props) => props.ariaLive, '');
 	}
 
 	public get placeHolder(): string {


### PR DESCRIPTION
Addresses #6795

Adds support for the `aria-live` property, which indicates to screen-readers that it had dynamic content which may be updated without focus.  Sets level to "polite" for DacFx wizard file selection controls