### PR TITLE
Fix TelemetryOptOut error for tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,7 @@
 			"request": "attach",
 			"name": "Attach to Extension Host",
 			"port": 5870,
+			"timeout": 30000,
 			"restart": true,
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
@@ -186,6 +187,22 @@
 			"webRoot": "${workspaceFolder}",
 			"timeout": 45000
 		},
+		{
+			"type": "chrome",
+			"request": "launch",
+			"name": "Run Extension Integration Tests",
+			"windows": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/sql-test-integration.bat"
+			},
+			"osx": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/sql-test-integration.sh"
+			},
+			"linux": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/sql-test-integration.sh"
+			},
+			"webRoot": "${workspaceFolder}",
+			"timeout": 45000
+		},
 	],
 	"compounds": [
 		{
@@ -200,6 +217,13 @@
 			"configurations": [
 				"Attach to Extension Host",
 				"Run Extension Unit Tests"
+			]
+		},
+		{
+			"name": "Debug Extension Integration Tests",
+			"configurations": [
+				"Attach to Extension Host",
+				"Run Extension Integration Tests"
 			]
 		},
 		{

--- a/src/vs/workbench/contrib/welcome/gettingStarted/electron-browser/telemetryOptOut.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/electron-browser/telemetryOptOut.ts
@@ -33,6 +33,6 @@ export class NativeTelemetryOptOut extends AbstractTelemetryOptOut {
 	}
 
 	protected getWindowCount(): Promise<number> {
-		return this.electronService.getWindowCount();
+		return this.electronService ? this.electronService.getWindowCount() : Promise.resolve(0); // {{SQL CARBON EDIT}} Tests run without UI context so electronService is undefined in that case
 	}
 }


### PR DESCRIPTION
Also added debug targets for running/debugging extension integration tests and increased timeout for attach since it can take a while to start up the process