### PR TITLE
Disable failing test

### DIFF
--- a/src/vs/platform/telemetry/test/electron-browser/commonProperties.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/commonProperties.test.ts
@@ -82,7 +82,7 @@ suite('Telemetry - common properties', function () {
 		assert.ok(value1 !== value2, 'timesincesessionstart');
 	});
 
-	test('mixes in additional properties', async function () {
+	test.skip('mixes in additional properties', async function () { // {{SQL CARBON EDIT}} skip test
 		const resolveCommonTelemetryProperties = () => {
 			return {
 				'userId': '1'


### PR DESCRIPTION
We don't add in those properties for stable builds currently so disabling until they're added back in. 

#7881