### PR TITLE
Fix HDFS paths to be encoded properly

### DIFF
--- a/extensions/mssql/src/hdfs/webhdfs.ts
+++ b/extensions/mssql/src/hdfs/webhdfs.ts
@@ -73,10 +73,10 @@ export class WebHDFS {
 	 */
 	private getOperationEndpoint(operation: string, path: string, params?: object): string {
 		let endpoint = this._url;
-		endpoint.pathname = this._opts.path + path;
+		endpoint.pathname = encodeURI(this._opts.path + path);
 		let searchOpts = Object.assign(
 			{ 'op': operation },
-			// this._opts.user ? { 'user.name': this._opts.user } : {},
+			this._opts.user ? { 'user.name': this._opts.user } : {},
 			params || {}
 		);
 		endpoint.search = querystring.stringify(searchOpts);


### PR DESCRIPTION
Fixes #7885

A previous change removed the encoding since we were already encoding the URL options in the call to querystring.stringify so it was double-escaping them. 

https://github.com/microsoft/azuredatastudio/pull/7378/files

We still don't want to do the encodeURI for the entire endpoint URL to avoid this - but now we weren't escaping the path correctly so anything with invalid characters was causing an error to occur.

![Capture](https://user-images.githubusercontent.com/28519865/67315258-09ae7280-f4bb-11e9-8219-a286c5eff773.gif)

Note - I also fixed the accident removal of setting the user option. This was done mistakenly in a previous PR as well. 
