### PR TITLE
Fix Manage Access dialog to not allow entering blank user

### DIFF
--- a/extensions/mssql/src/hdfs/hdfsModel.ts
+++ b/extensions/mssql/src/hdfs/hdfsModel.ts
@@ -54,7 +54,7 @@ export class HdfsModel {
 	 * @param type The type of ACL to create
 	 */
 	public createAndAddAclEntry(name: string, type: AclType): void {
-		if (!this.permissionStatus) {
+		if (!this.permissionStatus || !name || name.length < 1) {
 			return;
 		}
 		const newEntry = new AclEntry(type, name, name);


### PR DESCRIPTION
Pressing enter in a blank input box was adding a user with a blank name. 