### PR TITLE
Remove the eol character at the end of the copy string

### DIFF
--- a/src/sql/platform/query/common/gridDataProvider.ts
+++ b/src/sql/platform/query/common/gridDataProvider.ts
@@ -94,6 +94,7 @@ export async function getResultsString(provider: IGridDataProvider, selection: S
 		}
 		copyString = copyString.concat(row.join('\t').concat(eol));
 	});
+	copyString = copyString.slice(0, -1 * eol.length);
 
 	return copyString;
 }


### PR DESCRIPTION
Removes the EoL string at the end of the copy string
Fixes #6803 
