### PR TITLE
Fix checkbox component layout

### DIFF
--- a/src/sql/workbench/browser/modelComponents/checkbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/checkbox.component.ts
@@ -20,7 +20,7 @@ import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/work
 @Component({
 	selector: 'modelview-checkbox',
 	template: `
-		<div #input [style.width]="getWidth()" [style.height]="getHeight()"></div>
+		<div #input width="100%"></div>
 	`
 })
 export default class CheckBoxComponent extends ComponentBase implements IComponent, OnDestroy, AfterViewInit {


### PR DESCRIPTION
The div shouldn't have the height and width since that's handled by the checkbox component itself. Putting the height/width on the div breaks the view when a label is added :

![image](https://user-images.githubusercontent.com/28519865/66663106-f53ac200-ebfe-11e9-986b-5a0cf91f85e8.png)

After fix :

![image](https://user-images.githubusercontent.com/28519865/66663187-10a5cd00-ebff-11e9-9edf-d410d9792b65.png)

This is the same thing that the button component does. 