### PR TITLE
Only show options on BDC Controller viewlet

### DIFF
--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -57,17 +57,17 @@
 			"view/item/context": [
 				{
 					"command": "bigDataClusters.command.manageController",
-					"when": "viewItem == bigDataClusters.itemType.controllerNode",
+					"when": "view == sqlBigDataCluster && viewItem == bigDataClusters.itemType.controllerNode",
 					"group": "navigation@1"
 				},
 				{
 					"command": "bigDataClusters.command.refreshController",
-					"when": "viewItem == bigDataClusters.itemType.controllerNode",
+					"when": "view == sqlBigDataCluster && viewItem == bigDataClusters.itemType.controllerNode",
 					"group": "navigation@2"
 				},
 				{
 					"command": "bigDataClusters.command.deleteController",
-					"when": "viewItem == bigDataClusters.itemType.controllerNode",
+					"when": "view == sqlBigDataCluster && viewItem == bigDataClusters.itemType.controllerNode",
 					"group": "navigation@3"
 				}
 			]


### PR DESCRIPTION
Please bear with me here... I'm still learning about all of the OE keys and how they work together 😄.

When first going to the controller dashboard and then going to the books viewlet, "Manage", "Delete", and "Refresh" were previously shown.

I debugged through the context key service, and saw that, in the books viewlet, viewItem was still being set to bigDataClusters.itemType.controllerNode. However, view changes between sqlBigDataCluster and bookTreeView correctly. So, the right click options are still there for the controller.

If anyone has a better suggestion for how to fix this, I'm all ears. This just seemed like a non-risky fix that mitigates the issue (in case there's work to do to better set the viewItem from the books viewlet).