### PR TITLE
Fix ModelView tree A11y issue

### DIFF
--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -17,6 +17,8 @@ import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
 import { ModelComponentWrapper } from 'sql/workbench/browser/modelComponents/modelComponentWrapper.component';
 import { URI } from 'vs/base/common/uri';
 import * as nls from 'vs/nls';
+import { EventType, addDisposableListener } from 'vs/base/browser/dom';
+import { IKeyboardEvent, StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 
 
 export type IUserFriendlyIcon = string | URI | { light: string | URI; dark: string | URI };
@@ -248,6 +250,10 @@ export abstract class ComponentBase extends Disposable implements IComponent, On
 			}
 			return isValid;
 		});
+	}
+
+	protected onkeydown(domNode: HTMLElement, listener: (e: IKeyboardEvent) => void): void {
+		this._register(addDisposableListener(domNode, EventType.KEY_DOWN, (e: KeyboardEvent) => listener(new StandardKeyboardEvent(e))));
 	}
 }
 

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -20,8 +20,7 @@ import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/work
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import * as nls from 'vs/nls';
 import { inputBackground, inputBorder } from 'vs/platform/theme/common/colorRegistry';
-import * as DomUtils from 'vs/base/browser/dom';
-import { StandardKeyboardEvent, IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 
 @Component({
@@ -107,10 +106,6 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 			this.registerInput(this._textAreaInput, () => this.multiline);
 		}
 		this.inputElement.hideErrors = true;
-	}
-
-	private onkeydown(domNode: HTMLElement, listener: (e: IKeyboardEvent) => void): void {
-		this._register(DomUtils.addDisposableListener(domNode, DomUtils.EventType.KEY_DOWN, (e: KeyboardEvent) => listener(new StandardKeyboardEvent(e))));
 	}
 
 	private tryHandleKeyEvent(e: StandardKeyboardEvent): boolean {

--- a/src/sql/workbench/browser/modelComponents/tree.component.ts
+++ b/src/sql/workbench/browser/modelComponents/tree.component.ts
@@ -126,6 +126,7 @@ export default class TreeComponent extends ComponentBase implements IComponent, 
 				// but if not stopped here then will propagate up.
 				// This might have unintended effects such as a dialog closing.
 				if (e.keyCode === KeyCode.Enter) {
+					this._tree.toggleExpansion(this._tree.getFocus());
 					e.stopPropagation();
 				}
 			});

--- a/src/sql/workbench/browser/modelComponents/tree.component.ts
+++ b/src/sql/workbench/browser/modelComponents/tree.component.ts
@@ -24,8 +24,8 @@ import { DefaultFilter, DefaultAccessibilityProvider, DefaultController } from '
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ITreeComponentItem } from 'sql/workbench/common/views';
 import { TreeViewDataProvider } from 'sql/workbench/browser/modelComponents/treeViewDataProvider';
-import { getContentHeight, getContentWidth, addDisposableListener, EventType } from 'vs/base/browser/dom';
-import { StandardKeyboardEvent, IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { getContentHeight, getContentWidth } from 'vs/base/browser/dom';
+import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 
 class Root implements ITreeComponentItem {
@@ -170,9 +170,5 @@ export default class TreeComponent extends ComponentBase implements IComponent, 
 
 	public set withCheckbox(newValue: boolean) {
 		this.setPropertyFromUI<azdata.TreeProperties, boolean>((properties, value) => { properties.withCheckbox = value; }, newValue);
-	}
-
-	private onkeydown(domNode: HTMLElement, listener: (e: IKeyboardEvent) => void): void {
-		this._register(addDisposableListener(domNode, EventType.KEY_DOWN, (e: KeyboardEvent) => listener(new StandardKeyboardEvent(e))));
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/tree.component.ts
+++ b/src/sql/workbench/browser/modelComponents/tree.component.ts
@@ -24,7 +24,9 @@ import { DefaultFilter, DefaultAccessibilityProvider, DefaultController } from '
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ITreeComponentItem } from 'sql/workbench/common/views';
 import { TreeViewDataProvider } from 'sql/workbench/browser/modelComponents/treeViewDataProvider';
-import { getContentHeight, getContentWidth } from 'vs/base/browser/dom';
+import { getContentHeight, getContentWidth, addDisposableListener, EventType } from 'vs/base/browser/dom';
+import { StandardKeyboardEvent, IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { KeyCode } from 'vs/base/common/keyCodes';
 
 class Root implements ITreeComponentItem {
 	label = {
@@ -119,6 +121,14 @@ export default class TreeComponent extends ComponentBase implements IComponent, 
 			this._register(this._tree.onDidChangeSelection(e => {
 				this._dataProvider.onNodeSelected(e.selection);
 			}));
+			this.onkeydown(this._inputContainer.nativeElement, (e: StandardKeyboardEvent) => {
+				// Enter on a tree will select the currently selected item as the default behavior
+				// but if not stopped here then will propagate up.
+				// This might have unintended effects such as a dialog closing.
+				if (e.keyCode === KeyCode.Enter) {
+					e.stopPropagation();
+				}
+			});
 			this._tree.refresh();
 			this.layout();
 		}
@@ -159,5 +169,9 @@ export default class TreeComponent extends ComponentBase implements IComponent, 
 
 	public set withCheckbox(newValue: boolean) {
 		this.setPropertyFromUI<azdata.TreeProperties, boolean>((properties, value) => { properties.withCheckbox = value; }, newValue);
+	}
+
+	private onkeydown(domNode: HTMLElement, listener: (e: IKeyboardEvent) => void): void {
+		this._register(addDisposableListener(domNode, EventType.KEY_DOWN, (e: KeyboardEvent) => listener(new StandardKeyboardEvent(e))));
 	}
 }


### PR DESCRIPTION
Fixes #6153

This will apply to all ModelView trees, but I feel like that's the correct behavior - that if enter is pressed while a tree is focused it shouldn't go outside of the tree regardless of what it's contained in.

![refresh](https://user-images.githubusercontent.com/28519865/67133129-5c88e100-f1c0-11e9-88b2-090fdeb50a2c.gif)
