### PR TITLE
Revert "Move Notebook tests back to stable"

### DIFF
--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -30,7 +30,7 @@ if (context.RunTest) {
 		});
 
 		// This test needs to be re-enabled once the SqlClient driver has been updated
-		test('Sql NB test @UNSTABLE@', async function () {
+		test('Sql NB test', async function () {
 			await (new NotebookTester()).sqlNbTest(this.test.title);
 		});
 

--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -29,7 +29,6 @@ if (context.RunTest) {
 			await (new NotebookTester()).cleanup(this.currentTest.title);
 		});
 
-		// This test needs to be re-enabled once the SqlClient driver has been updated
 		test('Sql NB test', async function () {
 			await (new NotebookTester()).sqlNbTest(this.test.title);
 		});

--- a/extensions/integration-tests/src/notebook.test.ts
+++ b/extensions/integration-tests/src/notebook.test.ts
@@ -29,11 +29,13 @@ if (context.RunTest) {
 			await (new NotebookTester()).cleanup(this.currentTest.title);
 		});
 
-		test('Sql NB test', async function () {
+		// This test needs to be re-enabled once the SqlClient driver has been updated
+		test('Sql NB test @UNSTABLE@', async function () {
 			await (new NotebookTester()).sqlNbTest(this.test.title);
 		});
 
-		test('Sql NB multiple cells test', async function () {
+		// This test needs to be re-enabled once the SqlClient driver has been updated
+		test('Sql NB multiple cells test @UNSTABLE@', async function () {
 			await (new NotebookTester()).sqlNbMultipleCellsTest(this.test.title);
 		});
 


### PR DESCRIPTION
These tests have failed on a few PR builds - we might have to mark them as unstable?

https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=42195&view=results