### PR TITLE
update timeout

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -67,15 +67,15 @@
 			"name": "Launch azuredatastudio",
 			"windows": {
 				"runtimeExecutable": "${workspaceFolder}/scripts/sql.bat",
-				"timeout": 20000
+				"timeout": 45000
 			},
 			"osx": {
 				"runtimeExecutable": "${workspaceFolder}/scripts/sql.sh",
-				"timeout": 20000
+				"timeout": 45000
 			},
 			"linux": {
 				"runtimeExecutable": "${workspaceFolder}/scripts/sql.sh",
-				"timeout": 20000
+				"timeout": 45000
 			},
 			"env": {
 				"VSCODE_EXTHOST_WILL_SEND_SOCKET": null


### PR DESCRIPTION
not sure whether I am the only one, 20 seconds timeout is never enough for my dev environments to launch ADS after git clean. and I noticed we have 45 seconds timeout elsewhere in the launch.json file which seems to be good enough for my MacBook.