### PR TITLE
Notebooks: Partial Fix for Bracket Closing Issue in Strings

### DIFF
--- a/src/sql/workbench/parts/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/parts/notebook/browser/models/notebookInput.ts
@@ -54,11 +54,6 @@ export class NotebookEditorModel extends EditorModel {
 						this._changeEventsHookedUp = true;
 						this._register(model.kernelChanged(e => this.updateModel(undefined, NotebookChangeType.KernelChanged)));
 						this._register(model.contentChanged(e => this.updateModel(e, e.changeType)));
-						this._register(notebook.model.onActiveCellChanged((cell) => {
-							if (cell) {
-								this._notebookTextFileModel.activeCellGuid = cell.cellGuid;
-							}
-						}));
 					}
 				}, err => undefined);
 			}

--- a/src/sql/workbench/parts/notebook/common/models/notebookTextFileModel.ts
+++ b/src/sql/workbench/parts/notebook/common/models/notebookTextFileModel.ts
@@ -193,6 +193,8 @@ export class NotebookTextFileModel {
 			}
 		}
 		let outputsEnd = textEditorModel.textEditorModel.matchBracket({ column: outputsBegin.endColumn - 1, lineNumber: outputsBegin.endLineNumber });
+		// The end of any cell's outputs cannot possibly be the second to last line in the text editor model
+		// The second to last line (']') is always the end of the "cells" array. This is a temporary solution to a larger bracket matching issue.
 		if (!outputsEnd || outputsEnd.length < 2 || outputsEnd[1].endLineNumber === textEditorModel.textEditorModel.getLineCount() - 1) {
 			return undefined;
 		}

--- a/src/sql/workbench/parts/notebook/common/models/notebookTextFileModel.ts
+++ b/src/sql/workbench/parts/notebook/common/models/notebookTextFileModel.ts
@@ -152,6 +152,7 @@ export class NotebookTextFileModel {
 			}
 			let firstQuoteOfSource = textEditorModel.textEditorModel.findNextMatch('"', { lineNumber: sourceBefore.range.startLineNumber, column: sourceBefore.range.endColumn }, false, true, undefined, true);
 			this._sourceBeginRange = firstQuoteOfSource.range;
+			this._activeCellGuid = cellGuid;
 		} else {
 			return;
 		}
@@ -171,6 +172,7 @@ export class NotebookTextFileModel {
 				return undefined;
 			}
 			this._outputBeginRange = outputsBegin.range;
+			this._activeCellGuid = cellGuid;
 		} else {
 			return undefined;
 		}
@@ -191,7 +193,7 @@ export class NotebookTextFileModel {
 			}
 		}
 		let outputsEnd = textEditorModel.textEditorModel.matchBracket({ column: outputsBegin.endColumn - 1, lineNumber: outputsBegin.endLineNumber });
-		if (!outputsEnd || outputsEnd.length < 2) {
+		if (!outputsEnd || outputsEnd.length < 2 || outputsEnd[1].endLineNumber === textEditorModel.textEditorModel.getLineCount() - 1) {
 			return undefined;
 		}
 		// single line output [i.e. no outputs exist for a cell]


### PR DESCRIPTION
#7080 occurs in a rare case.

Take this JSON:
 ```
           "outputs": [
                {
                    "name": "stdout",
                    "text": "\u001b[0m",
                    "output_type": "stream"
                }
            ],
```

In the NotebookTextFileModel, we leverage the TextEditorModel.matchBracket() API. For the .ipynb file type, the notebook extension references a copy of the JSON language-configuration.json:

```
	"brackets": [
		["{", "}"],
		["[", "]"]
	],
	"autoClosingPairs": [
		{ "open": "{", "close": "}", "notIn": ["string"] },
		{ "open": "[", "close": "]", "notIn": ["string"] },
		{ "open": "(", "close": ")", "notIn": ["string"] },
		{ "open": "'", "close": "'", "notIn": ["string"] },
		{ "open": "/*", "close": "*/", "notIn": ["string"] },
		{ "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
		{ "open": "`", "close": "`", "notIn": ["string", "comment"] }
	]
```

However, this API doesn't ignore brackets that are don't have pairs in a string literal.

So, the bug here is that, in this particular notebook, we try to find the closing bracket (given the opening bracket location for the "outputs" property in JSON), and we end up finding the closing bracket for something not corresponding to outputs at all:

`...u001b[0...",`

(This ends up matching with the last ']' in the file)

Note: this isn't the full fix for this issue; it's possible to have a string that has multiple opening (or closing) brackets. One solution may be to dynamically keep track of the location for a closing bracket, but that's a risky change, especially for an issue that is fairly rare.

While this bug is bad, I'm not convinced that it's a mainline scenario. If you save the notebook (instead of using "Save As", this bug doesn't repro at all.