### PR TITLE
Books/fix relative links

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -333,8 +333,9 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		return this._tableOfContentPaths;
 	}
 	getUntitledNotebookUri(resource: string): vscode.Uri {
-		let title = this.findNextUntitledFileName(resource);
+		let title = path.join(path.dirname(resource), this.findNextUntitledFileName(resource));
 		let untitledFileName: vscode.Uri = vscode.Uri.parse(`untitled:${title}`);
+		//let untitledFileName = vscode.Uri.parse(resource).with({ scheme: 'untitled' });
 		if (!this._allNotebooks.get(untitledFileName.fsPath)) {
 			let notebook = this._allNotebooks.get(resource);
 			this._allNotebooks.set(untitledFileName.fsPath, notebook);

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -276,7 +276,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 						notebooks.push(notebook);
 						this._allNotebooks.set(pathToNotebook, notebook);
 						if (this._openAsUntitled) {
-							this._allNotebooks.set(path.basename(pathToNotebook, '.ipynb'), notebook);
+							this._allNotebooks.set(path.basename(pathToNotebook), notebook);
 						}
 					} else if (fs.existsSync(pathToMarkdown)) {
 						let markdown = new BookTreeItem({
@@ -307,7 +307,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	}
 
 	getNavigation(uri: vscode.Uri): Thenable<azdata.nb.NavigationResult> {
-		let notebook = this._allNotebooks.get(uri.fsPath);
+		let notebook = uri.scheme !== 'untitled' ? this._allNotebooks.get(uri.fsPath) : this._allNotebooks.get(path.basename(uri.fsPath));
 		let result: azdata.nb.NavigationResult;
 		if (notebook) {
 			result = {
@@ -332,13 +332,19 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	public get tableOfContentPaths() {
 		return this._tableOfContentPaths;
 	}
+
 	getUntitledNotebookUri(resource: string): vscode.Uri {
-		let title = path.join(path.dirname(resource), this.findNextUntitledFileName(resource));
-		let untitledFileName: vscode.Uri = vscode.Uri.parse(`untitled:${title}`);
-		//let untitledFileName = vscode.Uri.parse(resource).with({ scheme: 'untitled' });
-		if (!this._allNotebooks.get(untitledFileName.fsPath)) {
+		let untitledFileName: vscode.Uri;
+		if (process.platform.indexOf('win') > -1) {
+			let title = path.join(path.dirname(resource), this.findNextUntitledFileName(resource));
+			untitledFileName = vscode.Uri.parse(`untitled:${title}`);
+		}
+		else {
+			untitledFileName = vscode.Uri.parse(resource).with({ scheme: 'untitled' });
+		}
+		if (!this._allNotebooks.get(untitledFileName.fsPath) && !this._allNotebooks.get(path.basename(untitledFileName.fsPath))) {
 			let notebook = this._allNotebooks.get(resource);
-			this._allNotebooks.set(untitledFileName.fsPath, notebook);
+			this._allNotebooks.set(path.basename(untitledFileName.fsPath), notebook);
 		}
 		return untitledFileName;
 	}

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -350,8 +350,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	}
 
 	findNextUntitledFileName(filePath: string): string {
-		const fileExtension = path.extname(filePath);
-		const baseName = path.basename(filePath, fileExtension);
+		const baseName = path.basename(filePath);
 		let idx = 0;
 		let title = `${baseName}`;
 		do {

--- a/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -707,8 +707,8 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 			onNext: async (uri) => {
 				let result = await this._proxy.$getNavigation(handle, uri);
 				if (result) {
-					if (uri.scheme === Schemas.untitled) {
-						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.next.path, '.ipynb')}`);
+					if (result.next.scheme === Schemas.untitled) {
+						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.next.path)}`);
 						this.doOpenEditor(untitledNbName, { initialContent: fs.readFileSync(result.next.path).toString(), initialDirtyState: false });
 					}
 					else {
@@ -719,8 +719,8 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 			onPrevious: async (uri) => {
 				let result = await this._proxy.$getNavigation(handle, uri);
 				if (result) {
-					if (uri.scheme === Schemas.untitled) {
-						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.previous.path, '.ipynb')}`);
+					if (result.previous.scheme === Schemas.untitled) {
+						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.previous.path)}`);
 						this.doOpenEditor(untitledNbName, { initialContent: fs.readFileSync(result.previous.path).toString(), initialDirtyState: false });
 					}
 					else {

--- a/src/sql/workbench/parts/notebook/electron-browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/parts/notebook/electron-browser/outputs/notebookMarkdown.ts
@@ -226,6 +226,8 @@ export class NotebookMarkdownRenderer {
 			return base.replace(/:[\s\S]*/, ':') + href;
 		} else if (href.charAt(0) === '/') {
 			return base.replace(/(:\/*[^/]*)[\s\S]*/, '$1') + href;
+		} else if (href.slice(0, 2) === '..') {
+			return path.join(base, href);
 		} else {
 			return base + href;
 		}


### PR DESCRIPTION
Fix for #6973 

Relative links don't work on untitled files. 
Fix: Opening them with untitled scheme works on Mac but for windows the entire path of the resource file with untitled scheme is needed. (TO DO: Need to test on Linux - hoping the mac way would work it too.)


