### PR TITLE
Automatically focus the execute button in the DacFx wizard summary screens

### DIFF
--- a/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
@@ -54,6 +54,9 @@ export class DacFxSummaryPage extends BasePage {
 		if (this.model.upgradeExisting && this.instance.selectedOperation === Operation.deploy) {
 			this.instance.wizard.generateScriptButton.hidden = false;
 		}
+
+		this.instance.wizard.doneButton.focused = true;
+
 		return true;
 	}
 

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3536,6 +3536,11 @@ declare module 'azdata' {
 			hidden: boolean;
 
 			/**
+			 * Whether the button is focused
+			 */
+			focused?: boolean;
+
+			/**
 			 * Raised when the button is clicked
 			 */
 			readonly onClick: vscode.Event<void>;

--- a/src/sql/platform/dialog/browser/wizardModal.ts
+++ b/src/sql/platform/dialog/browser/wizardModal.ts
@@ -119,6 +119,11 @@ export class WizardModal extends Modal {
 		buttonElement.label = dialogButton.label;
 		buttonElement.enabled = requirePageValid ? dialogButton.enabled && this._wizard.pages[this._wizard.currentPage].valid : dialogButton.enabled;
 		dialogButton.hidden ? buttonElement.element.parentElement.classList.add('dialogModal-hidden') : buttonElement.element.parentElement.classList.remove('dialogModal-hidden');
+
+		if (dialogButton.focused) {
+			buttonElement.focus();
+		}
+
 		this.setButtonsForPage(this._wizard.currentPage);
 	}
 

--- a/src/sql/platform/dialog/common/dialogTypes.ts
+++ b/src/sql/platform/dialog/common/dialogTypes.ts
@@ -83,6 +83,7 @@ export class DialogButton implements azdata.window.Button {
 	private _label: string;
 	private _enabled: boolean;
 	private _hidden: boolean;
+	private _focused: boolean;
 	private _onClick: Emitter<void> = new Emitter<void>();
 	public readonly onClick: Event<void> = this._onClick.event;
 	private _onUpdate: Emitter<void> = new Emitter<void>();
@@ -118,6 +119,15 @@ export class DialogButton implements azdata.window.Button {
 
 	public set hidden(hidden: boolean) {
 		this._hidden = hidden;
+		this._onUpdate.fire();
+	}
+
+	public get focused(): boolean {
+		return this._focused;
+	}
+
+	public set focused(focused: boolean) {
+		this._focused = focused;
 		this._onUpdate.fire();
 	}
 

--- a/src/sql/workbench/api/common/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/common/extHostModelViewDialog.ts
@@ -252,8 +252,8 @@ class ButtonImpl implements azdata.window.Button {
 	 * Focuses the button when set to "true", then the internal value is immediately reset to 'undefined'.
 	 *
 	 * @remarks
-	 * Because communication between ADS and extensions is unidirectional, that update is not communicated
-	 * to the extension.  The internal value is reset to avoid inconsistent models of where focus is.
+	 * Because communication between ADS and extensions is unidirectional, a focus change by the user is not
+	 * communicated to the extension.  The internal value is reset to avoid inconsistent models of where focus is.
 	 */
 	public set focused(focused: boolean) {
 		this._focused = focused;

--- a/src/sql/workbench/api/common/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/common/extHostModelViewDialog.ts
@@ -207,6 +207,7 @@ class ButtonImpl implements azdata.window.Button {
 	private _label: string;
 	private _enabled: boolean;
 	private _hidden: boolean;
+	private _focused: boolean;
 
 	private _onClick = new Emitter<void>();
 	public onClick = this._onClick.event;
@@ -240,6 +241,15 @@ class ButtonImpl implements azdata.window.Button {
 
 	public set hidden(hidden: boolean) {
 		this._hidden = hidden;
+		this._extHostModelViewDialog.updateButton(this);
+	}
+
+	public get focused(): boolean {
+		return this._focused;
+	}
+
+	public set focused(focused: boolean) {
+		this._focused = focused;
 		this._extHostModelViewDialog.updateButton(this);
 	}
 
@@ -568,7 +578,8 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 		this._proxy.$setButtonDetails(handle, {
 			label: button.label,
 			enabled: button.enabled,
-			hidden: button.hidden
+			hidden: button.hidden,
+			focused: button.focused
 		});
 	}
 

--- a/src/sql/workbench/api/common/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/common/extHostModelViewDialog.ts
@@ -248,9 +248,17 @@ class ButtonImpl implements azdata.window.Button {
 		return this._focused;
 	}
 
+	/**
+	 * Focuses the button when set to "true", then the internal value is immediately reset to 'undefined'.
+	 *
+	 * @remarks
+	 * Because communication between ADS and extensions is unidirectional, that update is not communicated
+	 * to the extension.  The internal value is reset to avoid inconsistent models of where focus is.
+	 */
 	public set focused(focused: boolean) {
 		this._focused = focused;
 		this._extHostModelViewDialog.updateButton(this);
+		this._focused = undefined;
 	}
 
 	public getOnClickCallback(): () => void {

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -250,6 +250,7 @@ export interface IModelViewButtonDetails {
 	label: string;
 	enabled: boolean;
 	hidden: boolean;
+	focused?: boolean;
 }
 
 export interface IModelViewWizardPageDetails {

--- a/src/sql/workbench/api/electron-browser/mainThreadModelViewDialog.ts
+++ b/src/sql/workbench/api/electron-browser/mainThreadModelViewDialog.ts
@@ -133,6 +133,7 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 			button.label = details.label;
 			button.enabled = details.enabled;
 			button.hidden = details.hidden;
+			button.focused = details.focused;
 		}
 
 		return Promise.resolve();


### PR DESCRIPTION
Addresses the request made in https://github.com/microsoft/azuredatastudio/issues/6746#issuecomment-524996846

Adds piping to extension buttons to set focus, and automatically sets the focus to the Done button in the summary page of DacFx wizard paths.