### PR TITLE
Inform screen-readers of Dacpac Deploy loading and loading complete for summary

### DIFF
--- a/extensions/dacpac/src/wizard/pages/deployPlanPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployPlanPage.ts
@@ -88,6 +88,7 @@ export class DeployPlanPage extends DacFxConfigPage {
 		this.table.data = [];
 		await this.populateTable();
 		this.loader.loading = false;
+		this.table.focused = true;
 		return true;
 	}
 

--- a/extensions/dacpac/src/wizard/pages/deployPlanPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployPlanPage.ts
@@ -100,8 +100,7 @@ export class DeployPlanPage extends DacFxConfigPage {
 			columns: this.getTableColumns(result.dataLossAlerts.size > 0),
 			width: 875,
 			height: 300,
-			ariaRole: 'alert',
-			focused: true
+			ariaRole: 'alert'
 		});
 
 		if (result.dataLossAlerts.size > 0) {

--- a/extensions/dacpac/src/wizard/pages/deployPlanPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployPlanPage.ts
@@ -88,7 +88,6 @@ export class DeployPlanPage extends DacFxConfigPage {
 		this.table.data = [];
 		await this.populateTable();
 		this.loader.loading = false;
-		this.table.focused = true;
 		return true;
 	}
 
@@ -100,7 +99,9 @@ export class DeployPlanPage extends DacFxConfigPage {
 			data: this.getColumnData(result),
 			columns: this.getTableColumns(result.dataLossAlerts.size > 0),
 			width: 875,
-			height: 300
+			height: 300,
+			ariaRole: 'alert',
+			focused: true
 		});
 
 		if (result.dataLossAlerts.size > 0) {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2944,6 +2944,7 @@ declare module 'azdata' {
 		title?: string;
 		ariaRowCount?: number;
 		ariaColumnCount?: number;
+		focused?: boolean;
 		moveFocusOutWithTab?: boolean; //accessibility requirement for tables with no actionable cells
 	}
 

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2565,7 +2565,6 @@ declare module 'azdata' {
 		title: string;
 		actions?: Component[];
 		required?: boolean;
-		ariaLive?: string;
 	}
 
 	/**

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2565,6 +2565,7 @@ declare module 'azdata' {
 		title: string;
 		actions?: Component[];
 		required?: boolean;
+		ariaLive?: string;
 	}
 
 	/**
@@ -2944,6 +2945,7 @@ declare module 'azdata' {
 		title?: string;
 		ariaRowCount?: number;
 		ariaColumnCount?: number;
+		ariaRole?: string;
 		focused?: boolean;
 		moveFocusOutWithTab?: boolean; //accessibility requirement for tables with no actionable cells
 	}

--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -359,4 +359,8 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 	public set ariaColumnCount(value: number) {
 		this._tableContainer.setAttribute('aria-colcount', value.toString());
 	}
+
+	public set ariaRole(value: string) {
+		this._tableContainer.setAttribute('role', value);
+	}
 }

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1160,6 +1160,13 @@ class TableComponentWrapper extends ComponentWrapper implements azdata.TableComp
 		this.setProperty('moveFocusOutWithTab', v);
 	}
 
+	public get focused(): boolean {
+		return this.properties['focused'];
+	}
+	public set focused(v: boolean) {
+		this.setProperty('focused', v);
+	}
+
 	public get onRowSelected(): vscode.Event<any> {
 		let emitter = this._emitterMap.get(ComponentEventType.onSelectedRowChanged);
 		return emitter && emitter.event;
@@ -1169,6 +1176,8 @@ class TableComponentWrapper extends ComponentWrapper implements azdata.TableComp
 		let emitter = this._emitterMap.get(ComponentEventType.onCellAction);
 		return emitter && emitter.event;
 	}
+
+
 }
 
 class DropDownWrapper extends ComponentWrapper implements azdata.DropDownComponent {

--- a/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
+++ b/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
@@ -17,7 +17,7 @@ import * as nls from 'vs/nls';
 @Component({
 	selector: 'modelview-loadingComponent',
 	template: `
-		<div class="modelview-loadingComponent-container" *ngIf="loading">
+		<div class="modelview-loadingComponent-container" role="alert" aria-busy="true" *ngIf="loading">
 			<div class="modelview-loadingComponent-spinner" *ngIf="loading" [title]=_loadingTitle #spinnerElement></div>
 		</div>
 		<model-component-wrapper #childElement [descriptor]="_component" [modelStore]="modelStore" *ngIf="_component" [ngClass]="{'modelview-loadingComponent-content-loading': loading}">

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -247,6 +247,10 @@ export default class TableComponent extends ComponentBase implements IComponent,
 			this._table.ariaColumnCount = this.ariaColumnCount;
 		}
 
+		if (this.focused) {
+			this._table.focus();
+		}
+
 		this.layoutTable();
 		this.validate();
 	}
@@ -336,5 +340,13 @@ export default class TableComponent extends ComponentBase implements IComponent,
 
 	public get moveFocusOutWithTab(): boolean {
 		return this.getPropertyOrDefault<azdata.TableComponentProperties, boolean>((props) => props.moveFocusOutWithTab, false);
+	}
+
+	public get focused(): boolean {
+		return this.getPropertyOrDefault<azdata.RadioButtonProperties, boolean>((props) => props.focused, false);
+	}
+
+	public set focused(newValue: boolean) {
+		this.setPropertyFromUI<azdata.RadioButtonProperties, boolean>((properties, value) => { properties.focused = value; }, newValue);
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -247,6 +247,10 @@ export default class TableComponent extends ComponentBase implements IComponent,
 			this._table.ariaColumnCount = this.ariaColumnCount;
 		}
 
+		if (this.ariaRole) {
+			this._table.ariaRole = this.ariaRole;
+		}
+
 		if (this.focused) {
 			this._table.focus();
 		}
@@ -332,6 +336,10 @@ export default class TableComponent extends ComponentBase implements IComponent,
 
 	public get ariaColumnCount(): number {
 		return this.getPropertyOrDefault<azdata.TableComponentProperties, number>((props) => props.ariaColumnCount, -1);
+	}
+
+	public get ariaRole(): string {
+		return this.getPropertyOrDefault<azdata.TableComponentProperties, string>((props) => props.ariaRole, undefined);
 	}
 
 	public set moveFocusOutWithTab(newValue: boolean) {


### PR DESCRIPTION
Fixes #6943 and #6826 by adding ability Aria `role` attribute support to tables and loadingComponent objects.

Also adds ability to focus an extension table, though it ended up not being necessary for the fix.