### PR TITLE
hide save book action from command pallet

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -143,6 +143,7 @@
       {
         "command": "notebook.command.saveBook",
         "title": "%title.saveJupyterBook%",
+        "category": "%books-preview-category%",
         "icon": {
           "dark": "resources/dark/save_inverse.svg",
           "light": "resources/light/save.svg"
@@ -151,6 +152,7 @@
       {
         "command": "notebook.command.searchBook",
         "title": "%title.searchJupyterBook%",
+        "category": "%books-preview-category%",
         "icon": {
           "dark": "resources/dark/search_inverse.svg",
           "light": "resources/light/search.svg"
@@ -159,6 +161,7 @@
       {
         "command": "notebook.command.searchUntitledBook",
         "title": "%title.searchJupyterBook%",
+        "category": "%books-preview-category%",
         "icon": {
           "dark": "resources/dark/search_inverse.svg",
           "light": "resources/light/search.svg"
@@ -244,6 +247,10 @@
         {
           "command": "books.sqlserver2019",
           "when": "sqlserver2019"
+        },
+        {
+          "command": "notebook.command.saveBook",
+          "when": "false"
         }
       ],
       "touchBar": [


### PR DESCRIPTION
Hide the save book action from command pallet since it should only be exposed from the untitled book tree and doesn;t make sense to have it exposed from a common place. 
Leaving the search book action since they can still launch it and it doesn't error out when there aren't books. I can look into hiding it out when there aren't any active books.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
