### PR TITLE
Skip failing notebook tests due to sqlclient issues

### DIFF
--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -29,11 +29,13 @@ if (context.RunTest) {
 			await (new NotebookTester()).cleanup(this.currentTest.title);
 		});
 
-		test('Sql NB test', async function () {
+		// This test needs to be re-enabled once the SqlClient driver has been updated
+		test.skip('Sql NB test', async function () {
 			await (new NotebookTester()).sqlNbTest(this.test.title);
 		});
 
-		test('Sql NB multiple cells test', async function () {
+		// This test needs to be re-enabled once the SqlClient driver has been updated
+		test.skip('Sql NB multiple cells test', async function () {
 			await (new NotebookTester()).sqlNbMultipleCellsTest(this.test.title);
 		});
 


### PR DESCRIPTION
Until we get a SqlClient fix, these tests will fail. Skipping them for now, after the decision was made in DRI meeting.