### PR TITLE
Trying to remove intermittent ext test failure

### DIFF
--- a/extensions/integration-tests/src/dacpac.test.ts
+++ b/extensions/integration-tests/src/dacpac.test.ts
@@ -59,7 +59,7 @@ if (context.RunTest) {
 
 				assert(extractResult.success === true && extractResult.errorMessage === '', `Extract dacpac should succeed. Expected: there should be no error. Actual Error message: "${extractResult.errorMessage}"`);
 			} finally {
-				await utils.deleteDB(databaseName, ownerUri);
+				await utils.deleteDB(server, databaseName, ownerUri);
 			}
 		});
 
@@ -94,7 +94,7 @@ if (context.RunTest) {
 				await utils.assertFileGenerationResult(packageFilePath, retryCount);
 				assert(exportResult.success === true && exportResult.errorMessage === '', `Expected: Export bacpac should succeed and there should be no error. Actual Error message: "${exportResult.errorMessage}"`);
 			} finally {
-				await utils.deleteDB(databaseName, ownerUri);
+				await utils.deleteDB(server, databaseName, ownerUri);
 			}
 		});
 	});

--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -160,7 +160,7 @@ class ObjectExplorerTester {
 			assert(expectedActions.length === actions.length && expectedString === actualString, `Expected actions: "${expectedString}", Actual actions: "${actualString}"`);
 		}
 		finally {
-			await deleteDB(dbName, ownerUri);
+			await deleteDB(server, dbName, ownerUri);
 		}
 	}
 }

--- a/extensions/integration-tests/src/schemaCompare.test.ts
+++ b/extensions/integration-tests/src/schemaCompare.test.ts
@@ -179,8 +179,8 @@ class SchemaCompareTester {
 			fs.unlinkSync(filepath);
 		}
 		finally {
-			await utils.deleteDB(sourceDB, ownerUri);
-			await utils.deleteDB(targetDB, ownerUri);
+			await utils.deleteDB(server, sourceDB, ownerUri);
+			await utils.deleteDB(server, targetDB, ownerUri);
 		}
 	}
 
@@ -249,7 +249,7 @@ class SchemaCompareTester {
 			assert(openScmpResult.targetEndpointInfo.databaseName === target.databaseName, `Expected: target database to be ${target.databaseName}, Actual: ${openScmpResult.targetEndpointInfo.databaseName}`);
 		}
 		finally {
-			await utils.deleteDB(targetDB, ownerUri);
+			await utils.deleteDB(server, targetDB, ownerUri);
 		}
 	}
 


### PR DESCRIPTION
This is expected to fix the tests - will disable test temporarily if this doesn't work too.

The common code between ObjExp and Dacpac tests outside of try-catch is **cleanup of DB** which uses SimpleQueryExecute call to delete dB. This call from sqltoolsservice can throw "Editor not connected" if the connection has been removed while the test is going on. Although I am not able to repro the issue and hence not able to confirm this theory 100% - this seems closest based on the range of tests all containing this path.