### PR TITLE
Make wizard page names get announced by screen reader

### DIFF
--- a/src/sql/platform/dialog/browser/dialogContainer.component.ts
+++ b/src/sql/platform/dialog/browser/dialogContainer.component.ts
@@ -29,7 +29,7 @@ export interface DialogComponentParams extends IBootstrapParams {
 		<div class="dialogContainer" *ngIf="_dialogPane && _dialogPane.displayPageTitle">
 			<div class="dialogModal-wizardHeader" *ngIf="_dialogPane && _dialogPane.displayPageTitle">
 				<div *ngIf="_dialogPane.pageNumber" class="wizardPageNumber">Step {{_dialogPane.pageNumber}}</div>
-				<h1 class="wizardPageTitle">{{_dialogPane.title}}</h1>
+				<h1 class="wizardPageTitle" role="alert">{{_dialogPane.title}}</h1>
 				<div *ngIf="_dialogPane.description">{{_dialogPane.description}}</div>
 			</div>
 			<div style="flex: 1 1 auto; position: relative;">


### PR DESCRIPTION
Fixes #6824. This makes the wizard page names get announced when the page is changed. Previously, only the wizard name was announced when the wizard first opens.