### PR TITLE
Revert zone.js changes

### DIFF
--- a/src/sql/setup.js
+++ b/src/sql/setup.js
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-define(["require", "exports", "vs/base/common/errors"], function (require, exports, errors) {
+define(["require", "exports"], function (require) {
 	const jquerylib = require.__$__nodeRequire('jquery');
 
 	window['jQuery'] = jquerylib;
@@ -18,10 +18,6 @@ define(["require", "exports", "vs/base/common/errors"], function (require, expor
 	require.__$__nodeRequire('slickgrid/slick.dataview');
 	require.__$__nodeRequire('slickgrid/plugins/slick.cellrangedecorator');
 	require.__$__nodeRequire('reflect-metadata');
-	require.__$__nodeRequire('zone.js/dist/zone');
-	require.__$__nodeRequire('zone.js/dist/zone-error');
+	require.__$__nodeRequire('zone.js');
 	require.__$__nodeRequire('chart.js');
-
-	window["Zone"]["__zone_symbol__ignoreConsoleErrorUncaughtError"] = true;
-	window["Zone"]["__zone_symbol__unhandledPromiseRejectionHandler"] = errors.onUnexpectedError;
 });


### PR DESCRIPTION
This reverts commit d91488da6283d42e119667e3bb6367a74cc09799.

Fixes #7562. Don't know exactly why this is breaking but a build produced without this change works as expected.