### PR TITLE
Use the default connect timeout in OE tests

### DIFF
--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -9,7 +9,7 @@ import 'mocha';
 import * as azdata from 'azdata';
 import { context } from './testContext';
 import { getBdcServer, TestServerProfile, getAzureServer, getStandaloneServer } from './testConfig';
-import { connectToServer, createDB, deleteDB } from './utils';
+import { connectToServer, createDB, deleteDB, DefaultConnectTimeoutInMs } from './utils';
 import assert = require('assert');
 import { stressify } from 'adstest';
 
@@ -43,7 +43,7 @@ class ObjectExplorerTester {
 	async bdcNodeLabelTest(): Promise<void> {
 		const expectedNodeLabel = ['Databases', 'Security', 'Server Objects', 'Data Services'];
 		const server = await getBdcServer();
-		await this.verifyOeNode(server, 6000, expectedNodeLabel);
+		await this.verifyOeNode(server, DefaultConnectTimeoutInMs, expectedNodeLabel);
 	}
 
 	@stressify({ dop: ObjectExplorerTester.ParallelCount })
@@ -51,7 +51,7 @@ class ObjectExplorerTester {
 		if (process.platform === 'win32') {
 			const expectedNodeLabel = ['Databases', 'Security', 'Server Objects'];
 			const server = await getStandaloneServer();
-			await this.verifyOeNode(server, 3000, expectedNodeLabel);
+			await this.verifyOeNode(server, DefaultConnectTimeoutInMs, expectedNodeLabel);
 		}
 	}
 
@@ -59,7 +59,7 @@ class ObjectExplorerTester {
 	async sqlDbNodeLabelTest(): Promise<void> {
 		const expectedNodeLabel = ['Databases', 'Security'];
 		const server = await getAzureServer();
-		await this.verifyOeNode(server, 3000, expectedNodeLabel);
+		await this.verifyOeNode(server, DefaultConnectTimeoutInMs, expectedNodeLabel);
 	}
 
 	@stressify({ dop: ObjectExplorerTester.ParallelCount })
@@ -80,7 +80,7 @@ class ObjectExplorerTester {
 		else {
 			expectedActions = ['Manage', 'New Query', 'New Notebook', 'Refresh', 'Backup', 'Restore', 'Data-tier Application wizard', 'Schema Compare', 'Import wizard'];
 		}
-		await this.verifyDBContextMenu(server, 3000, expectedActions);
+		await this.verifyDBContextMenu(server, DefaultConnectTimeoutInMs, expectedActions);
 	}
 
 	@stressify({ dop: ObjectExplorerTester.ParallelCount })
@@ -98,7 +98,7 @@ class ObjectExplorerTester {
 	}
 
 	async verifyContextMenu(server: TestServerProfile, expectedActions: string[]): Promise<void> {
-		await connectToServer(server, 3000);
+		await connectToServer(server, DefaultConnectTimeoutInMs);
 		const nodes = <azdata.objectexplorer.ObjectExplorerNode[]>await azdata.objectexplorer.getActiveConnectionNodes();
 		assert(nodes.length > 0, `Expecting at least one active connection, actual: ${nodes.length}`);
 

--- a/extensions/integration-tests/src/utils.ts
+++ b/extensions/integration-tests/src/utils.ts
@@ -9,12 +9,15 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { TestServerProfile } from './testConfig';
 
+// default server connection timeout
+export const DefaultConnectTimeoutInMs: number = 10000;
+
 /**
  * @param server test connection profile
  * @param timeout optional timeout parameter
  * Returns connection id for a new connection
  */
-export async function connectToServer(server: TestServerProfile, timeout: number = 10000): Promise<string> {
+export async function connectToServer(server: TestServerProfile, timeout: number = DefaultConnectTimeoutInMs): Promise<string> {
 	let connectionProfile: azdata.IConnectionProfile = {
 		serverName: server.serverName,
 		databaseName: server.database,


### PR DESCRIPTION
Update the OE tests to use the normal connect timeout, rather than the shorter timeouts that are currently in the tests.  We're seeing numerous flaky failures in these tests so I'm not sure why they have reduced timeouts.

I've left the timeout parameters in place (using the default value) in case we want to increase the timeouts above the defaults in specific cases in the future.