### PR TITLE
Notebooks: ensure python path dirs added to path on session start

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterNotebookManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterNotebookManager.ts
@@ -18,7 +18,8 @@ export class JupyterNotebookManager implements nb.NotebookManager, vscode.Dispos
 	private _sessionManager: JupyterSessionManager;
 
 	constructor(private _serverManager: LocalJupyterServerManager, sessionManager?: JupyterSessionManager, private apiWrapper: ApiWrapper = new ApiWrapper()) {
-		this._sessionManager = sessionManager || new JupyterSessionManager();
+		let pythonEnvVarPath = this._serverManager && this._serverManager.instanceOptions && this._serverManager.instanceOptions.install && this._serverManager.instanceOptions.install.pythonEnvVarPath;
+		this._sessionManager = sessionManager || new JupyterSessionManager(pythonEnvVarPath);
 		this._serverManager.onServerStarted(() => {
 			this.setServerSettings(this._serverManager.serverSettings);
 		});

--- a/extensions/notebook/src/jupyter/jupyterNotebookManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterNotebookManager.ts
@@ -18,7 +18,7 @@ export class JupyterNotebookManager implements nb.NotebookManager, vscode.Dispos
 	private _sessionManager: JupyterSessionManager;
 
 	constructor(private _serverManager: LocalJupyterServerManager, sessionManager?: JupyterSessionManager, private apiWrapper: ApiWrapper = new ApiWrapper()) {
-		let pythonEnvVarPath = this._serverManager && this._serverManager.jupyterInstallation && this._serverManager.jupyterInstallation.pythonEnvVarPath;
+		let pythonEnvVarPath = this._serverManager && this._serverManager.jupyterServerInstallation && this._serverManager.jupyterServerInstallation.pythonEnvVarPath;
 		this._sessionManager = sessionManager || new JupyterSessionManager(pythonEnvVarPath);
 		this._serverManager.onServerStarted(() => {
 			this.setServerSettings(this._serverManager.serverSettings);

--- a/extensions/notebook/src/jupyter/jupyterNotebookManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterNotebookManager.ts
@@ -18,7 +18,7 @@ export class JupyterNotebookManager implements nb.NotebookManager, vscode.Dispos
 	private _sessionManager: JupyterSessionManager;
 
 	constructor(private _serverManager: LocalJupyterServerManager, sessionManager?: JupyterSessionManager, private apiWrapper: ApiWrapper = new ApiWrapper()) {
-		let pythonEnvVarPath = this._serverManager && this._serverManager.instanceOptions && this._serverManager.instanceOptions.install && this._serverManager.instanceOptions.install.pythonEnvVarPath;
+		let pythonEnvVarPath = this._serverManager && this._serverManager.jupyterInstallation && this._serverManager.jupyterInstallation.pythonEnvVarPath;
 		this._sessionManager = sessionManager || new JupyterSessionManager(pythonEnvVarPath);
 		this._serverManager.onServerStarted(() => {
 			this.setServerSettings(this._serverManager.serverSettings);

--- a/extensions/notebook/src/jupyter/jupyterServerManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerManager.ts
@@ -54,6 +54,10 @@ export class LocalJupyterServerManager implements nb.ServerManager, vscode.Dispo
 		return this._onServerStarted.event;
 	}
 
+	public get jupyterInstallation(): JupyterServerInstallation {
+		return this.options && this.options.jupyterInstallation && this.options.jupyterInstallation;
+	}
+
 	public async startServer(): Promise<void> {
 		try {
 			if (!this._jupyterServer) {

--- a/extensions/notebook/src/jupyter/jupyterServerManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerManager.ts
@@ -54,8 +54,8 @@ export class LocalJupyterServerManager implements nb.ServerManager, vscode.Dispo
 		return this._onServerStarted.event;
 	}
 
-	public get jupyterInstallation(): JupyterServerInstallation {
-		return this.options && this.options.jupyterInstallation && this.options.jupyterInstallation;
+	public get jupyterServerInstallation(): JupyterServerInstallation | undefined {
+		return this.options && this.options.jupyterInstallation;
 	}
 
 	public async startServer(): Promise<void> {


### PR DESCRIPTION
We add to the path when starting notebooks, which was getting lost when starting sessions due to recent changes in how we use start up servers (we were just passing on whatever the value of PATH was instead of prepending the ADS-specific folders to the PATH)

LocalJupyterServerManager waits on JupyterServerInstallation to complete (i.e. when the pythonPathEnvVars are set), and a session is created in the JupyterNotebookManager with the serverManager already passed in. Long way of saying that the path will be set before the code in the session is run.