### PR TITLE
Fix for Notebook Cell Height Not Resizing

### DIFF
--- a/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
+import { IEditorOptions, EditorOption } from 'vs/editor/common/config/editorOptions';
 import * as nls from 'vs/nls';
 import * as DOM from 'vs/base/browser/dom';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
@@ -150,7 +150,7 @@ export class QueryTextEditor extends BaseTextEditor {
 		let shouldAddHorizontalScrollbarHeight = false;
 		if (!this._editorWorkspaceConfig || configChanged) {
 			this._editorWorkspaceConfig = this.workspaceConfigurationService.getValue('editor');
-			this._lineHeight = editorWidget.getRawOptions().lineHeight;
+			this._lineHeight = editorWidget.getOption(EditorOption.lineHeight) || 18;
 		}
 		let wordWrapEnabled: boolean = this._editorWorkspaceConfig && this._editorWorkspaceConfig['wordWrap'] && this._editorWorkspaceConfig['wordWrap'] === 'on' ? true : false;
 		if (wordWrapEnabled) {


### PR DESCRIPTION
Fixes #7246.

Caused by https://github.com/microsoft/azuredatastudio/commit/ea0f9e6ce95b45def2b694efcd8ffe909bc43d20#diff-0308fd66e25b4760ce1a2b0a35757513

`this._lineHeight = editorWidget.getConfiguration().lineHeight;`

was changed to

`this._lineHeight = editorWidget.getRawOptions().lineHeight;`

which returns a lineHeight of 0, as getRawOptions() doesn't include any defaults apparently.

Also added a default just in case.