### PR TITLE
Create the azure folder differently.

### DIFF
--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -87,7 +87,13 @@ async function findOrMakeStoragePath() {
 	let defaultLogLocation = getDefaultLogLocation();
 	let storagePath = path.join(defaultLogLocation, constants.extensionName);
 
-	const stat = await fs.stat(storagePath);
+	let stat;
+	try {
+		stat = await fs.stat(storagePath);
+	} catch (ex) {
+		console.log(`Folder doesn't exist. Creating...`);
+	}
+
 	if (!stat || !stat.isDirectory()) {
 		try {
 			await fs.mkdir(defaultLogLocation, { recursive: true });

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -90,9 +90,7 @@ async function findOrMakeStoragePath() {
 		await fs.mkdir(defaultLogLocation, { recursive: true });
 	}
 	catch (e) {
-		console.error(`Initialization of Azure account extension storage failed: ${e}`);
-		console.error('Azure accounts will not be available');
-		return undefined;
+		console.error(`Create Directory 1: ${e}`);
 	}
 
 	try {

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -87,23 +87,19 @@ async function findOrMakeStoragePath() {
 	let defaultLogLocation = getDefaultLogLocation();
 	let storagePath = path.join(defaultLogLocation, constants.extensionName);
 
-	let stat;
 	try {
-		stat = await fs.stat(storagePath);
-	} catch (ex) {
-		console.log(`Folder doesn't exist. Creating...`);
+		await fs.mkdir(defaultLogLocation, { recursive: true });
+	} catch (e) {
+		if (e.code !== 'EEXIST') {
+			console.log(`Creating the base directory failed... ${e}`);
+			return undefined;
+		}
 	}
 
-	if (!stat || !stat.isDirectory()) {
-		try {
-			await fs.mkdir(defaultLogLocation, { recursive: true });
-		} catch (e) {
-			console.log(`Creating the base directory failed (probably not an issue): ${e}`);
-		}
-
-		try {
-			await fs.mkdir(storagePath, { recursive: true });
-		} catch (e) {
+	try {
+		await fs.mkdir(storagePath, { recursive: true });
+	} catch (e) {
+		if (e.code !== 'EEXIST') {
 			console.error(`Initialization of Azure account extension storage failed: ${e}`);
 			console.error('Azure accounts will not be available');
 			return undefined;

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -88,13 +88,22 @@ async function findOrMakeStoragePath() {
 	let storagePath = path.join(defaultLogLocation, constants.extensionName);
 	try {
 		await fs.mkdir(defaultLogLocation, { recursive: true });
-		await fs.mkdir(storagePath, { recursive: true });
-		console.log('Initialized Azure account extension storage.');
 	}
 	catch (e) {
 		console.error(`Initialization of Azure account extension storage failed: ${e}`);
 		console.error('Azure accounts will not be available');
+		return undefined;
 	}
+
+	try {
+		await fs.mkdir(storagePath, { recursive: true });
+	} catch (e) {
+		console.error(`Initialization of Azure account extension storage failed: ${e}`);
+		console.error('Azure accounts will not be available');
+		return undefined;
+	}
+
+	console.log('Initialized Azure account extension storage.');
 	return storagePath;
 }
 

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -86,19 +86,22 @@ export async function activate(context: vscode.ExtensionContext) {
 async function findOrMakeStoragePath() {
 	let defaultLogLocation = getDefaultLogLocation();
 	let storagePath = path.join(defaultLogLocation, constants.extensionName);
-	try {
-		await fs.mkdir(defaultLogLocation, { recursive: true });
-	}
-	catch (e) {
-		console.error(`Create Directory 1: ${e}`);
-	}
 
-	try {
-		await fs.mkdir(storagePath, { recursive: true });
-	} catch (e) {
-		console.error(`Initialization of Azure account extension storage failed: ${e}`);
-		console.error('Azure accounts will not be available');
-		return undefined;
+	const stat = await fs.stat(storagePath);
+	if (!stat || !stat.isDirectory()) {
+		try {
+			await fs.mkdir(defaultLogLocation, { recursive: true });
+		} catch (e) {
+			console.log(`Creating the base directory failed (probably not an issue): ${e}`);
+		}
+
+		try {
+			await fs.mkdir(storagePath, { recursive: true });
+		} catch (e) {
+			console.error(`Initialization of Azure account extension storage failed: ${e}`);
+			console.error('Azure accounts will not be available');
+			return undefined;
+		}
 	}
 
 	console.log('Initialized Azure account extension storage.');

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -84,8 +84,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
 // Create the folder for storing the token caches
 async function findOrMakeStoragePath() {
-	let storagePath = path.join(getDefaultLogLocation(), constants.extensionName);
+	let defaultLogLocation = getDefaultLogLocation();
+	let storagePath = path.join(defaultLogLocation, constants.extensionName);
 	try {
+		await fs.mkdir(defaultLogLocation, { recursive: true });
 		await fs.mkdir(storagePath, { recursive: true });
 		console.log('Initialized Azure account extension storage.');
 	}


### PR DESCRIPTION
{recursive: true} is supposed to not let the EEXIST error be thrown but electron decided to treat it differently.