### PR TITLE
reclassified autoinstallrequired message to error

### DIFF
--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -253,7 +253,7 @@ export class ResourceTypePickerDialog extends DialogBase {
 					// we don't have scenarios that have mixed type of tools
 					// either we don't support auto install: docker, or we support auto install for all required tools
 					this._dialogObject.message = {
-						level: azdata.window.MessageLevel.Error,
+						level: azdata.window.MessageLevel.Warning,
 						text: localize('deploymentDialog.InstallToolsHint', "Some required tools are not installed, you can click the \"{0}\" button to install them.", this._installToolButton.label)
 					};
 				}

--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -253,7 +253,7 @@ export class ResourceTypePickerDialog extends DialogBase {
 					// we don't have scenarios that have mixed type of tools
 					// either we don't support auto install: docker, or we support auto install for all required tools
 					this._dialogObject.message = {
-						level: azdata.window.MessageLevel.Information,
+						level: azdata.window.MessageLevel.Error,
 						text: localize('deploymentDialog.InstallToolsHint', "Some required tools are not installed, you can click the \"{0}\" button to install them.", this._installToolButton.label)
 					};
 				}


### PR DESCRIPTION
Very simple fix, since this is essentially still an error but is fixable by installing the tools, this type of situation can be classified as an error as requested in #7903 for all instances it is called. Unless this is ONLY meant to be done for BDC deployment errors, in which case, additional checks will need to be implemented.

This PR fixes #7903
