### PR TITLE
Set preview = true for Notebooks Opened from Jupyter Books

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -112,7 +112,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			}
 			else {
 				let doc = await vscode.workspace.openTextDocument(resource);
-				vscode.window.showTextDocument(doc);
+				vscode.window.showTextDocument(doc, { preview: true });
 			}
 		} catch (e) {
 			vscode.window.showErrorMessage(localize('openNotebookError', "Open file {0} failed: {1}",
@@ -141,7 +141,8 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				azdata.nb.showNotebookDocument(untitledFileName, {
 					connectionProfile: null,
 					initialContent: initialContent,
-					initialDirtyState: false
+					initialDirtyState: false,
+					preview: true
 				});
 			});
 		} catch (e) {

--- a/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -704,10 +704,10 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 				if (result) {
 					if (uri.scheme === Schemas.untitled) {
 						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.next.path, '.ipynb')}`);
-						this.doOpenEditor(untitledNbName, { initialContent: fs.readFileSync(result.next.path).toString(), initialDirtyState: false });
+						this.doOpenEditor(untitledNbName, { initialContent: fs.readFileSync(result.next.path).toString(), initialDirtyState: false, preview: true });
 					}
 					else {
-						this.doOpenEditor(result.next, {});
+						this.doOpenEditor(result.next, { preview: true });
 					}
 				}
 			},
@@ -716,10 +716,10 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 				if (result) {
 					if (uri.scheme === Schemas.untitled) {
 						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.previous.path, '.ipynb')}`);
-						this.doOpenEditor(untitledNbName, { initialContent: fs.readFileSync(result.previous.path).toString(), initialDirtyState: false });
+						this.doOpenEditor(untitledNbName, { initialContent: fs.readFileSync(result.previous.path).toString(), initialDirtyState: false, preview: true });
 					}
 					else {
-						this.doOpenEditor(result.previous, {});
+						this.doOpenEditor(result.previous, { preview: true });
 					}
 				}
 			}


### PR DESCRIPTION
By default, set preview = true when opening notebooks from Jupyter books. The active notebook (opened from a book) will then be replaced when navigating to different pages in a book.

Ensured that we still open new notebooks and existing notebooks (not in books) with 'preview' as false.