### PR TITLE
Fix BDC and resource-deploy extensions to not be packaged separately

### DIFF
--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -200,8 +200,7 @@ const sqlBuiltInExtensions = [
     'dacpac',
     'schema-compare',
     'cms',
-    'query-history',
-    'resource-deployment'
+    'query-history'
 ];
 const builtInExtensions = process.env['VSCODE_QUALITY'] === 'stable' ? require('../builtInExtensions.json') : require('../builtInExtensions-insiders.json');
 // {{SQL CARBON EDIT}} - End

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -230,15 +230,13 @@ const sqlBuiltInExtensions = [
 	// the extension will be excluded from SQLOps package and will have separate vsix packages
 	'admin-tool-ext-win',
 	'agent',
-	'big-data-cluster',
 	'import',
 	'profiler',
 	'admin-pack',
 	'dacpac',
 	'schema-compare',
 	'cms',
-	'query-history',
-	'resource-deployment'
+	'query-history'
 ];
 
 interface IBuiltInExtension {


### PR DESCRIPTION
These extensions should be included with ADS, but in https://github.com/microsoft/azuredatastudio/commit/4dd6db57ee5e01841d84eed805a59c1b4fab1cd1 they were changed to be built as separate VSIX's. 

Fixes #7859