### PR TITLE
Mount delete, refresh and default to new folder for mount create

### DIFF
--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -91,7 +91,7 @@
 				},
 				{
 					"command": "bigDataClusters.command.refreshmount",
-					"when": "nodeType == mssqlCluster:folder && nodeSubType=~/^:mount:$/",
+					"when": "nodeType == mssqlCluster:folder && nodeSubType==:mount:",
 					"group": "1mssqlCluster@11"
 				},
 				{

--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -49,6 +49,14 @@
 				{
 					"command": "bigDataClusters.command.mount",
 					"when": "false"
+				},
+				{
+					"command": "bigDataClusters.command.refreshmount",
+					"when": "false"
+				},
+				{
+					"command": "bigDataClusters.command.deletemount",
+					"when": "false"
 				}
 			],
 			"view/title": [
@@ -80,6 +88,16 @@
 					"command": "bigDataClusters.command.mount",
 					"when": "nodeType=~/^mssqlCluster/ && nodeType!=mssqlCluster:message && nodeSubType=~/^(?!:mount).*$/",
 					"group": "1mssqlCluster@10"
+				},
+				{
+					"command": "bigDataClusters.command.refreshmount",
+					"when": "nodeType == mssqlCluster:folder && nodeSubType=~/^:mount:$/",
+					"group": "1mssqlCluster@11"
+				},
+				{
+					"command": "bigDataClusters.command.deletemount",
+					"when": "nodeType == mssqlCluster:folder && nodeSubType==:mount:",
+					"group": "1mssqlCluster@12"
 				}
 			]
 		},
@@ -112,6 +130,14 @@
 			{
 				"command": "bigDataClusters.command.mount",
 				"title": "%command.mount.title%"
+			},
+			{
+				"command": "bigDataClusters.command.refreshmount",
+				"title": "%command.refreshmount.title%"
+			},
+			{
+				"command": "bigDataClusters.command.deletemount",
+				"title": "%command.deletemount.title%"
 			}
 		]
 	},

--- a/extensions/big-data-cluster/package.nls.json
+++ b/extensions/big-data-cluster/package.nls.json
@@ -5,5 +5,7 @@
 	"command.deleteController.title" : "Delete",
 	"command.refreshController.title" : "Refresh",
 	"command.manageController.title" : "Manage",
-	"command.mount.title" : "Mount HDFS"
+	"command.mount.title" : "Mount HDFS",
+	"command.refreshmount.title" : "Refresh Mount",
+	"command.deletemount.title" : "Delete Mount"
 }

--- a/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
@@ -214,6 +214,37 @@ export class ClusterController {
 		}
 	}
 
+	public async refreshMount(mountPath: string): Promise<MountResponse> {
+		let auth = await this.authPromise;
+		const api = new DefaultApiWrapper(this.username, this.password, this._url, auth);
+
+		try {
+			const mountStatus = await api.refreshMount('', '', mountPath);
+			return {
+				response: mountStatus.response,
+				status: mountStatus.body
+			};
+		} catch (error) {
+			// TODO handle 401 by reauthenticating
+			throw new ControllerError(error, localize('bdc.error.refreshHdfs', "Error refreshing mount"));
+		}
+	}
+
+	public async deleteMount(mountPath: string): Promise<MountResponse> {
+		let auth = await this.authPromise;
+		const api = new DefaultApiWrapper(this.username, this.password, this._url, auth);
+
+		try {
+			const mountStatus = await api.deleteMount('', '', mountPath);
+			return {
+				response: mountStatus.response,
+				status: mountStatus.body
+			};
+		} catch (error) {
+			// TODO handle 401 by reauthenticating
+			throw new ControllerError(error, localize('bdc.error.deleteHdfs', "Error deleting mount"));
+		}
+	}
 }
 /**
  * Fixes missing protocol and wrong character for port entered by user

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/mountHdfsDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/mountHdfsDialog.ts
@@ -137,7 +137,6 @@ abstract class HdfsDialogModelBase<T extends DialogProperties> {
 				throw new Error(localize('mount.hdfs.loginerror1', "Login to controller failed"));
 			}
 		} catch (err) {
-			// An error here means we failed to
 			throw new Error(localize('mount.hdfs.loginerror2', "Login to controller failed: {0}", err.message));
 		}
 		return controller;


### PR DESCRIPTION
- Delete mount action added
- Refresh mount action added
- Added "mymount" to the end of existing path so that we don't use already-existing HDFS folder. The call fails unless folder doesn't exist

**Screenshots**
![image](https://user-images.githubusercontent.com/10819925/66689955-2b4d6580-ec42-11e9-8649-c02a00a9b949.png)
Refresh
![image](https://user-images.githubusercontent.com/10819925/66689960-33a5a080-ec42-11e9-999e-d86ff22322af.png)
Delete
![image](https://user-images.githubusercontent.com/10819925/66689963-3e603580-ec42-11e9-8751-2cffa3fe67bb.png)
Status:
![image](https://user-images.githubusercontent.com/10819925/66689999-4c15bb00-ec42-11e9-966e-afde8439373f.png)


