### PR TITLE
Fix #7357 schema compare results not showing

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -341,7 +341,7 @@ export class SchemaCompareMainWindow {
 		this.resetButtons(ResetButtonState.afterCompareComplete);
 
 		if (this.comparisonResult.differences.length > 0) {
-			this.flexModel.addItem(this.splitView, { CSSStyles: { 'overflow': 'hidden' } });
+			this.flexModel.addItem(this.splitView, { CSSStyles: { 'overflow': 'hidden', 'height': '100%' } });
 
 			// only enable generate script button if the target is a db
 			if (this.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {

--- a/src/sql/workbench/browser/modelComponents/diffeditor.component.ts
+++ b/src/sql/workbench/browser/modelComponents/diffeditor.component.ts
@@ -19,7 +19,7 @@ import { ComponentBase } from 'sql/workbench/browser/modelComponents/componentBa
 import { IComponent, IComponentDescriptor, IModelStore } from 'sql/workbench/browser/modelComponents/interfaces';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { SimpleEditorProgressService } from 'vs/editor/standalone/browser/simpleServices';
-import { IProgressService } from 'vs/platform/progress/common/progress';
+import { IEditorProgressService } from 'vs/platform/progress/common/progress';
 import { TextDiffEditor } from 'vs/workbench/browser/parts/editor/textDiffEditor';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { TextDiffEditorModel } from 'vs/workbench/common/editor/textDiffEditorModel';
@@ -70,7 +70,7 @@ export default class DiffEditorComponent extends ComponentBase implements ICompo
 	}
 
 	private _createEditor(): void {
-		this._instantiationService = this._instantiationService.createChild(new ServiceCollection([IProgressService, new SimpleEditorProgressService()]));
+		this._instantiationService = this._instantiationService.createChild(new ServiceCollection([IEditorProgressService, new SimpleEditorProgressService()]));
 		this._editor = this._instantiationService.createInstance(TextDiffEditor);
 		this._editor.reverseColoring();
 		this._editor.create(this._el.nativeElement);


### PR DESCRIPTION
This fixes the error in #7357 and the split view with the differences table and diff editor not showing. The behavior change was caused by the vs code merge  ea0f9e6ce95b45def2b694efcd8ffe909bc43d20. 