### PR TITLE
Change BDC view errors to use modal dialog instead of error toast

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
@@ -238,7 +238,7 @@ export class BdcDashboardOverviewPage {
 		if (serviceStatus.healthStatus !== 'healthy' && serviceStatus.details && serviceStatus.details.length > 0) {
 			const viewDetailsButton = this.modelBuilder.button().withProperties<azdata.ButtonProperties>({ label: localize('bdc.dashboard.viewDetails', "View Details") }).component();
 			viewDetailsButton.onDidClick(() => {
-				vscode.window.showErrorMessage(serviceStatus.details);
+				vscode.window.showErrorMessage(serviceStatus.details, { modal: true });
 			});
 			serviceStatusRow.addItem(viewDetailsButton, { flex: '0 0 auto' });
 		}

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
@@ -13,6 +13,7 @@ import { IconPathHelper, cssStyles } from '../constants';
 import { getStateDisplayText, getHealthStatusDisplayText, getEndpointDisplayText, getHealthStatusIcon, getServiceNameDisplayText, Endpoint } from '../utils';
 import { EndpointModel, ServiceStatusModel, BdcStatusModel } from '../controller/apiGenerated';
 import { BdcDashboard } from './bdcDashboard';
+import { createViewDetailsButton } from './commonControls';
 
 const localize = nls.loadMessageBundle();
 
@@ -28,6 +29,8 @@ const serviceEndpointRowServiceNameCellWidth = 200;
 const serviceEndpointRowEndpointCellWidth = 350;
 
 const hyperlinkedEndpoints = [Endpoint.metricsui, Endpoint.logsui, Endpoint.sparkHistory, Endpoint.yarnUi];
+
+type ActionItem = (vscode.MessageItem & { execute: () => void; });
 
 export class BdcDashboardOverviewPage {
 
@@ -236,11 +239,7 @@ export class BdcDashboardOverviewPage {
 		serviceStatusRow.addItem(healthStatusCell, { CSSStyles: { 'width': `${overviewHealthStatusCellWidthPx}px`, 'min-width': `${overviewHealthStatusCellWidthPx}px` } });
 
 		if (serviceStatus.healthStatus !== 'healthy' && serviceStatus.details && serviceStatus.details.length > 0) {
-			const viewDetailsButton = this.modelBuilder.button().withProperties<azdata.ButtonProperties>({ label: localize('bdc.dashboard.viewDetails', "View Details") }).component();
-			viewDetailsButton.onDidClick(() => {
-				vscode.window.showErrorMessage(serviceStatus.details, { modal: true });
-			});
-			serviceStatusRow.addItem(viewDetailsButton, { flex: '0 0 auto' });
+			serviceStatusRow.addItem(createViewDetailsButton(this.modelBuilder, serviceStatus.details), { flex: '0 0 auto' });
 		}
 
 		container.addItem(serviceStatusRow, { CSSStyles: { 'padding-left': '10px', 'border-top': 'solid 1px #ccc', 'border-bottom': isLastRow ? 'solid 1px #ccc' : '', 'box-sizing': 'border-box', 'user-select': 'text' } });

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
@@ -183,7 +183,7 @@ function createInstanceHealthStatusRow(modelBuilder: azdata.ModelBuilder, instan
 	if (instanceStatus.healthStatus !== 'healthy' && instanceStatus.details && instanceStatus.details.length > 0) {
 		const viewDetailsButton = modelBuilder.button().withProperties<azdata.ButtonProperties>({ label: localize('bdc.dashboard.viewDetails', "View Details") }).component();
 		viewDetailsButton.onDidClick(() => {
-			vscode.window.showErrorMessage(instanceStatus.details);
+			vscode.window.showErrorMessage(instanceStatus.details, { modal: true });
 		});
 		instanceHealthStatusRow.addItem(viewDetailsButton, { flex: '0 0 auto' });
 	}

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
@@ -5,13 +5,13 @@
 'use strict';
 
 import * as azdata from 'azdata';
-import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import { BdcDashboardModel } from './bdcDashboardModel';
 import { BdcStatusModel, InstanceStatusModel } from '../controller/apiGenerated';
 import { getHealthStatusDisplayText, getHealthStatusIcon, getStateDisplayText } from '../utils';
 import { cssStyles } from '../constants';
 import { isNullOrUndefined } from 'util';
+import { createViewDetailsButton } from './commonControls';
 
 const localize = nls.loadMessageBundle();
 
@@ -181,11 +181,7 @@ function createInstanceHealthStatusRow(modelBuilder: azdata.ModelBuilder, instan
 	instanceHealthStatusRow.addItem(healthStatusCell, { CSSStyles: { 'width': `${healthAndStatusHealthColumnWidth}px`, 'min-width': `${healthAndStatusHealthColumnWidth}px` } });
 
 	if (instanceStatus.healthStatus !== 'healthy' && instanceStatus.details && instanceStatus.details.length > 0) {
-		const viewDetailsButton = modelBuilder.button().withProperties<azdata.ButtonProperties>({ label: localize('bdc.dashboard.viewDetails', "View Details") }).component();
-		viewDetailsButton.onDidClick(() => {
-			vscode.window.showErrorMessage(instanceStatus.details, { modal: true });
-		});
-		instanceHealthStatusRow.addItem(viewDetailsButton, { flex: '0 0 auto' });
+		instanceHealthStatusRow.addItem(createViewDetailsButton(modelBuilder, instanceStatus.details), { flex: '0 0 auto' });
 	}
 	return instanceHealthStatusRow;
 }

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/commonControls.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/commonControls.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from 'azdata';
+import * as vscode from 'vscode';
+import * as nls from 'vscode-nls';
+
+const localize = nls.loadMessageBundle();
+
+export function createViewDetailsButton(modelBuilder: azdata.ModelBuilder, text: string): azdata.ButtonComponent {
+	const viewDetailsButton = modelBuilder.button().withProperties<azdata.ButtonProperties>({ label: localize('bdc.dashboard.viewDetails', "View Details") }).component();
+	viewDetailsButton.onDidClick(() => {
+		vscode.window.showErrorMessage(text, { modal: true });
+	});
+	return viewDetailsButton;
+}


### PR DESCRIPTION
Improvement for #7510

This is from feedback that using the error toast is confusing. We still want to figure out a better way to display these though - this is just a temporary solution.

ctrl + c can be used to copy the text. We have the ability to add buttons to the dialog that can have actions associated with them (so we could add a "Copy Text" button) but vs code api limitations means that these buttons will always close the dialog which doesn't seem very friendly so I decided not to add that.

![image](https://user-images.githubusercontent.com/28519865/67512253-3f836080-f64d-11e9-84f3-25ffe21f6d4b.png)
