### PR TITLE
Revert "Revert "allows zone.js to cleanup error stacktraces""

### DIFF
--- a/src/sql/setup.js
+++ b/src/sql/setup.js
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-define(["require", "exports"], function (require) {
+define(["require", "exports", "vs/base/common/errors"], function (require, errors) {
 	const jquerylib = require.__$__nodeRequire('jquery');
 
 	window['jQuery'] = jquerylib;
@@ -18,6 +18,10 @@ define(["require", "exports"], function (require) {
 	require.__$__nodeRequire('slickgrid/slick.dataview');
 	require.__$__nodeRequire('slickgrid/plugins/slick.cellrangedecorator');
 	require.__$__nodeRequire('reflect-metadata');
-	require.__$__nodeRequire('zone.js');
+	require.__$__nodeRequire('zone.js/dist/zone');
+	require.__$__nodeRequire('zone.js/dist/zone-error');
 	require.__$__nodeRequire('chart.js');
+
+	window["Zone"]["__zone_symbol__ignoreConsoleErrorUncaughtError"] = true;
+	window["Zone"]["__zone_symbol__unhandledPromiseRejectionHandler"] = errors.onUnexpectedError;
 });

--- a/test/electron/renderer.js
+++ b/test/electron/renderer.js
@@ -13,7 +13,7 @@ const util = require('util');
 const bootstrap = require('../../src/bootstrap');
 const coverage = require('../coverage');
 
-require('reflect-metadata'); // {{SQL CARBON EDIT}}
+require('../../src/sql/setup'); // {{SQL CARBON EDIT}}
 
 // Disabled custom inspect. See #38847
 if (util.inspect && util.inspect['defaultOptions']) {


### PR DESCRIPTION
Reverts microsoft/azuredatastudio#7499

Keeping this for later when I can do more tests.