### PR TITLE
Makes the OE tests less strict

### DIFF
--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -108,9 +108,18 @@ class ObjectExplorerTester {
 		const node = nodes[index];
 		const actions = await azdata.objectexplorer.getNodeActions(node.connectionId, node.nodePath);
 
+		let containsAll = true;
+		for(const action of expectedActions){
+			if (!containsAll) { return; }
+			if (actions.indexOf(action) < 0) {
+				containsAll = false;
+				break;
+			}
+		}
+
 		const expectedString = expectedActions.join(',');
 		const actualString = actions.join(',');
-		assert(expectedActions.length === actions.length && expectedString === actualString, `Expected actions: "${expectedString}", Actual actions: "${actualString}"`);
+		assert(expectedActions.length === actions.length && containsAll, `Expected actions: "${expectedString}", Actual actions: "${actualString}"`);
 	}
 
 	async verifyOeNode(server: TestServerProfile, timeout: number, expectedNodeLabel: string[]): Promise<void> {


### PR DESCRIPTION
We're making a lot of changes in the OE context menu due to isolation of features.

Idea: So to stop potentially breaking changes and having to modify the test on every update, let's make it less strict for now?

#6792 #6854 #6873

Feel free to close if this isn't something we want to do.