### PR TITLE
Notebooks: Fix double-click to edit with source as array

### DIFF
--- a/src/sql/workbench/parts/notebook/electron-browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/parts/notebook/electron-browser/cellViews/textCell.component.ts
@@ -164,10 +164,11 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	 */
 	private updatePreview(): void {
 		let trustedChanged = this.cellModel && this._lastTrustedMode !== this.cellModel.trustedMode;
-		let contentChanged = this._content !== this.cellModel.source || this.cellModel.source.length === 0;
+		let cellModelSourceJoined = Array.isArray(this.cellModel.source) ? this.cellModel.source.join('') : this.cellModel.source;
+		let contentChanged = this._content !== this.cellModel.source || cellModelSourceJoined.length === 0;
 		if (trustedChanged || contentChanged) {
 			this._lastTrustedMode = this.cellModel.trustedMode;
-			if (!this.cellModel.source && !this.isEditMode) {
+			if ((!cellModelSourceJoined) && !this.isEditMode) {
 				this._content = localize('doubleClickEdit', "Double-click to edit");
 			} else {
 				this._content = this.cellModel.source;

--- a/src/sql/workbench/parts/notebook/electron-browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/parts/notebook/electron-browser/cellViews/textCell.component.ts
@@ -165,7 +165,8 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	private updatePreview(): void {
 		let trustedChanged = this.cellModel && this._lastTrustedMode !== this.cellModel.trustedMode;
 		let cellModelSourceJoined = Array.isArray(this.cellModel.source) ? this.cellModel.source.join('') : this.cellModel.source;
-		let contentChanged = this._content !== this.cellModel.source || cellModelSourceJoined.length === 0;
+		let contentJoined = Array.isArray(this._content) ? this._content.join('') : this._content;
+		let contentChanged = contentJoined !== cellModelSourceJoined || cellModelSourceJoined.length === 0;
 		if (trustedChanged || contentChanged) {
 			this._lastTrustedMode = this.cellModel.trustedMode;
 			if ((!cellModelSourceJoined) && !this.isEditMode) {


### PR DESCRIPTION
Fixes #7026.

Since cell source can now be an array, we were incorrectly doing comparisons between the previous and new source values in the text component. This meant that the "Double-click to edit" message was gone when a markdown cell is empty.