### PR TITLE
Don't add unnecessary separator to OE action menu

### DIFF
--- a/src/sql/workbench/parts/objectExplorer/browser/serverTreeActionProvider.ts
+++ b/src/sql/workbench/parts/objectExplorer/browser/serverTreeActionProvider.ts
@@ -106,7 +106,7 @@ export class ServerTreeActionProvider extends ContributableActionProvider {
 		fillInActions(groups, actions, false);
 
 		if (insertIndex) {
-			if (!(actions[insertIndex] instanceof Separator)) {
+			if (!(actions[insertIndex] instanceof Separator) && builtIn.length > 0) {
 				builtIn.unshift(new Separator());
 			}
 			actions.splice(insertIndex, 0, ...builtIn);

--- a/src/sql/workbench/parts/objectExplorer/browser/serverTreeActionProvider.ts
+++ b/src/sql/workbench/parts/objectExplorer/browser/serverTreeActionProvider.ts
@@ -111,7 +111,7 @@ export class ServerTreeActionProvider extends ContributableActionProvider {
 			}
 			actions.splice(insertIndex, 0, ...builtIn);
 		} else {
-			if (actions.length > 0) {
+			if (actions.length > 0 && builtIn.length > 0) {
 				builtIn.push(new Separator());
 			}
 			actions.unshift(...builtIn);


### PR DESCRIPTION
Fixes #7038

With Properties (which adds the separator already)

![image](https://user-images.githubusercontent.com/28519865/64304551-15f96300-cf41-11e9-87d7-45369bc1508f.png)

Without properties or built-in actions : 

![image](https://user-images.githubusercontent.com/28519865/64304601-578a0e00-cf41-11e9-9a2f-c5928b3103c5.png)
