### PR TITLE
Add (dummy) IPyWidgets Renderer

### DIFF
--- a/src/sql/workbench/parts/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/parts/notebook/browser/notebook.contribution.ts
@@ -292,4 +292,17 @@ registerComponentType({
 	selector: MarkdownOutputComponent.SELECTOR
 });
 
+/**
+ * A mime renderer for IPyWidgets
+ */
+registerComponentType({
+	mimeTypes: [
+		'application/vnd.jupyter.widget-view',
+		'application/vnd.jupyter.widget-view+json'
+	],
+	rank: 47,
+	safe: true,
+	ctor: MimeRendererComponent,
+	selector: MimeRendererComponent.SELECTOR
+});
 registerCellComponent(TextCellComponent);

--- a/src/sql/workbench/parts/notebook/browser/outputs/factories.ts
+++ b/src/sql/workbench/parts/notebook/browser/outputs/factories.ts
@@ -80,6 +80,16 @@ export const dataResourceRendererFactory: IRenderMime.IRendererFactory = {
 	createRenderer: options => new widgets.RenderedDataResource(options)
 };
 
+export const ipywidgetFactory: IRenderMime.IRendererFactory = {
+	safe: false,
+	mimeTypes: [
+		'application/vnd.jupyter.widget-view',
+		'application/vnd.jupyter.widget-view+json'
+	],
+	defaultRank: 45,
+	createRenderer: options => new widgets.RenderedIPyWidget(options)
+};
+
 /**
  * The standard factories provided by the rendermime package.
  */
@@ -90,5 +100,6 @@ export const standardRendererFactories: ReadonlyArray<IRenderMime.IRendererFacto
 	imageRendererFactory,
 	javaScriptRendererFactory,
 	textRendererFactory,
-	dataResourceRendererFactory
+	dataResourceRendererFactory,
+	ipywidgetFactory
 ];

--- a/src/sql/workbench/parts/notebook/browser/outputs/widgets.ts
+++ b/src/sql/workbench/parts/notebook/browser/outputs/widgets.ts
@@ -7,6 +7,7 @@ import * as renderers from './renderers';
 import { IRenderMime } from '../models/renderMimeInterfaces';
 import { ReadonlyJSONObject } from '../../common/models/jsonext';
 import * as tableRenderers from 'sql/workbench/parts/notebook/browser/outputs/tableRenderers';
+import { Deferred } from 'sql/base/common/promise';
 
 /**
  * A common base class for mime renderers.
@@ -374,5 +375,33 @@ export class RenderedDataResource extends RenderedCommon {
 			source: JSON.stringify(model.data[this.mimeType]),
 			themeService: model.themeService
 		});
+	}
+}
+
+/**
+ * A dummy widget for (not) displaying ipywidgets.
+ */
+export class RenderedIPyWidget extends RenderedCommon {
+	/**
+	 * Construct a new rendered widget.
+	 *
+	 * @param options - The options for initializing the widget.
+	 */
+	constructor(options: IRenderMime.IRendererOptions) {
+		super(options);
+		this.addClass('jp-RenderedIPyWidget');
+	}
+
+	/**
+	 * Render a mime model.
+	 *
+	 * @param model - The mime model to render.
+	 *
+	 * @returns A promise which resolves when rendering is complete.
+	 */
+	render(model: IRenderMime.IMimeModel): Promise<void> {
+		let deferred = new Deferred<void>();
+		deferred.resolve();
+		return deferred.promise;
 	}
 }


### PR DESCRIPTION
Fixes #7786. Adds (what is now) a dummy IPyWidgets renderer to ensure that we can prevent the spark kernels from falling back to ugly text output.

After the fix, with the PySpark kernel:
![image](https://user-images.githubusercontent.com/40371649/67178301-0b771980-f387-11e9-82cc-414692c6aac2.png)
