### PR TITLE
Re-center Schema Compare arrow

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -169,7 +169,8 @@ export class SchemaCompareMainWindow {
 			}).component();
 
 			let arrowLabel = view.modelBuilder.text().withProperties({
-				value: localize('schemaCompare.switchLabel', '➔')
+				value: localize('schemaCompare.switchLabel', '➔'),
+				CSSStyles: { 'justify-content': 'center' }
 			}).component();
 
 			this.sourceName = getEndpointName(this.sourceEndpointInfo);

--- a/src/sql/workbench/browser/modelComponents/text.component.ts
+++ b/src/sql/workbench/browser/modelComponents/text.component.ts
@@ -18,7 +18,7 @@ import { TitledComponent } from 'sql/workbench/browser/modelComponents/titledCom
 @Component({
 	selector: 'modelview-text',
 	template: `
-		<div style="display:flex;flex-flow:row;align-items:center;" [style.width]="getWidth()">
+		<div style="display:flex;flex-flow:row;align-items:center;" [style.width]="getWidth()" [style.justifyContent]="getJustifyContent()">
 			<p [innerHTML]="getValue()" [title]="title" [ngStyle]="this.CSSStyles" (click)="onClick()"></p>
 			<p  *ngIf="requiredIndicator" style="color:red;margin-left:5px;">*</p>
 			<div *ngIf="description" tabindex="0" class="modelview-text-tooltip" [attr.aria-label]="description">
@@ -77,6 +77,10 @@ export default class TextComponent extends TitledComponent implements IComponent
 
 	public get requiredIndicator(): boolean {
 		return this.getPropertyOrDefault<azdata.TextComponentProperties, boolean>((props) => props.requiredIndicator, false);
+	}
+
+	public getJustifyContent(): string {
+		return this.CSSStyles['justify-content'];
 	}
 
 	public getValue(): SafeHtml {


### PR DESCRIPTION
The schema compare arrow label wasn't centered anymore after a div got added around the  p with text of the text component in #7183. This adds justify-content to the div so that text in the p can be centered.
![image](https://user-images.githubusercontent.com/31145923/65724295-eda6e500-e064-11e9-9c86-683d5366a660.png)


![image](https://user-images.githubusercontent.com/31145923/65724231-d1a34380-e064-11e9-947a-dcac59e949ff.png)
