### PR TITLE
Skip prompting for package upgrade if a python install is already in progress.

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -388,8 +388,15 @@ export class JupyterServerInstallation {
 	/**
 	 * Prompts user to upgrade certain python packages if they're below the minimum expected version.
 	 */
-	public promptForPackageUpgrade(): Promise<void> {
-		return this.upgradePythonPackages(true, false);
+	public async promptForPackageUpgrade(): Promise<void> {
+		if (!this._installInProgress) {
+			this._installInProgress = true;
+			try {
+				await this.upgradePythonPackages(true, false);
+			} finally {
+				this._installInProgress = false;
+			}
+		}
 	}
 
 	private async upgradePythonPackages(promptForUpgrade: boolean, forceInstall: boolean): Promise<void> {

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -389,13 +389,20 @@ export class JupyterServerInstallation {
 	 * Prompts user to upgrade certain python packages if they're below the minimum expected version.
 	 */
 	public async promptForPackageUpgrade(): Promise<void> {
-		if (!this._installInProgress) {
-			this._installInProgress = true;
-			try {
-				await this.upgradePythonPackages(true, false);
-			} finally {
-				this._installInProgress = false;
-			}
+		if (this._installInProgress) {
+			return;
+		}
+
+		let isPythonRunning = await this.isPythonRunning(this._pythonInstallationPath, this._usingExistingPython);
+		if (isPythonRunning) {
+			return;
+		}
+
+		this._installInProgress = true;
+		try {
+			await this.upgradePythonPackages(true, false);
+		} finally {
+			this._installInProgress = false;
 		}
 	}
 

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -393,11 +393,6 @@ export class JupyterServerInstallation {
 			return;
 		}
 
-		let isPythonRunning = await this.isPythonRunning(this._pythonInstallationPath, this._usingExistingPython);
-		if (isPythonRunning) {
-			return;
-		}
-
 		this._installInProgress = true;
 		try {
 			await this.upgradePythonPackages(true, false);

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -34,6 +34,7 @@ const msgInstallPkgFinish = localize('msgInstallPkgFinish', "Notebook dependenci
 const msgPythonRunningError = localize('msgPythonRunningError', "Cannot overwrite an existing Python installation while python is running. Please close any active notebooks before proceeding.");
 const msgPendingInstallError = localize('msgPendingInstallError', "Another Python installation is currently in progress.");
 const msgSkipPythonInstall = localize('msgSkipPythonInstall', "Python already exists at the specific location. Skipping install.");
+const msgSkippedPackageUpgrade = localize('msgSkippedPackageUpgrade', "Skipping notebook package upgrade since another Python install is currently in progress.");
 function msgDependenciesInstallationFailed(errorMessage: string): string { return localize('msgDependenciesInstallationFailed', "Installing Notebook dependencies failed with error: {0}", errorMessage); }
 function msgDownloadPython(platform: string, pythonDownloadUrl: string): string { return localize('msgDownloadPython', "Downloading local python for platform: {0} to {1}", platform, pythonDownloadUrl); }
 
@@ -390,6 +391,7 @@ export class JupyterServerInstallation {
 	 */
 	public async promptForPackageUpgrade(): Promise<void> {
 		if (this._installInProgress) {
+			this.apiWrapper.showInfoMessage(msgSkippedPackageUpgrade);
 			return;
 		}
 


### PR DESCRIPTION
A lot of packages can get installed during upgrades, so if there's another install in progress there can be some file permission failures due to trying to overwrite the same packages.