### PR TITLE
Remove EOL from copy string

### DIFF
--- a/src/sql/platform/query/common/gridDataProvider.ts
+++ b/src/sql/platform/query/common/gridDataProvider.ts
@@ -95,6 +95,8 @@ export async function getResultsString(provider: IGridDataProvider, selection: S
 		copyString = copyString.concat(row.join('\t').concat(eol));
 	});
 
+	copyString = copyString.trimRight();
+
 	return copyString;
 }
 


### PR DESCRIPTION
Fixes #6803 

Removes the EoL character from the copy string