### PR TITLE
Fix agent extension version back to 0.42.0

### DIFF
--- a/extensions/agent/package.json
+++ b/extensions/agent/package.json
@@ -2,7 +2,7 @@
   "name": "agent",
   "displayName": "SQL Server Agent",
   "description": "Manage and troubleshoot SQL Server Agent jobs",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",


### PR DESCRIPTION
Looks like the extension version was incorrectly reset during Notebook merge.