### PR TITLE
Add PS to standard kernels in package.json

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -360,6 +360,11 @@
           "name": "python3",
           "displayName": "Python 3",
           "connectionProviderIds": []
+        },
+        {
+          "name": "powershell",
+          "displayName": "PowerShell",
+          "connectionProviderIds": []
         }
       ]
     },


### PR DESCRIPTION
Add powershell to standard kernels so that it shows up by default.

Note: we're figuring out the story for what to do if the powershell kernel isn't installed, so right now, an error message will occur. Will fix that in an upcoming PR once the story is fleshed out.