### PR TITLE
Add powershell kernel.json

### DIFF
--- a/extensions/notebook/kernels/powershell/kernel.json
+++ b/extensions/notebook/kernels/powershell/kernel.json
@@ -1,0 +1,14 @@
+{
+	"argv": [
+		"python",
+		"-m",
+		"powershell_kernel",
+		"-f",
+		"{connection_file}"
+	],
+	"display_name": "PowerShell",
+	"env": {
+		"powershell_command": "powershell"
+	},
+	"language": "powershell"
+}


### PR DESCRIPTION
Add powershell kernel.json so that users don't have to run the extra step when using the powershell kernel to copy the file over to a Jupyter-friendly location.

We already do the same thing with other kernels, just using prior art here 😄 