### PR TITLE
Remove Search Book Commands from Command Palette

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -251,6 +251,14 @@
         {
           "command": "notebook.command.saveBook",
           "when": "false"
+        },
+        {
+          "command": "notebook.command.searchBook",
+          "when": "false"
+        },
+        {
+          "command": "notebook.command.searchUntitledBook",
+          "when": "false"
         }
       ],
       "touchBar": [


### PR DESCRIPTION
Fixes #7917 

(the second part 😄)

We really don't need search book in the command palette, and given that it doesn't do anything unless the books viewlet is in focus, let's just always hide it from there. It's more confusing than anything else.