### PR TITLE
Add connect protocol handler to SQL command line service

### DIFF
--- a/src/sql/workbench/parts/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/parts/commandLine/electron-browser/commandLine.ts
@@ -44,6 +44,7 @@ interface SqlArgs {
 	command?: string;
 	provider?: string;
 }
+
 export class CommandLineWorkbenchContribution implements IWorkbenchContribution, IURLHandler {
 
 	constructor(

--- a/src/sql/workbench/parts/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/parts/commandLine/electron-browser/commandLine.ts
@@ -28,7 +28,6 @@ import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { openNewQuery } from 'sql/workbench/parts/query/browser/queryActions';
 import { IURLService, IURLHandler } from 'vs/platform/url/common/url';
-import { parse } from 'vs/base/common/marshalling';
 import { getErrorMessage } from 'vs/base/common/errors';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 
@@ -153,12 +152,16 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 		}
 	}
 
-	async handleURL(uri: URI): Promise<boolean> {
+	public async handleURL(uri: URI): Promise<boolean> {
 		// Catch file URLs
 		let authority = uri.authority.toLowerCase();
 		if (authority === connectAuthority) {
 			try {
 				let args = this.parseProtocolArgs(uri);
+				if (!args.server) {
+					this._notificationService.warn(localize('warnServerRequired', "Cannot connect as no server information was provided"));
+					return true;
+				}
 				let isOpenOk = await this.confirmConnect(args);
 				if (isOpenOk) {
 					await this.processCommandLine(args);

--- a/src/sql/workbench/parts/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/parts/commandLine/electron-browser/commandLine.ts
@@ -189,6 +189,8 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 
 	private parseProtocolArgs(uri: URI): SqlArgs {
 		let args: SqlArgs = querystring.parse(uri.query);
+		// Clear out command, not supporting arbitrary command via this path
+		args.command = undefined;
 		return args;
 	}
 

--- a/src/sql/workbench/parts/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/parts/commandLine/test/electron-browser/commandLine.test.ts
@@ -115,6 +115,8 @@ suite('commandLineService tests', () => {
 			configurationService,
 			undefined,
 			logService,
+			undefined,
+			undefined,
 			undefined
 		);
 	}

--- a/src/sql/workbench/parts/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/parts/commandLine/test/electron-browser/commandLine.test.ts
@@ -21,11 +21,14 @@ import { TestCommandService } from 'vs/editor/test/browser/editorTestServices';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { assertThrowsAsync } from 'sqltest/utils/testUtils';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { TestEditorService } from 'vs/workbench/test/workbenchTestServices';
+import { TestEditorService, TestDialogService } from 'vs/workbench/test/workbenchTestServices';
 import { QueryInput, QueryEditorState } from 'sql/workbench/parts/query/common/queryInput';
 import { URI } from 'vs/base/common/uri';
 import { ILogService, NullLogService } from 'vs/platform/log/common/log';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
+import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 
 class TestParsedArgs implements ParsedArgs {
 	[arg: string]: any;
@@ -93,7 +96,6 @@ class TestParsedArgs implements ParsedArgs {
 suite('commandLineService tests', () => {
 
 	let capabilitiesService: TestCapabilitiesService;
-
 	setup(() => {
 		capabilitiesService = new TestCapabilitiesService();
 	});
@@ -104,7 +106,9 @@ suite('commandLineService tests', () => {
 		capabilitiesService?: ICapabilitiesService,
 		commandService?: ICommandService,
 		editorService?: IEditorService,
-		logService?: ILogService
+		logService?: ILogService,
+		dialogService?: IDialogService,
+		notificationService?: INotificationService
 	): CommandLineWorkbenchContribution {
 		return new CommandLineWorkbenchContribution(
 			capabilitiesService,
@@ -113,11 +117,11 @@ suite('commandLineService tests', () => {
 			editorService,
 			commandService,
 			configurationService,
-			undefined,
+			notificationService,
 			logService,
 			undefined,
 			undefined,
-			undefined
+			dialogService
 		);
 	}
 
@@ -390,5 +394,166 @@ suite('commandLineService tests', () => {
 		await contribution.processCommandLine(args);
 		queryInput.verifyAll();
 		connectionManagementService.verifyAll();
+	});
+
+	suite('URL Handler', () => {
+
+		let dialogService: TypeMoq.Mock<TestDialogService>;
+
+		setup(() => {
+			dialogService = TypeMoq.Mock.ofType(TestDialogService);
+		});
+
+
+		test('handleUrl ignores non-connect URLs', async () => {
+			// Given a URI pointing to a server
+			let uri: URI = URI.parse('azuredatastudio://file?server=myserver&database=mydatabase&user=myuser');
+
+			const connectionManagementService: TypeMoq.Mock<IConnectionManagementService>
+				= TypeMoq.Mock.ofType<IConnectionManagementService>(TestConnectionManagementService, TypeMoq.MockBehavior.Strict);
+			const configurationService = getConfigurationServiceMock(true);
+			const logService = new NullLogService();
+			let contribution = getCommandLineContribution(connectionManagementService.object, configurationService.object, capabilitiesService, undefined, undefined, logService, dialogService.object);
+
+			// When I call the URL handler and user confirms they should connect
+			dialogService.setup(d => d.confirm(TypeMoq.It.isAny())).returns(() => Promise.resolve({ confirmed: true }));
+			let result = await contribution.handleURL(uri);
+
+			// Then I expect connection management service to have been called
+			assert.equal(result, false, 'Expected URL to be ignored');
+		});
+
+		test('handleUrl opens a new connection if a server name is passed', async () => {
+			// Given a URI pointing to a server
+			let uri: URI = URI.parse('azuredatastudio://connect?server=myserver&database=mydatabase&user=myuser');
+
+			const connectionManagementService: TypeMoq.Mock<IConnectionManagementService>
+				= TypeMoq.Mock.ofType<IConnectionManagementService>(TestConnectionManagementService, TypeMoq.MockBehavior.Strict);
+
+			connectionManagementService.setup((c) => c.showConnectionDialog()).verifiable(TypeMoq.Times.never());
+			connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());
+			connectionManagementService.setup(c => c.getConnectionGroups(TypeMoq.It.isAny())).returns(() => []);
+			let originalProfile: IConnectionProfile = undefined;
+			connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.sqlLogin), 'connection', true))
+				.returns((conn) => {
+					originalProfile = conn;
+					return Promise.resolve('unused');
+				})
+				.verifiable(TypeMoq.Times.once());
+			connectionManagementService.setup(c => c.getConnectionProfileById(TypeMoq.It.isAnyString())).returns(() => originalProfile);
+			const configurationService = getConfigurationServiceMock(true);
+			const logService = new NullLogService();
+			let contribution = getCommandLineContribution(connectionManagementService.object, configurationService.object, capabilitiesService, undefined, undefined, logService, dialogService.object);
+
+			// When I call the URL handler and user confirms they should connect
+			dialogService.setup(d => d.confirm(TypeMoq.It.isAny())).returns(() => Promise.resolve({ confirmed: true }));
+			let result = await contribution.handleURL(uri);
+
+			// Then I expect connection management service to have been called
+			assert.equal(result, true, 'Expected URL to be handled');
+			connectionManagementService.verifyAll();
+		});
+
+		test('handleUrl does nothing if a user does not confirm', async () => {
+			// Given a URI pointing to a server
+			let uri: URI = URI.parse('azuredatastudio://connect?server=myserver&database=mydatabase&user=myuser');
+
+			const connectionManagementService: TypeMoq.Mock<IConnectionManagementService>
+				= TypeMoq.Mock.ofType<IConnectionManagementService>(TestConnectionManagementService, TypeMoq.MockBehavior.Strict);
+
+			connectionManagementService.setup((c) => c.showConnectionDialog()).verifiable(TypeMoq.Times.never());
+			connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());
+			connectionManagementService.setup(c => c.getConnectionGroups(TypeMoq.It.isAny())).returns(() => []);
+			let originalProfile: IConnectionProfile = undefined;
+			connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.sqlLogin), 'connection', true))
+				.returns((conn) => {
+					originalProfile = conn;
+					return Promise.resolve('unused');
+				})
+				// Note: should not run since we expect to cancel before this
+				.verifiable(TypeMoq.Times.never());
+			connectionManagementService.setup(c => c.getConnectionProfileById(TypeMoq.It.isAnyString())).returns(() => originalProfile);
+			const configurationService = getConfigurationServiceMock(true);
+			const logService = new NullLogService();
+			let contribution = getCommandLineContribution(connectionManagementService.object, configurationService.object, capabilitiesService, undefined, undefined, logService, dialogService.object);
+
+			// When I call the URL handler and user says no on confirmation dialog
+			dialogService.setup(d => d.confirm(TypeMoq.It.isAny())).returns(() => Promise.resolve({ confirmed: false }));
+			let result = await contribution.handleURL(uri);
+
+			// Then I expect no connection, but the URL should still be handled
+			assert.equal(result, true, 'Expected URL to be handled');
+			connectionManagementService.verifyAll();
+		});
+
+		test('handleUrl ignores commands', async () => {
+			// Given I pass a command
+			let uri: URI = URI.parse('azuredatastudio://connect?command=mycommand');
+
+			const connectionManagementService: TypeMoq.Mock<IConnectionManagementService>
+				= TypeMoq.Mock.ofType<IConnectionManagementService>(TestConnectionManagementService, TypeMoq.MockBehavior.Strict);
+			const commandService: TypeMoq.Mock<ICommandService> = TypeMoq.Mock.ofType<ICommandService>(TestCommandService);
+
+			connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true);
+			commandService.setup(c => c.executeCommand('mycommand'))
+				.returns(() => Promise.resolve())
+				.verifiable(TypeMoq.Times.never());
+			const configurationService = getConfigurationServiceMock(true);
+
+			const notificationService = TypeMoq.Mock.ofType(TestNotificationService);
+			notificationService.setup(n => n.warn(TypeMoq.It.isAny())).returns(() => undefined)
+				.verifiable(TypeMoq.Times.once());
+			let contribution = getCommandLineContribution(connectionManagementService.object, configurationService.object, capabilitiesService, commandService.object, undefined, new NullLogService(), dialogService.object, notificationService.object);
+
+			// When I handle the command URL
+			let result = await contribution.handleURL(uri);
+
+			// Then command service should not have been called, and instead connection should be handled
+			assert.equal(result, true);
+			commandService.verifyAll();
+			notificationService.verifyAll();
+		});
+
+		test('handleUrl ignores commands and connects', async () => {
+			// Given I pass a command
+			let uri: URI = URI.parse('azuredatastudio://connect?command=mycommand&server=myserver&database=mydatabase&user=myuser');
+
+			const connectionManagementService: TypeMoq.Mock<IConnectionManagementService>
+				= TypeMoq.Mock.ofType<IConnectionManagementService>(TestConnectionManagementService, TypeMoq.MockBehavior.Strict);
+			const commandService: TypeMoq.Mock<ICommandService> = TypeMoq.Mock.ofType<ICommandService>(TestCommandService);
+
+			connectionManagementService.setup((c) => c.showConnectionDialog()).verifiable(TypeMoq.Times.never());
+			connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());
+			connectionManagementService.setup(c => c.getConnectionGroups(TypeMoq.It.isAny())).returns(() => []);
+			let originalProfile: IConnectionProfile = undefined;
+			connectionManagementService.setup(c => c.connectIfNotConnected(TypeMoq.It.is<ConnectionProfile>(p => p.serverName === 'myserver' && p.authenticationType === Constants.sqlLogin), 'connection', true))
+				.returns((conn) => {
+					originalProfile = conn;
+					return Promise.resolve('unused');
+				})
+				.verifiable(TypeMoq.Times.once());
+
+			commandService.setup(c => c.executeCommand('mycommand'))
+				.returns(() => Promise.resolve())
+				.verifiable(TypeMoq.Times.never());
+			const configurationService = getConfigurationServiceMock(true);
+
+			const notificationService = TypeMoq.Mock.ofType(TestNotificationService);
+			notificationService.setup(n => n.warn(TypeMoq.It.isAny())).returns(() => undefined)
+				.verifiable(TypeMoq.Times.never());
+			let contribution = getCommandLineContribution(connectionManagementService.object, configurationService.object, capabilitiesService, commandService.object, undefined, new NullLogService(), dialogService.object, notificationService.object);
+
+			// When I handle the command URL
+			dialogService.setup(d => d.confirm(TypeMoq.It.isAny())).returns(() => Promise.resolve({ confirmed: true }));
+			let result = await contribution.handleURL(uri);
+
+			// Then command service should not have been called, and instead connection should be handled
+			assert.equal(result, true);
+			commandService.verifyAll();
+			notificationService.verifyAll();
+			connectionManagementService.verifyAll();
+		});
+
+
 	});
 });


### PR DESCRIPTION
- This already handles commandline which needs same logic
- Includes visual confirmation to avoid connecting by default to untrusted server
- If successful will connect & expand in Connections tree
- If failed, will show dialog with all presets
- Shows New Query by default, can add option for New Notebook instead in the future

Connection protocol is `azuredatastudio://connect?server=mysqldw.database.windows.net&database=db1&user=myusername&aad=true`
Same args as commandline, namely:
- server
- database
- user
- aad
- integrated

I have also added `provider` arg to allow non-MSSQL providers. In the future, we should update logic to prompt for install of correct extension for that provider if it's missing.

![ConnectProtocol](https://user-images.githubusercontent.com/10819925/63973026-bdb4f380-ca5e-11e9-90c2-ab788761bd88.gif)
