### PR TITLE
Add Option to Halt Notebook when Error Occurs in SQL Kernel

### DIFF
--- a/src/sql/workbench/parts/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/parts/notebook/browser/notebook.contribution.ts
@@ -165,10 +165,10 @@ configurationRegistry.registerConfiguration({
 	'title': 'Notebook',
 	'type': 'object',
 	'properties': {
-		'notebook.sqlKernelStopOnError': {
+		'notebook.sqlStopOnError': {
 			'type': 'boolean',
 			'default': true,
-			'description': localize('notebook.sqlKernelStopOnError', "SQL kernel: stop notebook execution when error occurs in a cell.")
+			'description': localize('notebook.sqlStopOnError', "SQL kernel: stop Notebook execution when error occurs in a cell.")
 		}
 	}
 });

--- a/src/sql/workbench/parts/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/parts/notebook/browser/notebook.contribution.ts
@@ -160,6 +160,19 @@ configurationRegistry.registerConfiguration({
 	}
 });
 
+configurationRegistry.registerConfiguration({
+	'id': 'notebook',
+	'title': 'Notebook',
+	'type': 'object',
+	'properties': {
+		'notebook.sqlKernelStopOnError': {
+			'type': 'boolean',
+			'default': true,
+			'description': localize('notebook.sqlKernelStopOnError', "SQL kernel: stop notebook execution when error occurs in a cell.")
+		}
+	}
+});
+
 registerAction({
 	id: 'workbench.books.action.focusBooksExplorer',
 	handler: async (accessor) => {

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -30,7 +30,7 @@ export const sqlKernelError: string = localize("sqlKernelError", "SQL kernel err
 export const MAX_ROWS = 5000;
 export const NotebookConfigSectionName = 'notebook';
 export const MaxTableRowsConfigName = 'maxTableRows';
-export const SqlKernelStopOnErrorConfigName = 'sqlKernelStopOnError';
+export const SqlStopOnErrorConfigName = 'sqlStopOnError';
 
 const languageMagics: ILanguageMagic[] = [{
 	language: 'Python',
@@ -381,7 +381,7 @@ export class SQLFuture extends Disposable implements FutureInternal {
 	private _outputAddedPromises: Promise<void>[] = [];
 	private _querySubsetResultMap: Map<number, QueryExecuteSubsetResult> = new Map<number, QueryExecuteSubsetResult>();
 	private _errorOccurred: boolean = false;
-	private _stopOnError: boolean = false;
+	private _stopOnError: boolean = true;
 	constructor(
 		private _queryRunner: QueryRunner,
 		private _executionCount: number | undefined,
@@ -395,7 +395,7 @@ export class SQLFuture extends Disposable implements FutureInternal {
 			if (maxRows && maxRows > 0) {
 				this.configuredMaxRows = maxRows;
 			}
-			this._stopOnError = config[SqlKernelStopOnErrorConfigName] ? config[SqlKernelStopOnErrorConfigName] : false;
+			this._stopOnError = !!config[SqlStopOnErrorConfigName];
 		}
 	}
 
@@ -623,8 +623,9 @@ export class SQLFuture extends Disposable implements FutureInternal {
 	}
 
 	private convertToError(msg: IResultMessage | string): nb.IIOPubMessage {
+		this._errorOccurred = true;
+
 		if (msg) {
-			this._errorOccurred = true;
 			let msgData = typeof msg === 'string' ? msg : msg.message;
 			return {
 				channel: 'iopub',


### PR DESCRIPTION
Implements #7862.

Adding option to halt notebook execution when an error occurs with the SQL kernel.

I've defaulted this option to true (as it would match the behavior of other kernels), but totally willing to listen to feedback and change this if this could break existing scenarios.

@yualan can you help as well give some feedback? Also, I probably need help on the strings 😄.

![image](https://user-images.githubusercontent.com/40371649/67258742-f19d0b80-f446-11e9-9b60-2c0eccb77b08.png)
