### PR TITLE
rename button and update dialog button width

### DIFF
--- a/extensions/resource-deployment/src/ui/deployClusterWizard/deployClusterWizard.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/deployClusterWizard.ts
@@ -47,7 +47,7 @@ export class DeployClusterWizard extends WizardBase<DeployClusterWizard, DeployC
 	protected initialize(): void {
 		this.setPages(this.getPages());
 		this.wizardObject.generateScriptButton.hidden = true;
-		this.wizardObject.doneButton.label = localize('deployCluster.openNotebook', 'Open Notebook');
+		this.wizardObject.doneButton.label = localize('deployCluster.ScriptToNotebook', 'Script to Notebook');
 	}
 
 	protected onCancel(): void {

--- a/src/sql/workbench/browser/modal/media/modal.css
+++ b/src/sql/workbench/browser/modal/media/modal.css
@@ -139,7 +139,8 @@
 }
 
 .modal .footer-button a.monaco-button.monaco-text-button {
-	width: 100px;
+	min-width: 100px;
+	padding: 4px 10px;
 }
 
 .vs .monaco-text-button:focus {

--- a/src/sql/workbench/browser/modal/media/modal.css
+++ b/src/sql/workbench/browser/modal/media/modal.css
@@ -140,7 +140,8 @@
 
 .modal .footer-button a.monaco-button.monaco-text-button {
 	min-width: 100px;
-	padding: 4px 10px;
+	padding-left: 20px;
+	padding-right: 20px;
 }
 
 .vs .monaco-text-button:focus {


### PR DESCRIPTION
right now, our dialog buttons are fixed width, I ran into a problem that the text doesn't fit anymore. Consulted @angdesign yesterday and he confirmed it is totally to have buttons with different width on one screen. Azure portal is an example.

![Screen Shot 2019-09-25 at 3 50 41 PM](https://user-images.githubusercontent.com/13777222/65645676-4024ca80-dfad-11e9-9758-bae230c5cb07.png)
