### PR TITLE
added openLocalizedook action that opens up the link to localized books.

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -141,6 +141,11 @@
         "category": "%books-preview-category%"
       },
       {
+        "command": "books.command.openLocalizedBooks",
+        "title": "%title.PreviewLocalizedBook%",
+        "category": "%books-preview-category%"
+      },
+      {
         "command": "notebook.command.saveBook",
         "title": "%title.saveJupyterBook%",
         "category": "%books-preview-category%",

--- a/extensions/notebook/package.nls.json
+++ b/extensions/notebook/package.nls.json
@@ -33,5 +33,5 @@
 	"title.searchJupyterBook": "Search Book",
 	"title.SavedBooks": "Saved Books",
 	"title.UnsavedBooks": "Unsaved Books",
-	"title.PreviewLocalizedBook": "Get localized BDC troubleshooting book"
+	"title.PreviewLocalizedBook": "Get localized SQL Server 2019 guide"
 }

--- a/extensions/notebook/package.nls.json
+++ b/extensions/notebook/package.nls.json
@@ -32,5 +32,6 @@
 	"title.saveJupyterBook": "Save Book",
 	"title.searchJupyterBook": "Search Book",
 	"title.SavedBooks": "Saved Books",
-	"title.UnsavedBooks": "Unsaved Books"
+	"title.UnsavedBooks": "Unsaved Books",
+	"title.PreviewLocalizedBook": "Get localized BDC troubleshooting book"
 }

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -91,6 +91,10 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	}));
 	extensionContext.subscriptions.push(vscode.window.registerUriHandler(new NotebookUriHandler()));
 
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('books.command.openLocalizedBooks', () => {
+		const urlToOpen: string = 'https://aka.ms/localized-BDC-book';
+		vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(urlToOpen));
+	}));
 
 	let appContext = new AppContext(extensionContext, new ApiWrapper());
 	controller = new JupyterController(appContext);

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -44,17 +44,17 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 		}
 		newNotebook(connectionProfile);
 	}));
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.open', () => {
-		openNotebook();
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.open', async () => {
+		await openNotebook();
 	}));
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.runactivecell', () => {
-		runActiveCell();
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.runactivecell', async () => {
+		await runActiveCell();
 	}));
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.runallcells', () => {
-		runAllCells();
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.runallcells', async () => {
+		await runAllCells();
 	}));
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.clearactivecellresult', () => {
-		clearActiveCellOutput();
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.clearactivecellresult', async () => {
+		await clearActiveCellOutput();
 	}));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.addcell', async () => {
 		let cellType: CellType;
@@ -77,23 +77,23 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 			return;
 		}
 		if (cellType) {
-			addCell(cellType);
+			await addCell(cellType);
 		}
 	}));
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.addcode', () => {
-		addCell('code');
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.addcode', async () => {
+		await addCell('code');
 	}));
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.addtext', () => {
-		addCell('markdown');
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.addtext', async () => {
+		await addCell('markdown');
 	}));
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.analyzeNotebook', (explorerContext: azdata.ObjectExplorerContext) => {
-		analyzeNotebook(explorerContext);
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.analyzeNotebook', async (explorerContext: azdata.ObjectExplorerContext) => {
+		await analyzeNotebook(explorerContext);
 	}));
 	extensionContext.subscriptions.push(vscode.window.registerUriHandler(new NotebookUriHandler()));
 
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('books.command.openLocalizedBooks', () => {
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('books.command.openLocalizedBooks', async () => {
 		const urlToOpen: string = 'https://aka.ms/localized-BDC-book';
-		vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(urlToOpen));
+		await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(urlToOpen));
 	}));
 
 	let appContext = new AppContext(extensionContext, new ApiWrapper());


### PR DESCRIPTION
For #7990 : Added command that opens the localized book content (https://aka.ms/localized-BDC-book) in the browser. Temporary experience for users to get to localized books. 

Command: "Jupyter Books: Get localized BDC troubleshooting book"

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
