### PR TITLE
Bug/Accessibility fix for 6796 (partial), 6800 and 6745

### DIFF
--- a/extensions/dacpac/src/wizard/pages/selectOperationpage.ts
+++ b/extensions/dacpac/src/wizard/pages/selectOperationpage.ts
@@ -53,6 +53,7 @@ export class SelectOperationPage extends BasePage {
 
 		// default have the first radio button checked
 		this.deployRadioButton.checked = true;
+		this.deployRadioButton.focused = true;
 		this.instance.setDoneButton(Operation.deploy);
 		return true;
 	}

--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -42,7 +42,7 @@ const defaultOptions: ICheckboxSelectColumnOptions = {
 };
 
 const checkboxTemplate = `<div style="display: flex; align-items: center; flex-direction: column">
-								<input type="checkbox" {0}>
+								<input type="checkbox" {0} aria-label={1}>
 							</div>`;
 
 export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Plugin<T> {
@@ -99,11 +99,11 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		if (!this._options.title) {
 			if (selectedRows.length && selectedRows.length === this._grid.getDataLength()) {
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, 'checked'),
+					strings.format(checkboxTemplate, 'checked', this._options.title),
 					this._options.toolTip);
 			} else {
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, ''),
+					strings.format(checkboxTemplate, '',this._options.title),
 					this._options.toolTip);
 			}
 		}
@@ -187,6 +187,9 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 			this._grid.invalidateRow(row);
 			this._grid.render();
 		}
+
+		//Ensure that the focus stays correct
+		this._grid.getActiveCellNode().focus();
 	}
 
 	private handleHeaderClick(e: Event, args: Slick.OnHeaderClickEventArgs<T>): void {
@@ -207,12 +210,12 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 				const rows = range(this._grid.getDataLength());
 				this._grid.setSelectedRows(rows);
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, 'checked'),
+					strings.format(checkboxTemplate, 'checked', this._options.title),
 					this._options.toolTip);
 			} else {
 				this._grid.setSelectedRows([]);
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, ''), this._options.toolTip);
+					strings.format(checkboxTemplate, '', this._options.title), this._options.toolTip);
 				e.stopPropagation();
 				e.stopImmediatePropagation();
 			}
@@ -222,7 +225,7 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 	public getColumnDefinition(): Slick.Column<T> {
 		return {
 			id: this._options.columnId,
-			name: this._options.title || strings.format(checkboxTemplate, ''),
+			name: this._options.title || strings.format(checkboxTemplate, '', ''),
 			toolTip: this._options.toolTip,
 			field: 'sel',
 			width: this._options.width,
@@ -240,16 +243,16 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		}
 
 		return this._selectedRowsLookup[row]
-			? strings.format(checkboxTemplate, 'checked')
-			: strings.format(checkboxTemplate, '');
+			? strings.format(checkboxTemplate, 'checked', this._options.title)
+			: strings.format(checkboxTemplate, '', this._options.title);
 	}
 
 	checkboxTemplateCustom(row: number): string {
 		// use state after toggles
 		if (this._useState) {
 			return this._selectedCheckBoxLookup[row]
-				? strings.format(checkboxTemplate, 'checked')
-				: strings.format(checkboxTemplate, '');
+				? strings.format(checkboxTemplate, 'checked', this._options.title)
+				: strings.format(checkboxTemplate, '', this._options.title);
 		}
 
 		// use data for first time rendering
@@ -257,11 +260,11 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		let rowVal = (this._grid) ? this._grid.getDataItem(row) : null;
 		if (rowVal && this._options.title && rowVal[this._options.title] === true) {
 			this._selectedCheckBoxLookup[row] = true;
-			return strings.format(checkboxTemplate, 'checked');
+			return strings.format(checkboxTemplate, 'checked', this._options.title);
 		}
 		else {
 			delete this._selectedCheckBoxLookup[row];
-			return strings.format(checkboxTemplate, '');
+			return strings.format(checkboxTemplate, '', this._options.title);
 		}
 	}
 

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -229,9 +229,7 @@ export default class TableComponent extends ComponentBase implements IComponent,
 			this._table.setSelectedRows(this.selectedRows);
 		}
 
-		for (const col of this._checkboxColumns) {
-			this.registerCheckboxPlugin(col);
-		}
+		Object.keys(this._checkboxColumns).forEach(col => this.registerCheckboxPlugin(this._checkboxColumns[col]));
 
 		if (this.ariaRowCount === -1) {
 			this._table.removeAriaRowCount();


### PR DESCRIPTION
Fix for

#6796 (partial) 
Checkbox cells in table don't have name - fixed
Empty cells in table don't have name - not fixed needs followup

#6800 
After space/enter on checkbox cell - focus doesn't stay correctly on the cell

#6745 
After DacFx wizard opens the focus should shift to the wizard

Regression 
After Lint update checkbox columns were not getting rendered. For --> Foreach change fixes this