### PR TITLE
Fix hygiene errors

### DIFF
--- a/extensions/notebook/src/common/utils.ts
+++ b/extensions/notebook/src/common/utils.ts
@@ -75,7 +75,7 @@ export function executeStreamedCommand(cmd: string, options: childProcess.SpawnO
 			if (code === 0) {
 				resolve();
 			} else {
-				reject(localize('executeCommandProcessExited', 'Process exited with  with error code: {0}. StdErr Output: {1}', code, stdErrLog));
+				reject(localize('executeCommandProcessExited', "Process exited with  with error code: {0}. StdErr Output: {1}", code, stdErrLog));
 			}
 		});
 

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -260,7 +260,7 @@ export class PerFolderServerInstance implements IServerInstance {
 			let onErrorBeforeStartup = (err: any) => reject(err);
 			let onExitBeforeStart = (err: any) => {
 				if (!this.isStarted) {
-					reject(localize('notebookStartProcessExitPremature', 'Notebook process exited prematurely with error code: {0}. StdErr Output: {1}', err, stdErrLog));
+					reject(localize('notebookStartProcessExitPremature', "Notebook process exited prematurely with error code: {0}. StdErr Output: {1}", err, stdErrLog));
 				}
 			};
 			this.childProcess.on('error', onErrorBeforeStartup);


### PR DESCRIPTION
Fix a couple hygiene errors for non-double quoted args to localize

@corivera This should have been caught by the precommit hooks. Can you check your .git\hooks folder and make sure you have a file named `pre-commit` (no extension)?