### PR TITLE
Fix wrong Dacfx wizard radio button count

### DIFF
--- a/extensions/dacpac/src/wizard/pages/selectOperationpage.ts
+++ b/extensions/dacpac/src/wizard/pages/selectOperationpage.ts
@@ -39,6 +39,10 @@ export class SelectOperationPage extends BasePage {
 		let importComponent = await this.createImportRadioButton();
 		let exportComponent = await this.createExportRadioButton();
 
+		// default have the first radio button checked
+		this.deployRadioButton.checked = true;
+		this.deployRadioButton.focused = true;
+
 		this.form = this.view.modelBuilder.formContainer()
 			.withFormItems(
 				[
@@ -51,9 +55,6 @@ export class SelectOperationPage extends BasePage {
 				}).component();
 		await this.view.initializeModel(this.form);
 
-		// default have the first radio button checked
-		this.deployRadioButton.checked = true;
-		this.deployRadioButton.focused = true;
 		this.instance.setDoneButton(Operation.deploy);
 		return true;
 	}


### PR DESCRIPTION
Fixes #6747. Previously screenreaders were counting only 3 radio buttons when it should be 4. Moving the setting the first radio button to checked and focused to before initializing the form seems to fix the wrong radio button count.

![image](https://user-images.githubusercontent.com/31145923/63817977-a3aad200-c8f3-11e9-9c34-7cfa77230bd4.png)
