### PR TITLE
Fix connection group input not correctly selecting nested groups

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -547,7 +547,12 @@ export class ConnectionWidget extends lifecycle.Disposable {
 		if (this._serverGroupSelectBox) {
 			this._serverGroupOptions = connectionGroups;
 			this._serverGroupOptions.push(this._addNewServerGroup);
-			this._serverGroupSelectBox.setOptions(this._serverGroupOptions.map(g => g.name));
+			this._serverGroupSelectBox.setOptions(this._serverGroupOptions.map(g => {
+				if (g instanceof ConnectionProfileGroup) {
+					return g.fullName;
+				}
+				return g.name;
+			}));
 			if (groupName) {
 				this._serverGroupSelectBox.selectWithOptionName(groupName);
 				this._previousGroupOption = this._serverGroupSelectBox.value;


### PR DESCRIPTION
Fixes #7565

The server group input was only storing the name of the group - not the full path name - which didn't work because when we populate the dialog we use the group full name.

Changing it so the input now stores the full group name not only fixes this issue but is actually a better experience overall - previously if you had groups with the same name but different paths you'd have no way to know which option was which 

![image](https://user-images.githubusercontent.com/28519865/66579769-30bb8a80-eb32-11e9-90a0-41d6a42252f9.png)

Now since we show the full path it's much clearer (and fixes the issue above so that we select the group correctly not)

![image](https://user-images.githubusercontent.com/28519865/66579835-4b8dff00-eb32-11e9-87ba-5661bd4f5091.png)
