### PR TITLE
builtinExtension-insiders to builtinExtension

### DIFF
--- a/build/builtInExtensions-insiders.json
+++ b/build/builtInExtensions-insiders.json
@@ -1,2 +1,7 @@
 [
+	{
+		"name": "Microsoft.sqlservernotebook",
+		"version": "0.3.1",
+		"repo": "https://github.com/Microsoft/azuredatastudio"
+	}
 ]

--- a/build/lib/builtInExtensions.js
+++ b/build/lib/builtInExtensions.js
@@ -19,7 +19,8 @@ const ansiColors = require('ansi-colors');
 
 const root = path.dirname(path.dirname(__dirname));
 // {{SQL CARBON EDIT}}
-const builtInExtensions = require('../builtInExtensions.json');
+const quality = process.env['VSCODE_QUALITY'];
+const builtInExtensions = quality && quality === 'stable' ? require('../builtInExtensions.json') : require('../builtInExtensions-insiders.json');
 // {{SQL CARBON EDIT}} - END
 const controlFilePath = path.join(os.homedir(), '.vscode-oss-dev', 'extensions', 'control.json');
 

--- a/build/lib/builtInExtensions.js
+++ b/build/lib/builtInExtensions.js
@@ -16,11 +16,10 @@ const vfs = require('vinyl-fs');
 const ext = require('./extensions');
 const fancyLog = require('fancy-log');
 const ansiColors = require('ansi-colors');
-const product =  require('vs/platform/product/common/product');
 
 const root = path.dirname(path.dirname(__dirname));
 // {{SQL CARBON EDIT}}
-const builtInExtensions = product.quality === 'stable' ? require('../builtInExtensions.json') : require('../builtInExtensions-insiders.json');
+const builtInExtensions = require('../builtInExtensions.json');
 // {{SQL CARBON EDIT}} - END
 const controlFilePath = path.join(os.homedir(), '.vscode-oss-dev', 'extensions', 'control.json');
 

--- a/build/lib/builtInExtensions.js
+++ b/build/lib/builtInExtensions.js
@@ -19,7 +19,7 @@ const ansiColors = require('ansi-colors');
 
 const root = path.dirname(path.dirname(__dirname));
 // {{SQL CARBON EDIT}}
-const builtInExtensions = require('../builtInExtensions-insiders.json');
+const builtInExtensions = require('../builtInExtensions.json');
 // {{SQL CARBON EDIT}} - END
 const controlFilePath = path.join(os.homedir(), '.vscode-oss-dev', 'extensions', 'control.json');
 

--- a/build/lib/builtInExtensions.js
+++ b/build/lib/builtInExtensions.js
@@ -16,10 +16,11 @@ const vfs = require('vinyl-fs');
 const ext = require('./extensions');
 const fancyLog = require('fancy-log');
 const ansiColors = require('ansi-colors');
+const product =  require('vs/platform/product/common/product');
 
 const root = path.dirname(path.dirname(__dirname));
 // {{SQL CARBON EDIT}}
-const builtInExtensions = require('../builtInExtensions.json');
+const builtInExtensions = product.quality === 'stable' ? require('../builtInExtensions.json') : require('../builtInExtensions-insiders.json');
 // {{SQL CARBON EDIT}} - END
 const controlFilePath = path.join(os.homedir(), '.vscode-oss-dev', 'extensions', 'control.json');
 


### PR DESCRIPTION
Replacing the builtinExtension-insiders with builtinExtension since we moved the extension details to stable. Missed this update in my previous insidersTostable commit. 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
