### PR TITLE
Add collapsed argument to insertCell extension method.

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -4442,8 +4442,9 @@ declare module 'azdata' {
 			 *
 			 * @param index The position where the new text should be inserted.
 			 * @param value The new text this operation should insert.
+			 * @param collapsed The collapsible state of the new cell.
 			 */
-			insertCell(value: ICellContents, index?: number): void;
+			insertCell(value: ICellContents, index?: number, collapsed?: boolean): void;
 
 			/**
 			 * Delete a certain cell.

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -4442,7 +4442,7 @@ declare module 'azdata' {
 			 *
 			 * @param index The position where the new text should be inserted.
 			 * @param value The new text this operation should insert.
-			 * @param collapsed The collapsible state of the new cell.
+			 * @param collapsed The collapsed state of the new cell. Default value is `false` if not provided.
 			 */
 			insertCell(value: ICellContents, index?: number, collapsed?: boolean): void;
 

--- a/src/sql/workbench/api/common/extHostNotebookEditor.ts
+++ b/src/sql/workbench/api/common/extHostNotebookEditor.ts
@@ -13,6 +13,7 @@ import { readonly } from 'vs/base/common/errors';
 import { MainThreadNotebookDocumentsAndEditorsShape } from 'sql/workbench/api/common/sqlExtHost.protocol';
 import { ExtHostNotebookDocumentData } from 'sql/workbench/api/common/extHostNotebookDocumentData';
 import { CellRange, ISingleNotebookEditOperation, ICellRange } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { HideInputTag } from 'sql/workbench/parts/notebook/browser/models/cell';
 
 export interface INotebookEditOperation {
 	range: azdata.nb.CellRange;
@@ -80,12 +81,21 @@ export class NotebookEditorEdit {
 		return range;
 	}
 
-	insertCell(value: Partial<azdata.nb.ICellContents>, location?: number): void {
-		if (location === null || location === undefined) {
+	insertCell(value: Partial<azdata.nb.ICellContents>, index?: number, collapsed?: boolean): void {
+		if (index === null || index === undefined) {
 			// If not specified, assume adding to end of list
-			location = this._document.cells.length;
+			index = this._document.cells.length;
 		}
-		this._pushEdit(new CellRange(location, location), value, true);
+		if (!!collapsed) {
+			if (!value.metadata) {
+				value.metadata = { tags: [HideInputTag] };
+			} else if (!value.metadata.tags) {
+				value.metadata.tags = [HideInputTag];
+			} else if (!value.metadata.tags.includes(HideInputTag)) {
+				value.metadata.tags.push(HideInputTag);
+			}
+		}
+		this._pushEdit(new CellRange(index, index), value, true);
 	}
 
 	deleteCell(index: number): void {

--- a/src/sql/workbench/parts/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/parts/notebook/browser/models/cell.ts
@@ -24,6 +24,8 @@ import { generateUuid } from 'vs/base/common/uuid';
 import { IModelContentChangedEvent } from 'vs/editor/common/model/textModelEvents';
 let modelId = 0;
 
+export const HideInputTag = 'hide_input';
+
 export class CellModel implements ICellModel {
 	public id: string;
 
@@ -51,8 +53,6 @@ export class CellModel implements ICellModel {
 	private _isCollapsed: boolean;
 	private _onCollapseStateChanged = new Emitter<boolean>();
 	private _modelContentChangedEvent: IModelContentChangedEvent;
-
-	private readonly _hideInputTag = 'hide_input';
 
 	constructor(cellData: nb.ICellContents,
 		private _options: ICellModelOptions,
@@ -112,7 +112,7 @@ export class CellModel implements ICellModel {
 
 		let tagIndex = -1;
 		if (this._metadata.tags) {
-			tagIndex = this._metadata.tags.findIndex(tag => tag === this._hideInputTag);
+			tagIndex = this._metadata.tags.findIndex(tag => tag === HideInputTag);
 		}
 
 		if (this._isCollapsed) {
@@ -120,7 +120,7 @@ export class CellModel implements ICellModel {
 				if (!this._metadata.tags) {
 					this._metadata.tags = [];
 				}
-				this._metadata.tags.push(this._hideInputTag);
+				this._metadata.tags.push(HideInputTag);
 			}
 		} else {
 			if (tagIndex > -1) {
@@ -605,7 +605,7 @@ export class CellModel implements ICellModel {
 		this._source = this.getMultilineSource(cell.source);
 		this._metadata = cell.metadata || {};
 
-		if (this._metadata.tags && this._metadata.tags.includes(this._hideInputTag)) {
+		if (this._metadata.tags && this._metadata.tags.includes(HideInputTag)) {
 			this._isCollapsed = true;
 		} else {
 			this._isCollapsed = false;


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/7306

Tried to add an integration test for this, but apparently we don't correctly update the contents in the notebook object returned by openNotebook after inserting a cell. That's a pretty big bug that we need to fix. Manually verified that this works instead.