### PR TITLE
min version check

### DIFF
--- a/extensions/resource-deployment/package.json
+++ b/extensions/resource-deployment/package.json
@@ -254,7 +254,8 @@
                 "name": "azure-cli"
               },
               {
-                "name": "azdata"
+                "name": "azdata",
+                "version": "15.0.2070"
               }
             ],
             "when": "target=new-aks&&version=bdc2019"

--- a/extensions/resource-deployment/src/interfaces.ts
+++ b/extensions/resource-deployment/src/interfaces.ts
@@ -246,6 +246,7 @@ export interface ITool {
 	showOutputChannel(preserveFocus?: boolean): void;
 	loadInformation(): Promise<void>;
 	install(): Promise<void>;
+	isSameOrNewerThan(version: string): boolean;
 }
 
 export const enum BdcDeploymentType {

--- a/extensions/resource-deployment/src/interfaces.ts
+++ b/extensions/resource-deployment/src/interfaces.ts
@@ -226,6 +226,7 @@ export const enum ToolStatus {
 }
 
 export interface ITool {
+	readonly status: ToolStatus;
 	readonly isInstalling: boolean;
 	readonly name: string;
 	readonly displayName: string;

--- a/extensions/resource-deployment/src/services/tools/toolBase.ts
+++ b/extensions/resource-deployment/src/services/tools/toolBase.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { EOL } from 'os';
 import { delimiter } from 'path';
-import { SemVer } from 'semver';
+import { SemVer, compare } from 'semver';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import { Command, ITool, OsType, ToolStatus, ToolType } from '../../interfaces';
@@ -268,6 +268,13 @@ export abstract class ToolBase implements ITool {
 		} else {
 			this._installationPath = commandOutput.split(EOL)[0];
 		}
+	}
+
+	isSameOrNewerThan(version: string): boolean {
+		const currentVersion = new SemVer(this.fullVersion!);
+		const requiredVersion = new SemVer(version);
+
+		return compare(currentVersion, requiredVersion) >= 0;
 	}
 
 	private _storagePathEnsured: boolean = false;

--- a/extensions/resource-deployment/src/services/tools/toolBase.ts
+++ b/extensions/resource-deployment/src/services/tools/toolBase.ts
@@ -63,11 +63,11 @@ export abstract class ToolBase implements ITool {
 		return this._onDidUpdateData.event;
 	}
 
-	protected get status(): ToolStatus {
+	get status(): ToolStatus {
 		return this._status;
 	}
 
-	protected set status(value: ToolStatus) {
+	set status(value: ToolStatus) {
 		this._status = value;
 		this._onDidUpdateData.fire(this);
 	}

--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -5,12 +5,13 @@
 import * as azdata from 'azdata';
 import { EOL } from 'os';
 import * as nls from 'vscode-nls';
-import { AgreementInfo, DeploymentProvider, ITool, ResourceType } from '../interfaces';
+import { AgreementInfo, DeploymentProvider, ITool, ResourceType, ToolStatus } from '../interfaces';
 import { IResourceTypeService } from '../services/resourceTypeService';
 import { IToolsService } from '../services/toolsService';
 import { getErrorMessage, setEnvironmentVariablesForInstallPaths } from '../utils';
 import { DialogBase } from './dialogBase';
 import { createFlexContainer } from './modelViewUtils';
+import { SemVer, compare } from 'semver';
 
 const localize = nls.loadMessageBundle();
 
@@ -84,10 +85,14 @@ export class ResourceTypePickerDialog extends DialogBase {
 				value: localize('deploymentDialog.toolVersionColumnHeader', "Version"),
 				width: 100
 			};
+			const minVersionColumn: azdata.TableColumn = {
+				value: localize('deploymentDialog.toolMinimumVersionColumnHeader', "Minimum Version"),
+				width: 100
+			};
 
 			this._toolsTable = view.modelBuilder.table().withProperties<azdata.TableComponentProperties>({
 				data: [],
-				columns: [toolColumn, descriptionColumn, installStatusColumn, versionColumn],
+				columns: [toolColumn, descriptionColumn, installStatusColumn, versionColumn, minVersionColumn],
 				width: tableWidth
 			}).component();
 
@@ -222,6 +227,7 @@ export class ResourceTypePickerDialog extends DialogBase {
 					return;
 				}
 				let autoInstallRequired = false;
+				let minVersionCheckFailed = false;
 				const messages: string[] = [];
 				this._toolsTable.data = toolRequirements.map(toolReq => {
 					const tool = this.toolsService.getToolByName(toolReq.name)!;
@@ -234,19 +240,28 @@ export class ResourceTypePickerDialog extends DialogBase {
 						if (tool.statusDescription !== undefined) {
 							console.warn(localize('deploymentDialog.DetailToolStatusDescription', "Additional status information for tool: '{0}' [ {1} ]. {2}", tool.name, tool.homePage, tool.statusDescription));
 						}
-					}
+					} else if (tool.status === ToolStatus.Installed && toolReq.version) {
+						const currentVersion = new SemVer(tool.fullVersion!);
+						const requiredVersion = new SemVer(toolReq.version);
 
-					autoInstallRequired = tool.autoInstallRequired;
-					return [tool.displayName, tool.description, tool.displayStatus, tool.fullVersion || ''];
+						if (compare(currentVersion, requiredVersion) < 0) {
+							minVersionCheckFailed = true;
+							messages.push(localize('deploymentDialog.ToolDoesNotMeetVersionRequirement', "'{0}' [ {1} ] does not meet the minimum version requirement, please uninstall it and restart Azure Data Studio.", tool.displayName, tool.homePage));
+						}
+					}
+					autoInstallRequired = autoInstallRequired || tool.autoInstallRequired;
+					return [tool.displayName, tool.description, tool.displayStatus, tool.fullVersion || '', toolReq.version || ''];
 				});
 
 				this._installToolButton.hidden = !autoInstallRequired;
 				this._dialogObject.okButton.enabled = messages.length === 0 && !autoInstallRequired;
 				if (messages.length !== 0) {
-					messages.push(localize('deploymentDialog.VersionInformationDebugHint', "You will need to restart Azure Data Studio if the tools are installed by yourself after Azure Data Studio is launched to pick up the updated PATH environment variable. You may find additional details in the debug console by running the 'Toggle Developer Tools' command in the Azure Data Studio Command Palette."));
+					if (!minVersionCheckFailed) {
+						messages.push(localize('deploymentDialog.VersionInformationDebugHint', "You will need to restart Azure Data Studio if the tools are installed by yourself after Azure Data Studio is launched to pick up the updated PATH environment variable. You may find additional details in the debug console by running the 'Toggle Developer Tools' command in the Azure Data Studio Command Palette."));
+					}
 					this._dialogObject.message = {
 						level: azdata.window.MessageLevel.Error,
-						text: localize('deploymentDialog.ToolCheckFailed', "Some required tools are not installed."),
+						text: localize('deploymentDialog.ToolCheckFailed', "Some required tools are not installed or do not meet the minimum version requirement."),
 						description: messages.join(EOL)
 					};
 				} else if (autoInstallRequired) {
@@ -295,7 +310,7 @@ export class ResourceTypePickerDialog extends DialogBase {
 	public updateToolsDisplayTableData(tool: ITool) {
 		this._toolsTable.data = this._toolsTable.data.map(rowData => {
 			if (rowData[0] === tool.displayName) {
-				return [tool.displayName, tool.description, tool.displayStatus, tool.fullVersion || ''];
+				return [tool.displayName, tool.description, tool.displayStatus, tool.fullVersion || '', rowData[4]];
 			} else {
 				return rowData;
 			}

--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -11,7 +11,6 @@ import { IToolsService } from '../services/toolsService';
 import { getErrorMessage, setEnvironmentVariablesForInstallPaths } from '../utils';
 import { DialogBase } from './dialogBase';
 import { createFlexContainer } from './modelViewUtils';
-import { SemVer, compare } from 'semver';
 
 const localize = nls.loadMessageBundle();
 
@@ -240,14 +239,10 @@ export class ResourceTypePickerDialog extends DialogBase {
 						if (tool.statusDescription !== undefined) {
 							console.warn(localize('deploymentDialog.DetailToolStatusDescription', "Additional status information for tool: '{0}' [ {1} ]. {2}", tool.name, tool.homePage, tool.statusDescription));
 						}
-					} else if (tool.status === ToolStatus.Installed && toolReq.version) {
-						const currentVersion = new SemVer(tool.fullVersion!);
-						const requiredVersion = new SemVer(toolReq.version);
+					} else if (tool.status === ToolStatus.Installed && toolReq.version && !tool.isSameOrNewerThan(toolReq.version)) {
+						minVersionCheckFailed = true;
+						messages.push(localize('deploymentDialog.ToolDoesNotMeetVersionRequirement', "'{0}' [ {1} ] does not meet the minimum version requirement, please uninstall it and restart Azure Data Studio.", tool.displayName, tool.homePage));
 
-						if (compare(currentVersion, requiredVersion) < 0) {
-							minVersionCheckFailed = true;
-							messages.push(localize('deploymentDialog.ToolDoesNotMeetVersionRequirement', "'{0}' [ {1} ] does not meet the minimum version requirement, please uninstall it and restart Azure Data Studio.", tool.displayName, tool.homePage));
-						}
 					}
 					autoInstallRequired = autoInstallRequired || tool.autoInstallRequired;
 					return [tool.displayName, tool.description, tool.displayStatus, tool.fullVersion || '', toolReq.version || ''];


### PR DESCRIPTION
This is not the final experience of how we want the version check to be, the main purpose of this PR is to stop the user from moving forward if they don't have the correct version. right now we only need to check the version of azdata, for other tools, we haven't experienced any issues so far.

This PR fixes #8021 
![Screen Shot 2019-10-25 at 3 55 32 PM](https://user-images.githubusercontent.com/13777222/67609427-86528280-f741-11e9-9a98-88bb0c9f4d5b.png)
