### PR TITLE
Trimming the text for SQLCMD button

### DIFF
--- a/src/sql/workbench/parts/query/browser/queryActions.ts
+++ b/src/sql/workbench/parts/query/browser/queryActions.ts
@@ -514,8 +514,8 @@ export class ToggleSqlCmdModeAction extends QueryTaskbarAction {
 	public static DisableSqlcmdClass = 'disablesqlcmd';
 	public static ID = 'ToggleSqlCmdModeAction';
 
-	private _enablesqlcmdLabel = nls.localize('enablesqlcmdLabel', "Enable SQLCMD Mode");
-	private _disablesqlcmdLabel = nls.localize('disablesqlcmdLabel', "Disable SQLCMD Mode");
+	private _enablesqlcmdLabel = nls.localize('enablesqlcmdLabel', "Enable SQLCMD");
+	private _disablesqlcmdLabel = nls.localize('disablesqlcmdLabel', "Disable SQLCMD");
 	constructor(
 		editor: QueryEditor,
 		private _isSqlCmdMode: boolean,


### PR DESCRIPTION
Trimming the text for SQLCMD button to remove the word 'Mode'. This helps with the issue : https://github.com/microsoft/azuredatastudio/issues/7010. We will investigate the hiding button behavior for coming releases...