### PR TITLE
renamed .icon to .codicon as per vscode updates that are merged.

### DIFF
--- a/src/sql/media/icons/common-icons.css
+++ b/src/sql/media/icons/common-icons.css
@@ -3,287 +3,287 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.vs .icon.backup {
+.vs .codicon.backup {
 	background: url("backup.svg") center center no-repeat;
 }
 
-.vs-dark .icon.backup,
-.hc-black .icon.backup {
+.vs-dark .codicon.backup,
+.hc-black .codicon.backup {
 	background: url("backup_inverse.svg") center center no-repeat;
 }
 
-.vs .icon.restore {
+.vs .codicon.restore {
 	background: url("restore.svg") center center no-repeat;
 }
 
-.vs-dark .icon.restore,
-.hc-black .icon.restore {
+.vs-dark .codicon.restore,
+.hc-black .codicon.restore {
 	background: url("restore_inverse.svg") center center no-repeat;
 }
 
-.vs .icon.database {
+.vs .codicon.database {
 	background: url("database.svg") center center no-repeat;
 }
 
-.vs-dark .icon.database,
-.hc-black .icon.database {
+.vs-dark .codicon.database,
+.hc-black .codicon.database {
 	background: url("database_inverse.svg") center center no-repeat;
 }
 
-.vs .icon.error,
-.vs-dark .icon.error,
-.hc-black .icon.error {
+.vs .codicon.error,
+.vs-dark .codicon.error,
+.hc-black .codicon.error {
 	background: url("globalerror_red.svg") center center no-repeat;
 }
 
-.vs .icon.file {
+.vs .codicon.file {
 	background: url("file.svg") center center no-repeat;
 }
 
-.vs-dark .icon.file,
-.hc-black .icon.file {
+.vs-dark .codicon.file,
+.hc-black .codicon.file {
 	background: url("file_inverse.svg") center center no-repeat;
 }
 
-.vs .icon.new-database {
+.vs .codicon.new-database {
 	background: url("new_database.svg") center center no-repeat;
 }
 
-.vs-dark .icon.new-database,
-.hc-black .icon.new-database {
+.vs-dark .codicon.new-database,
+.hc-black .codicon.new-database {
 	background: url("new_database_inverse.svg") center center no-repeat;
 }
 
-.vs .icon.server-page {
+.vs .codicon.server-page {
 	background: url("server_page.svg") center center no-repeat;
 }
 
-.vs-dark .icon.server-page,
-.hc-black .icon.server-page {
+.vs-dark .codicon.server-page,
+.hc-black .codicon.server-page {
 	background: url("server_page_inverse.svg") center center no-repeat;
 }
 
-.vs .icon.globalError,
-.vs-dark .icon.globalError,
-.hc-black .icon.globalError {
+.vs .codicon.globalError,
+.vs-dark .codicon.globalError,
+.hc-black .codicon.globalError {
 	background: url("globalerror.svg") center center no-repeat;
 }
 
-.vs .sql.icon.error,
-.vs-dark .sql.icon.error,
-.hc-black .sql.icon.error {
+.vs .sql.codicon.error,
+.vs-dark .sql.codicon.error,
+.hc-black .sql.codicon.error {
 	content: url("status_error.svg");
 }
 
-.vs .sql.icon.warning,
-.vs-dark .sql.icon.warning,
-.hc-black .sql.icon.warning {
+.vs .sql.codicon.warning,
+.vs-dark .sql.codicon.warning,
+.hc-black .sql.codicon.warning {
 	content: url("status_warning.svg");
 }
 
-.vs .sql.icon.info,
-.vs-dark .sql.icon.info,
-.hc-black .sql.icon.info {
+.vs .sql.codicon.info,
+.vs-dark .sql.codicon.info,
+.hc-black .sql.codicon.info {
 	content: url("status_info.svg");
 }
 
-.vs .icon.help {
+.vs .codicon.help {
 	content: url("help.svg");
 }
 
-.vs-dark .icon.help,
-.hc-black .icon.help {
+.vs-dark .codicon.help,
+.hc-black .codicon.help {
 	content: url("help_inverse.svg");
 }
 
-.vs .icon.success,
-.vs-dark .icon.success,
-.hc-black .icon.success {
+.vs .codicon.success,
+.vs-dark .codicon.success,
+.hc-black .codicon.success {
 	content: url("status_success.svg");
 }
 
-.vs .icon.canceled,
-.vs-dark .icon.canceled,
-.hc-black .icon.canceled {
+.vs .codicon.canceled,
+.vs-dark .codicon.canceled,
+.hc-black .codicon.canceled {
 	content: url("status_cancelled.svg");
 }
 
-.vs .icon.in-progress {
+.vs .codicon.in-progress {
 	content: url("loading.svg");
 }
 
-.vs-dark .icon.in-progress,
-.hc-black .icon.in-progress {
+.vs-dark .codicon.in-progress,
+.hc-black .codicon.in-progress {
 	content: url("loading_inverse.svg");
 }
 
-.vs .icon.scriptToClipboard,
-.vs-dark .icon.scriptToClipboard,
-.hc-black .icon.scriptToClipboard {
+.vs .codicon.scriptToClipboard,
+.vs-dark .codicon.scriptToClipboard,
+.hc-black .codicon.scriptToClipboard {
 	background-image: url('script_to_clipboard.svg');
 	background-repeat: no-repeat;
 	background-position: 2px center;
 }
 
-.vs .icon.close,
-.vs .icon.remove {
+.vs .codicon.close,
+.vs .codicon.remove {
 	background: url('close.svg') center center no-repeat !important;
 }
 
-.vs-dark .icon.close,
-.hc-black .icon.close,
-.vs-dark .icon.remove,
-.hc-black .icon.remove {
+.vs-dark .codicon.close,
+.hc-black .codicon.close,
+.vs-dark .codicon.remove,
+.hc-black .codicon.remove {
 	background: url('close_inverse.svg') center center no-repeat !important;
 }
 
-.vs .icon.filter {
+.vs .codicon.filter {
 	background: url("filter.svg") center center no-repeat !important;
 }
 
-.vs-dark .icon.filter,
-.hc-black .icon.filter {
+.vs-dark .codicon.filter,
+.hc-black .codicon.filter {
 	background: url("filter_inverse.svg") center center no-repeat !important;
 }
 
-.vs .icon.filterLabel {
+.vs .codicon.filterLabel {
 	background-image: url("filter.svg");
 }
 
-.vs-dark .icon.filterLabel,
-.hc-black .icon.filterLabel {
+.vs-dark .codicon.filterLabel,
+.hc-black .codicon.filterLabel {
 	background-image: url("filter_inverse.svg");
 }
 
-.vs .icon.clear-filter {
+.vs .codicon.clear-filter {
 	background-image: url("clearfilter.svg");
 }
 
-.vs-dark .icon.clear-filter,
-.hc-black .icon.clear-filter {
+.vs-dark .codicon.clear-filter,
+.hc-black .codicon.clear-filter {
 	background-image: url("clearfilter_inverse.svg");
 }
 
-.vs .icon.warning-badge,
-.vs-dark .icon.warning-badge,
-.hc-black .icon.warning-badge {
+.vs .codicon.warning-badge,
+.vs-dark .codicon.warning-badge,
+.hc-black .codicon.warning-badge {
 	background: url("status_warning.svg") center center no-repeat;
 }
 
-.vs .icon.refresh {
+.vs .codicon.refresh {
 	background-image: url('refresh.svg');
 }
 
-.vs-dark .icon.refresh,
-.hc-black .icon.refresh  {
+.vs-dark .codicon.refresh,
+.hc-black .codicon.refresh  {
 	background-image: url('refresh_inverse.svg');
 }
 
-.hc-black .icon.toggle-more,
-.vs-dark .icon.toggle-more {
+.hc-black .codicon.toggle-more,
+.vs-dark .codicon.toggle-more {
 	background: url('ellipsis-inverse.svg') center center no-repeat;
 }
 
-.vs .icon.toggle-more {
+.vs .codicon.toggle-more {
 	background: url('ellipsis.svg') center center no-repeat;
 }
 
-.hc-black .icon.new,
-.vs-dark .icon.new {
+.hc-black .codicon.new,
+.vs-dark .codicon.new {
 	background: url('new_inverse.svg') center center no-repeat;
 }
 
-.vs .icon.new {
+.vs .codicon.new {
 	background: url('new.svg') center center no-repeat;
 }
 
-.hc-black .icon.new-query,
-.vs-dark .icon.new-query {
+.hc-black .codicon.new-query,
+.vs-dark .codicon.new-query {
 	background: url('newquery_inverse.svg') center center no-repeat;
 }
 
-.vs .icon.new-query {
+.vs .codicon.new-query {
 	background: url('newquery.svg') center center no-repeat;
 }
 
-.hc-black .icon.configure-dashboard,
-.vs-dark .icon.configure-dashboard {
+.hc-black .codicon.configure-dashboard,
+.vs-dark .codicon.configure-dashboard {
 	background: url('configdashboard_inverse.svg') center center no-repeat;
 }
 
-.vs .icon.configure-dashboard {
+.vs .codicon.configure-dashboard {
 	background: url('configdashboard.svg') center center no-repeat;
 }
 
-.hc-black .icon.edit,
-.vs-dark .icon.edit {
+.hc-black .codicon.edit,
+.vs-dark .codicon.edit {
 	background: url('edit_inverse.svg') center center no-repeat;
 }
 
-.vs .icon.edit {
+.vs .codicon.edit {
 	background: url('edit.svg') center center no-repeat;
 }
 
-.hc-black .icon.pin,
-.vs-dark .icon.pin {
+.hc-black .codicon.pin,
+.vs-dark .codicon.pin {
 	background: url('pin_inverse.svg') center center no-repeat;
 }
 
-.vs .icon.pin {
+.vs .codicon.pin {
 	background: url('pin.svg') center center no-repeat;
 }
 
-.hc-black .icon.unpin,
-.vs-dark .icon.unpin {
+.hc-black .codicon.unpin,
+.vs-dark .codicon.unpin {
 	background: url('unpin_inverse.svg') center center no-repeat;
 }
 
-.vs .icon.unpin {
+.vs .codicon.unpin {
 	background: url('unpin.svg') center center no-repeat;
 }
 
-.vs .sql.icon.pause {
+.vs .sql.codicon.pause {
 	background-image: url('pause.svg')
 }
 
-.vs-dark .sql.icon.pause,
-.hc-black .sql.icon.pause {
+.vs-dark .sql.codicon.pause,
+.hc-black .sql.codicon.pause {
 	background-image: url('pause_inverse.svg')
 }
 
-.vs .sql.icon.continue {
+.vs .sql.codicon.continue {
 	background-image: url('continue.svg')
 }
 
-.vs-dark .sql.icon.continue,
-.hc-black .sql.icon.continue {
+.vs-dark .sql.codicon.continue,
+.hc-black .sql.codicon.continue {
 	background-image: url('continue_inverse.svg')
 }
 
-.vs .sql.icon.checked {
+.vs .sql.codicon.checked {
 	background-image: url('check.svg')
 }
 
-.vs-dark .sql.icon.checked,
-.hc-black .sql.icon.checked {
+.vs-dark .sql.codicon.checked,
+.hc-black .sql.codicon.checked {
 	background-image: url('check_inverse.svg')
 }
 
-.vs .sql.icon.start {
+.vs .sql.codicon.start {
 	background-image: url('start.svg')
 }
 
-.vs-dark .sql.icon.start,
-.hc-black .sql.icon.start {
+.vs-dark .sql.codicon.start,
+.hc-black .sql.codicon.start {
 	background-image: url('start_inverse.svg')
 }
 
-.vs .sql.icon.stop {
+.vs .sql.codicon.stop {
 	background-image: url('stop.svg')
 }
 
-.vs-dark .sql.icon.stop,
-.hc-black .sql.icon.stop {
+.vs-dark .sql.codicon.stop,
+.hc-black .sql.codicon.stop {
 	background-image: url('stop_inverse.svg')
 }
 

--- a/src/sql/workbench/parts/notebook/browser/cellViews/code.css
+++ b/src/sql/workbench/parts/notebook/browser/cellViews/code.css
@@ -65,12 +65,12 @@ code-component .monaco-editor .decorationsOverviewRuler {
 	visibility: hidden;
 }
 
-code-component .carbon-taskbar .icon {
+code-component .carbon-taskbar .codicon {
 	background-size: 20px;
 	width: 40px;
 }
 
-code-component .carbon-taskbar .icon.hideIcon {
+code-component .carbon-taskbar .codicon.hideIcon {
 	width: 0px;
 	padding-left: 0px;
 	padding-top: 6px;
@@ -78,11 +78,11 @@ code-component .carbon-taskbar .icon.hideIcon {
 	font-size: 12px;
 }
 
-code-component .carbon-taskbar .icon.hideIcon.execCountTen {
+code-component .carbon-taskbar .codicon.hideIcon.execCountTen {
 	margin-left: -2px;
 }
 
-code-component .carbon-taskbar .icon.hideIcon.execCountHundred {
+code-component .carbon-taskbar .codicon.hideIcon.execCountHundred {
 	margin-left: -6px;
 }
 

--- a/src/sql/workbench/parts/notebook/browser/notebook.css
+++ b/src/sql/workbench/parts/notebook/browser/notebook.css
@@ -94,7 +94,7 @@
 	background-image: url("./media/dark/clear_results_inverse.svg");
 }
 
-.moreActions .action-label.icon.toggle-more {
+.moreActions .action-label.codicon.toggle-more {
 	height: 20px;
 	width: 20px;
 }


### PR DESCRIPTION
After the vscode merge which has some styling changes (essentially renamed .icon to .codicon), it effected our current styles.
Fixes both #7325  and #7328 
![image](https://user-images.githubusercontent.com/12754347/65470921-ffe51100-de21-11e9-855d-773b2642423c.png)
