### PR TITLE
Fix to open ADS release notes instead of VS Code

### DIFF
--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -48,7 +48,7 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
-			description: localize('showReleaseNotes', "Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service."),
+			description: localize('showReleaseNotes', "Show Release Notes after an update. The Release Notes are opened in a new web browser window."), // {{SQL CARBON EDIT}} Update text to be correct for ADS
 			tags: ['usesOnlineServices']
 		}
 	}

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -11,7 +11,7 @@ import { generateTokensCSSForColorMap } from 'vs/editor/common/modes/supports/to
 import { IModeService } from 'vs/editor/common/services/modeService';
 import * as nls from 'vs/nls';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
-import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { ServicesAccessor, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IRequestService, asText } from 'vs/platform/request/common/request';
@@ -24,8 +24,9 @@ import { KeybindingParser } from 'vs/base/common/keybindingParser';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { generateUuid } from 'vs/base/common/uuid';
+// import { generateUuid } from 'vs/base/common/uuid'; // {{SQL CARBON EDIT}} Not needed currently
 import { renderMarkdownDocument } from 'vs/workbench/contrib/markdown/common/markdownDocumentRenderer';
+import { OpenLatestReleaseNotesInBrowserAction } from 'vs/workbench/contrib/update/browser/update';
 
 export class ReleaseNotesManager {
 
@@ -62,6 +63,11 @@ export class ReleaseNotesManager {
 		accessor: ServicesAccessor,
 		version: string
 	): Promise<boolean> {
+		// {{SQL CARBON EDIT}} Open release notes in browser until we can get ADS notes from web
+		const action = accessor.get(IInstantiationService).createInstance(OpenLatestReleaseNotesInBrowserAction);
+		await action.run();
+		return true;
+		/*
 		const releaseNoteText = await this.loadReleaseNotes(version);
 		this._lastText = releaseNoteText;
 		const html = await this.renderBody(releaseNoteText);
@@ -99,6 +105,7 @@ export class ReleaseNotesManager {
 		}
 
 		return true;
+		*/
 	}
 
 	private loadReleaseNotes(version: string): Promise<string> {

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -11,7 +11,7 @@ import { generateTokensCSSForColorMap } from 'vs/editor/common/modes/supports/to
 import { IModeService } from 'vs/editor/common/services/modeService';
 import * as nls from 'vs/nls';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
-import { ServicesAccessor, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IRequestService, asText } from 'vs/platform/request/common/request';

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -24,9 +24,8 @@ import { KeybindingParser } from 'vs/base/common/keybindingParser';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
-// import { generateUuid } from 'vs/base/common/uuid'; // {{SQL CARBON EDIT}} Not needed currently
+import { generateUuid } from 'vs/base/common/uuid';
 import { renderMarkdownDocument } from 'vs/workbench/contrib/markdown/common/markdownDocumentRenderer';
-import { OpenLatestReleaseNotesInBrowserAction } from 'vs/workbench/contrib/update/browser/update';
 
 export class ReleaseNotesManager {
 
@@ -63,11 +62,6 @@ export class ReleaseNotesManager {
 		accessor: ServicesAccessor,
 		version: string
 	): Promise<boolean> {
-		// {{SQL CARBON EDIT}} Open release notes in browser until we can get ADS notes from web
-		const action = accessor.get(IInstantiationService).createInstance(OpenLatestReleaseNotesInBrowserAction);
-		await action.run();
-		return true;
-		/*
 		const releaseNoteText = await this.loadReleaseNotes(version);
 		this._lastText = releaseNoteText;
 		const html = await this.renderBody(releaseNoteText);
@@ -105,7 +99,6 @@ export class ReleaseNotesManager {
 		}
 
 		return true;
-		*/
 	}
 
 	private loadReleaseNotes(version: string): Promise<string> {

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -39,11 +39,20 @@ const CONTEXT_UPDATE_STATE = new RawContextKey<string>('updateState', StateType.
 let releaseNotesManager: ReleaseNotesManager | undefined = undefined;
 
 function showReleaseNotes(instantiationService: IInstantiationService, version: string) {
+	/* // {{SQL CARBON EDIT}} just open release notes in browser until we can get ADS release notes from the web
 	if (!releaseNotesManager) {
 		releaseNotesManager = instantiationService.createInstance(ReleaseNotesManager);
 	}
 
 	return instantiationService.invokeFunction(accessor => releaseNotesManager!.show(accessor, version));
+	*/
+
+	// {{SQL CARBON EDIT}} Open release notes in browser until we can get ADS notes from web
+	return instantiationService.invokeFunction(async accessor => {
+		const action = accessor.get(IInstantiationService).createInstance(OpenLatestReleaseNotesInBrowserAction);
+		await action.run();
+	});
+
 }
 
 export class OpenLatestReleaseNotesInBrowserAction extends Action {
@@ -139,21 +148,23 @@ export class ProductContribution implements IWorkbenchContribution {
 		// was there an update? if so, open release notes
 		const releaseNotesUrl = productService.releaseNotesUrl;
 		if (shouldShowReleaseNotes && !environmentService.skipReleaseNotes && releaseNotesUrl && lastVersion && productService.version !== lastVersion && productService.quality === 'stable') { // {{SQL CARBON EDIT}} Only show release notes for stable build
+			/* // {{SQL CARBON EDIT}} Prompt user to open release notes in browser until we can get ADS release notes from the web
 			showReleaseNotes(instantiationService, productService.version)
 				.then(undefined, () => {
-					notificationService.prompt(
-						severity.Info,
-						nls.localize('read the release notes', "Welcome to {0} v{1}! Would you like to read the Release Notes?", productService.nameLong, productService.version),
-						[{
-							label: nls.localize('releaseNotes', "Release Notes"),
-							run: () => {
-								const uri = URI.parse(releaseNotesUrl);
-								openerService.open(uri);
-							}
-						}],
-						{ sticky: true }
-					);
-				});
+			*/
+			notificationService.prompt(
+				severity.Info,
+				nls.localize('read the release notes', "Welcome to {0} v{1}! Would you like to read the Release Notes?", productService.nameLong, productService.version),
+				[{
+					label: nls.localize('releaseNotes', "Release Notes"),
+					run: () => {
+						const uri = URI.parse(releaseNotesUrl);
+						openerService.open(uri);
+					}
+				}],
+				{ sticky: true }
+			);
+			// }); // {{SQL CARBON EDIT}}
 		}
 
 		// should we show the new license?

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -138,7 +138,7 @@ export class ProductContribution implements IWorkbenchContribution {
 
 		// was there an update? if so, open release notes
 		const releaseNotesUrl = productService.releaseNotesUrl;
-		if (shouldShowReleaseNotes && !environmentService.skipReleaseNotes && releaseNotesUrl && lastVersion && productService.version !== lastVersion) {
+		if (shouldShowReleaseNotes && !environmentService.skipReleaseNotes && releaseNotesUrl && lastVersion && productService.version !== lastVersion && productService.quality === 'stable') { // {{SQL CARBON EDIT}} Only show release notes for stable build
 			showReleaseNotes(instantiationService, productService.version)
 				.then(undefined, () => {
 					notificationService.prompt(


### PR DESCRIPTION
Fixes #7242