### PR TITLE
Don't allow tabbing into table

### DIFF
--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -30,7 +30,7 @@ import { slickGridDataItemColumnValueWithNoData, textFormatter } from 'sql/base/
 @Component({
 	selector: 'modelview-table',
 	template: `
-		<div #table style="height:100%;" [style.font-size]="fontSize" [style.width]="width"></div>
+		<div #table style="height:100%;" [style.font-size]="fontSize" [style.width]="width" tabindex="-1"></div>
 	`
 })
 export default class TableComponent extends ComponentBase implements IComponent, OnDestroy, AfterViewInit {


### PR DESCRIPTION
Fixes #6729. For accessibility, tabbing to a table shouldn't be allowed if the table cells aren't actionable. Previously, if arrow keys were used to navigate into the table, pressing tab for the first time would go to the next cell, then the following tab would exit the table. This fixes that so the first tab will leave the table.

![tableNoTab](https://user-images.githubusercontent.com/31145923/67043612-5111b900-f0df-11e9-85c8-fb04d945baef.gif)
