### PR TITLE
Fix CMS server deletion from memento

### DIFF
--- a/extensions/cms/src/cmsUtils.ts
+++ b/extensions/cms/src/cmsUtils.ts
@@ -126,7 +126,7 @@ export class CmsUtils {
 	}
 
 	public async deleteCmsServer(cmsServerName: string, connection: azdata.connection.Connection): Promise<void> {
-		const servers: ICmsResourceNodeInfo[] = this._memento.get('servers');
+		const servers: ICmsResourceNodeInfo[] = this._memento.get('centralManagementServers');
 		if (servers) {
 			const newServers: ICmsResourceNodeInfo[] = servers.filter((cachedServer) => {
 				return cachedServer.name !== cmsServerName;


### PR DESCRIPTION
CMS server wasn't getting removed from the tree when deleted because it was still looking in the old place instead of memento which was recently added.