### PR TITLE
Fix async problem with jupyter book viewlet loading

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -45,16 +45,17 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 
 	}
 
-	private async initialize(bookPaths: string[]): Promise<any> {
+	private async initialize(bookPaths: string[]): Promise<void> {
 		await vscode.commands.executeCommand('setContext', 'untitledBooks', this._openAsUntitled);
-		return Promise.all(bookPaths.map(async (bookPath) => {
+		await Promise.all(bookPaths.map(async (bookPath) => {
 			let book: BookModel = new BookModel(bookPath, this._openAsUntitled, this._extensionContext);
 			await book.initializeContents();
 			this.books.push(book);
 			if (!this.currentBook) {
 				this.currentBook = book;
 			}
-		})).then(() => this._initializeDeferred.resolve());
+		}));
+		this._initializeDeferred.resolve();
 	}
 
 	public get onReadAllTOCFiles(): vscode.Event<void> {

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -13,6 +13,7 @@ import { BookTreeItem } from './bookTreeItem';
 import * as nls from 'vscode-nls';
 import { isEditorTitleFree } from '../common/utils';
 import { BookModel } from './bookModel';
+import { Deferred } from '../common/promise';
 
 const localize = nls.loadMessageBundle();
 
@@ -24,6 +25,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	private _resource: string;
 	private _extensionContext: vscode.ExtensionContext;
 	private prompter: IPrompter;
+	private _initializeDeferred: Deferred<void> = new Deferred<void>();
 
 	// For testing
 	private _errorMessage: string;
@@ -38,13 +40,13 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		this._extensionContext = extensionContext;
 		this.books = [];
 		this.initialize(workspaceFolders.map(a => a.uri.fsPath));
-		vscode.commands.executeCommand('setContext', 'untitledBooks', openAsUntitled);
 		this.viewId = view;
 		this.prompter = new CodeAdapter();
 
 	}
 
 	private async initialize(bookPaths: string[]): Promise<any> {
+		await vscode.commands.executeCommand('setContext', 'untitledBooks', this._openAsUntitled);
 		return Promise.all(bookPaths.map(async (bookPath) => {
 			let book: BookModel = new BookModel(bookPath, this._openAsUntitled, this._extensionContext);
 			await book.initializeContents();
@@ -52,14 +54,16 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			if (!this.currentBook) {
 				this.currentBook = book;
 			}
-		}));
+		})).then(() => this._initializeDeferred.resolve());
 	}
 
 	public get onReadAllTOCFiles(): vscode.Event<void> {
 		return this._onReadAllTOCFiles.event;
 	}
 
-
+	public get initialized(): Promise<void> {
+		return this._initializeDeferred.promise;
+	}
 
 	async openBook(bookPath: string, urlToOpen?: string): Promise<void> {
 		try {

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -28,10 +28,6 @@ let controller: JupyterController;
 type ChooseCellType = { label: string, id: CellType };
 
 export async function activate(extensionContext: vscode.ExtensionContext): Promise<IExtensionApi> {
-	const bookTreeViewProvider = new BookTreeViewProvider(vscode.workspace.workspaceFolders || [], extensionContext, false, BOOKS_VIEWID);
-	const untitledBookTreeViewProvider = new BookTreeViewProvider([], extensionContext, true, READONLY_BOOKS_VIEWID);
-	extensionContext.subscriptions.push(vscode.window.registerTreeDataProvider(BOOKS_VIEWID, bookTreeViewProvider));
-	extensionContext.subscriptions.push(vscode.window.registerTreeDataProvider(READONLY_BOOKS_VIEWID, untitledBookTreeViewProvider));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('bookTreeView.openBook', (bookPath: string, openAsUntitled: boolean, urlToOpen?: string) => openAsUntitled ? untitledBookTreeViewProvider.openBook(bookPath, urlToOpen) : bookTreeViewProvider.openBook(bookPath, urlToOpen)));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('bookTreeView.openNotebook', (resource) => bookTreeViewProvider.openNotebook(resource)));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('bookTreeView.openUntitledNotebook', (resource) => untitledBookTreeViewProvider.openNotebookAsUntitled(resource)));
@@ -100,6 +96,15 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	if (!result) {
 		return undefined;
 	}
+
+	let workspaceFolders = vscode.workspace.workspaceFolders || [];
+	const bookTreeViewProvider = new BookTreeViewProvider(workspaceFolders, extensionContext, false, BOOKS_VIEWID);
+	await bookTreeViewProvider.initialized;
+	const untitledBookTreeViewProvider = new BookTreeViewProvider([], extensionContext, true, READONLY_BOOKS_VIEWID);
+	await untitledBookTreeViewProvider.initialized;
+
+	extensionContext.subscriptions.push(vscode.window.registerTreeDataProvider(BOOKS_VIEWID, bookTreeViewProvider));
+	extensionContext.subscriptions.push(vscode.window.registerTreeDataProvider(READONLY_BOOKS_VIEWID, untitledBookTreeViewProvider));
 
 	return {
 		getJupyterController() {


### PR DESCRIPTION
Fixes an issue where the Jupyter Books viewlet wouldn't show anything if a user navigated to it immediately upon opening ADS.

There was a race condition with how the viewlet was originally written, as we weren't properly awaiting async methods, so calls that relied upon this.books being fully populated would instead see this.books as an empty array.