### PR TITLE
Use test.skip instead of commenting out disabled test

### DIFF
--- a/extensions/integration-tests/src/dacpac.test.ts
+++ b/extensions/integration-tests/src/dacpac.test.ts
@@ -62,12 +62,11 @@ if (context.RunTest) {
 			}
 		});
 
-		/*
 		// Disabling due to intermittent failure with error Editor is not connected
 		// Tracking bug https://github.com/microsoft/azuredatastudio/issues/7323
 
-		const bacpac1: string = path.join(__dirname, '../testData/Database1.bacpac');
-		test('Import and export bacpac', async function () {
+		const bacpac1: string = path.join(__dirname, '..', 'testData', 'Database1.bacpac');
+		test.skip('Import and export bacpac', async function () {
 			const server = await getStandaloneServer();
 			await utils.connectToServer(server);
 
@@ -101,6 +100,5 @@ if (context.RunTest) {
 				await utils.deleteDB(server, databaseName, ownerUri);
 			}
 		});
-		*/
 	});
 }

--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -30,7 +30,7 @@ if (context.RunTest) {
 		test('Azure SQL DB context menu test', async function () {
 			await (new ObjectExplorerTester()).sqlDbContextMenuTest();
 		});
-		test('Standalone database context menu test', async function () {
+		test.skip('Standalone database context menu test', async function () {
 			await (new ObjectExplorerTester()).standaloneContextMenuTest();
 		});
 	});


### PR DESCRIPTION
Using test.skip makes it easier to find disabled tests and includes these tests in the test run output (it'll say how many tests it skipped) which is useful to make sure we don't forget about disabled tests. 