### PR TITLE
Fix troubleshoot URL lookup

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
@@ -99,7 +99,8 @@ export class BdcDashboardModel {
  * troubleshoot notebook if the service name is unknown.
  * @param service The service name to get the troubleshoot notebook URL for
  */
-export function getTroubleshootNotebookUrl(service: string): string {
+export function getTroubleshootNotebookUrl(service?: string): string {
+	service = service || '';
 	switch (service.toLowerCase()) {
 		case Service.sql:
 			return 'troubleshooters/tsg101-troubleshoot-sql-server';


### PR DESCRIPTION
Fixes #7977

Undefined is use for the overview page (since it's not associated with an actual service)