### PR TITLE
fix issue 7489 and disposable handling

### DIFF
--- a/extensions/resource-deployment/package.nls.json
+++ b/extensions/resource-deployment/package.nls.json
@@ -3,7 +3,7 @@
 	"extension-description": "Provides a notebook-based experience to deploy Microsoft SQL Server",
 	"deploy-sql-image-command-name": "Deploy SQL Server on Docker…",
 	"deploy-sql-bdc-command-name": "Deploy SQL Server Big Data Cluster…",
-	"deploy-resource-command-name": "Open SQL Server deployment dialog",
+	"deploy-resource-command-name": "More deployment options…",
 	"deploy-resource-command-category": "Deployment",
 	"resource-type-sql-image-display-name": "SQL Server container image",
 	"resource-type-sql-image-description": "Run SQL Server container image with Docker",

--- a/extensions/resource-deployment/src/main.ts
+++ b/extensions/resource-deployment/src/main.ts
@@ -44,8 +44,12 @@ export function activate(context: vscode.ExtensionContext) {
 	vscode.commands.registerCommand('azdata.resource.sql-bdc.deploy', () => {
 		openDialog('sql-bdc');
 	});
-	vscode.commands.registerCommand('azdata.resource.deploy', (resourceType: string = 'sql-image') => {
-		openDialog(resourceType);
+	vscode.commands.registerCommand('azdata.resource.deploy', (resourceType: string) => {
+		if (typeof resourceType === 'string') {
+			openDialog(resourceType);
+		} else {
+			openDialog('sql-image');
+		}
 	});
 	vscode.commands.registerCommand('azdata.openNotebookInputDialog', (dialogInfo: NotebookBasedDialogInfo) => {
 		const dialog = new DeploymentInputDialog(notebookService, dialogInfo);

--- a/extensions/resource-deployment/src/ui/deploymentInputDialog.ts
+++ b/extensions/resource-deployment/src/ui/deploymentInputDialog.ts
@@ -23,7 +23,6 @@ export class DeploymentInputDialog extends DialogBase {
 		private dialogInfo: DialogInfo) {
 		super(dialogInfo.title, dialogInfo.name, false);
 		this._dialogObject.okButton.label = localize('deploymentDialog.OKButtonText', 'Open Notebook');
-		this._dialogObject.okButton.onClick(() => this.onComplete());
 	}
 
 	protected initialize() {
@@ -59,7 +58,7 @@ export class DeploymentInputDialog extends DialogBase {
 		});
 	}
 
-	private onComplete(): void {
+	protected onComplete(): void {
 		const model: Model = new Model();
 		setModelValues(this.inputComponents, model);
 		if (instanceOfNotebookBasedDialogInfo(this.dialogInfo)) {
@@ -70,6 +69,5 @@ export class DeploymentInputDialog extends DialogBase {
 		} else {
 			vscode.commands.executeCommand(this.dialogInfo.command, model);
 		}
-		this.dispose();
 	}
 }

--- a/extensions/resource-deployment/src/ui/dialogBase.ts
+++ b/extensions/resource-deployment/src/ui/dialogBase.ts
@@ -12,7 +12,8 @@ export abstract class DialogBase {
 
 	constructor(dialogTitle: string, dialogName: string, isWide: boolean = false) {
 		this._dialogObject = azdata.window.createModelViewDialog(dialogTitle, dialogName, isWide);
-		this._dialogObject.cancelButton.onClick(() => this.onCancel());
+		this._toDispose.push(this._dialogObject.cancelButton.onClick(() => this.onCancelButtonClicked()));
+		this._toDispose.push(this._dialogObject.okButton.onClick(() => this.onOkButtonClicked()));
 	}
 
 	protected abstract initialize(): void;
@@ -22,9 +23,16 @@ export abstract class DialogBase {
 		azdata.window.openDialog(this._dialogObject);
 	}
 
-	protected onCancel(): void {
+	private onCancelButtonClicked(): void {
 		this.dispose();
 	}
+
+	private onOkButtonClicked(): void {
+		this.onComplete();
+		this.dispose();
+	}
+
+	protected onComplete(): void { }
 
 	protected dispose(): void {
 		this._toDispose.forEach(disposable => disposable.dispose());

--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -35,7 +35,6 @@ export class ResourceTypePickerDialog extends DialogBase {
 		super(localize('resourceTypePickerDialog.title', "Select the deployment options"), 'ResourceTypePickerDialog', true);
 		this._selectedResourceType = resourceType;
 		this._dialogObject.okButton.label = localize('deploymentDialog.OKButtonText', 'Select');
-		this._dialogObject.okButton.onClick(() => this.onComplete());
 	}
 
 	initialize() {
@@ -259,8 +258,7 @@ export class ResourceTypePickerDialog extends DialogBase {
 		return this._selectedResourceType.getProvider(options)!;
 	}
 
-	private onComplete(): void {
+	protected onComplete(): void {
 		this.resourceTypeService.startDeployment(this.getCurrentProvider());
-		this.dispose();
 	}
 }


### PR DESCRIPTION
1. fixes #7489. vscode made some changes and will pass extra arguments to the command, adding argument type check and use default resource type if the argument is not string typed.

2. rename the "Open SQL Server deployment dialog" menu to "More deployment options..." to avoid confusion, I've seen people raising question about this multiple times.

3. Refactor the disposable handling logic into the DialogBase class.