### PR TITLE
Add Insert Cell actions back into cell overflow menu in Notebooks.

### DIFF
--- a/src/sql/workbench/parts/notebook/browser/cellToggleMoreActions.ts
+++ b/src/sql/workbench/parts/notebook/browser/cellToggleMoreActions.ts
@@ -30,6 +30,10 @@ export class CellToggleMoreActions {
 		@IInstantiationService private instantiationService: IInstantiationService) {
 		this._actions.push(
 			instantiationService.createInstance(DeleteCellAction, 'delete', localize('delete', "Delete")),
+			instantiationService.createInstance(AddCellFromContextAction, 'codeBefore', localize('codeBefore', "Insert Code Before"), CellTypes.Code, false),
+			instantiationService.createInstance(AddCellFromContextAction, 'codeAfter', localize('codeAfter', "Insert Code After"), CellTypes.Code, true),
+			instantiationService.createInstance(AddCellFromContextAction, 'markdownBefore', localize('markdownBefore', "Insert Text Before"), CellTypes.Markdown, false),
+			instantiationService.createInstance(AddCellFromContextAction, 'markdownAfter', localize('markdownAfter', "Insert Text After"), CellTypes.Markdown, true),
 			instantiationService.createInstance(RunCellsAction, 'runAllBefore', localize('runAllBefore', "Run Cells Before"), false),
 			instantiationService.createInstance(RunCellsAction, 'runAllAfter', localize('runAllAfter', "Run Cells After"), true),
 			instantiationService.createInstance(ClearCellOutputAction, 'clear', localize('clear', "Clear Output"))
@@ -57,6 +61,34 @@ export class CellToggleMoreActions {
 		} else {
 			DOM.removeClass(this._moreActionsElement, HIDDEN_CLASS);
 		}
+	}
+}
+
+export class AddCellFromContextAction extends CellActionBase {
+	constructor(
+		id: string, label: string, private cellType: CellType, private isAfter: boolean,
+		@INotificationService notificationService: INotificationService
+	) {
+		super(id, label, undefined, notificationService);
+	}
+
+	doRun(context: CellContext): Promise<void> {
+		try {
+			let model = context.model;
+			let index = model.cells.findIndex((cell) => cell.id === context.cell.id);
+			if (index !== undefined && this.isAfter) {
+				index += 1;
+			}
+			model.addCell(this.cellType, index);
+		} catch (error) {
+			let message = getErrorMessage(error);
+
+			this.notificationService.notify({
+				severity: Severity.Error,
+				message: message
+			});
+		}
+		return Promise.resolve();
 	}
 }
 


### PR DESCRIPTION
Some users have asked to maintain this older menu behavior. These menu actions are also reachable just with keyboard, so it's better for accessibility.