### PR TITLE
Added notification for unsaved file in scheduling

### DIFF
--- a/extensions/agent/src/data/notebookData.ts
+++ b/extensions/agent/src/data/notebookData.ts
@@ -25,11 +25,6 @@ const SelectStorageDatabaseErrorMessage = localize('notebookData.selectStorageDa
 const SelectExecutionDatabaseErrorMessage = localize('notebookData.selectExecutionDatabase', 'Select execution database');
 const JobWithSameNameExistsErrorMessage = localize('notebookData.jobExists', 'Job with similar name already exists');
 
-//added my own error message here.
-const NotebookNotSavedErrorMessage = localize('notebookData.notebookNotSaved', 'Notebook must be saved to local disk first');
-
-//Regex used to screenout file names (all three platforms do not permit the use of '/' for file names)
-const InvalidRegex = /[\/]/g;
 
 export class NotebookData implements IAgentDialogData {
 
@@ -193,14 +188,7 @@ export class NotebookData implements IAgentDialogData {
 				validationErrors.push(TemplatePathEmptyErrorMessage);
 			}
 			if (!(await exists(this.templatePath))) {
-				//check if filepath is actually a name of file instead of path to file.
-				if (InvalidRegex.exec(this.templatePath)) {
-					//Place saving prompt here.
-					validationErrors.push(NotebookNotSavedErrorMessage);
-				}
-				else {
-					validationErrors.push(InvalidNotebookPathErrorMessage);
-				}
+				validationErrors.push(InvalidNotebookPathErrorMessage);
 			}
 			if (NotebookData.jobLists) {
 				for (let i = 0; i < NotebookData.jobLists.length; i++) {

--- a/extensions/agent/src/data/notebookData.ts
+++ b/extensions/agent/src/data/notebookData.ts
@@ -28,8 +28,8 @@ const JobWithSameNameExistsErrorMessage = localize('notebookData.jobExists', 'Jo
 //added my own error message here.
 const NotebookNotSavedErrorMessage = localize('notebookData.notebookNotSaved', 'Notebook must be saved to local disk first');
 
-//Regex used to screenout file names.
-const InvalidRegex = /[\\\/\:\*\?\"\<\>\|]/g;
+//Regex used to screenout file names (all three platforms do not permit the use of '/' for file names)
+const InvalidRegex = /[\/]/g;
 
 export class NotebookData implements IAgentDialogData {
 
@@ -194,7 +194,7 @@ export class NotebookData implements IAgentDialogData {
 			}
 			if (!(await exists(this.templatePath))) {
 				//check if filepath is actually a name of file instead of path to file.
-				if (!InvalidRegex.exec(this.templatePath)) {
+				if (InvalidRegex.exec(this.templatePath)) {
 					//Place saving prompt here.
 					validationErrors.push(NotebookNotSavedErrorMessage);
 				}

--- a/extensions/agent/src/data/notebookData.ts
+++ b/extensions/agent/src/data/notebookData.ts
@@ -25,7 +25,6 @@ const SelectStorageDatabaseErrorMessage = localize('notebookData.selectStorageDa
 const SelectExecutionDatabaseErrorMessage = localize('notebookData.selectExecutionDatabase', 'Select execution database');
 const JobWithSameNameExistsErrorMessage = localize('notebookData.jobExists', 'Job with similar name already exists');
 
-
 export class NotebookData implements IAgentDialogData {
 
 	private _ownerUri: string;

--- a/extensions/agent/src/data/notebookData.ts
+++ b/extensions/agent/src/data/notebookData.ts
@@ -25,6 +25,12 @@ const SelectStorageDatabaseErrorMessage = localize('notebookData.selectStorageDa
 const SelectExecutionDatabaseErrorMessage = localize('notebookData.selectExecutionDatabase', 'Select execution database');
 const JobWithSameNameExistsErrorMessage = localize('notebookData.jobExists', 'Job with similar name already exists');
 
+//added my own error message here.
+const NotebookNotSavedErrorMessage = localize('notebookData.notebookNotSaved', 'Notebook must be saved to local disk first');
+
+//Regex used to screenout file names.
+const InvalidRegex = /[\\\/\:\*\?\"\<\>\|]/g;
+
 export class NotebookData implements IAgentDialogData {
 
 	private _ownerUri: string;
@@ -187,7 +193,14 @@ export class NotebookData implements IAgentDialogData {
 				validationErrors.push(TemplatePathEmptyErrorMessage);
 			}
 			if (!(await exists(this.templatePath))) {
-				validationErrors.push(InvalidNotebookPathErrorMessage);
+				//check if filepath is actually a name of file instead of path to file.
+				if (!InvalidRegex.exec(this.templatePath)) {
+					//Place saving prompt here.
+					validationErrors.push(NotebookNotSavedErrorMessage);
+				}
+				else {
+					validationErrors.push(InvalidNotebookPathErrorMessage);
+				}
 			}
 			if (NotebookData.jobLists) {
 				for (let i = 0; i < NotebookData.jobLists.length; i++) {
@@ -200,6 +213,7 @@ export class NotebookData implements IAgentDialogData {
 		}
 		else {
 			if (this.templatePath && this.templatePath !== '' && !(await exists(this.templatePath))) {
+				console.log('We have an error at line 205.');
 				validationErrors.push(InvalidNotebookPathErrorMessage);
 			}
 		}

--- a/extensions/agent/src/data/notebookData.ts
+++ b/extensions/agent/src/data/notebookData.ts
@@ -213,7 +213,6 @@ export class NotebookData implements IAgentDialogData {
 		}
 		else {
 			if (this.templatePath && this.templatePath !== '' && !(await exists(this.templatePath))) {
-				console.log('We have an error at line 205.');
 				validationErrors.push(InvalidNotebookPathErrorMessage);
 			}
 		}

--- a/extensions/agent/src/mainController.ts
+++ b/extensions/agent/src/mainController.ts
@@ -23,7 +23,6 @@ import { NotebookDialog, NotebookDialogOptions } from './dialogs/notebookDialog'
 
 const localize = nls.loadMessageBundle();
 
-
 /**
  * The main controller class that initializes the extension
  */
@@ -43,9 +42,6 @@ export class MainController {
 	private proxyDialog: ProxyDialog;
 	private notebookDialog: NotebookDialog;
 	private notebookTemplateMap = new Map<string, TemplateMapObject>();
-
-
-
 	// PUBLIC METHODS //////////////////////////////////////////////////////
 	public constructor(context: vscode.ExtensionContext) {
 		this._context = context;
@@ -174,7 +170,7 @@ export class MainController {
 				let path: string;
 				if (!ownerUri) {
 					if (azdata.nb.activeNotebookEditor.document.isDirty || azdata.nb.activeNotebookEditor.document.isUntitled) {
-						vscode.window.showErrorMessage(localize('agent.unsavedFileSchedulingError', 'Save file before scheduling'), { modal: true });
+						vscode.window.showErrorMessage(localize('agent.unsavedFileSchedulingError', 'The notebook must be saved before being scheduled. Please save and then retry scheduling again.'), { modal: true });
 						return;
 					}
 					path = azdata.nb.activeNotebookEditor.document.fileName;

--- a/extensions/agent/src/mainController.ts
+++ b/extensions/agent/src/mainController.ts
@@ -23,6 +23,7 @@ import { NotebookDialog, NotebookDialogOptions } from './dialogs/notebookDialog'
 
 const localize = nls.loadMessageBundle();
 
+
 /**
  * The main controller class that initializes the extension
  */
@@ -42,6 +43,9 @@ export class MainController {
 	private proxyDialog: ProxyDialog;
 	private notebookDialog: NotebookDialog;
 	private notebookTemplateMap = new Map<string, TemplateMapObject>();
+
+
+
 	// PUBLIC METHODS //////////////////////////////////////////////////////
 	public constructor(context: vscode.ExtensionContext) {
 		this._context = context;
@@ -169,7 +173,7 @@ export class MainController {
 			if (!ownerUri || ownerUri instanceof vscode.Uri) {
 				let path: string;
 				if (!ownerUri) {
-					if (azdata.nb.activeNotebookEditor.document.isDirty) {
+					if (azdata.nb.activeNotebookEditor.document.isDirty || azdata.nb.activeNotebookEditor.document.isUntitled) {
 						vscode.window.showErrorMessage(localize('agent.unsavedFileSchedulingError', 'Save file before scheduling'), { modal: true });
 						return;
 					}


### PR DESCRIPTION
Handling issue mentioned in #7274 where an unsaved notebook resulted in an "invalid notebook path" error, the code now detects if the name of the "path" could be a valid filename via a regex and asks the user to save the notebook before the process can be started. Ideally there needs to be a way to have a save prompt or window pop up so that the user can save immediately onto the disk. Currently it simply prints an error asking the user to save first.