### PR TITLE
BDC Dashboard connection retry

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
@@ -10,7 +10,6 @@ import { BdcRouterApi, Authentication, EndpointModel, BdcStatusModel, DefaultApi
 import { TokenRouterApi } from './clusterApiGenerated2';
 import { AuthType } from '../constants';
 import * as nls from 'vscode-nls';
-import { AddControllerDialog, AddControllerDialogModel, getAuthCategory } from '../dialog/addControllerDialog';
 import { ConnectControllerDialog, ConnectControllerModel } from '../dialog/connectControllerDialog';
 
 const localize = nls.loadMessageBundle();

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
@@ -47,12 +47,12 @@ export class BdcDashboardModel {
 
 	public async refresh(): Promise<void> {
 		await Promise.all([
-			this._clusterController.getBdcStatus().then(response => {
+			this._clusterController.getBdcStatus(true).then(response => {
 				this._bdcStatus = response.bdcStatus;
 				this._bdcStatusLastUpdated = new Date();
 				this._onDidUpdateBdcStatus.fire(this.bdcStatus);
 			}),
-			this._clusterController.getEndPoints().then(response => {
+			this._clusterController.getEndPoints(true).then(response => {
 				this._endpoints = response.endPoints || [];
 				fixEndpoints(this._endpoints);
 				this._endpointsLastUpdated = new Date();

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/connectControllerDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/connectControllerDialog.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from 'azdata';
+import * as nls from 'vscode-nls';
+import { HdfsDialogBase, HdfsDialogModelBase, HdfsDialogProperties } from './hdfsDialogBase';
+import { ClusterController } from '../controller/clusterControllerApi';
+
+const localize = nls.loadMessageBundle();
+
+export class ConnectControllerDialog extends HdfsDialogBase<HdfsDialogProperties, ClusterController> {
+	constructor(model: ConnectControllerModel) {
+		super(localize('connectController.dialog.title', "Connect to Controller"), model);
+	}
+
+	protected getMainSection(): azdata.FormComponentGroup {
+		return undefined;
+	}
+
+	protected async validate(): Promise<{ validated: boolean, value?: ClusterController }> {
+		try {
+			const controller = await this.model.onComplete({
+				url: this.urlInputBox && this.urlInputBox.value,
+				auth: this.authValue,
+				username: this.usernameInputBox && this.usernameInputBox.value,
+				password: this.passwordInputBox && this.passwordInputBox.value
+			});
+			return { validated: true, value: controller };
+		} catch (error) {
+			await this.reportError(error);
+			return { validated: false, value: undefined };
+		}
+	}
+}
+
+export class ConnectControllerModel extends HdfsDialogModelBase<HdfsDialogProperties, ClusterController> {
+
+	constructor(props: HdfsDialogProperties) {
+		super(props);
+	}
+
+	protected async handleCompleted(): Promise<ClusterController> {
+		this.throwIfMissingUsernamePassword();
+
+		// We pre-fetch the endpoints here to verify that the information entered is correct (the user is able to connect)
+		return await this.createAndVerifyControllerConnection();
+	}
+}

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/connectControllerDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/connectControllerDialog.ts
@@ -15,8 +15,8 @@ export class ConnectControllerDialog extends HdfsDialogBase<HdfsDialogProperties
 		super(localize('connectController.dialog.title', "Connect to Controller"), model);
 	}
 
-	protected getMainSection(): azdata.FormComponentGroup {
-		return undefined;
+	protected getMainSectionComponents(): (azdata.FormComponentGroup | azdata.FormComponent)[] {
+		return [];
 	}
 
 	protected async validate(): Promise<{ validated: boolean, value?: ClusterController }> {

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/hdfsDialogBase.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/hdfsDialogBase.ts
@@ -1,0 +1,239 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from 'azdata';
+import * as nls from 'vscode-nls';
+import { ClusterController, ControllerError, IEndPointsResponse } from '../controller/clusterControllerApi';
+import { AuthType } from '../constants';
+import { Deferred } from '../../common/promise';
+
+const localize = nls.loadMessageBundle();
+
+const basicAuthDisplay = localize('basicAuthName', "Basic");
+const integratedAuthDisplay = localize('integratedAuthName', "Windows Authentication");
+
+function getAuthCategory(name: AuthType): azdata.CategoryValue {
+	if (name === 'basic') {
+		return { name: name, displayName: basicAuthDisplay };
+	}
+	return { name: name, displayName: integratedAuthDisplay };
+}
+
+export interface HdfsDialogProperties {
+	url?: string;
+	auth?: AuthType;
+	username?: string;
+	password?: string;
+}
+
+export abstract class HdfsDialogModelBase<T extends HdfsDialogProperties, R> {
+	protected _canceled = false;
+	private _authTypes: azdata.CategoryValue[];
+	constructor(
+		public props: T
+	) {
+		if (!props.auth) {
+			this.props.auth = 'basic';
+		}
+	}
+
+	public get authCategories(): azdata.CategoryValue[] {
+		if (!this._authTypes) {
+			this._authTypes = [getAuthCategory('basic'), getAuthCategory('integrated')];
+		}
+		return this._authTypes;
+	}
+
+	public get authCategory(): azdata.CategoryValue {
+		return getAuthCategory(this.props.auth);
+	}
+
+	public async onComplete(props: T): Promise<R | undefined> {
+		try {
+			this.props = props;
+			return await this.handleCompleted();
+		} catch (error) {
+			// Ignore the error if we cancelled the request since we can't stop the actual request from completing
+			if (!this._canceled) {
+				throw error;
+			}
+			return undefined;
+		}
+	}
+
+	protected abstract handleCompleted(): Promise<R>;
+
+	public async onError(error: ControllerError): Promise<void> {
+		// implement
+	}
+
+	public async onCancel(): Promise<void> {
+		this._canceled = true;
+	}
+
+	protected createController(): ClusterController {
+		return new ClusterController(this.props.url, this.props.auth, this.props.username, this.props.password, true);
+	}
+
+	protected async createAndVerifyControllerConnection(): Promise<ClusterController> {
+		// We pre-fetch the endpoints here to verify that the information entered is correct (the user is able to connect)
+		let controller = this.createController();
+		let response: IEndPointsResponse;
+		try {
+			response = await controller.getEndPoints();
+			if (!response || !response.endPoints) {
+				throw new Error(localize('mount.hdfs.loginerror1', "Login to controller failed"));
+			}
+		} catch (err) {
+			throw new Error(localize('mount.hdfs.loginerror2', "Login to controller failed: {0}", err.message));
+		}
+		return controller;
+	}
+
+	protected throwIfMissingUsernamePassword(): void {
+		if (this.props.auth === 'basic') {
+			// Verify username and password as we can't make them required in the UI
+			if (!this.props.username) {
+				throw new Error(localize('err.controller.username.required', "Username is required"));
+			} else if (!this.props.password) {
+				throw new Error(localize('err.controller.password.required', "Password is required"));
+			}
+		}
+	}
+}
+
+export abstract class HdfsDialogBase<T extends HdfsDialogProperties, R> {
+
+	protected dialog: azdata.window.Dialog;
+	protected uiModelBuilder!: azdata.ModelBuilder;
+
+	protected urlInputBox!: azdata.InputBoxComponent;
+	protected authDropdown!: azdata.DropDownComponent;
+	protected usernameInputBox!: azdata.InputBoxComponent;
+	protected passwordInputBox!: azdata.InputBoxComponent;
+
+	private returnPromise: Deferred<R>;
+
+	constructor(private title: string, protected model: HdfsDialogModelBase<T, R>) {
+	}
+
+	public async showDialog(): Promise<R> {
+		this.returnPromise = new Deferred<R>();
+		this.createDialog();
+		azdata.window.openDialog(this.dialog);
+		return this.returnPromise.promise;
+	}
+
+	private createDialog(): void {
+		this.dialog = azdata.window.createModelViewDialog(this.title);
+		this.dialog.registerContent(async view => {
+			this.uiModelBuilder = view.modelBuilder;
+
+			this.urlInputBox = this.uiModelBuilder.inputBox()
+				.withProperties<azdata.InputBoxProperties>({
+					placeHolder: localize('textUrlLower', "url"),
+					value: this.model.props.url,
+					enabled: false
+				}).component();
+
+			this.authDropdown = this.uiModelBuilder.dropDown().withProperties({
+				values: this.model.authCategories,
+				value: this.model.authCategory,
+				editable: false,
+			}).component();
+			this.authDropdown.onValueChanged(e => this.onAuthChanged());
+			this.usernameInputBox = this.uiModelBuilder.inputBox()
+				.withProperties<azdata.InputBoxProperties>({
+					placeHolder: localize('textUsernameLower', "username"),
+					value: this.model.props.username
+				}).component();
+			this.passwordInputBox = this.uiModelBuilder.inputBox()
+				.withProperties<azdata.InputBoxProperties>({
+					placeHolder: localize('textPasswordLower', "password"),
+					inputType: 'password',
+					value: this.model.props.password
+				})
+				.component();
+
+			let connectionSection: azdata.FormComponentGroup = {
+				components: [
+					{
+						component: this.urlInputBox,
+						title: localize('textUrlCapital', "URL"),
+						required: true
+					}, {
+						component: this.authDropdown,
+						title: localize('textAuthCapital', "Authentication type"),
+						required: true
+					}, {
+						component: this.usernameInputBox,
+						title: localize('textUsernameCapital', "Username"),
+						required: false
+					}, {
+						component: this.passwordInputBox,
+						title: localize('textPasswordCapital', "Password"),
+						required: false
+					}
+				],
+				title: localize('hdsf.dialog.connection.section', "Cluster Connection")
+			};
+			let formModel = this.uiModelBuilder.formContainer()
+				.withFormItems([
+					this.getMainSection(),
+					connectionSection
+				].filter(c => c)).withLayout({ width: '100%' }).component();
+
+			await view.initializeModel(formModel);
+			this.onAuthChanged();
+		});
+
+		this.dialog.registerCloseValidator(async () => {
+			const result = await this.validate();
+			if (result.validated) {
+				this.returnPromise.resolve(result.value);
+				this.returnPromise = undefined;
+			}
+			return result.validated;
+		});
+		this.dialog.cancelButton.onClick(async () => await this.cancel());
+		this.dialog.okButton.label = localize('hdfs.dialog.ok', "OK");
+		this.dialog.cancelButton.label = localize('hdfs.dialog.cancel', "Cancel");
+	}
+
+	protected abstract getMainSection(): azdata.FormComponentGroup;
+
+	protected get authValue(): AuthType {
+		return (<azdata.CategoryValue>this.authDropdown.value).name as AuthType;
+	}
+
+	private onAuthChanged(): void {
+		let isBasic = this.authValue === 'basic';
+		this.usernameInputBox.enabled = isBasic;
+		this.passwordInputBox.enabled = isBasic;
+		if (!isBasic) {
+			this.usernameInputBox.value = '';
+			this.passwordInputBox.value = '';
+		}
+	}
+
+	protected abstract validate(): Promise<{ validated: boolean, value?: R }>;
+
+	private async cancel(): Promise<void> {
+		if (this.model && this.model.onCancel) {
+			await this.model.onCancel();
+		}
+		this.returnPromise.reject(new Error('Dialog cancelled'));
+	}
+
+	protected async reportError(error: any): Promise<void> {
+		this.dialog.message = {
+			text: (typeof error === 'string') ? error : error.message,
+			level: azdata.window.MessageLevel.Error
+		};
+		if (this.model && this.model.onError) {
+			await this.model.onError(error as ControllerError);
+		}
+	}
+}

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/hdfsDialogBase.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/hdfsDialogBase.ts
@@ -180,10 +180,10 @@ export abstract class HdfsDialogBase<T extends HdfsDialogProperties, R> {
 				title: localize('hdsf.dialog.connection.section', "Cluster Connection")
 			};
 			let formModel = this.uiModelBuilder.formContainer()
-				.withFormItems([
-					this.getMainSection(),
-					connectionSection
-				].filter(c => c)).withLayout({ width: '100%' }).component();
+				.withFormItems(
+					this.getMainSectionComponents().concat(
+						connectionSection)
+				).withLayout({ width: '100%' }).component();
 
 			await view.initializeModel(formModel);
 			this.onAuthChanged();
@@ -202,7 +202,7 @@ export abstract class HdfsDialogBase<T extends HdfsDialogProperties, R> {
 		this.dialog.cancelButton.label = localize('hdfs.dialog.cancel', "Cancel");
 	}
 
-	protected abstract getMainSection(): azdata.FormComponentGroup;
+	protected abstract getMainSectionComponents(): (azdata.FormComponentGroup | azdata.FormComponent)[];
 
 	protected get authValue(): AuthType {
 		return (<azdata.CategoryValue>this.authDropdown.value).name as AuthType;

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/mountHdfsDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/mountHdfsDialog.ts
@@ -152,7 +152,7 @@ export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties, void> {
 		super(localize('mount.dialog.title', "Mount HDFS Folder"), model);
 	}
 
-	protected getMainSection(): azdata.FormComponentGroup {
+	protected getMainSectionComponents(): (azdata.FormComponentGroup | azdata.FormComponent)[] {
 		const newMountName = '/mymount';
 		let pathVal = this.model.props.hdfsPath;
 		pathVal = (!pathVal || pathVal === '/') ? newMountName : (pathVal + newMountName);
@@ -172,24 +172,25 @@ export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties, void> {
 			})
 			.component();
 
-		return {
-			components: [
-				{
-					component: this.pathInputBox,
-					title: hdfsPathTitle,
-					required: true
-				}, {
-					component: this.remoteUriInputBox,
-					title: localize('mount.remoteUri', "Remote URI"),
-					required: true
-				}, {
-					component: this.credentialsInputBox,
-					title: localize('mount.credentials', "Credentials"),
-					required: false
-				}
-			],
-			title: mountConfigutationTitle
-		};
+		return [
+			{
+				components: [
+					{
+						component: this.pathInputBox,
+						title: hdfsPathTitle,
+						required: true
+					}, {
+						component: this.remoteUriInputBox,
+						title: localize('mount.remoteUri', "Remote URI"),
+						required: true
+					}, {
+						component: this.credentialsInputBox,
+						title: localize('mount.credentials', "Credentials"),
+						required: false
+					}
+				],
+				title: mountConfigutationTitle
+			}];
 	}
 
 	protected async validate(): Promise<{ validated: boolean }> {
@@ -218,21 +219,22 @@ export class RefreshMountDialog extends HdfsDialogBase<MountHdfsProperties, void
 		super(localize('refreshmount.dialog.title', "Refresh Mount"), model);
 	}
 
-	protected getMainSection(): azdata.FormComponentGroup {
+	protected getMainSectionComponents(): (azdata.FormComponentGroup | azdata.FormComponent)[] {
 		this.pathInputBox = this.uiModelBuilder.inputBox()
 			.withProperties<azdata.InputBoxProperties>({
 				value: this.model.props.hdfsPath
 			}).component();
-		return {
-			components: [
-				{
-					component: this.pathInputBox,
-					title: hdfsPathTitle,
-					required: true
-				}
-			],
-			title: mountConfigutationTitle
-		};
+		return [
+			{
+				components: [
+					{
+						component: this.pathInputBox,
+						title: hdfsPathTitle,
+						required: true
+					}
+				],
+				title: mountConfigutationTitle
+			}];
 	}
 
 	protected async validate(): Promise<{ validated: boolean }> {
@@ -298,21 +300,22 @@ export class DeleteMountDialog extends HdfsDialogBase<MountHdfsProperties, void>
 		super(localize('deleteMount.dialog.title', "Delete Mount"), model);
 	}
 
-	protected getMainSection(): azdata.FormComponentGroup {
+	protected getMainSectionComponents(): (azdata.FormComponentGroup | azdata.FormComponent)[] {
 		this.pathInputBox = this.uiModelBuilder.inputBox()
 			.withProperties<azdata.InputBoxProperties>({
 				value: this.model.props.hdfsPath
 			}).component();
-		return {
-			components: [
-				{
-					component: this.pathInputBox,
-					title: hdfsPathTitle,
-					required: true
-				}
-			],
-			title: mountConfigutationTitle
-		};
+		return [
+			{
+				components: [
+					{
+						component: this.pathInputBox,
+						title: hdfsPathTitle,
+						required: true
+					}
+				],
+				title: mountConfigutationTitle
+			}];
 	}
 
 	protected async validate(): Promise<{ validated: boolean }> {

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/mountHdfsDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/mountHdfsDialog.ts
@@ -6,22 +6,13 @@
 import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
-import { ClusterController, ControllerError, MountInfo, MountState, IEndPointsResponse } from '../controller/clusterControllerApi';
-import { AuthType } from '../constants';
+import { ClusterController, MountInfo, MountState } from '../controller/clusterControllerApi';
+import { HdfsDialogBase, HdfsDialogModelBase, HdfsDialogProperties } from './hdfsDialogBase';
 
 const localize = nls.loadMessageBundle();
 
-const basicAuthDisplay = localize('basicAuthName', "Basic");
-const integratedAuthDisplay = localize('integratedAuthName', "Windows Authentication");
 const mountConfigutationTitle = localize('mount.main.section', "Mount Configuration");
 const hdfsPathTitle = localize('mount.hdfsPath', "HDFS Path");
-
-function getAuthCategory(name: AuthType): azdata.CategoryValue {
-	if (name === 'basic') {
-		return { name: name, displayName: basicAuthDisplay };
-	}
-	return { name: name, displayName: integratedAuthDisplay };
-}
 
 /**
  * Converts a comma-delimited set of key value pair credentials to a JSON object.
@@ -65,96 +56,13 @@ function convertCredsToJson(creds: string): { credentials: {} } {
 	return credObj;
 }
 
-export interface DialogProperties {
-	url?: string;
-	auth?: AuthType;
-	username?: string;
-	password?: string;
-}
-
-export interface MountHdfsProperties extends DialogProperties {
+export interface MountHdfsProperties extends HdfsDialogProperties {
 	hdfsPath?: string;
 	remoteUri?: string;
 	credentials?: string;
 }
 
-abstract class HdfsDialogModelBase<T extends DialogProperties> {
-	protected _canceled = false;
-	private _authTypes: azdata.CategoryValue[];
-	constructor(
-		public props: T
-	) {
-		if (!props.auth) {
-			this.props.auth = 'basic';
-		}
-	}
-
-	public get authCategories(): azdata.CategoryValue[] {
-		if (!this._authTypes) {
-			this._authTypes = [getAuthCategory('basic'), getAuthCategory('integrated')];
-		}
-		return this._authTypes;
-	}
-
-	public get authCategory(): azdata.CategoryValue {
-		return getAuthCategory(this.props.auth);
-	}
-
-	public async onComplete(props: T): Promise<void> {
-		try {
-			this.props = props;
-			await this.handleCompleted();
-
-		} catch (error) {
-			// Ignore the error if we cancelled the request since we can't stop the actual request from completing
-			if (!this._canceled) {
-				throw error;
-			}
-		}
-	}
-
-	protected abstract handleCompleted(): Promise<void>;
-
-	public async onError(error: ControllerError): Promise<void> {
-		// implement
-	}
-
-	public async onCancel(): Promise<void> {
-		this._canceled = true;
-	}
-
-	protected createController(): ClusterController {
-		return new ClusterController(this.props.url, this.props.auth, this.props.username, this.props.password, true);
-	}
-
-	protected async createAndVerifyControllerConnection(): Promise<ClusterController> {
-		// We pre-fetch the endpoints here to verify that the information entered is correct (the user is able to connect)
-		let controller = this.createController();
-		let response: IEndPointsResponse;
-		try {
-			response = await controller.getEndPoints();
-			if (!response || !response.endPoints) {
-				throw new Error(localize('mount.hdfs.loginerror1', "Login to controller failed"));
-			}
-		} catch (err) {
-			throw new Error(localize('mount.hdfs.loginerror2', "Login to controller failed: {0}", err.message));
-		}
-		return controller;
-	}
-
-	protected throwIfMissingUsernamePassword(): void {
-		if (this.props.auth === 'basic') {
-			// Verify username and password as we can't make them required in the UI
-			if (!this.props.username) {
-				throw new Error(localize('err.controller.username.required', "Username is required"));
-			} else if (!this.props.password) {
-				throw new Error(localize('err.controller.password.required', "Password is required"));
-			}
-		}
-	}
-}
-
-export class MountHdfsDialogModel extends HdfsDialogModelBase<MountHdfsProperties> {
+export class MountHdfsDialogModel extends HdfsDialogModelBase<MountHdfsProperties, void> {
 	private credentials: {};
 
 	constructor(props: MountHdfsProperties) {
@@ -235,128 +143,7 @@ export class MountHdfsDialogModel extends HdfsDialogModelBase<MountHdfsPropertie
 	}
 }
 
-abstract class HdfsDialogBase<T extends DialogProperties> {
-
-	protected dialog: azdata.window.Dialog;
-	protected uiModelBuilder!: azdata.ModelBuilder;
-
-	protected urlInputBox!: azdata.InputBoxComponent;
-	protected authDropdown!: azdata.DropDownComponent;
-	protected usernameInputBox!: azdata.InputBoxComponent;
-	protected passwordInputBox!: azdata.InputBoxComponent;
-
-	constructor(private title: string, protected model: HdfsDialogModelBase<T>) {
-	}
-
-	public showDialog(): void {
-		this.createDialog();
-		azdata.window.openDialog(this.dialog);
-	}
-
-	private createDialog(): void {
-		this.dialog = azdata.window.createModelViewDialog(this.title);
-		this.dialog.registerContent(async view => {
-			this.uiModelBuilder = view.modelBuilder;
-
-			this.urlInputBox = this.uiModelBuilder.inputBox()
-				.withProperties<azdata.InputBoxProperties>({
-					placeHolder: localize('textUrlLower', "url"),
-					value: this.model.props.url,
-				}).component();
-			this.urlInputBox.enabled = false;
-
-			this.authDropdown = this.uiModelBuilder.dropDown().withProperties({
-				values: this.model.authCategories,
-				value: this.model.authCategory,
-				editable: false,
-			}).component();
-			this.authDropdown.onValueChanged(e => this.onAuthChanged());
-			this.usernameInputBox = this.uiModelBuilder.inputBox()
-				.withProperties<azdata.InputBoxProperties>({
-					placeHolder: localize('textUsernameLower', "username"),
-					value: this.model.props.username
-				}).component();
-			this.passwordInputBox = this.uiModelBuilder.inputBox()
-				.withProperties<azdata.InputBoxProperties>({
-					placeHolder: localize('textPasswordLower', "password"),
-					inputType: 'password',
-					value: this.model.props.password
-				})
-				.component();
-
-			let connectionSection: azdata.FormComponentGroup = {
-				components: [
-					{
-						component: this.urlInputBox,
-						title: localize('textUrlCapital', "URL"),
-						required: true
-					}, {
-						component: this.authDropdown,
-						title: localize('textAuthCapital', "Authentication type"),
-						required: true
-					}, {
-						component: this.usernameInputBox,
-						title: localize('textUsernameCapital', "Username"),
-						required: false
-					}, {
-						component: this.passwordInputBox,
-						title: localize('textPasswordCapital', "Password"),
-						required: false
-					}
-				],
-				title: localize('hdsf.dialog.connection.section', "Cluster Connection")
-			};
-			let formModel = this.uiModelBuilder.formContainer()
-				.withFormItems([
-					this.getMainSection(),
-					connectionSection
-				]).withLayout({ width: '100%' }).component();
-
-			await view.initializeModel(formModel);
-			this.onAuthChanged();
-		});
-
-		this.dialog.registerCloseValidator(async () => await this.validate());
-		this.dialog.cancelButton.onClick(async () => await this.cancel());
-		this.dialog.okButton.label = localize('hdfs.dialog.ok', "OK");
-		this.dialog.cancelButton.label = localize('hdfs.dialog.cancel', "Cancel");
-	}
-
-	protected abstract getMainSection(): azdata.FormComponentGroup;
-
-	protected get authValue(): AuthType {
-		return (<azdata.CategoryValue>this.authDropdown.value).name as AuthType;
-	}
-
-	private onAuthChanged(): void {
-		let isBasic = this.authValue === 'basic';
-		this.usernameInputBox.enabled = isBasic;
-		this.passwordInputBox.enabled = isBasic;
-		if (!isBasic) {
-			this.usernameInputBox.value = '';
-			this.passwordInputBox.value = '';
-		}
-	}
-
-	protected abstract validate(): Promise<boolean>;
-
-	private async cancel(): Promise<void> {
-		if (this.model && this.model.onCancel) {
-			await this.model.onCancel();
-		}
-	}
-
-	protected async reportError(error: any): Promise<void> {
-		this.dialog.message = {
-			text: (typeof error === 'string') ? error : error.message,
-			level: azdata.window.MessageLevel.Error
-		};
-		if (this.model && this.model.onError) {
-			await this.model.onError(error as ControllerError);
-		}
-	}
-}
-export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties> {
+export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties, void> {
 	private pathInputBox: azdata.InputBoxComponent;
 	private remoteUriInputBox: azdata.InputBoxComponent;
 	private credentialsInputBox: azdata.InputBoxComponent;
@@ -405,7 +192,7 @@ export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties> {
 		};
 	}
 
-	protected async validate(): Promise<boolean> {
+	protected async validate(): Promise<{ validated: boolean }> {
 		try {
 			await this.model.onComplete({
 				url: this.urlInputBox && this.urlInputBox.value,
@@ -416,15 +203,15 @@ export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties> {
 				remoteUri: this.remoteUriInputBox && this.remoteUriInputBox.value,
 				credentials: this.credentialsInputBox && this.credentialsInputBox.value
 			});
-			return true;
+			return { validated: true };
 		} catch (error) {
 			await this.reportError(error);
-			return false;
+			return { validated: false };
 		}
 	}
 }
 
-export class RefreshMountDialog extends HdfsDialogBase<MountHdfsProperties> {
+export class RefreshMountDialog extends HdfsDialogBase<MountHdfsProperties, void> {
 	private pathInputBox: azdata.InputBoxComponent;
 
 	constructor(model: RefreshMountModel) {
@@ -448,7 +235,7 @@ export class RefreshMountDialog extends HdfsDialogBase<MountHdfsProperties> {
 		};
 	}
 
-	protected async validate(): Promise<boolean> {
+	protected async validate(): Promise<{ validated: boolean }> {
 		try {
 			await this.model.onComplete({
 				url: this.urlInputBox && this.urlInputBox.value,
@@ -457,15 +244,15 @@ export class RefreshMountDialog extends HdfsDialogBase<MountHdfsProperties> {
 				password: this.passwordInputBox && this.passwordInputBox.value,
 				hdfsPath: this.pathInputBox && this.pathInputBox.value
 			});
-			return true;
+			return { validated: true };
 		} catch (error) {
 			await this.reportError(error);
-			return false;
+			return { validated: false };
 		}
 	}
 }
 
-export class RefreshMountModel extends HdfsDialogModelBase<MountHdfsProperties> {
+export class RefreshMountModel extends HdfsDialogModelBase<MountHdfsProperties, void> {
 
 	constructor(props: MountHdfsProperties) {
 		super(props);
@@ -504,7 +291,7 @@ export class RefreshMountModel extends HdfsDialogModelBase<MountHdfsProperties> 
 	}
 }
 
-export class DeleteMountDialog extends HdfsDialogBase<MountHdfsProperties> {
+export class DeleteMountDialog extends HdfsDialogBase<MountHdfsProperties, void> {
 	private pathInputBox: azdata.InputBoxComponent;
 
 	constructor(model: DeleteMountModel) {
@@ -528,7 +315,7 @@ export class DeleteMountDialog extends HdfsDialogBase<MountHdfsProperties> {
 		};
 	}
 
-	protected async validate(): Promise<boolean> {
+	protected async validate(): Promise<{ validated: boolean }> {
 		try {
 			await this.model.onComplete({
 				url: this.urlInputBox && this.urlInputBox.value,
@@ -537,15 +324,15 @@ export class DeleteMountDialog extends HdfsDialogBase<MountHdfsProperties> {
 				password: this.passwordInputBox && this.passwordInputBox.value,
 				hdfsPath: this.pathInputBox && this.pathInputBox.value
 			});
-			return true;
+			return { validated: true };
 		} catch (error) {
 			await this.reportError(error);
-			return false;
+			return { validated: false };
 		}
 	}
 }
 
-export class DeleteMountModel extends HdfsDialogModelBase<MountHdfsProperties> {
+export class DeleteMountModel extends HdfsDialogModelBase<MountHdfsProperties, void> {
 
 	constructor(props: MountHdfsProperties) {
 		super(props);

--- a/extensions/big-data-cluster/src/common/promise.ts
+++ b/extensions/big-data-cluster/src/common/promise.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Deferred promise
+ */
+export class Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value?: T | PromiseLike<T>) => void;
+	reject: (reason?: any) => void;
+	constructor() {
+		this.promise = new Promise<T>((resolve, reject) => {
+			this.resolve = resolve;
+			this.reject = reject;
+		});
+	}
+
+	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => TResult | Thenable<TResult>): Thenable<TResult>;
+	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => void): Thenable<TResult>;
+	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => TResult | Thenable<TResult>): Thenable<TResult> {
+		return this.promise.then(onfulfilled, onrejected);
+	}
+}


### PR DESCRIPTION
Here's my take on updating the code to re-prompt for connection information if the status queries for the BDC dashboard fails. 

Note that currently this is based off of my open cluster dashboard PR - since this depends on changes made there so I didn't want to send out this PR with duplicate changes. I'll rebase this once that one is in.

Features in this PR :

- Changed generic HDFS dialog class to be able to return a value from the call to showDialog(). Essentially if the dialog is validated successfully we then return the value that the model is specified to return - otherwise we'll throw an error (for example if the user cancels out of the dialog)
- Added a new dialog that's just for connecting to a controller (so unlike the Mount ones it doesn't add any other sections itself)
- Added wrappers around all the HDFS API calls to allow re-prompting for a connection if the call fails. 

Things NOT in this PR that I plan on making follow-up issues to address
- Having other places (such as mount calls) use the re-prompt logic. Their calls are wrapped in the logic but by default won't retry currently
- Update the Add Controller dialog to re-use the generic dialog - it will likely use the ConnectController dialog and just allow an option to add the controller to the tree once it's finished if desired
- Check for specific error codes and not always re-prompt. Undecided on this one - 401 is the most obvious but there may be others we want to allow so I may just leave it like this
- Handle errors better when the dialog is cancelled
- Display error when prompt is opened. Want to get feedback from design on this - will likely show error similar to connection dialog

![refresh](https://user-images.githubusercontent.com/28519865/67058865-9055ff00-f10b-11e9-9c9a-55de296acb80.gif)

