### PR TITLE
Start Jupyter without MathJax Library by Default

### DIFF
--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -236,7 +236,7 @@ export class PerNotebookServerInstance implements IServerInstance {
 		let token = await notebookUtils.getRandomToken();
 		this._uri = vscode.Uri.parse(`http://localhost:${port}/?token=${token}`);
 		this._port = port.toString();
-		let startCommand = `"${this.options.install.pythonExecutable}" -m jupyter notebook --no-browser --notebook-dir "${notebookDirectory}" --port=${port} --NotebookApp.token=${token}`;
+		let startCommand = `"${this.options.install.pythonExecutable}" -m jupyter notebook --no-browser --no-mathjax --notebook-dir "${notebookDirectory}" --port=${port} --NotebookApp.token=${token}`;
 		this.notifyStarting(this.options.install, startCommand);
 
 		// Execute the command


### PR DESCRIPTION
```
--no-mathjax
    Disable MathJax
    
    MathJax is the javascript library Jupyter uses to render math/LaTeX. It is
    very large, so you may want to disable it if you have a slow internet
    connection, or for offline use of the notebook.
    
    When disabled, equations etc. will appear as their untransformed TeX source.
```

Since this is a rendering library that's apparently quite large (and since we do our own rendering in ADS), I investigated to see if we could get any perf gains at startup.

Saw a ~5% reduction in startup time for the `jupyter notebook` command, so it seems like it's worthwhile to start jupyter with this option in ADS.