### PR TITLE
Re-add carbon edit for handling undefined proxy in extHostTreeViews.

### DIFF
--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -201,7 +201,10 @@ export class ExtHostTreeView<T> extends Disposable {
 	constructor(private viewId: string, options: vscode.TreeViewOptions2<T>, private proxy: MainThreadTreeViewsShape, private commands: CommandsConverter, private logService: ILogService, private extension: IExtensionDescription) {
 		super();
 		this.dataProvider = options.treeDataProvider;
-		this.proxy.$registerTreeViewDataProvider(viewId, { showCollapseAll: !!options.showCollapseAll, canSelectMany: !!options.canSelectMany });
+		// {{SQL CARBON EDIT}}
+		if (this.proxy) {
+			this.proxy.$registerTreeViewDataProvider(viewId, { showCollapseAll: !!options.showCollapseAll, canSelectMany: !!options.canSelectMany });
+		}
 		if (this.dataProvider.onDidChangeTreeData) {
 			this._register(this.dataProvider.onDidChangeTreeData(element => this._onDidChangeData.fire({ message: false, element })));
 		}


### PR DESCRIPTION
This was causing some errors when trying to create the database object trees in the External Table wizard.

This edit was missed in this merge commit: https://github.com/microsoft/azuredatastudio/commit/6f297efb880037dde203a6d2fe5ffaff5c1c1924#diff-9cac4292d1fe863254c28648b24ee20eL193