### PR TITLE
Update Resource Type Service Tests to use correct number of resource types.

### DIFF
--- a/extensions/resource-deployment/src/test/resourceTypeService.test.ts
+++ b/extensions/resource-deployment/src/test/resourceTypeService.test.ts
@@ -23,20 +23,20 @@ suite('Resource Type Service Tests', function (): void {
 		const resourceTypeService = new ResourceTypeService(mockPlatformService.object, toolsService, notebookService);
 		// index 0: platform name, index 1: number of expected resource types
 		const platforms: { platform: string; resourceTypeCount: number }[] = [
-			{ platform: 'win32', resourceTypeCount: 2 },
+			{ platform: 'win32', resourceTypeCount: 3 },
 			{ platform: 'darwin', resourceTypeCount: 2 },
 			{ platform: 'linux', resourceTypeCount: 2 }];
-		const totalResourceTypeCount = 1;
+		const totalResourceTypeCount = 3;
 		platforms.forEach(platformInfo => {
 			mockPlatformService.reset();
 			mockPlatformService.setup(service => service.platform()).returns(() => platformInfo.platform);
 			mockPlatformService.setup(service => service.showErrorMessage(TypeMoq.It.isAnyString()));
 			const resourceTypes = resourceTypeService.getResourceTypes(true);
-			assert.equal(resourceTypes.length, platformInfo.resourceTypeCount, `number of resource types for platform:${platformInfo.resourceTypeCount} does not meet expected value.`);
+			assert.equal(resourceTypes.length, platformInfo.resourceTypeCount, `number of resource types for platform:${platformInfo.resourceTypeCount} does not meet expected value:${resourceTypes.length}.`);
 		});
 
 		const allResourceTypes = resourceTypeService.getResourceTypes(false);
-		assert.equal(allResourceTypes.length, totalResourceTypeCount, `number of resource types does not meet expected value.`);
+		assert.equal(allResourceTypes.length, totalResourceTypeCount, `number of resource types:${allResourceTypes.length} does not meet expected value:${totalResourceTypeCount}.`);
 
 		const validationErrors = resourceTypeService.validateResourceTypes(allResourceTypes);
 		assert(validationErrors.length === 0, `Validation errors detected in the package.json: ${validationErrors.join(EOL)}.`);


### PR DESCRIPTION
In the resource-deployment extension's package.json, there are 3 resource types listed: sql-image, sql-bdc, and sql-windows-setup. The first 2 are supported on all platforms, and the third only on windows. I've updated the resource type counts in the Resource Type Service tests to reflect this. I also added some extra information in the error messages, since the test runner outputs a lot of junk characters on windows that makes it hard to see the actual vs expected values.