### PR TITLE
Handling for parsing of iconpaths

### DIFF
--- a/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Registry } from 'vs/platform/registry/common/platform';
-import { IExtensionPointUser, ExtensionsRegistry} from 'vs/workbench/services/extensions/common/extensionsRegistry';
+import { IExtensionPointUser, ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { localize } from 'vs/nls';

--- a/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
@@ -158,9 +158,6 @@ const ConnectionProviderContrib: IJSONSchema = {
 	required: ['providerId']
 };
 
-//Map to check if an extension point user has already been used or not
-let resolver = new Set<string>();
-
 ExtensionsRegistry.registerExtensionPoint<ConnectionProviderProperties | ConnectionProviderProperties[]>({ extensionPoint: 'connectionProvider', jsonSchema: ConnectionProviderContrib }).setHandler(extensions => {
 
 	function handleCommand(contrib: ConnectionProviderProperties, extension: IExtensionPointUser<any>) {
@@ -169,9 +166,7 @@ ExtensionsRegistry.registerExtensionPoint<ConnectionProviderProperties | Connect
 
 	for (let extension of extensions) {
 		const { value } = extension;
-		if (!resolver.has(extension.description.identifier.value)) {
-			resolveIconPath(extension);
-		}
+		resolveIconPath(extension);
 		if (Array.isArray<ConnectionProviderProperties>(value)) {
 			for (let command of value) {
 				handleCommand(command, extension);
@@ -190,8 +185,8 @@ function resolveIconPath(extension: IExtensionPointUser<any>): void {
 		if (Array.isArray(iconPath)) {
 			for (let e of iconPath) {
 				e.path = {
-					light: resources.joinPath(extension.description.extensionLocation, e.path.light),
-					dark: resources.joinPath(extension.description.extensionLocation, e.path.dark)
+					light: resources.joinPath(extension.description.extensionLocation, e.path.light.toString()),
+					dark: resources.joinPath(extension.description.extensionLocation, e.path.dark.toString())
 				};
 			}
 		} else if (typeof iconPath === 'string') {
@@ -201,8 +196,8 @@ function resolveIconPath(extension: IExtensionPointUser<any>): void {
 			};
 		} else {
 			iconPath = {
-				light: resources.joinPath(extension.description.extensionLocation, iconPath.light),
-				dark: resources.joinPath(extension.description.extensionLocation, iconPath.dark)
+				light: resources.joinPath(extension.description.extensionLocation, iconPath.light.toString()),
+				dark: resources.joinPath(extension.description.extensionLocation, iconPath.dark.toString())
 			};
 		}
 	};
@@ -216,5 +211,5 @@ function resolveIconPath(extension: IExtensionPointUser<any>): void {
 	} else {
 		toAbsolutePath(properties['iconPath']);
 	}
-	resolver.add(extension.description.identifier.value);
+//	resolver.add(extension.description.identifier.value);
 }

--- a/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
@@ -166,8 +166,9 @@ ExtensionsRegistry.registerExtensionPoint<ConnectionProviderProperties | Connect
 
 	for (let extension of extensions) {
 		const { value } = extension;
-		//need to figure out when an extension is already registered so to avoid this process altogether.
-		resolveIconPath(extension);
+		if (!ExtensionsRegistry.checkResolvedUsers(extension)) {
+			resolveIconPath(extension);
+		}
 		if (Array.isArray<ConnectionProviderProperties>(value)) {
 			for (let command of value) {
 				handleCommand(command, extension);
@@ -179,19 +180,17 @@ ExtensionsRegistry.registerExtensionPoint<ConnectionProviderProperties | Connect
 });
 
 function resolveIconPath(extension: IExtensionPointUser<any>): void {
+
 	if (!extension || !extension.value) { return undefined; }
 
 	let toAbsolutePath = (iconPath: any) => {
 		if (!iconPath || !baseDir) { return; }
 		if (Array.isArray(iconPath)) {
 			for (let e of iconPath) {
-				//check to make sure if dark and light parts of iconPath are not already registered.
-				if (!URI.isUri(e.path.light) || !URI.isUri(e.path.dark)) {
-					e.path = {
-						light: resources.joinPath(extension.description.extensionLocation, e.path.light),
-						dark: resources.joinPath(extension.description.extensionLocation, e.path.dark)
-					};
-				}
+				e.path = {
+					light: resources.joinPath(extension.description.extensionLocation, e.path.light),
+					dark: resources.joinPath(extension.description.extensionLocation, e.path.dark)
+				};
 			}
 		} else if (typeof iconPath === 'string') {
 			iconPath = {
@@ -199,13 +198,10 @@ function resolveIconPath(extension: IExtensionPointUser<any>): void {
 				dark: resources.joinPath(extension.description.extensionLocation, iconPath)
 			};
 		} else {
-			//check to make sure if dark and light parts of iconPath are not already registered.
-			if (!URI.isUri(iconPath.light) || !URI.isUri(iconPath.dark)) {
-				iconPath = {
-					light: resources.joinPath(extension.description.extensionLocation, iconPath.light),
-					dark: resources.joinPath(extension.description.extensionLocation, iconPath.dark)
-				};
-			}
+			iconPath = {
+				light: resources.joinPath(extension.description.extensionLocation, iconPath.light),
+				dark: resources.joinPath(extension.description.extensionLocation, iconPath.dark)
+			};
 		}
 	};
 
@@ -218,4 +214,5 @@ function resolveIconPath(extension: IExtensionPointUser<any>): void {
 	} else {
 		toAbsolutePath(properties['iconPath']);
 	}
+	ExtensionsRegistry.addToResolvedUsers(extension);
 }

--- a/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
@@ -211,5 +211,5 @@ function resolveIconPath(extension: IExtensionPointUser<any>): void {
 	} else {
 		toAbsolutePath(properties['iconPath']);
 	}
-//	resolver.add(extension.description.identifier.value);
+	//	resolver.add(extension.description.identifier.value);
 }

--- a/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Registry } from 'vs/platform/registry/common/platform';
-import { IExtensionPointUser, ExtensionsRegistry, ExtensionMessageCollector, ExtensionPoint } from 'vs/workbench/services/extensions/common/extensionsRegistry';
+import { IExtensionPointUser, ExtensionsRegistry} from 'vs/workbench/services/extensions/common/extensionsRegistry';
+import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { localize } from 'vs/nls';
 import { Event, Emitter } from 'vs/base/common/event';
@@ -12,7 +13,7 @@ import { deepClone } from 'vs/base/common/objects';
 
 import * as azdata from 'azdata';
 import * as resources from 'vs/base/common/resources';
-import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
+
 
 export interface ConnectionProviderProperties {
 	providerId: string;
@@ -202,7 +203,6 @@ ExtensionsRegistry.registerExtensionPoint<ConnectionProviderProperties | Connect
 });
 
 function resolveIconPath(extension: IExtensionPointUser<any>): void {
-
 	if (!extension || !extension.value) { return undefined; }
 
 	let toAbsolutePath = (iconPath: any) => {

--- a/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/parts/connection/common/connectionProviderExtension.ts
@@ -211,5 +211,4 @@ function resolveIconPath(extension: IExtensionPointUser<any>): void {
 	} else {
 		toAbsolutePath(properties['iconPath']);
 	}
-	//	resolver.add(extension.description.identifier.value);
 }

--- a/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
@@ -387,6 +387,7 @@ export interface IExtensionPointDescriptor {
 export class ExtensionsRegistryImpl {
 
 	private readonly _extensionPoints = new Map<string, ExtensionPoint<any>>();
+	private _resolvedUsers = new Map<IExtensionDescription, boolean>();
 
 	public registerExtensionPoint<T>(desc: IExtensionPointDescriptor): IExtensionPoint<T> {
 		if (this._extensionPoints.has(desc.extensionPoint)) {
@@ -399,6 +400,22 @@ export class ExtensionsRegistryImpl {
 		schemaRegistry.registerSchema(schemaId, schema);
 
 		return result;
+	}
+
+	public removeFromResolvedUsers(oldUser: IExtensionPointUser<any>) {
+		this._resolvedUsers.delete(oldUser.description);
+	}
+
+	public clearResolvedUsers() {
+		this._resolvedUsers.clear();
+	}
+
+	public addToResolvedUsers(newUser: IExtensionPointUser<any>) {
+		this._resolvedUsers.set(newUser.description, true);
+	}
+
+	public checkResolvedUsers(thisUser: IExtensionPointUser<any>): boolean {
+		return this._resolvedUsers.has(thisUser.description);
 	}
 
 	public getExtensionPoints(): ExtensionPoint<any>[] {

--- a/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
@@ -402,22 +402,6 @@ export class ExtensionsRegistryImpl {
 		return result;
 	}
 
-	public removeFromResolvedUsers(oldUser: IExtensionPointUser<any>) {
-		this._resolvedUsers.delete(oldUser.description);
-	}
-
-	public clearResolvedUsers() {
-		this._resolvedUsers.clear();
-	}
-
-	public addToResolvedUsers(newUser: IExtensionPointUser<any>) {
-		this._resolvedUsers.set(newUser.description, true);
-	}
-
-	public checkResolvedUsers(thisUser: IExtensionPointUser<any>): boolean {
-		return this._resolvedUsers.has(thisUser.description);
-	}
-
 	public getExtensionPoints(): ExtensionPoint<any>[] {
 		return values(this._extensionPoints);
 	}

--- a/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
@@ -387,7 +387,6 @@ export interface IExtensionPointDescriptor {
 export class ExtensionsRegistryImpl {
 
 	private readonly _extensionPoints = new Map<string, ExtensionPoint<any>>();
-	private _resolvedUsers = new Map<IExtensionDescription, boolean>();
 
 	public registerExtensionPoint<T>(desc: IExtensionPointDescriptor): IExtensionPoint<T> {
 		if (this._extensionPoints.has(desc.extensionPoint)) {


### PR DESCRIPTION
Currently the only way to check to see if an extension already has its icon resolved is to see if its light and dark components are URIs or not (It will not parse it if its already has been parsed). There is currently no visible registry or list that can be used to check if an extension has its path resolved or not. Ideally the best solution for this would be to prevent executing resolveIconPath or processing the extension entirely. This is to handle an issue shown in #7471