### PR TITLE
Fix Issue when Saving Wrong Kernel

### DIFF
--- a/src/sql/workbench/parts/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/parts/notebook/browser/models/notebookModel.ts
@@ -489,8 +489,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		}
 	}
 
-	// When changing kernel, update the active session and register the kernel change event
-	// So KernelDropDown could get the event fired when added listerner on Model.KernelChange
+	// When changing kernel, update the active session
 	private updateActiveClientSession(clientSession: IClientSession) {
 		this._activeClientSession = clientSession;
 	}

--- a/src/sql/workbench/parts/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/parts/notebook/browser/models/notebookModel.ts
@@ -7,7 +7,7 @@ import { nb, connection } from 'azdata';
 
 import { localize } from 'vs/nls';
 import { Event, Emitter } from 'vs/base/common/event';
-import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { Disposable } from 'vs/base/common/lifecycle';
 
 import { IClientSession, INotebookModel, IDefaultConnection, INotebookModelOptions, ICellModel, NotebookContentChange, notebookConstants, INotebookContentsEditable } from 'sql/workbench/parts/notebook/browser/models/modelInterfaces';
 import { NotebookChangeType, CellType, CellTypes } from 'sql/workbench/parts/notebook/common/models/contracts';


### PR DESCRIPTION
Fixes #7280

The problem was that we were firing the notebook model's kernelChangeEvent too early, before the model updated `_savedKernelInfo`. In addition, we were also not previously waiting for configureKernel() or an updated languageInfo before sending the event, which wasn't good news either.

Here was the previous behavior:
- notebookModel: `kernelChanged()` event fired (from clientSession kernelChange completed)
- notebookEditorModel: listens on `model.kernelChange()`
- notebookTextFileModel asks notebookModel for its `toJson()`
- notebookModel serializes kernel info from  `this._savedKernelInfo` (which is now outdated)
- notebookModel sees that the `await this._activeClientSession.changeKernel()` has returned
- notebookModel calls `updateKernelInfo()`, updating `this._savedKernelInfo`

So, we now no