### PR TITLE
Handling for parsing IconPath error

### DIFF
--- a/extensions/agent/src/data/notebookData.ts
+++ b/extensions/agent/src/data/notebookData.ts
@@ -25,11 +25,6 @@ const SelectStorageDatabaseErrorMessage = localize('notebookData.selectStorageDa
 const SelectExecutionDatabaseErrorMessage = localize('notebookData.selectExecutionDatabase', 'Select execution database');
 const JobWithSameNameExistsErrorMessage = localize('notebookData.jobExists', 'Job with similar name already exists');
 
-//added my own error message here.
-const NotebookNotSavedErrorMessage = localize('notebookData.notebookNotSaved', 'Notebook must be saved to local disk first');
-
-//Regex used to screenout file names (all three platforms do not permit the use of '/' for file names)
-const InvalidRegex = /[\/]/g;
 
 export class NotebookData implements IAgentDialogData {
 
@@ -193,14 +188,7 @@ export class NotebookData implements IAgentDialogData {
 				validationErrors.push(TemplatePathEmptyErrorMessage);
 			}
 			if (!(await exists(this.templatePath))) {
-				//check if filepath is actually a name of file instead of path to file.
-				if (InvalidRegex.exec(this.templatePath)) {
-					//Place saving prompt here.
-					validationErrors.push(NotebookNotSavedErrorMessage);
-				}
-				else {
-					validationErrors.push(InvalidNotebookPathErrorMessage);
-				}
+				validationErrors.push(InvalidNotebookPathErrorMessage);
 			}
 			if (NotebookData.jobLists) {
 				for (let i = 0; i < NotebookData.jobLists.length; i++) {

--- a/extensions/agent/src/data/notebookData.ts
+++ b/extensions/agent/src/data/notebookData.ts
@@ -28,8 +28,8 @@ const JobWithSameNameExistsErrorMessage = localize('notebookData.jobExists', 'Jo
 //added my own error message here.
 const NotebookNotSavedErrorMessage = localize('notebookData.notebookNotSaved', 'Notebook must be saved to local disk first');
 
-//Regex used to screenout file names.
-const InvalidRegex = /[\\\/\:\*\?\"\<\>\|]/g;
+//Regex used to screenout file names (all three platforms do not permit the use of '/' for file names)
+const InvalidRegex = /[\/]/g;
 
 export class NotebookData implements IAgentDialogData {
 
@@ -194,7 +194,7 @@ export class NotebookData implements IAgentDialogData {
 			}
 			if (!(await exists(this.templatePath))) {
 				//check if filepath is actually a name of file instead of path to file.
-				if (!InvalidRegex.exec(this.templatePath)) {
+				if (InvalidRegex.exec(this.templatePath)) {
 					//Place saving prompt here.
 					validationErrors.push(NotebookNotSavedErrorMessage);
 				}

--- a/extensions/agent/src/data/notebookData.ts
+++ b/extensions/agent/src/data/notebookData.ts
@@ -25,7 +25,6 @@ const SelectStorageDatabaseErrorMessage = localize('notebookData.selectStorageDa
 const SelectExecutionDatabaseErrorMessage = localize('notebookData.selectExecutionDatabase', 'Select execution database');
 const JobWithSameNameExistsErrorMessage = localize('notebookData.jobExists', 'Job with similar name already exists');
 
-
 export class NotebookData implements IAgentDialogData {
 
 	private _ownerUri: string;

--- a/extensions/agent/src/data/notebookData.ts
+++ b/extensions/agent/src/data/notebookData.ts
@@ -25,6 +25,12 @@ const SelectStorageDatabaseErrorMessage = localize('notebookData.selectStorageDa
 const SelectExecutionDatabaseErrorMessage = localize('notebookData.selectExecutionDatabase', 'Select execution database');
 const JobWithSameNameExistsErrorMessage = localize('notebookData.jobExists', 'Job with similar name already exists');
 
+//added my own error message here.
+const NotebookNotSavedErrorMessage = localize('notebookData.notebookNotSaved', 'Notebook must be saved to local disk first');
+
+//Regex used to screenout file names.
+const InvalidRegex = /[\\\/\:\*\?\"\<\>\|]/g;
+
 export class NotebookData implements IAgentDialogData {
 
 	private _ownerUri: string;
@@ -187,7 +193,14 @@ export class NotebookData implements IAgentDialogData {
 				validationErrors.push(TemplatePathEmptyErrorMessage);
 			}
 			if (!(await exists(this.templatePath))) {
-				validationErrors.push(InvalidNotebookPathErrorMessage);
+				//check if filepath is actually a name of file instead of path to file.
+				if (!InvalidRegex.exec(this.templatePath)) {
+					//Place saving prompt here.
+					validationErrors.push(NotebookNotSavedErrorMessage);
+				}
+				else {
+					validationErrors.push(InvalidNotebookPathErrorMessage);
+				}
 			}
 			if (NotebookData.jobLists) {
 				for (let i = 0; i < NotebookData.jobLists.length; i++) {
@@ -200,6 +213,7 @@ export class NotebookData implements IAgentDialogData {
 		}
 		else {
 			if (this.templatePath && this.templatePath !== '' && !(await exists(this.templatePath))) {
+				console.log('We have an error at line 205.');
 				validationErrors.push(InvalidNotebookPathErrorMessage);
 			}
 		}

--- a/extensions/agent/src/data/notebookData.ts
+++ b/extensions/agent/src/data/notebookData.ts
@@ -213,7 +213,6 @@ export class NotebookData implements IAgentDialogData {
 		}
 		else {
 			if (this.templatePath && this.templatePath !== '' && !(await exists(this.templatePath))) {
-				console.log('We have an error at line 205.');
 				validationErrors.push(InvalidNotebookPathErrorMessage);
 			}
 		}

--- a/extensions/agent/src/mainController.ts
+++ b/extensions/agent/src/mainController.ts
@@ -23,7 +23,6 @@ import { NotebookDialog, NotebookDialogOptions } from './dialogs/notebookDialog'
 
 const localize = nls.loadMessageBundle();
 
-
 /**
  * The main controller class that initializes the extension
  */
@@ -43,9 +42,6 @@ export class MainController {
 	private proxyDialog: ProxyDialog;
 	private notebookDialog: NotebookDialog;
 	private notebookTemplateMap = new Map<string, TemplateMapObject>();
-
-
-
 	// PUBLIC METHODS //////////////////////////////////////////////////////
 	public constructor(context: vscode.ExtensionContext) {
 		this._context = context;
@@ -174,7 +170,7 @@ export class MainController {
 				let path: string;
 				if (!ownerUri) {
 					if (azdata.nb.activeNotebookEditor.document.isDirty || azdata.nb.activeNotebookEditor.document.isUntitled) {
-						vscode.window.showErrorMessage(localize('agent.unsavedFileSchedulingError', 'Save file before scheduling'), { modal: true });
+						vscode.window.showErrorMessage(localize('agent.unsavedFileSchedulingError', 'The notebook must be saved before being scheduled. Please save and then retry scheduling again.'), { modal: true });
 						return;
 					}
 					path = azdata.nb.activeNotebookEditor.document.fileName;

--- a/extensions/agent/src/mainController.ts
+++ b/extensions/agent/src/mainController.ts
@@ -23,6 +23,7 @@ import { NotebookDialog, NotebookDialogOptions } from './dialogs/notebookDialog'
 
 const localize = nls.loadMessageBundle();
 
+
 /**
  * The main controller class that initializes the extension
  */
@@ -42,6 +43,9 @@ export class MainController {
 	private proxyDialog: ProxyDialog;
 	private notebookDialog: NotebookDialog;
 	private notebookTemplateMap = new Map<string, TemplateMapObject>();
+
+
+
 	// PUBLIC METHODS //////////////////////////////////////////////////////
 	public constructor(context: vscode.ExtensionContext) {
 		this._context = context;
@@ -169,7 +173,7 @@ export class MainController {
 			if (!ownerUri || ownerUri instanceof vscode.Uri) {
 				let path: string;
 				if (!ownerUri) {
-					if (azdata.nb.activeNotebookEditor.document.isDirty) {
+					if (azdata.nb.activeNotebookEditor.document.isDirty || azdata.nb.activeNotebookEditor.document.isUntitled) {
 						vscode.window.showErrorMessage(localize('agent.unsavedFileSchedulingError', 'Save file before scheduling'), { modal: true });
 						return;
 					}

--- a/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Registry } from 'vs/platform/registry/common/platform';
-import { IExtensionPointUser, ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
+import { IExtensionPointUser, ExtensionsRegistry, ExtensionMessageCollector, ExtensionPoint } from 'vs/workbench/services/extensions/common/extensionsRegistry';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { localize } from 'vs/nls';
 import { Event, Emitter } from 'vs/base/common/event';
 import { deepClone } from 'vs/base/common/objects';
+import {URI} from 'vs/base/common/uri';
 
 import * as azdata from 'azdata';
 import * as resources from 'vs/base/common/resources';
@@ -165,6 +166,7 @@ ExtensionsRegistry.registerExtensionPoint<ConnectionProviderProperties | Connect
 
 	for (let extension of extensions) {
 		const { value } = extension;
+		//need to figure out when an extension is already registered so to avoid this process.
 		resolveIconPath(extension);
 		if (Array.isArray<ConnectionProviderProperties>(value)) {
 			for (let command of value) {
@@ -183,10 +185,13 @@ function resolveIconPath(extension: IExtensionPointUser<any>): void {
 		if (!iconPath || !baseDir) { return; }
 		if (Array.isArray(iconPath)) {
 			for (let e of iconPath) {
-				e.path = {
-					light: resources.joinPath(extension.description.extensionLocation, e.path.light),
-					dark: resources.joinPath(extension.description.extensionLocation, e.path.dark)
-				};
+				//check to make sure if dark and light parts of iconPath are not already registered.
+				if(!URI.isUri(e.path.light) || !URI.isUri(e.path.dark)){
+					e.path = {
+						light: resources.joinPath(extension.description.extensionLocation, e.path.light),
+						dark: resources.joinPath(extension.description.extensionLocation, e.path.dark)
+					};
+				}
 			}
 		} else if (typeof iconPath === 'string') {
 			iconPath = {
@@ -194,10 +199,13 @@ function resolveIconPath(extension: IExtensionPointUser<any>): void {
 				dark: resources.joinPath(extension.description.extensionLocation, iconPath)
 			};
 		} else {
-			iconPath = {
-				light: resources.joinPath(extension.description.extensionLocation, iconPath.light),
-				dark: resources.joinPath(extension.description.extensionLocation, iconPath.dark)
-			};
+			//check to make sure if dark and light parts of iconPath are not already registered.
+			if(!URI.isUri(iconPath.light) || !URI.isUri(iconPath.dark)){
+				iconPath = {
+					light: resources.joinPath(extension.description.extensionLocation, iconPath.light),
+					dark: resources.joinPath(extension.description.extensionLocation, iconPath.dark)
+				};
+			}
 		}
 	};
 

--- a/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
@@ -9,7 +9,7 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { localize } from 'vs/nls';
 import { Event, Emitter } from 'vs/base/common/event';
 import { deepClone } from 'vs/base/common/objects';
-import {URI} from 'vs/base/common/uri';
+import { URI } from 'vs/base/common/uri';
 
 import * as azdata from 'azdata';
 import * as resources from 'vs/base/common/resources';
@@ -166,7 +166,7 @@ ExtensionsRegistry.registerExtensionPoint<ConnectionProviderProperties | Connect
 
 	for (let extension of extensions) {
 		const { value } = extension;
-		//need to figure out when an extension is already registered so to avoid this process.
+		//need to figure out when an extension is already registered so to avoid this process altogether.
 		resolveIconPath(extension);
 		if (Array.isArray<ConnectionProviderProperties>(value)) {
 			for (let command of value) {
@@ -186,7 +186,7 @@ function resolveIconPath(extension: IExtensionPointUser<any>): void {
 		if (Array.isArray(iconPath)) {
 			for (let e of iconPath) {
 				//check to make sure if dark and light parts of iconPath are not already registered.
-				if(!URI.isUri(e.path.light) || !URI.isUri(e.path.dark)){
+				if (!URI.isUri(e.path.light) || !URI.isUri(e.path.dark)) {
 					e.path = {
 						light: resources.joinPath(extension.description.extensionLocation, e.path.light),
 						dark: resources.joinPath(extension.description.extensionLocation, e.path.dark)
@@ -200,7 +200,7 @@ function resolveIconPath(extension: IExtensionPointUser<any>): void {
 			};
 		} else {
 			//check to make sure if dark and light parts of iconPath are not already registered.
-			if(!URI.isUri(iconPath.light) || !URI.isUri(iconPath.dark)){
+			if (!URI.isUri(iconPath.light) || !URI.isUri(iconPath.dark)) {
 				iconPath = {
 					light: resources.joinPath(extension.description.extensionLocation, iconPath.light),
 					dark: resources.joinPath(extension.description.extensionLocation, iconPath.dark)


### PR DESCRIPTION
Currently the only way to identify when an extension has its icon path already been resolved is to check if its light and dark sections are URIs or not. There is no clear list or registry that indicate when an extension has been processed or not. Ideally the best solution would be to somehow prevent running the resolveIconPath or skip processing the extension if its already registered. This fix will prevent toAbsolutePath from processing the light and dark parts of the path if they are already URIs (I.E. already processed) as shown in #7471 