### PR TITLE
Roll back tree icon merge changes to fix loading icon issue

### DIFF
--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -154,7 +154,7 @@ export class ViewItem implements IViewItem {
 	}
 
 	set loading(value: boolean) {
-		value ? this.addClass('codicon-loading') : this.removeClass('codicon-loading');
+		value ? this.addClass('loading') : this.removeClass('loading'); // {{SQL CARBON EDIT}} Use old icons - codicon font icons aren't working currently #7715
 	}
 
 	set draggable(value: boolean) {


### PR DESCRIPTION
Temporary fix for #7715. I dug into this a bit but it seems like it might be a VS Code issue so rolling back until we can figure out for sure. 

![Capture](https://user-images.githubusercontent.com/28519865/66804367-1ccbac00-eed7-11e9-82fb-66cbed97a62b.gif)
