### PR TITLE
New rule to stop floating promises

### DIFF
--- a/tslint-sql.json
+++ b/tslint-sql.json
@@ -15,6 +15,14 @@
 		],
 		"no-floating-promises":{
 			"severity": "warn"
+		},
+		"await-promise": {
+			"severity": "warn",
+			"options": ["Thenable"]
+		},
+		"no-promise-as-boolean": {
+			"severity": "error",
+			"options": ["Thenable"]
 		}
 	},
 	"linterOptions": {

--- a/tslint-sql.json
+++ b/tslint-sql.json
@@ -12,7 +12,10 @@
 				],
 				"argIndex": 1
 			}
-		]
+		],
+		"no-floating-promises":{
+			"severity": "warn"
+		}
 	},
 	"linterOptions": {
 		"exclude": ["src/vs/**/*.ts"]


### PR DESCRIPTION
We currently have 450 places where we're getting a promise in a function call and we're not making sure it succeeded, failed, etc.

But essentially unawaited promises are an anti pattern and they __should__ be awaited unless we explicitly decide to not enforce the rule on a certain area.

As Palantir puts it: Unhandled Promises can cause unexpected behavior, such as resolving at unexpected times.



