### PR TITLE
Fix for Manage Packages Showing Up for SQL Kernel (in some cases)

### DIFF
--- a/src/sql/workbench/parts/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/parts/notebook/browser/notebook.component.ts
@@ -280,8 +280,8 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		await this.awaitNonDefaultProvider();
 		await this._model.requestModelLoad();
 		this.detectChanges();
-		await this._model.startSession(this._model.notebookManager, undefined, true);
 		this.setContextKeyServiceWithProviderId(this._model.providerId);
+		await this._model.startSession(this._model.notebookManager, undefined, true);
 		this.fillInActionsForCurrentContext();
 		this.detectChanges();
 	}


### PR DESCRIPTION
Fixes #6922.

Ensure context key provider set before session start. There was the possibility of the previous value being used when session start happens, and the button being added before the value of the current provider was set.

![image](https://user-images.githubusercontent.com/40371649/64051040-a8a79580-cb2e-11e9-90c5-4d4bbca73aad.png)

![image](https://user-images.githubusercontent.com/40371649/64051054-b3622a80-cb2e-11e9-9c00-6bcbd8af740a.png)
