### PR TITLE
Ensure Jupyter Server Started After Nb Provider Change

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerManager.ts
@@ -84,6 +84,7 @@ export class LocalJupyterServerManager implements nb.ServerManager, vscode.Dispo
 	public async stopServer(): Promise<void> {
 		if (this._jupyterServer) {
 			await this._jupyterServer.stop();
+			this._jupyterServer = undefined;
 		}
 	}
 

--- a/src/sql/workbench/parts/notebook/browser/models/clientSession.ts
+++ b/src/sql/workbench/parts/notebook/browser/models/clientSession.ts
@@ -78,7 +78,7 @@ export class ClientSession implements IClientSession {
 
 	private async startServer(): Promise<void> {
 		let serverManager = this.notebookManager.serverManager;
-		if (serverManager && !serverManager.isStarted) {
+		if (serverManager) {
 			await serverManager.startServer();
 			if (!serverManager.isStarted) {
 				throw new Error(localize('ServerNotStarted', "Server did not start for unknown reason"));


### PR DESCRIPTION
Fixes #8016 

There are some details in the bug, but the lowdown is the following:
- The serverManager knows best when a server needs to be started; the clientSession just talks to mainThreadNotebook to ask around whether a server needs to be started, but mainThreadNotebook uses a crappy heuristic to determine this. Better to talk directly to the source.
- Actually set `this._jupyterServer` to undefined when stopping server in the jupyterServerManager, so that future calls to `startServer()` actually go through the whole... starting a server... codepath 🤒 