### PR TITLE
Remove custom tree indent guide

### DIFF
--- a/src/vs/base/browser/ui/tree/media/tree.css
+++ b/src/vs/base/browser/ui/tree/media/tree.css
@@ -26,7 +26,7 @@
 	display: inline-block;
 	box-sizing: border-box;
 	height: 100%;
-	border-left: 1px solid transparent;
+	/* border-left: 1px solid transparent; {{SQL CARBON EDIT}} Remove indent guide from all custom tree views */
 }
 
 .monaco-tl-indent > .indent-guide {


### PR DESCRIPTION
This is by suggestion of @angdesign - 

Before :

![image](https://user-images.githubusercontent.com/28519865/64546088-d59e3a00-d2de-11e9-8053-f505d6cdc39e.png)

After :

![image](https://user-images.githubusercontent.com/28519865/64546013-ac7da980-d2de-11e9-9584-6c8747946b98.png)

Fixes #7117
