### PR TITLE
Block Enter key from closing Manage Packages dialog.

### DIFF
--- a/extensions/notebook/src/dialog/managePackages/managePackagesDialog.ts
+++ b/extensions/notebook/src/dialog/managePackages/managePackagesDialog.ts
@@ -38,6 +38,10 @@ export class ManagePackagesDialog {
 
 		this.dialog.content = [this.installedPkgTab.tab, this.addNewPkgTab.tab];
 
+		this.dialog.registerCloseValidator(() => {
+			return false; // Blocks Enter key from closing dialog.
+		});
+
 		azdata.window.openDialog(this.dialog);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/7264

RegisterCloseValidator doesn't affect the Cancel button in the dialog, only the OK button (which is hidden here) and the Enter key.