### PR TITLE
change field type to Password

### DIFF
--- a/extensions/resource-deployment/src/ui/deployClusterWizard/pages/clusterSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/pages/clusterSettingsPage.ts
@@ -110,7 +110,7 @@ export class ClusterSettingsPage extends WizardPageBase<DeployClusterWizard> {
 					required: false,
 					variableName: VariableNames.DockerUsername_VariableName
 				}, {
-					type: FieldType.Text,
+					type: FieldType.Password,
 					label: localize('deployCluster.DockerPassword', "Password"),
 					required: false,
 					variableName: VariableNames.DockerPassword_VariableName


### PR DESCRIPTION
mistakenly left the docker password field as plain text instead of password, now fixing it.