### PR TITLE
Ensure we call layout() as few times as possible for notebook cells

### DIFF
--- a/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
@@ -155,8 +155,8 @@ export class QueryTextEditor extends BaseTextEditor {
 		let wordWrapEnabled: boolean = this._editorWorkspaceConfig && this._editorWorkspaceConfig['wordWrap'] && this._editorWorkspaceConfig['wordWrap'] === 'on' ? true : false;
 		if (wordWrapEnabled) {
 			for (let line = 1; line <= lineCount; line++) {
-				// 4 columns is equivalent to the viewport column width and the edge of the editor
-				if (editorWidgetModel.getLineMaxColumn(line) >= layoutInfo.viewportColumn + 4) {
+				// 2 columns is equivalent to the viewport column width and the edge of the editor
+				if (editorWidgetModel.getLineMaxColumn(line) >= layoutInfo.viewportColumn + 2) {
 					// Subtract 1 because the first line should not count as a wrapped line
 					numberWrappedLines += Math.ceil(editorWidgetModel.getLineMaxColumn(line) / layoutInfo.viewportColumn) - 1;
 				}

--- a/src/sql/workbench/parts/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/parts/notebook/browser/cellViews/code.component.ts
@@ -177,7 +177,6 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 	}
 
 	ngAfterViewInit(): void {
-		this._layoutEmitter.fire();
 	}
 
 	get model(): NotebookModel {
@@ -225,8 +224,6 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 			this.cellModel.source = this._editorModel.getValue();
 			this.onContentChanged.emit();
 			this.checkForLanguageMagics();
-			// TODO see if there's a better way to handle reassessing size.
-			setTimeout(() => this._layoutEmitter.fire(), 250);
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('editor.wordWrap') || e.affectsConfiguration('editor.fontSize')) {

--- a/src/sql/workbench/parts/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/parts/notebook/browser/cellViews/code.component.ts
@@ -176,9 +176,6 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 		}));
 	}
 
-	ngAfterViewInit(): void {
-	}
-
 	get model(): NotebookModel {
 		return this._model;
 	}


### PR DESCRIPTION
Fixes #7252.

setHeightToScrollHeight() in queryTextEditor is an expensive operation, as there isn't a great way to determine how many wrapped lines exist in an editor today.

Looking at some perf logs on notebook loading, rendering tends to take the vast majority of the time on larger notebooks, so we should be calling layout() as few times as possible for each code component.

Problem 1: In code.component.ts, we react to this._editorModel.onDidChangeContent. Inside of that event hook, we directly call this._editor.setHeightToScrollHeight(). We were also calling this._layoutEmitter.fire(), which calls layout(), which calls this._editor.setHeightToScrollHeight().

Problem 2: We called layout() in ngAfterViewInit(). This appears to be unnecessary, as it's already been called when each editor was created. In addition, any changes to each editor's content will cause layout() to be called again anyway.

Problem 3:  The max line column calculation appears to be a couple of characters off (the code cell expands 2 characters too late).

Tested the following:
- Opened large test notebook, ensured that no scroll bars were visible
- Resized the ADS window with a notebook open, ensured that the notebook cells reacted to changes in width
- Tested manually in a sample code cell by creating/deleting newlines, copying as many characters as could fit on a line to test off-by-one errors in height calculation

![layoutevents](https://user-images.githubusercontent.com/40371649/65107201-de040e00-d98b-11e9-8881-751414a65c12.gif)
