### PR TITLE
Bug/accessibility 5

### DIFF
--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { escape } from 'sql/base/common/strings';
+import { localize } from 'vs/nls';
 
 export class DBCellValue {
 	displayValue: string;
@@ -78,15 +79,15 @@ export function slickGridDataItemColumnValueExtractor(value: any, columnDef: any
 }
 
 /**
- * Alterate function to provide slick grid cell with area label and plain text
- * In this case, for no display value arialable will be set to specific string "no data available" for accessibily support for screen readers
- * Set 'no data' lable only if cell is present and has no value (so that checkbox and other custom plugings do not get 'no data' label)
+ * Alternate function to provide slick grid cell with ariaLabel and plain text
+ * In this case, for no display value ariaLabel will be set to specific string "no data available" for accessibily support for screen readers
+ * Set 'no data' lable only if cell is present and has no value (so that checkbox and other custom plugins do not get 'no data' label)
  */
 export function slickGridDataItemColumnValueWithNoData(value: any, columnDef: any): { text: string; ariaLabel: string; } {
 	let displayValue = value[columnDef.field];
 	return {
 		text: displayValue,
-		ariaLabel: displayValue ? escape(displayValue) : ((displayValue !== undefined) ? 'no data available' : displayValue)
+		ariaLabel: displayValue ? escape(displayValue) : ((displayValue !== undefined) ? localize("tableCell.NoDataAvailable", "no data available") : displayValue)
 	};
 }
 

--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -77,6 +77,18 @@ export function slickGridDataItemColumnValueExtractor(value: any, columnDef: any
 	};
 }
 
+/**
+ * Alterate function to provide slick grid cell with area label and plain text
+ * In this case, for no display value arialable will be set to specific string "no data available" for accessibily support for screen readers
+ */
+export function slickGridDataItemColumnValueWithNoData(value: any, columnDef: any): { text: string; ariaLabel: string; } {
+	let displayValue = value[columnDef.field];
+	return {
+		text: displayValue,
+		ariaLabel: displayValue ? escape(displayValue) : ((displayValue !== undefined) ? 'no data available' : displayValue) // so that we dont override the checkboxes etc. plugins with no data available
+	};
+}
+
 /** The following code is a rewrite over the both formatter function using dom builder
  * rather than string manipulation, which is a safer and easier method of achieving the same goal.
  * However, when electron is in "Run as node" mode, dom creation acts differently than normal and therefore

--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -80,12 +80,13 @@ export function slickGridDataItemColumnValueExtractor(value: any, columnDef: any
 /**
  * Alterate function to provide slick grid cell with area label and plain text
  * In this case, for no display value arialable will be set to specific string "no data available" for accessibily support for screen readers
+ * Set 'no data' lable only if cell is present and has no value (so that checkbox and other custom plugings do not get 'no data' label)
  */
 export function slickGridDataItemColumnValueWithNoData(value: any, columnDef: any): { text: string; ariaLabel: string; } {
 	let displayValue = value[columnDef.field];
 	return {
 		text: displayValue,
-		ariaLabel: displayValue ? escape(displayValue) : ((displayValue !== undefined) ? 'no data available' : displayValue) // so that we dont override the checkboxes etc. plugins with no data available
+		ariaLabel: displayValue ? escape(displayValue) : ((displayValue !== undefined) ? 'no data available' : displayValue)
 	};
 }
 

--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -99,11 +99,11 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		if (!this._options.title) {
 			if (selectedRows.length && selectedRows.length === this._grid.getDataLength()) {
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, 'checked', this._options.title),
+					strings.format(checkboxTemplate, 'checked', this.getariaLabel(true)),
 					this._options.toolTip);
 			} else {
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, '',this._options.title),
+					strings.format(checkboxTemplate, '', this.getariaLabel(false)),
 					this._options.toolTip);
 			}
 		}
@@ -210,12 +210,12 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 				const rows = range(this._grid.getDataLength());
 				this._grid.setSelectedRows(rows);
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, 'checked', this._options.title),
+					strings.format(checkboxTemplate, 'checked', this.getariaLabel(true)),
 					this._options.toolTip);
 			} else {
 				this._grid.setSelectedRows([]);
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, '', this._options.title), this._options.toolTip);
+					strings.format(checkboxTemplate, '', this.getariaLabel(false)), this._options.toolTip);
 				e.stopPropagation();
 				e.stopImmediatePropagation();
 			}
@@ -243,16 +243,16 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		}
 
 		return this._selectedRowsLookup[row]
-			? strings.format(checkboxTemplate, 'checked', this._options.title)
-			: strings.format(checkboxTemplate, '', this._options.title);
+			? strings.format(checkboxTemplate, 'checked', this.getariaLabel(true))
+			: strings.format(checkboxTemplate, '', this.getariaLabel(false));
 	}
 
 	checkboxTemplateCustom(row: number): string {
 		// use state after toggles
 		if (this._useState) {
 			return this._selectedCheckBoxLookup[row]
-				? strings.format(checkboxTemplate, 'checked', this._options.title)
-				: strings.format(checkboxTemplate, '', this._options.title);
+				? strings.format(checkboxTemplate, 'checked', this.getariaLabel(true))
+				: strings.format(checkboxTemplate, '', this.getariaLabel(false));
 		}
 
 		// use data for first time rendering
@@ -260,15 +260,20 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		let rowVal = (this._grid) ? this._grid.getDataItem(row) : null;
 		if (rowVal && this._options.title && rowVal[this._options.title] === true) {
 			this._selectedCheckBoxLookup[row] = true;
-			return strings.format(checkboxTemplate, 'checked', this._options.title);
+			return strings.format(checkboxTemplate, 'checked', this.getariaLabel(true));
 		}
 		else {
 			delete this._selectedCheckBoxLookup[row];
-			return strings.format(checkboxTemplate, '', this._options.title);
+			return strings.format(checkboxTemplate, '', this.getariaLabel(false));
 		}
 	}
 
 	private isCustomActionRequested(): boolean {
 		return (this._options.actionOnCheck === ActionOnCheck.customAction);
+	}
+
+	private getariaLabel(checked: boolean): string {
+		return checked ? strings.format('"{0} {1}"', this._options.title, 'checkbox checked') :
+			strings.format('"{0} {1}"', this._options.title, 'checkbox unchecked');
 	}
 }

--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -99,11 +99,11 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		if (!this._options.title) {
 			if (selectedRows.length && selectedRows.length === this._grid.getDataLength()) {
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, 'checked', this.getariaLabel(true)),
+					strings.format(checkboxTemplate, 'checked', this.getAriaLabel(true)),
 					this._options.toolTip);
 			} else {
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, '', this.getariaLabel(false)),
+					strings.format(checkboxTemplate, '', this.getAriaLabel(false)),
 					this._options.toolTip);
 			}
 		}
@@ -210,12 +210,12 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 				const rows = range(this._grid.getDataLength());
 				this._grid.setSelectedRows(rows);
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, 'checked', this.getariaLabel(true)),
+					strings.format(checkboxTemplate, 'checked', this.getAriaLabel(true)),
 					this._options.toolTip);
 			} else {
 				this._grid.setSelectedRows([]);
 				this._grid.updateColumnHeader(this._options.columnId!,
-					strings.format(checkboxTemplate, '', this.getariaLabel(false)), this._options.toolTip);
+					strings.format(checkboxTemplate, '', this.getAriaLabel(false)), this._options.toolTip);
 				e.stopPropagation();
 				e.stopImmediatePropagation();
 			}
@@ -243,16 +243,16 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		}
 
 		return this._selectedRowsLookup[row]
-			? strings.format(checkboxTemplate, 'checked', this.getariaLabel(true))
-			: strings.format(checkboxTemplate, '', this.getariaLabel(false));
+			? strings.format(checkboxTemplate, 'checked', this.getAriaLabel(true))
+			: strings.format(checkboxTemplate, '', this.getAriaLabel(false));
 	}
 
 	checkboxTemplateCustom(row: number): string {
 		// use state after toggles
 		if (this._useState) {
 			return this._selectedCheckBoxLookup[row]
-				? strings.format(checkboxTemplate, 'checked', this.getariaLabel(true))
-				: strings.format(checkboxTemplate, '', this.getariaLabel(false));
+				? strings.format(checkboxTemplate, 'checked', this.getAriaLabel(true))
+				: strings.format(checkboxTemplate, '', this.getAriaLabel(false));
 		}
 
 		// use data for first time rendering
@@ -260,11 +260,11 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		let rowVal = (this._grid) ? this._grid.getDataItem(row) : null;
 		if (rowVal && this._options.title && rowVal[this._options.title] === true) {
 			this._selectedCheckBoxLookup[row] = true;
-			return strings.format(checkboxTemplate, 'checked', this.getariaLabel(true));
+			return strings.format(checkboxTemplate, 'checked', this.getAriaLabel(true));
 		}
 		else {
 			delete this._selectedCheckBoxLookup[row];
-			return strings.format(checkboxTemplate, '', this.getariaLabel(false));
+			return strings.format(checkboxTemplate, '', this.getAriaLabel(false));
 		}
 	}
 
@@ -272,8 +272,8 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		return (this._options.actionOnCheck === ActionOnCheck.customAction);
 	}
 
-	private getariaLabel(checked: boolean): string {
-		return checked ? strings.format('"{0} {1}"', this._options.title, 'checkbox checked') :
-			strings.format('"{0} {1}"', this._options.title, 'checkbox unchecked');
+	private getAriaLabel(checked: boolean): string {
+		return checked ? strings.format('"{0} {1}"', this._options.title, nls.localize("tableCheckboxCell.Checked", "checkbox checked")) :
+			strings.format('"{0} {1}"', this._options.title, nls.localize("tableCheckboxCell.unChecked", "checkbox unchecked"));
 	}
 }

--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -273,7 +273,7 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 	}
 
 	private getAriaLabel(checked: boolean): string {
-		return checked ? strings.format('"{0} {1}"', this._options.title, nls.localize("tableCheckboxCell.Checked", "checkbox checked")) :
-			strings.format('"{0} {1}"', this._options.title, nls.localize("tableCheckboxCell.unChecked", "checkbox unchecked"));
+		return checked ? `"${this._options.title} ${nls.localize("tableCheckboxCell.Checked", "checkbox checked")}"` :
+			`"${this._options.title} ${nls.localize("tableCheckboxCell.unChecked", "checkbox unchecked")}"`;
 	}
 }

--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -322,6 +322,7 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 
 		if (styles.listFocusOutline) {
 			content.push(`.monaco-table.${this.idPrefix}.focused .slick-row .selected { outline: 1px solid ${styles.listFocusOutline}; outline-offset: -1px; }`);
+			content.push(`.monaco-table.${this.idPrefix}.focused .slick-row .selected.active { outline: 2px solid ${styles.listFocusOutline}; outline-offset: -1px; }`);
 		}
 
 		if (styles.listInactiveFocusOutline) {

--- a/src/sql/platform/dialog/browser/dialogModal.ts
+++ b/src/sql/platform/dialog/browser/dialogModal.ts
@@ -110,12 +110,12 @@ export class DialogModal extends Modal {
 		dialogButton.hidden ? buttonElement.element.parentElement.classList.add('dialogModal-hidden') : buttonElement.element.parentElement.classList.remove('dialogModal-hidden');
 	}
 
-	protected renderBody(container: HTMLElement): void {
+	protected renderBody(container: HTMLElement): HTMLElement {
 		const body = append(container, $('div.dialogModal-body'));
 
 		this._dialogPane = new DialogPane(this._dialog.title, this._dialog.content,
 			valid => this._dialog.notifyValidityChanged(valid), this._instantiationService, this._themeService, false);
-		this._dialogPane.createBody(body);
+		return this._dialogPane.createBody(body);
 	}
 
 	public open(): void {

--- a/src/sql/platform/dialog/browser/dialogModal.ts
+++ b/src/sql/platform/dialog/browser/dialogModal.ts
@@ -110,12 +110,12 @@ export class DialogModal extends Modal {
 		dialogButton.hidden ? buttonElement.element.parentElement.classList.add('dialogModal-hidden') : buttonElement.element.parentElement.classList.remove('dialogModal-hidden');
 	}
 
-	protected renderBody(container: HTMLElement): HTMLElement {
+	protected renderBody(container: HTMLElement): void {
 		const body = append(container, $('div.dialogModal-body'));
 
 		this._dialogPane = new DialogPane(this._dialog.title, this._dialog.content,
 			valid => this._dialog.notifyValidityChanged(valid), this._instantiationService, this._themeService, false);
-		return this._dialogPane.createBody(body);
+		this._dialogPane.createBody(body);
 	}
 
 	public open(): void {

--- a/src/sql/platform/dialog/browser/dialogPane.ts
+++ b/src/sql/platform/dialog/browser/dialogPane.ts
@@ -79,7 +79,7 @@ export class DialogPane extends Disposable implements IThemable {
 							tabContainer.style.display = 'block';
 						},
 						layout: (dimension) => { this.getTabDimension(); },
-						focus: () => { }
+						focus: () => { this.focus(); }
 					}
 				});
 			});

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -105,6 +105,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	private _leftFooter: HTMLElement;
 	private _rightFooter: HTMLElement;
 	private _footerButtons: Button[];
+	private _dialogPaneBody: HTMLElement;
 
 	private _keydownListener: IDisposable;
 	private _resizeListener: IDisposable;
@@ -234,7 +235,7 @@ export abstract class Modal extends Disposable implements IThemable {
 		const modalBodyClass = (this._modalOptions.isAngular === false ? 'modal-body' : 'modal-body-and-footer');
 
 		this._modalBodySection = DOM.append(modalContent, DOM.$(`.${modalBodyClass}`));
-		this.renderBody(this._modalBodySection);
+		this._dialogPaneBody = <HTMLElement>this.renderBody(this._modalBodySection);
 
 		// This modal footer section refers to the footer of of the dialog
 		if (!this._modalOptions.isAngular) {
@@ -252,7 +253,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	 * Called for extended classes to render the body
 	 * @param container The parent container to attach the rendered body to
 	 */
-	protected abstract renderBody(container: HTMLElement): void;
+	protected abstract renderBody(container: HTMLElement): HTMLElement | void;
 
 	/**
 	 * Overridable to change behavior of escape key
@@ -319,13 +320,21 @@ export abstract class Modal extends Disposable implements IThemable {
 	 * Set focusable elements in the modal dialog
 	 */
 	public setFocusableElements() {
-		this._focusableElements = this._bodyContainer.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]');
+		// try to find focuable element in dialog pane rather than overall bodycontainer
+		this._focusableElements = this._dialogPaneBody ?
+			this._dialogPaneBody.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]') :
+			this._bodyContainer.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]');
 		if (this._focusableElements && this._focusableElements.length > 0) {
 			this._firstFocusableElement = <HTMLElement>this._focusableElements[0];
 			this._lastFocusableElement = <HTMLElement>this._focusableElements[this._focusableElements.length - 1];
 		}
 
 		this._focusedElementBeforeOpen = <HTMLElement>document.activeElement;
+
+		// focus the first element if found
+		if (this._firstFocusableElement) {
+			this._firstFocusableElement.focus();
+		}
 	}
 
 	/**

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -105,7 +105,6 @@ export abstract class Modal extends Disposable implements IThemable {
 	private _leftFooter: HTMLElement;
 	private _rightFooter: HTMLElement;
 	private _footerButtons: Button[];
-	private _dialogPaneBody: HTMLElement;
 
 	private _keydownListener: IDisposable;
 	private _resizeListener: IDisposable;
@@ -235,7 +234,7 @@ export abstract class Modal extends Disposable implements IThemable {
 		const modalBodyClass = (this._modalOptions.isAngular === false ? 'modal-body' : 'modal-body-and-footer');
 
 		this._modalBodySection = DOM.append(modalContent, DOM.$(`.${modalBodyClass}`));
-		this._dialogPaneBody = <HTMLElement>this.renderBody(this._modalBodySection);
+		this.renderBody(this._modalBodySection);
 
 		// This modal footer section refers to the footer of of the dialog
 		if (!this._modalOptions.isAngular) {
@@ -253,7 +252,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	 * Called for extended classes to render the body
 	 * @param container The parent container to attach the rendered body to
 	 */
-	protected abstract renderBody(container: HTMLElement): HTMLElement | void;
+	protected abstract renderBody(container: HTMLElement): void;
 
 	/**
 	 * Overridable to change behavior of escape key
@@ -321,8 +320,8 @@ export abstract class Modal extends Disposable implements IThemable {
 	 */
 	public setFocusableElements() {
 		// try to find focusable element in dialog pane rather than overall container
-		this._focusableElements = this._dialogPaneBody ?
-			this._dialogPaneBody.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]') :
+		this._focusableElements = this._modalBodySection ?
+			this._modalBodySection.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]') :
 			this._bodyContainer.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]');
 		if (this._focusableElements && this._focusableElements.length > 0) {
 			this._firstFocusableElement = <HTMLElement>this._focusableElements[0];
@@ -330,8 +329,14 @@ export abstract class Modal extends Disposable implements IThemable {
 		}
 
 		this._focusedElementBeforeOpen = <HTMLElement>document.activeElement;
+		this.focus();
+	}
 
-		// focus the first element if found
+	/**
+	 * Focuses the modal
+	 * Default behavior: focus the first focusable element
+	 */
+	protected focus() {
 		if (this._firstFocusableElement) {
 			this._firstFocusableElement.focus();
 		}

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -320,7 +320,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	 * Set focusable elements in the modal dialog
 	 */
 	public setFocusableElements() {
-		// try to find focuable element in dialog pane rather than overall bodycontainer
+		// try to find focusable element in dialog pane rather than overall container
 		this._focusableElements = this._dialogPaneBody ?
 			this._dialogPaneBody.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]') :
 			this._bodyContainer.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]');

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -25,6 +25,7 @@ import { CheckboxSelectColumn, ICheckboxCellActionEventArgs } from 'sql/base/bro
 import { Emitter, Event as vsEvent } from 'vs/base/common/event';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
+import { slickGridDataItemColumnValueWithNoData, textFormatter } from 'sql/base/browser/ui/table/formatters';
 
 @Component({
 	selector: 'modelview-table',
@@ -72,13 +73,15 @@ export default class TableComponent extends ComponentBase implements IComponent,
 						width: col.width,
 						cssClass: col.cssClass,
 						headerCssClass: col.headerCssClass,
-						toolTip: col.toolTip
+						toolTip: col.toolTip,
+						formatter: textFormatter,
 					});
 				} else {
 					mycolumns.push(<Slick.Column<any>>{
 						name: <string>col,
 						id: <string>col,
-						field: <string>col
+						field: <string>col,
+						formatter: textFormatter
 					});
 				}
 				index++;
@@ -94,8 +97,6 @@ export default class TableComponent extends ComponentBase implements IComponent,
 			});
 		}
 	}
-
-
 
 	public static transformData(rows: string[][], columns: any[]): { [key: string]: string }[] {
 		if (rows && columns) {
@@ -122,7 +123,8 @@ export default class TableComponent extends ComponentBase implements IComponent,
 				syncColumnCellResize: true,
 				enableColumnReorder: false,
 				enableCellNavigation: true,
-				forceFitColumns: true // default to true during init, actual value will be updated when setProperties() is called
+				forceFitColumns: true, // default to true during init, actual value will be updated when setProperties() is called
+				dataItemColumnValueExtractor: slickGridDataItemColumnValueWithNoData // must change formatter if you are changing explicit column value extractor
 			};
 
 			this._table = new Table<Slick.SlickData>(this._inputContainer.nativeElement, { dataProvider: this._tableData, columns: this._tableColumns }, options);


### PR DESCRIPTION
Fix for

#6946
Schema compare options dialog tabs are not accessible through tabbing. This is because options dialogs don't gain focus when opened) Fixed in core. Tested with core and Ext dialogs.

#6796 (second part)
Data cells (text data mostly) with no data in table should announce no data available. Ensuring that this doesn't affect checkbox cells.
 
#6726
Checkboxes should announce 'checkbox' and their status

https://github.com/microsoft/azuredatastudio/issues/6852
Focus wasn't visible when moving in grid in HC since the whole row is selected in same color. Added stronger border for active cell.
