### PR TITLE
Make health status header wider so text isn't multiline

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
@@ -29,7 +29,7 @@ export interface IInstanceStatus {
 const healthAndStatusIconColumnWidth = 25;
 const healthAndStatusInstanceNameColumnWidth = 100;
 const healthAndStatusStateColumnWidth = 75;
-const healthAndStatusHealthColumnWidth = 75;
+const healthAndStatusHealthColumnWidth = 100;
 
 const metricsAndLogsInstanceNameColumnWidth = 125;
 const metricsAndLogsMetricsColumnWidth = 75;


### PR DESCRIPTION
Fixes #7636

![image](https://user-images.githubusercontent.com/28519865/66604117-5a8ca580-eb62-11e9-967c-577534d0ca4c.png)
