### PR TITLE
Add return to getControllerEndpoint

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/utils.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/utils.ts
@@ -253,4 +253,5 @@ export function getControllerEndpoint(serverInfo: azdata.ServerInfo): string | u
 		if (index < 0) { return undefined; }
 		return endpoints[index].endpoint;
 	}
+	return undefined;
 }


### PR DESCRIPTION
Technically this is unnecessary (undefined is returned by default) but it's good to be explicit with returns. 