### PR TITLE
Fix for relative links not being resolved in notebook outputs

### DIFF
--- a/src/sql/workbench/parts/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/parts/notebook/browser/outputs/notebookMarkdown.ts
@@ -190,7 +190,7 @@ export class NotebookMarkdownRenderer {
 			}
 		}
 		try {
-			if (URI.parse(href)) {
+			if (URI.parse(href) && path.isAbsolute(href)) {
 				return href;
 			}
 		} catch {

--- a/src/sql/workbench/parts/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/parts/notebook/browser/outputs/notebookMarkdown.ts
@@ -190,6 +190,8 @@ export class NotebookMarkdownRenderer {
 			}
 		}
 		try {
+			// The call to resolveUrl() (where relative hrefs are converted to absolute ones) comes after this point
+			// Therefore, we only want to return immediately if the path is absolute here
 			if (URI.parse(href) && path.isAbsolute(href)) {
 				return href;
 			}


### PR DESCRIPTION
In notebook outputs, links are rendered in notebookMarkdown. The method was being returned too quickly, as we want to ensure that a relative path isn't displayed (and we convert it to an appropriate absolute link) in order to prevent ADS from thinking that notebooks live in the extensions folder.