### PR TITLE
Don't Inform extHostNotebookDocuments Unnecessarily on Cell Source Changes

### DIFF
--- a/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -575,7 +575,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 			let modelUrl = editor.uri;
 			const store = new DisposableStore();
 			store.add(editor.contentChanged((e) => {
-				// Cell source updates are handled by vscode editor things
+				// Cell source updates are handled by vscode editor updates in main/extHost Documents
 				if (e.changeType !== NotebookChangeType.CellSourceUpdated) {
 					this._proxy.$acceptModelChanged(modelUrl, this._toNotebookChangeData(e, editor));
 				}


### PR DESCRIPTION
Problem: we spend significant amounts of processing time sending notebook contents over the extension host. This is most obvious when a cell's source is being updated. There is noticeable lag when a notebook is large enough between when a user types and when the character(s) appear on the screen.

Observation: In mainThreadNotebookDocumentsAndEditors, we don't send the source as part of the NotebookCell object:

```
	private convertCellModelToNotebookCell(cells: ICellModel | ICellModel[]): azdata.nb.NotebookCell[] {
		...
						source: undefined,
						...
		}
		else {
		...
					source: undefined
				...
	}
```

So, it seems a bit silly to me to be creating all of these objects and sending them over the wire to the extHost, especially when extHostDocuments knows about any content change in any cell.

Solution: Stop sending a changed model over the wire when it's unnecessary (i.e. for CellChangeUpdated changes). vscode APIs can be used to get a cell's contents if necessary, as we expose each cell's URI.