### PR TITLE
Add Title to Grids for Screen Readers

### DIFF
--- a/src/sql/workbench/parts/query/browser/gridPanel.ts
+++ b/src/sql/workbench/parts/query/browser/gridPanel.ts
@@ -449,6 +449,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		};
 		this.dataProvider = new AsyncDataProvider(collection);
 		this.table = this._register(new Table(tableContainer, { dataProvider: this.dataProvider, columns: this.columns }, tableOptions));
+		this.table.setTableTitle(localize('resultsGrid', "Results grid"));
 		this.table.setSelectionModel(this.selectionModel);
 		this.table.registerPlugin(new MouseWheelSupport());
 		this.table.registerPlugin(new AutoColumnSize({ autoSizeOnRender: !this.state.columnSizes && this.configurationService.getValue('resultsGrid.autoSizeColumns'), maxWidth: this.configurationService.getValue<number>('resultsGrid.maxColumnWidth') }));


### PR DESCRIPTION
This is for #5615.

Also reproes in the query editor, as we share grid code. Building off the work that @kisantia did previously for other grids in ADS.