### PR TITLE
Fixing two backup/restore issues - opening context of dialog and footer color

### DIFF
--- a/src/sql/workbench/parts/backup/browser/backup.component.ts
+++ b/src/sql/workbench/parts/backup/browser/backup.component.ts
@@ -33,6 +33,7 @@ import { ISelectOptionItem } from 'vs/base/browser/ui/selectBox/selectBox';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { ITheme } from 'vs/platform/theme/common/themeService';
 import { AngularDisposable } from 'sql/base/browser/lifecycle';
+import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 
 export const BACKUP_SELECTOR: string = 'backup-component';
 
@@ -558,7 +559,7 @@ export class BackupComponent extends AngularDisposable {
 	private updateTheme(theme: ITheme): void {
 		// set modal footer style
 		let footerHtmlElement: HTMLElement = <HTMLElement>this.modalFooterElement.nativeElement;
-		const backgroundColor = theme.getColor(cr.foreground);
+		const backgroundColor = theme.getColor(SIDE_BAR_BACKGROUND);
 		const border = theme.getColor(cr.contrastBorder) ? theme.getColor(cr.contrastBorder).toString() : null;
 		const footerBorderTopWidth = border ? '1px' : null;
 		const footerBorderTopStyle = border ? 'solid' : null;

--- a/src/sql/workbench/parts/backup/browser/backup.contribution.ts
+++ b/src/sql/workbench/parts/backup/browser/backup.contribution.ts
@@ -15,10 +15,11 @@ import { MssqlNodeContext } from 'sql/workbench/parts/dataExplorer/common/mssqlN
 import { NodeType } from 'sql/workbench/parts/objectExplorer/common/nodeType';
 import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { localize } from 'vs/nls';
-import { ObjectExplorerActionsContext } from 'sql/workbench/parts/objectExplorer/browser/objectExplorerActions';
+import { OEAction } from 'sql/workbench/parts/objectExplorer/browser/objectExplorerActions';
 import { TreeNodeContextKey } from 'sql/workbench/parts/objectExplorer/common/treeNodeContextKey';
 import { ConnectionContextKey } from 'sql/workbench/parts/connection/common/connectionContextKey';
 import { ServerInfoContextKey } from 'sql/workbench/parts/connection/common/serverInfoContextKey';
+import { ServicesAccessor, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 new BackupAction().registerTask();
 
@@ -47,9 +48,9 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 const OE_BACKUP_COMMAND_ID = 'objectExplorer.backup';
 CommandsRegistry.registerCommand({
 	id: OE_BACKUP_COMMAND_ID,
-	handler: (accessor, args: ObjectExplorerActionsContext) => {
-		const commandService = accessor.get(ICommandService);
-		return commandService.executeCommand(BackupAction.ID, args.connectionProfile);
+	handler: (accessor: ServicesAccessor, actionContext: any) => {
+		const instantiationService = accessor.get(IInstantiationService);
+		return instantiationService.createInstance(OEAction, BackupAction.ID, BackupAction.LABEL).run(actionContext);
 	}
 });
 

--- a/src/sql/workbench/parts/backup/browser/backupActions.ts
+++ b/src/sql/workbench/parts/backup/browser/backupActions.ts
@@ -65,6 +65,7 @@ export class BackupAction extends Task {
 
 		const capabilitiesService = accessor.get(ICapabilitiesService);
 		const instantiationService = accessor.get(IInstantiationService);
-		return instantiationService.invokeFunction(showBackup, new ConnectionProfile(capabilitiesService, profile));
+		profile = profile ? profile : new ConnectionProfile(capabilitiesService, profile);
+		return instantiationService.invokeFunction(showBackup, profile);
 	}
 }

--- a/src/sql/workbench/parts/restore/browser/restoreActions.ts
+++ b/src/sql/workbench/parts/restore/browser/restoreActions.ts
@@ -61,6 +61,7 @@ export class RestoreAction extends Task {
 
 		const capabilitiesService = accessor.get(ICapabilitiesService);
 		const instantiationService = accessor.get(IInstantiationService);
-		return instantiationService.invokeFunction(showRestore, new ConnectionProfile(capabilitiesService, profile));
+		profile = profile ? profile : new ConnectionProfile(capabilitiesService, profile);
+		return instantiationService.invokeFunction(showRestore, profile);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/7017 and https://github.com/microsoft/azuredatastudio/issues/7015

These were some recent regression and would be good to take in Sept.

Back up and restore dialogs from OE context menu were always opening in master context. this fixes the same. For backup additionally the task was starting with metadata around master even when dialog was fixed. Needed to ensure it clones the connection profile in DB context. changing to run as OE action fixed this. (Thanks @anthonydresser for the pointers)
