### PR TITLE
Stop grabbing focus when nb editor isn't in view

### DIFF
--- a/src/sql/workbench/parts/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/parts/notebook/browser/cellViews/code.component.ts
@@ -305,6 +305,8 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 	}
 
 	private setFocusAndScroll(): void {
+		// If offsetParent is null, the element isn't visible
+		// In this case, we don't want a cell to grab focus for an editor that isn't in the foreground
 		if (this.cellModel.id === this._activeCellId && this._editor.getContainer().offsetParent) {
 			this._editor.focus();
 			this._editor.getContainer().scrollIntoView({ behavior: 'smooth', block: 'nearest' });

--- a/src/sql/workbench/parts/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/parts/notebook/browser/cellViews/code.component.ts
@@ -305,7 +305,7 @@ export class CodeComponent extends AngularDisposable implements OnInit, OnChange
 	}
 
 	private setFocusAndScroll(): void {
-		if (this.cellModel.id === this._activeCellId) {
+		if (this.cellModel.id === this._activeCellId && this._editor.getContainer().offsetParent) {
 			this._editor.focus();
 			this._editor.getContainer().scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 		}

--- a/src/sql/workbench/parts/notebook/browser/cellViews/outputArea.component.ts
+++ b/src/sql/workbench/parts/notebook/browser/cellViews/outputArea.component.ts
@@ -54,6 +54,8 @@ export class OutputAreaComponent extends AngularDisposable implements OnInit {
 	}
 
 	private setFocusAndScroll(node: HTMLElement): void {
+		// If offsetParent is null, the element isn't visible
+		// In this case, we don't want a cell to grab focus for an editor that isn't in the foreground
 		if (node && node.offsetParent) {
 			node.focus();
 			node.scrollIntoView({ behavior: 'smooth', block: 'nearest' });

--- a/src/sql/workbench/parts/notebook/browser/cellViews/outputArea.component.ts
+++ b/src/sql/workbench/parts/notebook/browser/cellViews/outputArea.component.ts
@@ -54,7 +54,7 @@ export class OutputAreaComponent extends AngularDisposable implements OnInit {
 	}
 
 	private setFocusAndScroll(node: HTMLElement): void {
-		if (node) {
+		if (node && node.offsetParent) {
 			node.focus();
 			node.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 		}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent via https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom 😄 

This fixes the issue that @vickyharp was encountering where you could type into the wrong notebook, as we always grabbed focus on whatever code cell was being executed.

Also did the same check for output areas, as it's silly to grab focus/scroll when it's not in view. May be the cause of another bug there that we didn't know about yet.