### PR TITLE
Clean up bdc devDependencies

### DIFF
--- a/extensions/big-data-cluster/.vscodeignore
+++ b/extensions/big-data-cluster/.vscodeignore
@@ -1,2 +1,7 @@
+.gitignore
+instructions.txt
 src/**
+out/**
+extension.webpack.config.js
 tsconfig.json
+yarn.lock

--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -148,11 +148,6 @@
 	},
 	"devDependencies": {
 		"@types/kerberos": "^1.1.0",
-		"@types/mocha": "^5.2.5",
-		"@types/node": "^8.0.24",
-		"mocha": "^5.2.0",
-		"should": "^13.2.1",
-		"typemoq": "^2.1.0",
 		"vscode": "^1.1.26"
 	}
 }

--- a/extensions/big-data-cluster/src/bigDataCluster/controller/apiGenerated.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/controller/apiGenerated.ts
@@ -489,7 +489,7 @@ export class BdcRouterApi {
      * @param data Cluster configuration in JSON format
      * @param {*} [options] Override http request options.
      */
-    public createCluster (xRequestId: string, connection: string, data: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: any;  }> {
+    public createCluster (xRequestId: string, connection: string, data: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
         const localVarPath = this.basePath + '/api/v1/bdc';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -537,7 +537,7 @@ export class BdcRouterApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: any;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: any;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -557,7 +557,7 @@ export class BdcRouterApi {
      * @param endpointName
      * @param {*} [options] Override http request options.
      */
-    public endpointsByNameGet (endpointName: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: EndpointModel;  }> {
+    public endpointsByNameGet (endpointName: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: EndpointModel;  }> {
         const localVarPath = this.basePath + '/api/v1/bdc/endpoints/{endpointName}'
             .replace('{' + 'endpointName' + '}', encodeURIComponent(String(endpointName)));
         let localVarQueryParameters: any = {};
@@ -591,7 +591,7 @@ export class BdcRouterApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: EndpointModel;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: EndpointModel;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -610,7 +610,7 @@ export class BdcRouterApi {
      *
      * @param {*} [options] Override http request options.
      */
-    public endpointsGet (options: any = {}) : Promise<{ response: http.ClientResponse; body: Array<EndpointModel>;  }> {
+    public endpointsGet (options: any = {}) : Promise<{ response: http.IncomingMessage; body: Array<EndpointModel>;  }> {
         const localVarPath = this.basePath + '/api/v1/bdc/endpoints';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -638,7 +638,7 @@ export class BdcRouterApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<EndpointModel>;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: Array<EndpointModel>;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -662,7 +662,7 @@ export class BdcRouterApi {
      * @param all Whether you want all of the instances within the given resource
      * @param {*} [options] Override http request options.
      */
-    public getBdcResourceStatus (resourceName: string, xRequestId?: string, connection?: string, all?: boolean, options: any = {}) : Promise<{ response: http.ClientResponse; body: BdcStatusModel;  }> {
+    public getBdcResourceStatus (resourceName: string, xRequestId?: string, connection?: string, all?: boolean, options: any = {}) : Promise<{ response: http.IncomingMessage; body: BdcStatusModel;  }> {
         const localVarPath = this.basePath + '/api/v1/bdc/resources/{resourceName}/status'
             .replace('{' + 'resourceName' + '}', encodeURIComponent(String(resourceName)));
         let localVarQueryParameters: any = {};
@@ -704,7 +704,7 @@ export class BdcRouterApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: BdcStatusModel;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: BdcStatusModel;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -729,7 +729,7 @@ export class BdcRouterApi {
      * @param all Whether you want all of the instances within the given resource
      * @param {*} [options] Override http request options.
      */
-    public getBdcServiceResourceStatus (serviceName: string, resourceName: string, xRequestId?: string, connection?: string, all?: boolean, options: any = {}) : Promise<{ response: http.ClientResponse; body: ResourceStatusModel;  }> {
+    public getBdcServiceResourceStatus (serviceName: string, resourceName: string, xRequestId?: string, connection?: string, all?: boolean, options: any = {}) : Promise<{ response: http.IncomingMessage; body: ResourceStatusModel;  }> {
         const localVarPath = this.basePath + '/api/v1/bdc/services/{serviceName}/resources/{resourceName}/status'
             .replace('{' + 'serviceName' + '}', encodeURIComponent(String(serviceName)))
             .replace('{' + 'resourceName' + '}', encodeURIComponent(String(resourceName)));
@@ -777,7 +777,7 @@ export class BdcRouterApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: ResourceStatusModel;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: ResourceStatusModel;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -800,7 +800,7 @@ export class BdcRouterApi {
      * @param all Whether you want all of the instances within the given resource
      * @param {*} [options] Override http request options.
      */
-    public getBdcStatus (xRequestId?: string, connection?: string, all?: boolean, options: any = {}) : Promise<{ response: http.ClientResponse; body: BdcStatusModel;  }> {
+    public getBdcStatus (xRequestId?: string, connection?: string, all?: boolean, options: any = {}) : Promise<{ response: http.IncomingMessage; body: BdcStatusModel;  }> {
         const localVarPath = this.basePath + '/api/v1/bdc/status';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -836,7 +836,7 @@ export class BdcRouterApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: BdcStatusModel;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: BdcStatusModel;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -859,7 +859,7 @@ export class BdcRouterApi {
      * @param connection
      * @param {*} [options] Override http request options.
      */
-    public getCluster (xRequestId: string, connection: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: any;  }> {
+    public getCluster (xRequestId: string, connection: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
         const localVarPath = this.basePath + '/api/v1/bdc/';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -901,7 +901,7 @@ export class BdcRouterApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: any;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: any;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -924,7 +924,7 @@ export class BdcRouterApi {
      * @param offset
      * @param {*} [options] Override http request options.
      */
-    public getLogs (xRequestId: string, connection: string, offset: number, options: any = {}) : Promise<{ response: http.ClientResponse; body: string;  }> {
+    public getLogs (xRequestId: string, connection: string, offset: number, options: any = {}) : Promise<{ response: http.IncomingMessage; body: string;  }> {
         const localVarPath = this.basePath + '/api/v1/bdc/log';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -975,7 +975,7 @@ export class BdcRouterApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: string;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: string;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -1053,7 +1053,7 @@ export class ControlRouterApi {
      * @param connection
      * @param {*} [options] Override http request options.
      */
-    public getControlStatus (xRequestId: string, connection: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: any;  }> {
+    public getControlStatus (xRequestId: string, connection: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
         const localVarPath = this.basePath + '/api/v1/control/status';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1095,7 +1095,7 @@ export class ControlRouterApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: any;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: any;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -1176,7 +1176,7 @@ export class DefaultApi {
      * @param credentials Credentials to create the mount
      * @param {*} [options] Override http request options.
      */
-    public createMount (xRequestId: string, connection: string, remote: string, mount: string, credentials?: any, options: any = {}) : Promise<{ response: http.ClientResponse; body: any;  }> {
+    public createMount (xRequestId: string, connection: string, remote: string, mount: string, credentials?: any, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
         const localVarPath = this.basePath + '/api/v1/storage/mounts';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1237,7 +1237,7 @@ export class DefaultApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: any;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: any;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -1259,7 +1259,7 @@ export class DefaultApi {
      * @param connection
      * @param {*} [options] Override http request options.
      */
-    public deleteCluster (xRequestId: string, connection: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: any;  }> {
+    public deleteCluster (xRequestId: string, connection: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
         const localVarPath = this.basePath + '/api/v1/bdc/';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1301,7 +1301,7 @@ export class DefaultApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: any;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: any;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -1324,7 +1324,7 @@ export class DefaultApi {
      * @param mount Local HDFS mount path
      * @param {*} [options] Override http request options.
      */
-    public deleteMount (xRequestId: string, connection: string, mount: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: any;  }> {
+    public deleteMount (xRequestId: string, connection: string, mount: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
         const localVarPath = this.basePath + '/api/v1/storage/mounts';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1375,7 +1375,7 @@ export class DefaultApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: any;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: any;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -1398,7 +1398,7 @@ export class DefaultApi {
      * @param query The query in the json format for the health properties
      * @param {*} [options] Override http request options.
      */
-    public getHealthProperties (xRequestId: string, connection: string, query: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: any;  }> {
+    public getHealthProperties (xRequestId: string, connection: string, query: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
         const localVarPath = this.basePath + '/api/v1/health';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1449,7 +1449,7 @@ export class DefaultApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: any;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: any;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -1471,7 +1471,7 @@ export class DefaultApi {
      * @param connection
      * @param {*} [options] Override http request options.
      */
-    public getHome (xRequestId: string, connection: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public getHome (xRequestId: string, connection: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body?: any;  }> {
         const localVarPath = this.basePath + '/api/v1';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1513,7 +1513,7 @@ export class DefaultApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body?: any;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -1537,7 +1537,7 @@ export class DefaultApi {
      * @param all Whether you want all of the instances within the given resource
      * @param {*} [options] Override http request options.
      */
-    public getPoolStatus (bdcName: string, serviceName: string, xRequestId?: string, connection?: string, all?: boolean, options: any = {}) : Promise<{ response: http.ClientResponse; body: ServiceStatusModel;  }> {
+    public getPoolStatus (bdcName: string, serviceName: string, xRequestId?: string, connection?: string, all?: boolean, options: any = {}) : Promise<{ response: http.IncomingMessage; body: ServiceStatusModel;  }> {
         const localVarPath = this.basePath + '/api/v1/bdc/services/{serviceName}/status'
             .replace('{' + 'bdcName' + '}', encodeURIComponent(String(bdcName)))
             .replace('{' + 'serviceName' + '}', encodeURIComponent(String(serviceName)));
@@ -1585,7 +1585,7 @@ export class DefaultApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: ServiceStatusModel;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: ServiceStatusModel;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -1608,7 +1608,7 @@ export class DefaultApi {
      * @param mount
      * @param {*} [options] Override http request options.
      */
-    public listMounts (xRequestId: string, connection: string, mount?: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: any;  }> {
+    public listMounts (xRequestId: string, connection: string, mount?: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
         const localVarPath = this.basePath + '/api/v1/storage/mounts';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1654,7 +1654,7 @@ export class DefaultApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: any;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: any;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -1677,7 +1677,7 @@ export class DefaultApi {
      * @param mount Local path to mount on HDFS
      * @param {*} [options] Override http request options.
      */
-    public refreshMount (xRequestId: string, connection: string, mount: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: any;  }> {
+    public refreshMount (xRequestId: string, connection: string, mount: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
         const localVarPath = this.basePath + '/api/v1/storage/mounts/refresh';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1728,7 +1728,7 @@ export class DefaultApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: any;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body: any;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -1753,7 +1753,7 @@ export class DefaultApi {
      * @param data Password and cluster name in JSON format
      * @param {*} [options] Override http request options.
      */
-    public updatePassword (xRequestId: string, connection: string, serviceName: string, serviceUsername: string, data: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePassword (xRequestId: string, connection: string, serviceName: string, serviceUsername: string, data: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body?: any;  }> {
         const localVarPath = this.basePath + '/api/v1/passwords/{serviceName}/{serviceUsername}'
             .replace('{' + 'serviceName' + '}', encodeURIComponent(String(serviceName)))
             .replace('{' + 'serviceUsername' + '}', encodeURIComponent(String(serviceUsername)));
@@ -1813,7 +1813,7 @@ export class DefaultApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body?: any;  }>((resolve, reject) => {
+        return new Promise<{ response: http.IncomingMessage; body?: any;  }>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/extensions/big-data-cluster/src/bigDataCluster/controller/clusterApiGenerated2.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/controller/clusterApiGenerated2.ts
@@ -383,7 +383,7 @@ export class AppRouterApi {
 	* @param version
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1AppByNameAndVersionDelete(name: string, version: string, options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public apiV1AppByNameAndVersionDelete(name: string, version: string, options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/api/v1/app/{name}/{version}'
 			.replace('{' + 'name' + '}', encodeURIComponent(String(name)))
 			.replace('{' + 'version' + '}', encodeURIComponent(String(version)));
@@ -425,7 +425,7 @@ export class AppRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -446,7 +446,7 @@ export class AppRouterApi {
 	* @param version
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1AppByNameAndVersionGet(name: string, version: string, options: any = {}): Promise<{ response: http.ClientResponse; body: AppModel; }> {
+	public apiV1AppByNameAndVersionGet(name: string, version: string, options: any = {}): Promise<{ response: http.IncomingMessage; body: AppModel; }> {
 		const localVarPath = this.basePath + '/api/v1/app/{name}/{version}'
 			.replace('{' + 'name' + '}', encodeURIComponent(String(name)))
 			.replace('{' + 'version' + '}', encodeURIComponent(String(version)));
@@ -488,7 +488,7 @@ export class AppRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body: AppModel; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body: AppModel; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -509,7 +509,7 @@ export class AppRouterApi {
 	* @param name
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1AppByNameGet(name: string, options: any = {}): Promise<{ response: http.ClientResponse; body: Array<AppModel>; }> {
+	public apiV1AppByNameGet(name: string, options: any = {}): Promise<{ response: http.IncomingMessage; body: Array<AppModel>; }> {
 		const localVarPath = this.basePath + '/api/v1/app/{name}'
 			.replace('{' + 'name' + '}', encodeURIComponent(String(name)));
 		let localVarQueryParameters: any = {};
@@ -545,7 +545,7 @@ export class AppRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body: Array<AppModel>; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body: Array<AppModel>; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -565,7 +565,7 @@ export class AppRouterApi {
 	* @summary ApiV1App_GET
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1AppGet(options: any = {}): Promise<{ response: http.ClientResponse; body: Array<AppModel>; }> {
+	public apiV1AppGet(options: any = {}): Promise<{ response: http.IncomingMessage; body: Array<AppModel>; }> {
 		const localVarPath = this.basePath + '/api/v1/app';
 		let localVarQueryParameters: any = {};
 		let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -595,7 +595,7 @@ export class AppRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body: Array<AppModel>; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body: Array<AppModel>; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -617,7 +617,7 @@ export class AppRouterApi {
 	* @param _package
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1AppPatch(spec?: Buffer, _package?: Buffer, options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public apiV1AppPatch(spec?: Buffer, _package?: Buffer, options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/api/v1/app';
 		let localVarQueryParameters: any = {};
 		let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -657,7 +657,7 @@ export class AppRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -678,7 +678,7 @@ export class AppRouterApi {
 	* @param _package
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1AppPost(spec?: Buffer, _package?: Buffer, options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public apiV1AppPost(spec?: Buffer, _package?: Buffer, options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/api/v1/app';
 		let localVarQueryParameters: any = {};
 		let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -718,7 +718,7 @@ export class AppRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -739,7 +739,7 @@ export class AppRouterApi {
 	* @param version
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1AppSwaggerJsonByNameAndVersionGet(name: string, version: string, options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public apiV1AppSwaggerJsonByNameAndVersionGet(name: string, version: string, options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/api/v1/app/{name}/{version}/swagger.json'
 			.replace('{' + 'name' + '}', encodeURIComponent(String(name)))
 			.replace('{' + 'version' + '}', encodeURIComponent(String(version)));
@@ -781,7 +781,7 @@ export class AppRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -857,7 +857,7 @@ export class FileRouterApi {
 	* @param filePath
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1FilesByFilePathGet(filePath: string, options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public apiV1FilesByFilePathGet(filePath: string, options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/api/v1/files/{filePath}'
 			.replace('{' + 'filePath' + '}', encodeURIComponent(String(filePath)));
 		let localVarQueryParameters: any = {};
@@ -893,7 +893,7 @@ export class FileRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -914,7 +914,7 @@ export class FileRouterApi {
 	* @param containerName
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1FilesFilelistByPodNameAndContainerNameGet(podName: string, containerName: string, options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public apiV1FilesFilelistByPodNameAndContainerNameGet(podName: string, containerName: string, options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/api/v1/files/filelist/{podName}/{containerName}'
 			.replace('{' + 'podName' + '}', encodeURIComponent(String(podName)))
 			.replace('{' + 'containerName' + '}', encodeURIComponent(String(containerName)));
@@ -956,7 +956,7 @@ export class FileRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -976,7 +976,7 @@ export class FileRouterApi {
 	* @param filePath
 	* @param {*} [options] Override http request options.
 	*/
-	public filesByFilePathGet(filePath: string, options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public filesByFilePathGet(filePath: string, options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/files/{filePath}'
 			.replace('{' + 'filePath' + '}', encodeURIComponent(String(filePath)));
 		let localVarQueryParameters: any = {};
@@ -1012,7 +1012,7 @@ export class FileRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -1033,7 +1033,7 @@ export class FileRouterApi {
 	* @param containerName
 	* @param {*} [options] Override http request options.
 	*/
-	public filesFilelistByPodNameAndContainerNameGet(podName: string, containerName: string, options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public filesFilelistByPodNameAndContainerNameGet(podName: string, containerName: string, options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/files/filelist/{podName}/{containerName}'
 			.replace('{' + 'podName' + '}', encodeURIComponent(String(podName)))
 			.replace('{' + 'containerName' + '}', encodeURIComponent(String(containerName)));
@@ -1075,7 +1075,7 @@ export class FileRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -1151,7 +1151,7 @@ export class HealthRouterApi {
 	* @param query
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1HealthGet(query?: string, options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public apiV1HealthGet(query?: string, options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/api/v1/health';
 		let localVarQueryParameters: any = {};
 		let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1185,7 +1185,7 @@ export class HealthRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -1204,7 +1204,7 @@ export class HealthRouterApi {
 	* @summary ApiV1Health_POST
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1HealthPost(options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public apiV1HealthPost(options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/api/v1/health';
 		let localVarQueryParameters: any = {};
 		let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1234,7 +1234,7 @@ export class HealthRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -1254,7 +1254,7 @@ export class HealthRouterApi {
 	* @param query
 	* @param {*} [options] Override http request options.
 	*/
-	public healthGet(query?: string, options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public healthGet(query?: string, options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/health';
 		let localVarQueryParameters: any = {};
 		let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1288,7 +1288,7 @@ export class HealthRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -1307,7 +1307,7 @@ export class HealthRouterApi {
 	* @summary Health_POST
 	* @param {*} [options] Override http request options.
 	*/
-	public healthPost(options: any = {}): Promise<{ response: http.ClientResponse; body?: any; }> {
+	public healthPost(options: any = {}): Promise<{ response: http.IncomingMessage; body?: any; }> {
 		const localVarPath = this.basePath + '/health';
 		let localVarQueryParameters: any = {};
 		let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1337,7 +1337,7 @@ export class HealthRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body?: any; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body?: any; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -1412,7 +1412,7 @@ export class TokenRouterApi {
 	* @summary ApiV1Token_POST
 	* @param {*} [options] Override http request options.
 	*/
-	public apiV1TokenPost(options: any = {}): Promise<{ response: http.ClientResponse; body: TokenModel; }> {
+	public apiV1TokenPost(options: any = {}): Promise<{ response: http.IncomingMessage; body: TokenModel; }> {
 		const localVarPath = this.basePath + '/api/v1/token';
 		let localVarQueryParameters: any = {};
 		let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1442,7 +1442,7 @@ export class TokenRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body: TokenModel; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body: TokenModel; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);
@@ -1462,7 +1462,7 @@ export class TokenRouterApi {
 	* @summary Token_POST
 	* @param {*} [options] Override http request options.
 	*/
-	public tokenPost(options: any = {}): Promise<{ response: http.ClientResponse; body: TokenModel; }> {
+	public tokenPost(options: any = {}): Promise<{ response: http.IncomingMessage; body: TokenModel; }> {
 		const localVarPath = this.basePath + '/token';
 		let localVarQueryParameters: any = {};
 		let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1492,7 +1492,7 @@ export class TokenRouterApi {
 				localVarRequestOptions.form = localVarFormParams;
 			}
 		}
-		return new Promise<{ response: http.ClientResponse; body: TokenModel; }>((resolve, reject) => {
+		return new Promise<{ response: http.IncomingMessage; body: TokenModel; }>((resolve, reject) => {
 			localVarRequest(localVarRequestOptions, (error, response, body) => {
 				if (error) {
 					reject(error);

--- a/extensions/big-data-cluster/yarn.lock
+++ b/extensions/big-data-cluster/yarn.lock
@@ -7,16 +7,6 @@
   resolved "https://registry.yarnpkg.com/@types/kerberos/-/kerberos-1.1.0.tgz#fb1e5bc4f7272d152f67714deb100d5de7cb3e48"
   integrity sha512-ixpV6PSSMnIVpMNCLQ0gWguC2+pBxc0LeUCv9Ugj54opVSVFXfPNYP6sMa7UHvicYGDXAyHQSAzQC8VYEIgdFQ==
 
-"@types/mocha@^5.2.5":
-  version "5.2.7"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
-  integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
-
-"@types/node@^8.0.24":
-  version "8.10.49"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.49.tgz#f331afc5efed0796798e5591d6e0ece636969b7b"
-  integrity sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w==
-
 agent-base@4, agent-base@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
@@ -137,11 +127,6 @@ chownr@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
   integrity sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
-
-circular-json@^0.3.1:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
-  integrity sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -516,11 +501,6 @@ kerberos@^1.1.3:
     nan "^2.14.0"
     prebuild-install "^5.3.0"
 
-lodash@^4.17.4:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
 mime-db@1.40.0:
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
@@ -652,11 +632,6 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
-
-postinstall-build@^5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postinstall-build/-/postinstall-build-5.0.3.tgz#238692f712a481d8f5bc8960e94786036241efc7"
-  integrity sha512-vPvPe8TKgp4FLgY3+DfxCE5PIfoXBK2lyLfNCxsRbDsV6vS4oU5RG/IWxrblMn6heagbnMED3MemUQllQ2bQUg==
 
 prebuild-install@^5.3.0:
   version "5.3.2"
@@ -805,50 +780,6 @@ set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-should-equal@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/should-equal/-/should-equal-2.0.0.tgz#6072cf83047360867e68e98b09d71143d04ee0c3"
-  integrity sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==
-  dependencies:
-    should-type "^1.4.0"
-
-should-format@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/should-format/-/should-format-3.0.3.tgz#9bfc8f74fa39205c53d38c34d717303e277124f1"
-  integrity sha1-m/yPdPo5IFxT04w01xcwPidxJPE=
-  dependencies:
-    should-type "^1.3.0"
-    should-type-adaptors "^1.0.1"
-
-should-type-adaptors@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz#401e7f33b5533033944d5cd8bf2b65027792e27a"
-  integrity sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==
-  dependencies:
-    should-type "^1.3.0"
-    should-util "^1.0.0"
-
-should-type@^1.3.0, should-type@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/should-type/-/should-type-1.4.0.tgz#0756d8ce846dfd09843a6947719dfa0d4cff5cf3"
-  integrity sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=
-
-should-util@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/should-util/-/should-util-1.0.0.tgz#c98cda374aa6b190df8ba87c9889c2b4db620063"
-  integrity sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=
-
-should@^13.2.1:
-  version "13.2.3"
-  resolved "https://registry.yarnpkg.com/should/-/should-13.2.3.tgz#96d8e5acf3e97b49d89b51feaa5ae8d07ef58f10"
-  integrity sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==
-  dependencies:
-    should-equal "^2.0.0"
-    should-format "^3.0.3"
-    should-type "^1.4.0"
-    should-type-adaptors "^1.0.1"
-    should-util "^1.0.0"
-
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -994,15 +925,6 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-typemoq@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/typemoq/-/typemoq-2.1.0.tgz#4452ce360d92cf2a1a180f0c29de2803f87af1e8"
-  integrity sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==
-  dependencies:
-    circular-json "^0.3.1"
-    lodash "^4.17.4"
-    postinstall-build "^5.0.1"
-
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
@@ -1051,9 +973,9 @@ vscode-test@^0.4.1:
     https-proxy-agent "^2.2.1"
 
 vscode@^1.1.26:
-  version "1.1.35"
-  resolved "https://registry.yarnpkg.com/vscode/-/vscode-1.1.35.tgz#f8c6beb905738b874d539ddb3784e5feeec71c0a"
-  integrity sha512-xPnxzQU40LOS2yPyzWW+WKpTV6qA3z16TcgpZ9O38UWLA157Zz4GxUx5H7Gd07pxzw0GqvusbF4D+5GBgNxvEQ==
+  version "1.1.36"
+  resolved "https://registry.yarnpkg.com/vscode/-/vscode-1.1.36.tgz#5e1a0d1bf4977d0c7bc5159a9a13d5b104d4b1b6"
+  integrity sha512-cGFh9jmGLcTapCpPCKvn8aG/j9zVQ+0x5hzYJq5h5YyUXVGa1iamOaB2M2PZXoumQPES4qeAP1FwkI0b6tL4bQ==
   dependencies:
     glob "^7.1.2"
     mocha "^5.2.0"

--- a/extensions/resource-deployment/.vscodeignore
+++ b/extensions/resource-deployment/.vscodeignore
@@ -1,4 +1,6 @@
-coverage/**
-out/test/**
-src/**
 coverageConfig.json
+coverage
+out
+src
+tsconfig.json
+yarn.lock


### PR DESCRIPTION
Remove the test stuff - we're not using it currently.

Remove node type reference, we get it from the root typings file. The version this extension was referencing was old and contained a [deprecated alias of ClientResponse](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29674#issuecomment-430028328). So also updating that to IncomingMessage - the correct type to use (and verified that API calls still function as expected). 