### PR TITLE
Always send \n instead of \r\n to Jupyter kernel

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterKernel.ts
+++ b/extensions/notebook/src/jupyter/jupyterKernel.ts
@@ -87,6 +87,8 @@ export class JupyterKernel implements nb.IKernel {
 	}
 
 	requestExecute(content: nb.IExecuteRequest, disposeOnDone?: boolean): nb.IFuture {
+		content.code = Array.isArray(content.code) ? content.code.join('') : content.code;
+		content.code = content.code.split(/[\r\n]+/gm).join('\n');
 		let futureImpl = this.kernelImpl.requestExecute(content as KernelMessage.IExecuteRequest, disposeOnDone);
 		return new JupyterFuture(futureImpl);
 	}

--- a/extensions/notebook/src/jupyter/jupyterKernel.ts
+++ b/extensions/notebook/src/jupyter/jupyterKernel.ts
@@ -88,7 +88,7 @@ export class JupyterKernel implements nb.IKernel {
 
 	requestExecute(content: nb.IExecuteRequest, disposeOnDone?: boolean): nb.IFuture {
 		content.code = Array.isArray(content.code) ? content.code.join('') : content.code;
-		content.code = content.code.split(/[\r\n]+/gm).join('\n');
+		content.code = content.code.replace(/\r+\n/gm, '\n'); // Remove \r (if it exists) from newlines
 		let futureImpl = this.kernelImpl.requestExecute(content as KernelMessage.IExecuteRequest, disposeOnDone);
 		return new JupyterFuture(futureImpl);
 	}


### PR DESCRIPTION
Fixes #7514

Jupyter always strips out the \r (if it exists), so this matches their behavior.