### PR TITLE
Add help text to mount HDFS dialog

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/mountHdfsDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/mountHdfsDialog.ts
@@ -14,7 +14,7 @@ const localize = nls.loadMessageBundle();
 const basicAuthDisplay = localize('basicAuthName', "Basic");
 const integratedAuthDisplay = localize('integratedAuthName', "Windows Authentication");
 const mountConfigutationTitle = localize('mount.main.section', "Mount Configuration");
-const hdfsPathTitle = localize('mount.hdfsPath', "HDFS Path");
+const hdfsPathTitle = localize('mount.hdfsPath.title', "HDFS Path");
 
 function getAuthCategory(name: AuthType): azdata.CategoryValue {
 	if (name === 'basic') {
@@ -390,15 +390,24 @@ export class MountHdfsDialog extends HdfsDialogBase<MountHdfsProperties> {
 				{
 					component: this.pathInputBox,
 					title: hdfsPathTitle,
-					required: true
+					required: true,
+					layout: {
+						info: localize('mount.hdfsPath.info', "Path to a new (non-existing) directory which you want to associate with the mount")
+					}
 				}, {
 					component: this.remoteUriInputBox,
-					title: localize('mount.remoteUri', "Remote URI"),
-					required: true
+					title: localize('mount.remoteUri.title', "Remote URI"),
+					required: true,
+					layout: {
+						info: localize('mount.remoteUri.info', "The URI to the remote data source. Example for ADLS: abfs://fs@saccount.dfs.core.windows.net/")
+					}
 				}, {
 					component: this.credentialsInputBox,
-					title: localize('mount.credentials', "Credentials"),
-					required: false
+					title: localize('mount.credentials.title', "Credentials"),
+					required: false,
+					layout: {
+						info: localize('mount.credentials.info', "Mount credentials for authentication to remote data source, for access to read the remote data")
+					}
 				}
 			],
 			title: mountConfigutationTitle


### PR DESCRIPTION
Update help text for Mount dialog. As this relies on the help text fix to be in, comparing against that branch for now and will refresh with compare against master once that's committed in.