### PR TITLE
Fix aria labels for dacfx wizard database text boxes

### DIFF
--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -79,19 +79,19 @@ export abstract class DacFxConfigPage extends BasePage {
 		return true;
 	}
 
-	protected async createDatabaseTextBox(): Promise<azdata.FormComponent> {
+	protected async createDatabaseTextBox(title: string): Promise<azdata.FormComponent> {
 		this.databaseTextBox = this.view.modelBuilder.inputBox().withProperties({
 			required: true
 		}).component();
 
-		this.databaseTextBox.ariaLabel = localize('dacfx.databaseAriaLabel', "Database");
+		this.databaseTextBox.ariaLabel = title;
 		this.databaseTextBox.onTextChanged(async () => {
 			this.model.database = this.databaseTextBox.value;
 		});
 
 		return {
 			component: this.databaseTextBox,
-			title: localize('dacFx.databaseNameTextBox', 'Target Database')
+			title: title
 		};
 	}
 

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -35,8 +35,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 	async start(): Promise<boolean> {
 		let serverComponent = await this.createServerDropdown(true);
 		let fileBrowserComponent = await this.createFileBrowser();
-		this.databaseComponent = await this.createDatabaseTextBox();
-		this.databaseComponent.title = localize('dacFx.databaseNameTextBox', 'Database Name');
+		this.databaseComponent = await this.createDatabaseTextBox(localize('dacFx.databaseNameTextBox', "Database Name"));
 		this.databaseDropdownComponent = await this.createDeployDatabaseDropdown();
 		this.databaseDropdownComponent.title = localize('dacFx.databaseNameDropdown', 'Database Name');
 		let radioButtons = await this.createRadiobuttons();

--- a/extensions/dacpac/src/wizard/pages/importConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/importConfigPage.ts
@@ -30,7 +30,7 @@ export class ImportConfigPage extends DacFxConfigPage {
 	}
 
 	async start(): Promise<boolean> {
-		let databaseComponent = await this.createDatabaseTextBox();
+		let databaseComponent = await this.createDatabaseTextBox(localize('dacfx.targetDatabaseAriaLabel', "Target Database"));
 		let serverComponent = await this.createServerDropdown(true);
 		let fileBrowserComponent = await this.createFileBrowser();
 


### PR DESCRIPTION
Fixes the wrong label in #6731. Previously it was "Database" instead of "Target Database"
![image](https://user-images.githubusercontent.com/31145923/66590332-674ed080-eb45-11e9-97c5-0c41c3b8f872.png)
