### PR TITLE
Update workspace.rootPath in dacpac and SC extensions

### DIFF
--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -182,7 +182,7 @@ export abstract class DacFxConfigPage extends BasePage {
 		if (this.fileTextBox.value && path.dirname(this.fileTextBox.value)) {
 			return path.dirname(this.fileTextBox.value);
 		} else { // otherwise use the folder open in the Explorer or the home directory
-			return vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
+			return vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].name : os.homedir();
 		}
 	}
 

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -306,7 +306,7 @@ export class SchemaCompareDialog {
 
 		currentButton.onDidClick(async (click) => {
 			// file browser should open where the current dacpac is or the appropriate default folder
-			let rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
+			let rootPath = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].name : os.homedir();
 			let defaultUri = endpoint && endpoint.packageFilePath && existsSync(endpoint.packageFilePath) ? endpoint.packageFilePath : rootPath;
 
 			let fileUris = await vscode.window.showOpenDialog(

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -850,7 +850,7 @@ export class SchemaCompareMainWindow {
 
 		this.openScmpButton.onDidClick(async (click) => {
 			Telemetry.sendTelemetryEvent('SchemaCompareOpenScmpStarted');
-			const rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
+			const rootPath = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].name : os.homedir();
 			let fileUris = await vscode.window.showOpenDialog(
 				{
 					canSelectFiles: true,
@@ -947,7 +947,7 @@ export class SchemaCompareMainWindow {
 		}).component();
 
 		this.saveScmpButton.onDidClick(async (click) => {
-			const rootPath = vscode.workspace.rootPath ? vscode.workspace.rootPath : os.homedir();
+			const rootPath = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].name : os.homedir();
 			const filePath = await vscode.window.showSaveDialog(
 				{
 					defaultUri: vscode.Uri.file(rootPath),


### PR DESCRIPTION
Update dacpac and schema compare extensions to not use deprecated workspace.rootPath