### PR TITLE
Update and align endpoint names

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboard.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboard.ts
@@ -139,15 +139,8 @@ export class BdcDashboard {
 			this.initialized = true;
 
 			// Now that we've created the UI load data from the model in case it already had data
-			this.handleEndpointsUpdate(this.model.serviceEndpoints);
 			this.handleBdcStatusUpdate(this.model.bdcStatus);
 		});
-	}
-
-	private handleEndpointsUpdate(endpoints: EndpointModel[]): void {
-		if (!this.initialized || !endpoints) {
-			return;
-		}
 	}
 
 	private handleBdcStatusUpdate(bdcStatus: BdcStatusModel): void {

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import { BdcDashboardModel } from './bdcDashboardModel';
 import { IconPathHelper } from '../constants';
-import { getStateDisplayText, getHealthStatusDisplayText, getHealthStatusIcon, getEndpointDisplayText, getServiceNameDisplayText, Endpoint } from '../utils';
+import { getStateDisplayText, getHealthStatusDisplayText, getEndpointDisplayText, getHealthStatusIcon, getServiceNameDisplayText, Endpoint } from '../utils';
 import { EndpointModel, ServiceStatusModel, BdcStatusModel } from '../controller/apiGenerated';
 
 const localize = nls.loadMessageBundle();
@@ -20,7 +20,7 @@ const overviewServiceNameCellWidth = '100px';
 const overviewStateCellWidth = '75px';
 const overviewHealthStatusCellWidth = '100px';
 
-const serviceEndpointRowServiceNameCellWidth = '125px';
+const serviceEndpointRowServiceNameCellWidth = '175px';
 const serviceEndpointRowEndpointCellWidth = '350px';
 
 const hyperlinkedEndpoints = [Endpoint.metricsui, Endpoint.logsui, Endpoint.sparkHistory, Endpoint.yarnUi];
@@ -246,15 +246,15 @@ function createServiceEndpointRow(modelBuilder: azdata.ModelBuilder, container: 
 	endPointRow.addItem(nameCell, { CSSStyles: { 'width': serviceEndpointRowServiceNameCellWidth, 'min-width': serviceEndpointRowServiceNameCellWidth, 'user-select': 'text', 'text-align': 'center' } });
 	if (isHyperlink) {
 		const endpointCell = modelBuilder.hyperlink()
-			.withProperties({ label: endpoint.endpoint, url: endpoint.endpoint, CSSStyles: { 'height': '15px', 'padding-left': '10px' } })
+			.withProperties({ label: endpoint.endpoint, url: endpoint.endpoint, CSSStyles: { 'height': '15px' } })
 			.component();
-		endPointRow.addItem(endpointCell, { CSSStyles: { 'width': serviceEndpointRowEndpointCellWidth, 'min-width': serviceEndpointRowEndpointCellWidth, 'color': '#0078d4', 'text-decoration': 'underline', 'overflow': 'hidden' } });
+		endPointRow.addItem(endpointCell, { CSSStyles: { 'width': serviceEndpointRowEndpointCellWidth, 'min-width': serviceEndpointRowEndpointCellWidth, 'color': '#0078d4', 'text-decoration': 'underline', 'overflow': 'hidden', 'padding-left': '10px' } });
 	}
 	else {
 		const endpointCell = modelBuilder.text()
-			.withProperties({ value: endpoint.endpoint, CSSStyles: { 'margin-block-start': '0px', 'margin-block-end': '0px', 'user-select': 'text', 'padding-left': '10px' } })
+			.withProperties({ value: endpoint.endpoint, CSSStyles: { 'margin-block-start': '0px', 'margin-block-end': '0px', 'user-select': 'text' } })
 			.component();
-		endPointRow.addItem(endpointCell, { CSSStyles: { 'width': serviceEndpointRowEndpointCellWidth, 'min-width': serviceEndpointRowEndpointCellWidth, 'overflow': 'hidden' } });
+		endPointRow.addItem(endpointCell, { CSSStyles: { 'width': serviceEndpointRowEndpointCellWidth, 'min-width': serviceEndpointRowEndpointCellWidth, 'overflow': 'hidden', 'padding-left': '10px' } });
 	}
 	const copyValueCell = modelBuilder.button().component();
 	copyValueCell.iconPath = IconPathHelper.copy;

--- a/extensions/big-data-cluster/src/bigDataCluster/utils.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/utils.ts
@@ -112,30 +112,30 @@ export function getEndpointDisplayText(endpointName?: string, description?: stri
 		case Endpoint.appProxy:
 			return localize('endpoint.appproxy', "Application Proxy");
 		case Endpoint.controller:
-			return localize('endpoint.controller', "Controller");
+			return localize('endpoint.controller', "Cluster Management Service");
 		case Endpoint.gateway:
-			return localize('endpoint.gateway', "HDFS/Spark Gateway");
+			return localize('endpoint.gateway', "Gateway to access HDFS files, Spark");
 		case Endpoint.managementProxy:
 			return localize('endpoint.managementproxy', "Management Proxy");
 		case Endpoint.mgmtproxy:
 			return localize('endpoint.mgmtproxy', "Management Proxy");
 		case Endpoint.sqlServerMaster:
-			return localize('endpoint.sqlServerEndpoint', "SQL Server Master Instance");
+			return localize('endpoint.sqlServerEndpoint', "SQL Server Master Instance Front-End");
 		case Endpoint.metricsui:
 			return localize('endpoint.grafana', "Metrics Dashboard");
 		case Endpoint.logsui:
 			return localize('endpoint.kibana', "Log Search Dashboard");
 		case Endpoint.yarnUi:
-			return localize('endpoint.yarnHistory', "Spark Resource Management");
+			return localize('endpoint.yarnHistory', "Spark Diagnostics and Monitoring Dashboard");
 		case Endpoint.sparkHistory:
-			return localize('endpoint.sparkHistory', "Spark Job Monitoring");
+			return localize('endpoint.sparkHistory', "Spark Jobs Management and Monitoring Dashboard");
 		case Endpoint.webhdfs:
 			return localize('endpoint.webhdfs', "HDFS File System Proxy");
 		case Endpoint.livy:
-			return localize('endpoint.livy', "Spark Proxy");
+			return localize('endpoint.livy', "Proxy for running Spark statements, jobs, applications");
 		default:
 			// Default is to use the description if one was given, otherwise worst case just fall back to using the
-			// original service name
+			// original endpoint name
 			return description && description.length > 0 ? description : endpointName;
 	}
 }

--- a/extensions/mssql/src/dashboard/serviceEndpoints.ts
+++ b/extensions/mssql/src/dashboard/serviceEndpoints.ts
@@ -54,7 +54,7 @@ export function registerServiceEndpoints(context: vscode.ExtensionContext): void
 			}
 
 			endpointsArray = endpointsArray.map(e => {
-				e.description = getFriendlyEndpointNames(e);
+				e.description = getEndpointDisplayText(e.serviceName, e.description);
 				return e;
 			}).sort((a, b) => a.endpoint.localeCompare(b.endpoint));
 
@@ -105,44 +105,56 @@ function getCustomEndpoint(parentEndpoint: utils.IEndpoint, serviceName: string,
 	return null;
 }
 
-function getFriendlyEndpointNames(endpointInfo: utils.IEndpoint): string {
-	let friendlyName: string = endpointInfo.description || endpointInfo.serviceName;
-	switch (endpointInfo.serviceName) {
-		case 'app-proxy':
-			friendlyName = localize('approxy.description', "Application Proxy");
-			break;
-		case 'controller':
-			friendlyName = localize('controller.description', "Cluster Management Service");
-			break;
-		case 'gateway':
-			friendlyName = localize('gateway.description', "HDFS and Spark");
-			break;
-		case mgmtProxyName:
-			friendlyName = localize('mgmtproxy.description', "Management Proxy");
-			break;
-		case logsuiEndpointName:
-			friendlyName = logsuiDescription;
-			break;
-		case grafanaEndpointName:
-			friendlyName = grafanaDescription;
-			break;
-		case sparkHistoryEndpointName:
-			friendlyName = sparkHistoryDescription;
-			break;
-		case yarnUiEndpointName:
-			friendlyName = yarnHistoryDescription;
-			break;
-		case 'sql-server-master':
-			friendlyName = localize('sqlmaster.description', "SQL Server Master Instance Front-End");
-			break;
-		case 'webhdfs':
-			friendlyName = localize('webhdfs.description', "HDFS File System Proxy");
-			break;
-		case 'livy':
-			friendlyName = localize('livy.description', "Proxy for running Spark statements, jobs, applications");
-			break;
+export enum Endpoint {
+	gateway = 'gateway',
+	sparkHistory = 'spark-history',
+	yarnUi = 'yarn-ui',
+	appProxy = 'app-proxy',
+	mgmtproxy = 'mgmtproxy',
+	managementProxy = 'management-proxy',
+	logsui = 'logsui',
+	metricsui = 'metricsui',
+	controller = 'controller',
+	sqlServerMaster = 'sql-server-master',
+	webhdfs = 'webhdfs',
+	livy = 'livy'
+}
+
+/**
+ * Gets the localized text to display for a corresponding endpoint
+ * @param serviceName The endpoint name to get the display text for
+ * @param description The backup description to use if we don't have our own
+ */
+function getEndpointDisplayText(endpointName?: string, description?: string): string {
+	endpointName = endpointName || '';
+	switch (endpointName.toLowerCase()) {
+		case Endpoint.appProxy:
+			return localize('endpoint.appproxy', "Application Proxy");
+		case Endpoint.controller:
+			return localize('endpoint.controller', "Cluster Management Service");
+		case Endpoint.gateway:
+			return localize('endpoint.gateway', "Gateway to access HDFS files, Spark");
+		case Endpoint.managementProxy:
+			return localize('endpoint.managementproxy', "Management Proxy");
+		case Endpoint.mgmtproxy:
+			return localize('endpoint.mgmtproxy', "Management Proxy");
+		case Endpoint.sqlServerMaster:
+			return localize('endpoint.sqlServerEndpoint', "SQL Server Master Instance Front-End");
+		case Endpoint.metricsui:
+			return localize('endpoint.grafana', "Metrics Dashboard");
+		case Endpoint.logsui:
+			return localize('endpoint.kibana', "Log Search Dashboard");
+		case Endpoint.yarnUi:
+			return localize('endpoint.yarnHistory', "Spark Diagnostics and Monitoring Dashboard");
+		case Endpoint.sparkHistory:
+			return localize('endpoint.sparkHistory', "Spark Jobs Management and Monitoring Dashboard");
+		case Endpoint.webhdfs:
+			return localize('endpoint.webhdfs', "HDFS File System Proxy");
+		case Endpoint.livy:
+			return localize('endpoint.livy', "Proxy for running Spark statements, jobs, applications");
 		default:
-			break;
+			// Default is to use the description if one was given, otherwise worst case just fall back to using the
+			// original endpoint name
+			return description && description.length > 0 ? description : endpointName;
 	}
-	return friendlyName;
 }


### PR DESCRIPTION
Use hard-coded localized values until the platform can start returning localized values. If a new service is added we'll fall back to the description/service name as appropriate. 

Also fix spacing display issue that was causing gaps in the BDC Dashboard rows

![image](https://user-images.githubusercontent.com/28519865/63713388-6d3a5d80-c7f4-11e9-85c5-a698992a624b.png)

![image](https://user-images.githubusercontent.com/28519865/63713423-79beb600-c7f4-11e9-9680-19997e340583.png)
