### PR TITLE
Move Notebook tests back to stable

### DIFF
--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -30,12 +30,12 @@ if (context.RunTest) {
 		});
 
 		// This test needs to be re-enabled once the SqlClient driver has been updated
-		test('Sql NB test @UNSTABLE@', async function () {
+		test('Sql NB test', async function () {
 			await (new NotebookTester()).sqlNbTest(this.test.title);
 		});
 
 		// This test needs to be re-enabled once the SqlClient driver has been updated
-		test('Sql NB multiple cells test @UNSTABLE@', async function () {
+		test('Sql NB multiple cells test', async function () {
 			await (new NotebookTester()).sqlNbMultipleCellsTest(this.test.title);
 		});
 

--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -29,12 +29,10 @@ if (context.RunTest) {
 			await (new NotebookTester()).cleanup(this.currentTest.title);
 		});
 
-		// This test needs to be re-enabled once the SqlClient driver has been updated
 		test('Sql NB test', async function () {
 			await (new NotebookTester()).sqlNbTest(this.test.title);
 		});
 
-		// This test needs to be re-enabled once the SqlClient driver has been updated
 		test('Sql NB multiple cells test', async function () {
 			await (new NotebookTester()).sqlNbMultipleCellsTest(this.test.title);
 		});


### PR DESCRIPTION
Fixes #7347

SqlClient fix is in so these should be stable again (they've been passing successfully for a while now)

![image](https://user-images.githubusercontent.com/28519865/66957774-b69c7180-f01b-11e9-86e1-e926da52c7c9.png)

![image](https://user-images.githubusercontent.com/28519865/66957789-bf8d4300-f01b-11e9-9102-2ed54bcef2f9.png)
