### PR TITLE
work in progress handling for #7471

### DIFF
--- a/.lgtm/javascript-queries/promises.ql
+++ b/.lgtm/javascript-queries/promises.ql
@@ -1,0 +1,32 @@
+/**
+ * @kind problem
+ * @problem.severity warning
+ * @id js/experimental/floating-promise
+ */
+import javascript
+
+private predicate isEscapingPromise(PromiseDefinition promise) {
+  exists (DataFlow::Node escape | promise.flowsTo(escape) |
+    escape = any(DataFlow::InvokeNode invk).getAnArgument()
+    or
+    escape = any(DataFlow::FunctionNode fun).getAReturn()
+    or
+    escape = any(ThrowStmt t).getExpr().flow()
+    or
+    escape = any(GlobalVariable v).getAnAssignedExpr().flow()
+    or
+    escape = any(DataFlow::PropWrite write).getRhs()
+    or
+    exists(WithStmt with, Assignment assign |
+      with.mayAffect(assign.getLhs()) and
+      assign.getRhs().flow() = escape
+    )
+  )
+}
+
+from PromiseDefinition promise
+where
+  not exists(promise.getAMethodCall(any(string m | m = "then" or m = "catch" or m = "finally"))) and
+  not exists (AwaitExpr e | promise.flowsTo(e.getOperand().flow())) and
+  not isEscapingPromise(promise)
+select promise, "This promise appears to be a floating promise"

--- a/.lgtm/javascript-queries/promises.ql
+++ b/.lgtm/javascript-queries/promises.ql
@@ -1,6 +1,7 @@
 /**
+ * @name No floating promises
  * @kind problem
- * @problem.severity warning
+ * @problem.severity error
  * @id js/experimental/floating-promise
  */
 import javascript

--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -49,6 +49,14 @@
 				{
 					"command": "bigDataClusters.command.mount",
 					"when": "false"
+				},
+				{
+					"command": "bigDataClusters.command.refreshmount",
+					"when": "false"
+				},
+				{
+					"command": "bigDataClusters.command.deletemount",
+					"when": "false"
 				}
 			],
 			"view/title": [
@@ -80,6 +88,16 @@
 					"command": "bigDataClusters.command.mount",
 					"when": "nodeType=~/^mssqlCluster/ && nodeType!=mssqlCluster:message && nodeSubType=~/^(?!:mount).*$/",
 					"group": "1mssqlCluster@10"
+				},
+				{
+					"command": "bigDataClusters.command.refreshmount",
+					"when": "nodeType == mssqlCluster:folder && nodeSubType==:mount:",
+					"group": "1mssqlCluster@11"
+				},
+				{
+					"command": "bigDataClusters.command.deletemount",
+					"when": "nodeType == mssqlCluster:folder && nodeSubType==:mount:",
+					"group": "1mssqlCluster@12"
 				}
 			]
 		},
@@ -112,6 +130,14 @@
 			{
 				"command": "bigDataClusters.command.mount",
 				"title": "%command.mount.title%"
+			},
+			{
+				"command": "bigDataClusters.command.refreshmount",
+				"title": "%command.refreshmount.title%"
+			},
+			{
+				"command": "bigDataClusters.command.deletemount",
+				"title": "%command.deletemount.title%"
 			}
 		]
 	},

--- a/extensions/big-data-cluster/package.nls.json
+++ b/extensions/big-data-cluster/package.nls.json
@@ -5,5 +5,7 @@
 	"command.deleteController.title" : "Delete",
 	"command.refreshController.title" : "Refresh",
 	"command.manageController.title" : "Manage",
-	"command.mount.title" : "Mount HDFS"
+	"command.mount.title" : "Mount HDFS",
+	"command.refreshmount.title" : "Refresh Mount",
+	"command.deletemount.title" : "Delete Mount"
 }

--- a/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
@@ -214,6 +214,37 @@ export class ClusterController {
 		}
 	}
 
+	public async refreshMount(mountPath: string): Promise<MountResponse> {
+		let auth = await this.authPromise;
+		const api = new DefaultApiWrapper(this.username, this.password, this._url, auth);
+
+		try {
+			const mountStatus = await api.refreshMount('', '', mountPath);
+			return {
+				response: mountStatus.response,
+				status: mountStatus.body
+			};
+		} catch (error) {
+			// TODO handle 401 by reauthenticating
+			throw new ControllerError(error, localize('bdc.error.refreshHdfs', "Error refreshing mount"));
+		}
+	}
+
+	public async deleteMount(mountPath: string): Promise<MountResponse> {
+		let auth = await this.authPromise;
+		const api = new DefaultApiWrapper(this.username, this.password, this._url, auth);
+
+		try {
+			const mountStatus = await api.deleteMount('', '', mountPath);
+			return {
+				response: mountStatus.response,
+				status: mountStatus.body
+			};
+		} catch (error) {
+			// TODO handle 401 by reauthenticating
+			throw new ControllerError(error, localize('bdc.error.deleteHdfs', "Error deleting mount"));
+		}
+	}
 }
 /**
  * Fixes missing protocol and wrong character for port entered by user

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/mountHdfsDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/mountHdfsDialog.ts
@@ -6,13 +6,15 @@
 import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
-import { ClusterController, ControllerError, MountInfo, MountState } from '../controller/clusterControllerApi';
+import { ClusterController, ControllerError, MountInfo, MountState, IEndPointsResponse } from '../controller/clusterControllerApi';
 import { AuthType } from '../constants';
 
 const localize = nls.loadMessageBundle();
 
 const basicAuthDisplay = localize('basicAuthName', "Basic");
 const integratedAuthDisplay = localize('integratedAuthName', "Windows Authentication");
+const mountConfigutationTitle = localize('mount.main.section', "Mount Configuration");
+const hdfsPathTitle = localize('mount.hdfsPath', "HDFS Path");
 
 function getAuthCategory(name: AuthType): azdata.CategoryValue {
 	if (name === 'basic') {
@@ -125,6 +127,31 @@ abstract class HdfsDialogModelBase<T extends DialogProperties> {
 		return new ClusterController(this.props.url, this.props.auth, this.props.username, this.props.password, true);
 	}
 
+	protected async createAndVerifyControllerConnection(): Promise<ClusterController> {
+		// We pre-fetch the endpoints here to verify that the information entered is correct (the user is able to connect)
+		let controller = this.createController();
+		let response: IEndPointsResponse;
+		try {
+			response = await controller.getEndPoints();
+			if (!response || !response.endPoints) {
+				throw new Error(localize('mount.hdfs.loginerror1', "Login to controller failed"));
+			}
+		} catch (err) {
+			throw new Error(localize('mount.hdfs.loginerror2', "Login to controller failed: {0}", err.message));
+		}
+		return controller;
+	}
+
+	protected throwIfMissingUsernamePassword(): void {
+		if (this.props.auth === 'basic') {
+			// Verify username and password as we can't make them required in the UI
+			if (!this.props.username) {
+				throw new Error(localize('err.controller.username.required', "Username is required"));
+			} else if (!this.props.password) {
+				throw new Error(localize('err.controller.password.required', "Password is required"));
+			}
+		}
+	}
 }
 
 export class MountHdfsDialogModel extends HdfsDialogModelBase<MountHdfsProperties> {
@@ -135,37 +162,26 @@ export class MountHdfsDialogModel extends HdfsDialogModelBase<MountHdfsPropertie
 	}
 
 	protected async handleCompleted(): Promise<void> {
-		if (this.props.auth === 'basic') {
-			// Verify username and password as we can't make them required in the UI
-			if (!this.props.username) {
-				throw new Error(localize('err.controller.username.required', "Username is required"));
-			} else if (!this.props.password) {
-				throw new Error(localize('err.controller.password.required', "Password is required"));
-			}
-		}
+		this.throwIfMissingUsernamePassword();
 		// Validate credentials
 		this.credentials = convertCredsToJson(this.props.credentials);
 
 		// We pre-fetch the endpoints here to verify that the information entered is correct (the user is able to connect)
-		let controller = this.createController();
-		let response = await controller.getEndPoints();
-		if (response && response.endPoints) {
-			if (this._canceled) {
-				return;
-			}
-			//
-			azdata.tasks.startBackgroundOperation(
-				{
-					connection: undefined,
-					displayName: localize('mount.task.name', "Mounting HDFS folder on path {0}", this.props.hdfsPath),
-					description: '',
-					isCancelable: false,
-					operation: op => {
-						this.onSubmit(controller, op);
-					}
-				}
-			);
+		let controller = await this.createAndVerifyControllerConnection();
+		if (this._canceled) {
+			return;
 		}
+		azdata.tasks.startBackgroundOperation(
+			{
+				connection: undefined,
+				displayName: localize('mount.task.name', "Mounting HDFS folder on path {0}", this.props.hdfsPath),
+				description: '',
+				isCancelable: false,
+				operation: op => {
+					this.onSubmit(controller, op);
+				}
+			}
+		);
 	}
 
 	private async onSubmit(controller: ClusterController, op: azdata.BackgroundOperation): Promise<void> {
@@ -295,9 +311,9 @@ abstract class HdfsDialogBase<T extends DialogProperties> {
 					this.getMainSection(),
 					connectionSection
 				]).withLayout({ width: '100%' }).component();
-			this.onAuthChanged();
 
 			await view.initializeModel(formModel);
+			this.onAuthChanged();
 		});
 
 		this.dialog.registerCloseValidator(async () => await this.validate());
@@ -329,6 +345,16 @@ abstract class HdfsDialogBase<T extends DialogProperties> {
 			await this.model.onCancel();
 		}
 	}
+
+	protected async reportError(error: any): Promise<void> {
+		this.dialog.message = {
+			text: (typeof error === 'string') ? error : error.message,
+			level: azdata.window.MessageLevel.Error
+		};
+		if (this.model && this.model.onError) {
+			await this.model.onError(error as ControllerError);
+		}
+	}
 }
 export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties> {
 	private pathInputBox: azdata.InputBoxComponent;
@@ -340,9 +366,12 @@ export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties> {
 	}
 
 	protected getMainSection(): azdata.FormComponentGroup {
+		const newMountName = '/mymount';
+		let pathVal = this.model.props.hdfsPath;
+		pathVal = (!pathVal || pathVal === '/') ? newMountName : (pathVal + newMountName);
 		this.pathInputBox = this.uiModelBuilder.inputBox()
 			.withProperties<azdata.InputBoxProperties>({
-				value: this.model.props.hdfsPath
+				value: pathVal
 			}).component();
 		this.remoteUriInputBox = this.uiModelBuilder.inputBox()
 			.withProperties<azdata.InputBoxProperties>({
@@ -360,7 +389,7 @@ export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties> {
 			components: [
 				{
 					component: this.pathInputBox,
-					title: localize('mount.hdfsPath', "HDFS Path"),
+					title: hdfsPathTitle,
 					required: true
 				}, {
 					component: this.remoteUriInputBox,
@@ -372,7 +401,7 @@ export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties> {
 					required: false
 				}
 			],
-			title: localize('mount.main.section', "Mount Configuration")
+			title: mountConfigutationTitle
 		};
 	}
 
@@ -389,14 +418,168 @@ export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties> {
 			});
 			return true;
 		} catch (error) {
-			this.dialog.message = {
-				text: (typeof error === 'string') ? error : error.message,
-				level: azdata.window.MessageLevel.Error
-			};
-			if (this.model && this.model.onError) {
-				await this.model.onError(error as ControllerError);
-			}
+			await this.reportError(error);
 			return false;
+		}
+	}
+}
+
+export class RefreshMountDialog extends HdfsDialogBase<MountHdfsProperties> {
+	private pathInputBox: azdata.InputBoxComponent;
+
+	constructor(model: RefreshMountModel) {
+		super(localize('refreshmount.dialog.title', "Refresh Mount"), model);
+	}
+
+	protected getMainSection(): azdata.FormComponentGroup {
+		this.pathInputBox = this.uiModelBuilder.inputBox()
+			.withProperties<azdata.InputBoxProperties>({
+				value: this.model.props.hdfsPath
+			}).component();
+		return {
+			components: [
+				{
+					component: this.pathInputBox,
+					title: hdfsPathTitle,
+					required: true
+				}
+			],
+			title: mountConfigutationTitle
+		};
+	}
+
+	protected async validate(): Promise<boolean> {
+		try {
+			await this.model.onComplete({
+				url: this.urlInputBox && this.urlInputBox.value,
+				auth: this.authValue,
+				username: this.usernameInputBox && this.usernameInputBox.value,
+				password: this.passwordInputBox && this.passwordInputBox.value,
+				hdfsPath: this.pathInputBox && this.pathInputBox.value
+			});
+			return true;
+		} catch (error) {
+			await this.reportError(error);
+			return false;
+		}
+	}
+}
+
+export class RefreshMountModel extends HdfsDialogModelBase<MountHdfsProperties> {
+
+	constructor(props: MountHdfsProperties) {
+		super(props);
+	}
+
+	protected async handleCompleted(): Promise<void> {
+		this.throwIfMissingUsernamePassword();
+
+		// We pre-fetch the endpoints here to verify that the information entered is correct (the user is able to connect)
+		let controller = await this.createAndVerifyControllerConnection();
+		if (this._canceled) {
+			return;
+		}
+		azdata.tasks.startBackgroundOperation(
+			{
+				connection: undefined,
+				displayName: localize('refreshmount.task.name', "Refreshing HDFS Mount on path {0}", this.props.hdfsPath),
+				description: '',
+				isCancelable: false,
+				operation: op => {
+					this.onSubmit(controller, op);
+				}
+			}
+		);
+	}
+
+	private async onSubmit(controller: ClusterController, op: azdata.BackgroundOperation): Promise<void> {
+		try {
+			await controller.refreshMount(this.props.hdfsPath);
+			op.updateStatus(azdata.TaskStatus.Succeeded, localize('refreshmount.task.submitted', "Refresh mount request submitted"));
+		} catch (error) {
+			const errMsg = (error instanceof Error) ? error.message : error;
+			vscode.window.showErrorMessage(errMsg);
+			op.updateStatus(azdata.TaskStatus.Failed, errMsg);
+		}
+	}
+}
+
+export class DeleteMountDialog extends HdfsDialogBase<MountHdfsProperties> {
+	private pathInputBox: azdata.InputBoxComponent;
+
+	constructor(model: DeleteMountModel) {
+		super(localize('deleteMount.dialog.title', "Delete Mount"), model);
+	}
+
+	protected getMainSection(): azdata.FormComponentGroup {
+		this.pathInputBox = this.uiModelBuilder.inputBox()
+			.withProperties<azdata.InputBoxProperties>({
+				value: this.model.props.hdfsPath
+			}).component();
+		return {
+			components: [
+				{
+					component: this.pathInputBox,
+					title: hdfsPathTitle,
+					required: true
+				}
+			],
+			title: mountConfigutationTitle
+		};
+	}
+
+	protected async validate(): Promise<boolean> {
+		try {
+			await this.model.onComplete({
+				url: this.urlInputBox && this.urlInputBox.value,
+				auth: this.authValue,
+				username: this.usernameInputBox && this.usernameInputBox.value,
+				password: this.passwordInputBox && this.passwordInputBox.value,
+				hdfsPath: this.pathInputBox && this.pathInputBox.value
+			});
+			return true;
+		} catch (error) {
+			await this.reportError(error);
+			return false;
+		}
+	}
+}
+
+export class DeleteMountModel extends HdfsDialogModelBase<MountHdfsProperties> {
+
+	constructor(props: MountHdfsProperties) {
+		super(props);
+	}
+
+	protected async handleCompleted(): Promise<void> {
+		this.throwIfMissingUsernamePassword();
+
+		// We pre-fetch the endpoints here to verify that the information entered is correct (the user is able to connect)
+		let controller = await this.createAndVerifyControllerConnection();
+		if (this._canceled) {
+			return;
+		}
+		azdata.tasks.startBackgroundOperation(
+			{
+				connection: undefined,
+				displayName: localize('deletemount.task.name', "Deleting HDFS Mount on path {0}", this.props.hdfsPath),
+				description: '',
+				isCancelable: false,
+				operation: op => {
+					this.onSubmit(controller, op);
+				}
+			}
+		);
+	}
+
+	private async onSubmit(controller: ClusterController, op: azdata.BackgroundOperation): Promise<void> {
+		try {
+			await controller.deleteMount(this.props.hdfsPath);
+			op.updateStatus(azdata.TaskStatus.Succeeded, localize('deletemount.task.submitted', "Delete mount request submitted"));
+		} catch (error) {
+			const errMsg = (error instanceof Error) ? error.message : error;
+			vscode.window.showErrorMessage(errMsg);
+			op.updateStatus(azdata.TaskStatus.Failed, errMsg);
 		}
 	}
 }

--- a/extensions/big-data-cluster/src/bigDataCluster/utils.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/utils.ts
@@ -253,4 +253,5 @@ export function getControllerEndpoint(serverInfo: azdata.ServerInfo): string | u
 		if (index < 0) { return undefined; }
 		return endpoints[index].endpoint;
 	}
+	return undefined;
 }

--- a/extensions/mssql/src/hdfs/aclEntry.ts
+++ b/extensions/mssql/src/hdfs/aclEntry.ts
@@ -202,8 +202,8 @@ export class AclEntry {
 	 *		user::r-x
 	 *		default:group::r--
 	 */
-	toAclStrings(): string[] {
-		return Array.from(this.permissions.entries()).map((entry: [AclEntryScope, AclEntryPermission]) => {
+	toAclStrings(includeDefaults: boolean = true): string[] {
+		return Array.from(this.permissions.entries()).filter((entry: [AclEntryScope, AclEntryPermission]) => includeDefaults || entry[0] !== AclEntryScope.default).map((entry: [AclEntryScope, AclEntryPermission]) => {
 			return `${entry[0] === AclEntryScope.default ? 'default:' : ''}${getAclEntryType(this.type)}:${this.name}:${entry[1].toString()}`;
 		});
 	}

--- a/extensions/mssql/src/hdfs/fileStatus.ts
+++ b/extensions/mssql/src/hdfs/fileStatus.ts
@@ -3,10 +3,32 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export enum HdfsFileType {
+import { FileType } from '../objectExplorerNodeProvider/fileSources';
+
+export const enum HdfsFileType {
 	File = 'File',
 	Directory = 'Directory',
 	Symlink = 'Symlink'
+}
+
+/**
+ * Maps a @see HdfsFileType to its corresponding @see FileType. Will return undefined if
+ * passed in type is undefined.
+ * @param hdfsFileType The HdfsFileType to map from
+ */
+export function hdfsFileTypeToFileType(hdfsFileType: HdfsFileType | undefined): FileType | undefined {
+	switch (hdfsFileType) {
+		case HdfsFileType.Directory:
+			return FileType.Directory;
+		case HdfsFileType.File:
+			return FileType.File;
+		case HdfsFileType.Symlink:
+			return FileType.Symlink;
+		case undefined:
+			return undefined;
+		default:
+			throw new Error(`Unexpected file type ${hdfsFileType}`);
+	}
 }
 
 export class FileStatus {

--- a/extensions/mssql/src/hdfs/hdfsModel.ts
+++ b/extensions/mssql/src/hdfs/hdfsModel.ts
@@ -5,9 +5,9 @@
 
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
-import { IFileSource } from '../objectExplorerNodeProvider/fileSources';
+import { IFileSource, FileType } from '../objectExplorerNodeProvider/fileSources';
 import { PermissionStatus, AclEntry, AclEntryScope, AclType, AclEntryPermission } from './aclEntry';
-import { FileStatus } from './fileStatus';
+import { FileStatus, hdfsFileTypeToFileType } from './fileStatus';
 import * as nls from 'vscode-nls';
 
 const localize = nls.loadMessageBundle();
@@ -84,7 +84,7 @@ export class HdfsModel {
 	 * @param recursive Whether to apply the changes recursively (to all sub-folders and files)
 	 */
 	public async apply(recursive: boolean = false): Promise<void> {
-		await this.applyAclChanges(this.path);
+		await this.applyAclChanges(this.path, hdfsFileTypeToFileType(this.fileStatus ? this.fileStatus.type : undefined));
 		if (recursive) {
 			azdata.tasks.startBackgroundOperation(
 				{
@@ -112,10 +112,9 @@ export class HdfsModel {
 			const files = await this.fileSource.enumerateFiles(path, true);
 			// Apply changes to all children of this path and then recursively apply to children of any directories
 			await Promise.all(
-				[
-					files.map(file => this.applyAclChanges(file.path)),
-					files.filter(f => f.isDirectory).map(d => this.applyToChildrenRecursive(op, d.path))
-				]);
+				files.map(file => this.applyAclChanges(file.path, file.fileType)).concat(
+					files.filter(f => f.fileType === FileType.Directory).map(d => this.applyToChildrenRecursive(op, d.path)))
+			);
 		} catch (error) {
 			const errMsg = localize('mssql.recursivePermissionOpError', "Error applying permission changes: {0}", (error instanceof Error ? error.message : error));
 			vscode.window.showErrorMessage(errMsg);
@@ -127,7 +126,7 @@ export class HdfsModel {
 	 * Applies the current set of Permissions/ACLs to the specified path
 	 * @param path The path to apply the changes to
 	 */
-	private async applyAclChanges(path: string): Promise<any> {
+	private async applyAclChanges(path: string, fileType: FileType | undefined): Promise<any> {
 		// HDFS won't remove existing default ACLs even if you call setAcl with no default ACLs specified. You
 		// need to call removeDefaultAcl specifically to remove them.
 		if (!this.permissionStatus.owner.getPermission(AclEntryScope.default) &&
@@ -136,7 +135,7 @@ export class HdfsModel {
 			await this.fileSource.removeDefaultAcl(path);
 		}
 		return Promise.all([
-			this.fileSource.setAcl(path, this.permissionStatus.owner, this.permissionStatus.group, this.permissionStatus.other, this.permissionStatus.aclEntries),
+			this.fileSource.setAcl(path, fileType, this.permissionStatus),
 			this.fileSource.setPermission(path, this.permissionStatus)]);
 	}
 }

--- a/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
@@ -15,9 +15,9 @@ import * as nls from 'vscode-nls';
 
 import * as constants from '../constants';
 import { WebHDFS, HdfsError } from '../hdfs/webhdfs';
-import { AclEntry, PermissionStatus } from '../hdfs/aclEntry';
+import { PermissionStatus } from '../hdfs/aclEntry';
 import { Mount, MountStatus } from '../hdfs/mount';
-import { FileStatus, HdfsFileType } from '../hdfs/fileStatus';
+import { FileStatus, hdfsFileTypeToFileType } from '../hdfs/fileStatus';
 
 const localize = nls.loadMessageBundle();
 
@@ -28,15 +28,21 @@ export function joinHdfsPath(parent: string, child: string): string {
 	return `${parent}/${child}`;
 }
 
+export const enum FileType {
+	Directory = 'Directory',
+	File = 'File',
+	Symlink = 'Symlink'
+}
+
 export interface IFile {
 	path: string;
-	isDirectory: boolean;
+	fileType: FileType;
 	mountStatus?: MountStatus;
 }
 
 export class File implements IFile {
 	public mountStatus?: MountStatus;
-	constructor(public path: string, public isDirectory: boolean) {
+	constructor(public path: string, public fileType: FileType) {
 
 	}
 
@@ -44,16 +50,16 @@ export class File implements IFile {
 		return joinHdfsPath(path, fileName);
 	}
 
-	public static createChild(parent: IFile, fileName: string, isDirectory: boolean): IFile {
-		return new File(File.createPath(parent.path, fileName), isDirectory);
+	public static createChild(parent: IFile, fileName: string, fileType: FileType): IFile {
+		return new File(File.createPath(parent.path, fileName), fileType);
 	}
 
 	public static createFile(parent: IFile, fileName: string): File {
-		return File.createChild(parent, fileName, false);
+		return File.createChild(parent, fileName, FileType.File);
 	}
 
 	public static createDirectory(parent: IFile, fileName: string): IFile {
-		return File.createChild(parent, fileName, true);
+		return File.createChild(parent, fileName, FileType.Directory);
 	}
 
 	public static getBasename(file: IFile): string {
@@ -81,12 +87,10 @@ export interface IFileSource {
 	/**
 	 * Sets the ACL status for given path
 	 * @param path The path to the file/folder to set the ACL on
-	 * @param ownerEntry The entry corresponding to the path owner
-	 * @param groupEntry The entry corresponding to the path owning group
-	 * @param otherEntry The entry corresponding to default permissions for all other users
-	 * @param aclEntries The ACL entries to set
+	 * @param fileType The type of file we're setting to determine if defaults should be applied. Use undefined if type is unknown
+	 * @param permissionStatus The status containing the permissions to set
 	 */
-	setAcl(path: string, ownerEntry: AclEntry, groupEntry: AclEntry, otherEntry: AclEntry, aclEntries: AclEntry[]): Promise<void>;
+	setAcl(path: string, fileType: FileType | undefined, permissionStatus: PermissionStatus): Promise<void>;
 	/**
 	 * Removes the default ACLs for the specified path
 	 * @param path The path to remove the default ACLs for
@@ -204,7 +208,7 @@ export class HdfsFileSource implements IFileSource {
 				}
 				else {
 					let hdfsFiles: IFile[] = fileStatuses.map(fileStatus => {
-						let file = new File(File.createPath(path, fileStatus.pathSuffix), fileStatus.type === HdfsFileType.Directory);
+						let file = new File(File.createPath(path, fileStatus.pathSuffix), hdfsFileTypeToFileType(fileStatus.type));
 						if (this.mounts && this.mounts.has(file.path)) {
 							file.mountStatus = MountStatus.Mount;
 						}
@@ -385,14 +389,13 @@ export class HdfsFileSource implements IFileSource {
 	/**
 	 * Sets the ACL status for given path
 	 * @param path The path to the file/folder to set the ACL on
-	 * @param ownerEntry The entry corresponding to the path owner
-	 * @param groupEntry The entry corresponding to the path owning group
-	 * @param otherEntry The entry corresponding to default permissions for all other users
+	 * @param fileType The type of file we're setting to determine if defaults should be applied. Use undefined if type is unknown
+	 * @param ownerEntry The status containing the permissions to set
 	 * @param aclEntries The ACL entries to set
 	 */
-	public setAcl(path: string, ownerEntry: AclEntry, groupEntry: AclEntry, otherEntry: AclEntry, aclEntries: AclEntry[]): Promise<void> {
+	public setAcl(path: string, fileType: FileType | undefined, permissionStatus: PermissionStatus): Promise<void> {
 		return new Promise((resolve, reject) => {
-			this.client.setAcl(path, ownerEntry, groupEntry, otherEntry, aclEntries, (error: HdfsError) => {
+			this.client.setAcl(path, fileType, permissionStatus, (error: HdfsError) => {
 				if (error) {
 					reject(error);
 				} else {

--- a/extensions/mssql/src/objectExplorerNodeProvider/hdfsProvider.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/hdfsProvider.ts
@@ -11,7 +11,7 @@ import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
 import * as Constants from '../constants';
-import { IFileSource, IHdfsOptions, IFile, File, FileSourceFactory } from './fileSources';
+import { IFileSource, IHdfsOptions, IFile, File, FileSourceFactory, FileType } from './fileSources';
 import { CancelableStream } from './cancelableStream';
 import { TreeNode } from './treeNodes';
 import * as utils from '../utils';
@@ -132,8 +132,9 @@ export class FolderNode extends HdfsFileSourceNode {
 				if (files) {
 					// Note: for now, assuming HDFS-provided sorting is sufficient
 					this.children = files.map((file) => {
-						let node: TreeNode = file.isDirectory ? new FolderNode(this.context, file.path, this.fileSource, Constants.MssqlClusterItems.Folder, this.getChildMountStatus(file))
-							: new FileNode(this.context, file.path, this.fileSource, this.getChildMountStatus(file));
+						let node: TreeNode = file.fileType === FileType.File ?
+							new FileNode(this.context, file.path, this.fileSource, this.getChildMountStatus(file)) :
+							new FolderNode(this.context, file.path, this.fileSource, Constants.MssqlClusterItems.Folder, this.getChildMountStatus(file));
 						node.parent = this;
 						return node;
 					});

--- a/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkJobSubmissionModel.ts
+++ b/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkJobSubmissionModel.ts
@@ -3,8 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -17,7 +15,7 @@ import * as LocalizedConstants from '../../../localizedConstants';
 import * as utils from '../../../utils';
 import { SparkJobSubmissionService, SparkJobSubmissionInput, LivyLogResponse } from './sparkJobSubmissionService';
 import { AppContext } from '../../../appContext';
-import { IFileSource, File, joinHdfsPath } from '../../../objectExplorerNodeProvider/fileSources';
+import { IFileSource, File, joinHdfsPath, FileType } from '../../../objectExplorerNodeProvider/fileSources';
 
 
 // Stores important state and service methods used by the Spark Job Submission Dialog.
@@ -146,8 +144,8 @@ export class SparkJobSubmissionModel {
 				return Promise.reject(LocalizedConstants.sparkJobSubmissionLocalFileNotExisted(localFilePath));
 			}
 
-			let fileSource: IFileSource = await this._sqlClusterConnection.createHdfsFileSource();
-			await fileSource.writeFile(new File(localFilePath, false), hdfsFolderPath);
+			const fileSource: IFileSource = await this._sqlClusterConnection.createHdfsFileSource();
+			await fileSource.writeFile(new File(localFilePath, FileType.File), hdfsFolderPath);
 		} catch (error) {
 			return Promise.reject(error);
 		}

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -463,12 +463,16 @@ export class JupyterServerInstallation {
 			}
 
 			if (doUpgrade) {
-				let installPromise = new Promise(async resolve => {
-					if (this._usingConda) {
-						await this.installCondaPackages(condaPackagesToInstall, true);
+				let installPromise = new Promise(async (resolve, reject) => {
+					try {
+						if (this._usingConda) {
+							await this.installCondaPackages(condaPackagesToInstall, true);
+						}
+						await this.installPipPackages(pipPackagesToInstall, true);
+						resolve();
+					} catch (err) {
+						reject(err);
 					}
-					await this.installPipPackages(pipPackagesToInstall, true);
-					resolve();
 				});
 
 				if (promptForUpgrade) {

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,12 +1,2 @@
-path_classifiers:
-  vscode:
-    - "src/vs/**/"
-  ads:
-    - "src/sql/**/"
-  extensions:
-    - "extensions/**/"
-  build:
-    - "build/**/"
-
 queries:
   - include: "*"

--- a/src/sql/base/common/errors.ts
+++ b/src/sql/base/common/errors.ts
@@ -10,3 +10,9 @@ export function invalidProvider(name?: string): Error {
 		return new Error('Invalid provider');
 	}
 }
+
+export class UserCancelledConnectionError extends Error {
+	constructor(message?: string) {
+		super(message);
+	}
+}

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -173,7 +173,7 @@ export abstract class Modal extends Disposable implements IThemable {
 		this._bodyContainer = DOM.$(`.${builderClass}`, { role: 'dialog', 'aria-label': this._title });
 		const top = this.layoutService.getTitleBarOffset();
 		this._bodyContainer.style.top = `${top}px`;
-		this._modalDialog = DOM.append(this._bodyContainer, DOM.$('.modal-dialog', { role: 'document' }));
+		this._modalDialog = DOM.append(this._bodyContainer, DOM.$('.modal-dialog'));
 		const modalContent = DOM.append(this._modalDialog, DOM.$('.modal-content'));
 
 		if (!isUndefinedOrNull(this._title)) {

--- a/src/sql/workbench/browser/parts/views/customView.ts
+++ b/src/sql/workbench/browser/parts/views/customView.ts
@@ -48,6 +48,7 @@ import { CollapseAllAction } from 'vs/base/browser/ui/tree/treeDefaults';
 import { ITreeItem, ITreeView } from 'sql/workbench/common/views';
 import { IOEShimService } from 'sql/workbench/parts/objectExplorer/browser/objectExplorerViewTreeShim';
 import { NodeContextKey } from 'sql/workbench/parts/dataExplorer/browser/nodeContext';
+import { UserCancelledConnectionError } from 'sql/base/common/errors';
 
 export class CustomTreeViewPanel extends ViewletPanel {
 
@@ -700,6 +701,9 @@ class TreeDataSource implements IAsyncDataSource<ITreeItem, ITreeItem> {
 				// So in order to enable this we need to tell the tree to refresh this node so it will ask us for the data again
 				setTimeout(() => {
 					this.treeView.collapse(node);
+					if (e instanceof UserCancelledConnectionError) {
+						return;
+					}
 					this.treeView.refresh([node]);
 				});
 				return [];

--- a/src/sql/workbench/parts/objectExplorer/browser/objectExplorerViewTreeShim.ts
+++ b/src/sql/workbench/parts/objectExplorer/browser/objectExplorerViewTreeShim.ts
@@ -18,6 +18,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 import { TreeItemCollapsibleState } from 'vs/workbench/common/views';
 import { localize } from 'vs/nls';
 import { NodeType } from 'sql/workbench/parts/objectExplorer/common/nodeType';
+import { UserCancelledConnectionError } from 'sql/base/common/errors';
 
 export const SERVICE_ID = 'oeShimService';
 export const IOEShimService = createDecorator<IOEShimService>(SERVICE_ID);
@@ -90,7 +91,7 @@ export class OEShimService extends Disposable implements IOEShimService {
 					resolve(connProfile);
 				},
 				onConnectCanceled: () => {
-					reject(new Error(localize('loginCanceled', "User canceled")));
+					reject(new UserCancelledConnectionError(localize('loginCanceled', "User canceled")));
 				},
 				onConnectReject: undefined,
 				onConnectStart: undefined,

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -75,7 +75,7 @@ export class ErrorMessageDialog extends Modal {
 	private createCopyButton() {
 		let copyButtonLabel = localize('copyDetails', "Copy details");
 		this._copyButton = this.addFooterButton(copyButtonLabel, () => this._clipboardService.writeText(this._messageDetails), 'left');
-		this._copyButton.icon = 'icon scriptToClipboard';
+		this._copyButton.icon = 'codicon scriptToClipboard';
 		this._copyButton.element.title = copyButtonLabel;
 		this._register(attachButtonStyler(this._copyButton, this._themeService, { buttonBackground: SIDE_BAR_BACKGROUND, buttonHoverBackground: SIDE_BAR_BACKGROUND, buttonForeground: SIDE_BAR_FOREGROUND }));
 	}


### PR DESCRIPTION
Currently to handle the issue parsing iconPath of registered providers, I have been able to find that the light and dark sections of the iconPath or its elements turn into URIs upon processing.  Since there is no list or registry that lists when an extension has already been processed as far as I can see, this is current way of checking if an extension is processed at the moment.