### PR TITLE
os.EOL instead of hardcode \n for fast notebook source changes (#6986)

### DIFF
--- a/src/sql/workbench/parts/notebook/common/models/notebookTextFileModel.ts
+++ b/src/sql/workbench/parts/notebook/common/models/notebookTextFileModel.ts
@@ -9,6 +9,7 @@ import { TextFileEditorModel } from 'vs/workbench/services/textfile/common/textF
 import { FindMatch } from 'vs/editor/common/model';
 import { NotebookContentChange, INotebookModel } from 'sql/workbench/parts/notebook/common/models/modelInterfaces';
 import { NotebookChangeType } from 'sql/workbench/parts/notebook/common/models/contracts';
+import * as os from 'os';
 
 export class NotebookTextFileModel {
 	// save active cell's line/column in editor model for the beginning of the source property
@@ -52,7 +53,7 @@ export class NotebookTextFileModel {
 				//     this is another string
 				textEditorModel.textEditorModel.applyEdits([{
 					range: new Range(convertedRange.startLineNumber, convertedRange.startColumn, convertedRange.endLineNumber, convertedRange.endColumn),
-					text: change.text.split('\n').join('\\n\",\n'.concat(startSpaces).concat('\"'))
+					text: change.text.split(os.EOL).join('\\n\",'.concat(os.EOL).concat(startSpaces).concat('\"'))
 				}]);
 			});
 		} else {

--- a/src/sql/workbench/parts/notebook/test/common/notebookEditorModel.test.ts
+++ b/src/sql/workbench/parts/notebook/test/common/notebookEditorModel.test.ts
@@ -5,6 +5,7 @@
 
 import * as should from 'should';
 import * as TypeMoq from 'typemoq';
+import * as os from 'os';
 
 import { TestCapabilitiesService } from 'sql/platform/capabilities/test/common/testCapabilitiesService';
 import { ConnectionManagementService } from 'sql/platform/connection/common/connectionManagementService';
@@ -297,8 +298,8 @@ suite('Notebook Editor Model', function (): void {
 			cells: [newCell],
 			cellIndex: 0,
 			modelContentChangedEvent: {
-				changes: [{ range: new Range(1, 1, 1, 1), rangeLength: 0, rangeOffset: 0, text: 'This is a test\nLine 2 test\nLine 3 test' }],
-				eol: '\n',
+				changes: [{ range: new Range(1, 1, 1, 1), rangeLength: 0, rangeOffset: 0, text: 'This is a test' + os.EOL + 'Line 2 test' + os.EOL + 'Line 3 test' }],
+				eol: os.EOL,
 				isFlush: false,
 				isRedoing: false,
 				isUndoing: false,
@@ -450,8 +451,8 @@ suite('Notebook Editor Model', function (): void {
 			cells: [newCell],
 			cellIndex: 0,
 			modelContentChangedEvent: {
-				changes: [{ range: new Range(1, 1, 1, 1), rangeLength: 0, rangeOffset: 0, text: 'This is a test\nLine 2 test\nLine 3 test' }],
-				eol: '\n',
+				changes: [{ range: new Range(1, 1, 1, 1), rangeLength: 0, rangeOffset: 0, text: 'This is a test' + os.EOL + 'Line 2 test' + os.EOL + 'Line 3 test' }],
+				eol: os.EOL,
 				isFlush: false,
 				isRedoing: false,
 				isUndoing: false,


### PR DESCRIPTION
* os.EOL instead of hardcode \n

* test fixes