### PR TITLE
Fix context menu positioning.

### DIFF
--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -65,7 +65,7 @@ class ObjectExplorerTester {
 	@stressify({ dop: ObjectExplorerTester.ParallelCount })
 	async sqlDbContextMenuTest(): Promise<void> {
 		const server = await getAzureServer();
-		const expectedActions = ['Disconnect', 'Delete Connection', 'Refresh', 'New Query', 'Manage', 'New Notebook', 'Data-tier Application wizard', 'Launch Profiler'];
+		const expectedActions = ['Manage', 'New Query', 'New Notebook', 'Disconnect', 'Delete Connection', 'Refresh', 'Data-tier Application wizard', 'Launch Profiler'];
 		await this.verifyContextMenu(server, expectedActions);
 	}
 
@@ -75,10 +75,10 @@ class ObjectExplorerTester {
 		let expectedActions: string[] = [];
 		// Generate Scripts and Properties come from the admin-tool-ext-win extension which is for Windows only, so the item won't show up on non-Win32 platforms
 		if (process.platform === 'win32') {
-			expectedActions = ['Refresh', 'New Query', 'Manage', 'New Notebook', 'Backup', 'Restore', 'Data-tier Application wizard', 'Schema Compare', 'Import wizard', 'Generate Scripts...', 'Properties'];
+			expectedActions = ['Manage', 'New Query', 'New Notebook', 'Refresh', 'Backup', 'Restore', 'Data-tier Application wizard', 'Schema Compare', 'Import wizard', 'Generate Scripts...', 'Properties'];
 		}
 		else {
-			expectedActions = ['Refresh', 'New Query', 'Manage', 'New Notebook', 'Backup', 'Restore', 'Data-tier Application wizard', 'Schema Compare', 'Import wizard'];
+			expectedActions = ['Manage', 'New Query', 'New Notebook', 'Refresh', 'Backup', 'Restore', 'Data-tier Application wizard', 'Schema Compare', 'Import wizard'];
 		}
 		await this.verifyDBContextMenu(server, 3000, expectedActions);
 	}
@@ -89,10 +89,10 @@ class ObjectExplorerTester {
 		let expectedActions: string[];
 		// Properties comes from the admin-tool-ext-win extension which is for Windows only, so the item won't show up on non-Win32 platforms
 		if (process.platform === 'win32') {
-			expectedActions = ['Disconnect', 'Delete Connection', 'Refresh', 'New Query', 'Manage', 'New Notebook', 'Data-tier Application wizard', 'Launch Profiler', 'Properties'];
+			expectedActions = ['Manage', 'New Query', 'New Notebook', 'Disconnect', 'Delete Connection', 'Refresh', 'Data-tier Application wizard', 'Launch Profiler', 'Properties'];
 		}
 		else {
-			expectedActions = ['Disconnect', 'Delete Connection', 'Refresh', 'New Query', 'Manage', 'New Notebook', 'Data-tier Application wizard', 'Launch Profiler'];
+			expectedActions = ['Manage', 'New Query', 'New Notebook', 'Disconnect', 'Delete Connection', 'Refresh', 'Data-tier Application wizard', 'Launch Profiler'];
 		}
 		await this.verifyContextMenu(server, expectedActions);
 	}

--- a/src/sql/workbench/parts/dashboard/browser/dashboard.contribution.ts
+++ b/src/sql/workbench/parts/dashboard/browser/dashboard.contribution.ts
@@ -39,7 +39,7 @@ configurationRegistry.registerConfiguration(dashboardConfig);
 // // Manage
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: '0_query',
-	order: 1,
+	order: 0,
 	command: {
 		id: DE_MANAGE_COMMAND_ID,
 		title: localize('manage', "Manage")
@@ -49,7 +49,7 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 
 MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 	group: '0_query',
-	order: 1,
+	order: 0,
 	command: {
 		id: OE_MANAGE_COMMAND_ID,
 		title: localize('manage', "Manage")

--- a/src/sql/workbench/parts/query/browser/query.contribution.ts
+++ b/src/sql/workbench/parts/query/browser/query.contribution.ts
@@ -72,7 +72,7 @@ new NewQueryTask().registerTask();
 
 MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 	group: '0_query',
-	order: 0,
+	order: 1,
 	command: {
 		id: OE_NEW_QUERY_ACTION_ID,
 		title: localize('newQuery', "New Query")
@@ -83,7 +83,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 // New Query
 MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	group: '0_query',
-	order: 0,
+	order: 1,
 	command: {
 		id: DE_NEW_QUERY_COMMAND_ID,
 		title: localize('newQuery', "New Query")


### PR DESCRIPTION
Hard code in the Tree built in actions into the menu action array. Not an ideal solution, but it solves the problem.

Having the built in actions contributed is ideal, but I was having a lot of bugs pop up with interacting with the tree from a contributed action.

The build in actions are the server group actions, refresh, disconnect and delete. Which are all intrinsic to the tree so its not a problem that they are not contributed.