### PR TITLE
Fix schema compare include/exclude behavior

### DIFF
--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -75,7 +75,7 @@ export interface SchemaCompareResult extends azdata.ResultStatus {
 	differences: DiffEntry[];
 }
 
-export interface SchemaCompareIncludExcludeResult extends azdata.ResultStatus {
+export interface SchemaCompareIncludeExcludeResult extends azdata.ResultStatus {
 	affectedDependencies: DiffEntry[];
 	blockingDependencies: DiffEntry[];
 }
@@ -296,7 +296,7 @@ export interface ISchemaCompareService {
 	schemaCompareGenerateScript(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus>;
 	schemaComparePublishChanges(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus>;
 	schemaCompareGetDefaultOptions(): Thenable<SchemaCompareOptionsResult>;
-	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<SchemaCompareIncludExcludeResult>;
+	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<SchemaCompareIncludeExcludeResult>;
 	schemaCompareOpenScmp(filePath: string): Thenable<SchemaCompareOpenScmpResult>;
 	schemaCompareSaveScmp(sourceEndpointInfo: SchemaCompareEndpointInfo, targetEndpointInfo: SchemaCompareEndpointInfo, taskExecutionMode: azdata.TaskExecutionMode, deploymentOptions: DeploymentOptions, scmpFilePath: string, excludedSourceObjects: SchemaCompareObjectId[], excludedTargetObjects: SchemaCompareObjectId[]): Thenable<azdata.ResultStatus>;
 	schemaCompareCancel(operationId: string): Thenable<azdata.ResultStatus>;

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -75,6 +75,11 @@ export interface SchemaCompareResult extends azdata.ResultStatus {
 	differences: DiffEntry[];
 }
 
+export interface SchemaCompareIncludExcludeResult extends azdata.ResultStatus {
+	affectedDependencies: DiffEntry[];
+	blockingDependencies: DiffEntry[];
+}
+
 export interface SchemaCompareCompletionResult extends azdata.ResultStatus {
 	operationId: string;
 	areEqual: boolean;
@@ -91,6 +96,7 @@ export interface DiffEntry {
 	children: DiffEntry[];
 	sourceScript: string;
 	targetScript: string;
+	included: boolean;
 }
 
 export const enum SchemaUpdateAction {
@@ -290,7 +296,7 @@ export interface ISchemaCompareService {
 	schemaCompareGenerateScript(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus>;
 	schemaComparePublishChanges(operationId: string, targetServerName: string, targetDatabaseName: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus>;
 	schemaCompareGetDefaultOptions(): Thenable<SchemaCompareOptionsResult>;
-	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus>;
+	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<SchemaCompareIncludExcludeResult>;
 	schemaCompareOpenScmp(filePath: string): Thenable<SchemaCompareOpenScmpResult>;
 	schemaCompareSaveScmp(sourceEndpointInfo: SchemaCompareEndpointInfo, targetEndpointInfo: SchemaCompareEndpointInfo, taskExecutionMode: azdata.TaskExecutionMode, deploymentOptions: DeploymentOptions, scmpFilePath: string, excludedSourceObjects: SchemaCompareObjectId[], excludedTargetObjects: SchemaCompareObjectId[]): Thenable<azdata.ResultStatus>;
 	schemaCompareCancel(operationId: string): Thenable<azdata.ResultStatus>;

--- a/extensions/mssql/src/schemaCompare/schemaCompareService.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareService.ts
@@ -76,7 +76,7 @@ export class SchemaCompareService implements mssql.ISchemaCompareService {
 		);
 	}
 
-	public schemaCompareIncludeExcludeNode(operationId: string, diffEntry: mssql.DiffEntry, includeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
+	public schemaCompareIncludeExcludeNode(operationId: string, diffEntry: mssql.DiffEntry, includeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaCompareIncludExcludeResult> {
 		const params: contracts.SchemaCompareNodeParams = { operationId: operationId, diffEntry, includeRequest, taskExecutionMode: taskExecutionMode };
 		return this.client.sendRequest(contracts.SchemaCompareIncludeExcludeNodeRequest.type, params).then(
 			undefined,

--- a/extensions/mssql/src/schemaCompare/schemaCompareService.ts
+++ b/extensions/mssql/src/schemaCompare/schemaCompareService.ts
@@ -76,7 +76,7 @@ export class SchemaCompareService implements mssql.ISchemaCompareService {
 		);
 	}
 
-	public schemaCompareIncludeExcludeNode(operationId: string, diffEntry: mssql.DiffEntry, includeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaCompareIncludExcludeResult> {
+	public schemaCompareIncludeExcludeNode(operationId: string, diffEntry: mssql.DiffEntry, includeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaCompareIncludeExcludeResult> {
 		const params: contracts.SchemaCompareNodeParams = { operationId: operationId, diffEntry, includeRequest, taskExecutionMode: taskExecutionMode };
 		return this.client.sendRequest(contracts.SchemaCompareIncludeExcludeNodeRequest.type, params).then(
 			undefined,

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -426,9 +426,10 @@ export class SchemaCompareMainWindow {
 					// failed because of dependencies
 					if (result.blockingDependencies) {
 						// show the first dependent that caused this to fail in the warning message
+						const diffEntryName = this.createName(diff.sourceValue ? diff.sourceValue : diff.targetValue);
 						const firstDependentName = this.createName(result.blockingDependencies[0].sourceValue ? result.blockingDependencies[0].sourceValue : result.blockingDependencies[0].targetValue);
-						const cannotExcludeMessage = localize('schemaCompare.cannotExcludeMessage', "Cannot exclude. Included dependents exist such as {0}", firstDependentName);
-						const cannotIncludeMessage = localize('schemaCompare.cannotIncludeMessage', "Cannot include. Excluded dependents exist such as {0}", firstDependentName);
+						const cannotExcludeMessage = localize('schemaCompare.cannotExcludeMessage', "Cannot exclude {0}. Included dependents exist such as {1}", diffEntryName, firstDependentName);
+						const cannotIncludeMessage = localize('schemaCompare.cannotIncludeMessage', "Cannot include {0}. Excluded dependents exist such as {1}", diffEntryName, firstDependentName);
 						vscode.window.showWarningMessage(checkboxState.checked ? cannotIncludeMessage : cannotExcludeMessage);
 					} else {
 						vscode.window.showWarningMessage(result.errorMessage);

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -345,7 +345,7 @@ export class SchemaCompareMainWindow {
 
 			// create a map of the differences to row numbers
 			for (let i = 0; i < data.length; ++i) {
-				this.diffEntryRowMap[this.createDiffEntryKey(this.comparisonResult.differences[i])] = i;
+				this.diffEntryRowMap.set(this.createDiffEntryKey(this.comparisonResult.differences[i]), i);
 			}
 
 			// only enable generate script button if the target is a db
@@ -402,8 +402,9 @@ export class SchemaCompareMainWindow {
 					// depencies could have been included or excluded as a result, so save their exclude states
 					result.affectedDependencies.forEach(difference => {
 						// find the row of the difference and set it's checkbox
-						const row = this.diffEntryRowMap[this.createDiffEntryKey(difference)];
-						if (row !== -1) {
+						const diffEntryKey = this.createDiffEntryKey(difference);
+						if (this.diffEntryRowMap.has(diffEntryKey)) {
+							const row = this.diffEntryRowMap.get(diffEntryKey);
 							checkboxesToChange.push({ row: row, columnName: 'Include', checked: difference.included });
 							const dependencyCheckBoxState: azdata.ICheckboxCellActionEventArgs = {
 								checked: difference.included,
@@ -433,20 +434,6 @@ export class SchemaCompareMainWindow {
 				this.differencesTable.checked = checkboxesToChange;
 			}
 		}));
-	}
-
-	// get the row number of the difference in the table
-	private findDifferenceRow(difference: mssql.DiffEntry): number {
-		for (let i = 0; i < this.comparisonResult.differences.length; i++) {
-			if (this.comparisonResult.differences[i].differenceType === difference.differenceType
-				&& this.comparisonResult.differences[i].name === difference.name
-				&& this.createName(this.comparisonResult.differences[i].sourceValue) === this.createName(difference.sourceValue)
-				&& this.createName(this.comparisonResult.differences[i].targetValue) === this.createName(difference.targetValue)) {
-				return i;
-			}
-		}
-
-		return -1;
 	}
 
 	// save state based on source name if present otherwise target name (parity with SSDT)

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -406,13 +406,13 @@ export class SchemaCompareMainWindow {
 				if (result.success) {
 					this.saveExcludeState(checkboxState);
 
-					// depencies could have been included or excluded as a result, so save their exclude states
+					// dependencies could have been included or excluded as a result, so save their exclude states
 					result.affectedDependencies.forEach(difference => {
-						// find the row of the difference and set it's checkbox
+						// find the row of the difference and set its checkbox
 						const diffEntryKey = this.createDiffEntryKey(difference);
 						if (this.diffEntryRowMap.has(diffEntryKey)) {
 							const row = this.diffEntryRowMap.get(diffEntryKey);
-							checkboxesToChange.push({ row: row, columnName: 'Include', checked: difference.included });
+							checkboxesToChange.push({ row: row, column: 2, columnName: 'Include', checked: difference.included });
 							const dependencyCheckBoxState: azdata.ICheckboxCellActionEventArgs = {
 								checked: difference.included,
 								row: row,
@@ -435,11 +435,11 @@ export class SchemaCompareMainWindow {
 					}
 
 					// set checkbox back to previous state
-					checkboxesToChange.push({ row: checkboxState.row, columnName: 'Include', checked: !checkboxState.checked });
+					checkboxesToChange.push({ row: checkboxState.row, column: checkboxState.column, columnName: 'Include', checked: !checkboxState.checked });
 				}
 
 				if (checkboxesToChange.length > 0) {
-					this.differencesTable.checked = checkboxesToChange;
+					this.differencesTable.updateCells = checkboxesToChange;
 				}
 			}
 		}));

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -419,11 +419,13 @@ export class SchemaCompareMainWindow {
 						vscode.window.showWarningMessage(result.errorMessage);
 					}
 
-					// set checkbox back to previous state
-					this.differencesTable.checked = { row: checkboxState.row, columnName: 'Include', checked: !checkboxState.checked };
+
+					// if failed or needs to do something more, call the following or something more
+					let dependencies = [];
+					dependencies.push({ row: checkboxState.row, columnName: 'Include', checked: !checkboxState.checked });
+					this.differencesTable.checked = dependencies;
 				}
-			}
-		}));
+			}));
 	}
 
 	// get the row number of the difference in the table

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -105,12 +105,12 @@ export class SchemaCompareMainWindow {
 				title: localize('schemaCompare.differencesTableTitle', "Comparison between Source and Target")
 			}).component();
 
-			// this.diffEditor = view.modelBuilder.diffeditor().withProperties({
-			// 	contentLeft: os.EOL,
-			// 	contentRight: os.EOL,
-			// 	height: 500,
-			// 	title: diffEditorTitle
-			// }).component();
+			this.diffEditor = view.modelBuilder.diffeditor().withProperties({
+				contentLeft: os.EOL,
+				contentRight: os.EOL,
+				height: 500,
+				title: diffEditorTitle
+			}).component();
 
 			this.splitView = view.modelBuilder.splitViewContainer().component();
 
@@ -398,9 +398,15 @@ export class SchemaCompareMainWindow {
 
 					// add and remove table to refresh the checkbox
 					// TODO: need to figure out a better way to do this. For big tables, this will refresh the table and show it from the beginning after
-					this.flexModel.removeItem(this.differencesTable);
-					this.flexModel.addItem(this.differencesTable);
+					this.flexModel.removeItem(this.splitView);
+					this.splitView.addItem(this.differencesTable);
+					this.splitView.addItem(this.diffEditor);
+					this.splitView.setLayout({
+						orientation: 'vertical',
+						splitViewHeight: 800
+					});
 				}
+				this.flexModel.addItem(this.splitView);
 			}
 		}));
 	}

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -387,26 +387,13 @@ export class SchemaCompareMainWindow {
 			let checkboxState = <azdata.ICheckboxCellActionEventArgs>rowState;
 			if (checkboxState) {
 				let diff = this.comparisonResult.differences[checkboxState.row];
-				let result = await service.schemaCompareIncludeExcludeNode(this.comparisonResult.operationId, diff, checkboxState.checked, azdata.TaskExecutionMode.execute);
-				console.error('result.success is ' + result.success);
-				if (result.success) {
-					this.saveExcludeState(checkboxState);
-					this.differencesTable.data[checkboxState.row][checkboxState.column] = checkboxState.checked;
-				} else {
-					vscode.window.showWarningMessage(localize('schemaCompare.cannotExcludeMessage', 'Cannot exclude. Included dependents exist'));
-					this.differencesTable.data[checkboxState.row][checkboxState.column] = true;
+				await service.schemaCompareIncludeExcludeNode(this.comparisonResult.operationId, diff, checkboxState.checked, azdata.TaskExecutionMode.execute);
 
-					// add and remove table to refresh the checkbox
-					// TODO: need to figure out a better way to do this. For big tables, this will refresh the table and show it from the beginning after
-					this.flexModel.removeItem(this.splitView);
-					this.splitView.addItem(this.differencesTable);
-					this.splitView.addItem(this.diffEditor);
-					this.splitView.setLayout({
-						orientation: 'vertical',
-						splitViewHeight: 800
-					});
-				}
-				this.flexModel.addItem(this.splitView);
+				// check if if the called worked or not - if worked
+				this.saveExcludeState(checkboxState);
+
+				// if failed or needs to do something more, call the following or something more
+				this.differencesTable.checked = { row: checkboxState.row, columnName: 'Include', checked: !checkboxState.checked };
 			}
 		}));
 	}

--- a/extensions/schema-compare/src/test/testSchemaCompareService.ts
+++ b/extensions/schema-compare/src/test/testSchemaCompareService.ts
@@ -24,7 +24,7 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		return Promise.resolve(result);
 	}
 
-	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: mssql.DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaCompareIncludExcludeResult> {
+	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: mssql.DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaCompareIncludeExcludeResult> {
 		throw new Error('Method not implemented.');
 	}
 

--- a/extensions/schema-compare/src/test/testSchemaCompareService.ts
+++ b/extensions/schema-compare/src/test/testSchemaCompareService.ts
@@ -24,7 +24,7 @@ export class SchemaCompareTestService implements mssql.ISchemaCompareService {
 		return Promise.resolve(result);
 	}
 
-	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: mssql.DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<azdata.ResultStatus> {
+	schemaCompareIncludeExcludeNode(operationId: string, diffEntry: mssql.DiffEntry, IncludeRequest: boolean, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.SchemaCompareIncludExcludeResult> {
 		throw new Error('Method not implemented.');
 	}
 

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3086,7 +3086,7 @@ declare module 'azdata' {
 		ariaColumnCount?: number;
 		ariaRole?: string;
 		focused?: boolean;
-		checked?: CheckBoxInfo;
+		checked?: CheckBoxInfo[];
 		moveFocusOutWithTab?: boolean; //accessibility requirement for tables with no actionable cells
 	}
 

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3086,7 +3086,14 @@ declare module 'azdata' {
 		ariaColumnCount?: number;
 		ariaRole?: string;
 		focused?: boolean;
+		checked?: CheckBoxInfo;
 		moveFocusOutWithTab?: boolean; //accessibility requirement for tables with no actionable cells
+	}
+
+	export interface CheckBoxInfo {
+		row: number;
+		columnName: string;
+		checked: boolean;
 	}
 
 	export interface FileBrowserTreeProperties extends ComponentProperties {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3086,14 +3086,13 @@ declare module 'azdata' {
 		ariaColumnCount?: number;
 		ariaRole?: string;
 		focused?: boolean;
-		checked?: CheckBoxInfo[];
+		updateCells?: TableCell[];
 		moveFocusOutWithTab?: boolean; //accessibility requirement for tables with no actionable cells
 	}
 
-	export interface CheckBoxInfo {
-		row: number;
-		columnName: string;
+	export interface CheckBoxCell extends TableCell {
 		checked: boolean;
+		columnName: string;
 	}
 
 	export interface FileBrowserTreeProperties extends ComponentProperties {

--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -176,10 +176,10 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 
 		if (this._selectedCheckBoxLookup[row]) {
 			delete this._selectedCheckBoxLookup[row];
-			this._onChange.fire({ checked: false, row: row, column: col });
+				this._onChange.fire({ checked: false, row: row, column: col });
 		} else {
 			this._selectedCheckBoxLookup[row] = true;
-			this._onChange.fire({ checked: true, row: row, column: col });
+				this._onChange.fire({ checked: true, row: row, column: col });
 		}
 
 		if (reRender) {
@@ -192,6 +192,18 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		if(this._grid.getActiveCellNode()) {
 			this._grid.getActiveCellNode().focus();
 		}
+	}
+
+	// This call is to handle reactive changes in check box UI
+	// This DOES NOT fire UI change Events
+	reactiveCheckboxCheck(row: number, value: boolean) {
+		value ? this._selectedCheckBoxLookup[row] = true : delete this._selectedCheckBoxLookup[row];
+
+		// update row to call formatter
+		this._grid.updateRow(row);
+
+		// ensure that grid reflects the change
+		this._grid.scrollRowIntoView(row);
 	}
 
 	private handleHeaderClick(e: Event, args: Slick.OnHeaderClickEventArgs<T>): void {

--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -176,10 +176,10 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 
 		if (this._selectedCheckBoxLookup[row]) {
 			delete this._selectedCheckBoxLookup[row];
-				this._onChange.fire({ checked: false, row: row, column: col });
+			this._onChange.fire({ checked: false, row: row, column: col });
 		} else {
 			this._selectedCheckBoxLookup[row] = true;
-				this._onChange.fire({ checked: true, row: row, column: col });
+			this._onChange.fire({ checked: true, row: row, column: col });
 		}
 
 		if (reRender) {

--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -193,7 +193,7 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 			this._grid.getActiveCellNode().focus();
 		}
 
-		// set selected row to the row with this checkbox
+		// set selected row to the row of this checkbox
 		this._grid.setSelectedRows([row]);
 	}
 

--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -189,7 +189,9 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		}
 
 		//Ensure that the focus stays correct
-		this._grid.getActiveCellNode().focus();
+		if(this._grid.getActiveCellNode()) {
+			this._grid.getActiveCellNode().focus();
+		}
 	}
 
 	private handleHeaderClick(e: Event, args: Slick.OnHeaderClickEventArgs<T>): void {

--- a/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin.ts
@@ -192,6 +192,9 @@ export class CheckboxSelectColumn<T extends Slick.SlickData> implements Slick.Pl
 		if(this._grid.getActiveCellNode()) {
 			this._grid.getActiveCellNode().focus();
 		}
+
+		// set selected row to the row with this checkbox
+		this._grid.setSelectedRows([row]);
 	}
 
 	// This call is to handle reactive changes in check box UI

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1274,11 +1274,11 @@ class TableComponentWrapper extends ComponentWrapper implements azdata.TableComp
 		this.setProperty('focused', v);
 	}
 
-	public get checked(): CheckBoxInfo {
+	public get checked(): CheckBoxInfo[] {
 		return this.properties['checked'];
 	}
 
-	public set checked(v: CheckBoxInfo) {
+	public set checked(v: CheckBoxInfo[]) {
 		this.setProperty('checked', v);
 	}
 

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -13,7 +13,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 
 import { SqlMainContext, ExtHostModelViewShape, MainThreadModelViewShape, ExtHostModelViewTreeViewsShape } from 'sql/workbench/api/common/sqlExtHost.protocol';
-import { IItemConfig, ModelComponentTypes, IComponentShape, IComponentEventArgs, ComponentEventType, ColumnSizingMode } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { IItemConfig, ModelComponentTypes, IComponentShape, IComponentEventArgs, ComponentEventType, ColumnSizingMode, CheckBoxInfo } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 
 class ModelBuilderImpl implements azdata.ModelBuilder {
@@ -1272,6 +1272,14 @@ class TableComponentWrapper extends ComponentWrapper implements azdata.TableComp
 	}
 	public set focused(v: boolean) {
 		this.setProperty('focused', v);
+	}
+
+	public get checked(): CheckBoxInfo {
+		return this.properties['checked'];
+	}
+
+	public set checked(v: CheckBoxInfo) {
+		this.setProperty('checked', v);
 	}
 
 	public get onRowSelected(): vscode.Event<any> {

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -13,7 +13,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 
 import { SqlMainContext, ExtHostModelViewShape, MainThreadModelViewShape, ExtHostModelViewTreeViewsShape } from 'sql/workbench/api/common/sqlExtHost.protocol';
-import { IItemConfig, ModelComponentTypes, IComponentShape, IComponentEventArgs, ComponentEventType, ColumnSizingMode, CheckBoxInfo } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { IItemConfig, ModelComponentTypes, IComponentShape, IComponentEventArgs, ComponentEventType, ColumnSizingMode } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 
 class ModelBuilderImpl implements azdata.ModelBuilder {
@@ -1274,12 +1274,12 @@ class TableComponentWrapper extends ComponentWrapper implements azdata.TableComp
 		this.setProperty('focused', v);
 	}
 
-	public get checked(): CheckBoxInfo[] {
-		return this.properties['checked'];
+	public get updateCells(): azdata.TableCell[] {
+		return this.properties['updateCells'];
 	}
 
-	public set checked(v: CheckBoxInfo[]) {
-		this.setProperty('checked', v);
+	public set updateCells(v: azdata.TableCell[]) {
+		this.setProperty('updateCells', v);
 	}
 
 	public get onRowSelected(): vscode.Event<any> {

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -203,6 +203,12 @@ export enum ExtensionNodeType {
 	Database = 'Database'
 }
 
+export interface CheckBoxInfo {
+	row: number;
+	columnName: string;
+	checked: boolean;
+}
+
 export interface IComponentShape {
 	type: ModelComponentTypes;
 	id: string;

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -264,11 +264,13 @@ export default class TableComponent extends ComponentBase implements IComponent,
 		this.validate();
 	}
 
-	private check(checkInfo: azdata.CheckBoxInfo): void {
-		if (isNullOrUndefined(checkInfo.columnName) || isNullOrUndefined(checkInfo.row)) {
-			return;
-		}
-		this._checkboxColumns[checkInfo.columnName].reactiveCheckboxCheck(checkInfo.row, checkInfo.checked);
+	private check(checkInfos: azdata.CheckBoxInfo[]): void {
+		checkInfos.forEach((checkInfo) => {
+			if (isNullOrUndefined(checkInfo.columnName) || isNullOrUndefined(checkInfo.row) || checkInfo.row < 0 || checkInfo.row > this.data.length) {
+				return;
+			}
+			this._checkboxColumns[checkInfo.columnName].reactiveCheckboxCheck(checkInfo.row, checkInfo.checked);
+		});
 	}
 
 	private createCheckBoxPlugin(col: any, index: number) {
@@ -370,11 +372,11 @@ export default class TableComponent extends ComponentBase implements IComponent,
 		this.setPropertyFromUI<azdata.RadioButtonProperties, boolean>((properties, value) => { properties.focused = value; }, newValue);
 	}
 
-	public get checked(): azdata.CheckBoxInfo {
-		return this.getPropertyOrDefault<azdata.TableComponentProperties, azdata.CheckBoxInfo>((props) => props.checked, undefined);
+	public get checked(): azdata.CheckBoxInfo[] {
+		return this.getPropertyOrDefault<azdata.TableComponentProperties, azdata.CheckBoxInfo[]>((props) => props.checked, undefined);
 	}
 
-	public set checked(newValue: azdata.CheckBoxInfo) {
-		this.setPropertyFromUI<azdata.TableComponentProperties, azdata.CheckBoxInfo>((properties, value) => { properties.checked = value; }, newValue);
+	public set checked(newValue: azdata.CheckBoxInfo[]) {
+		this.setPropertyFromUI<azdata.TableComponentProperties, azdata.CheckBoxInfo[]>((properties, value) => { properties.checked = value; }, newValue);
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -26,6 +26,7 @@ import { Emitter, Event as vsEvent } from 'vs/base/common/event';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { slickGridDataItemColumnValueWithNoData, textFormatter } from 'sql/base/browser/ui/table/formatters';
+import { isNullOrUndefined } from 'util';
 
 @Component({
 	selector: 'modelview-table',
@@ -255,8 +256,19 @@ export default class TableComponent extends ComponentBase implements IComponent,
 			this._table.focus();
 		}
 
+		if (this.checked !== undefined) {
+			this.check(this.checked);
+		}
+
 		this.layoutTable();
 		this.validate();
+	}
+
+	private check(checkInfo: azdata.CheckBoxInfo): void {
+		if (isNullOrUndefined(checkInfo.columnName) || isNullOrUndefined(checkInfo.row)) {
+			return;
+		}
+		this._checkboxColumns[checkInfo.columnName].reactiveCheckboxCheck(checkInfo.row, checkInfo.checked);
 	}
 
 	private createCheckBoxPlugin(col: any, index: number) {
@@ -356,5 +368,13 @@ export default class TableComponent extends ComponentBase implements IComponent,
 
 	public set focused(newValue: boolean) {
 		this.setPropertyFromUI<azdata.RadioButtonProperties, boolean>((properties, value) => { properties.focused = value; }, newValue);
+	}
+
+	public get checked(): azdata.CheckBoxInfo {
+		return this.getPropertyOrDefault<azdata.TableComponentProperties, azdata.CheckBoxInfo>((props) => props.checked, undefined);
+	}
+
+	public set checked(newValue: azdata.CheckBoxInfo) {
+		this.setPropertyFromUI<azdata.TableComponentProperties, azdata.CheckBoxInfo>((properties, value) => { properties.checked = value; }, newValue);
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -256,20 +256,24 @@ export default class TableComponent extends ComponentBase implements IComponent,
 			this._table.focus();
 		}
 
-		if (this.checked !== undefined) {
-			this.check(this.checked);
+		if (this.updateCells !== undefined) {
+			this.updateTableCells(this.updateCells);
 		}
 
 		this.layoutTable();
 		this.validate();
 	}
 
-	private check(checkInfos: azdata.CheckBoxInfo[]): void {
-		checkInfos.forEach((checkInfo) => {
-			if (isNullOrUndefined(checkInfo.columnName) || isNullOrUndefined(checkInfo.row) || checkInfo.row < 0 || checkInfo.row > this.data.length) {
+	private updateTableCells(cellInfos): void {
+		cellInfos.forEach((cellInfo) => {
+			if (isNullOrUndefined(cellInfo.column) || isNullOrUndefined(cellInfo.row) || cellInfo.row < 0 || cellInfo.row > this.data.length) {
 				return;
 			}
-			this._checkboxColumns[checkInfo.columnName].reactiveCheckboxCheck(checkInfo.row, checkInfo.checked);
+
+			const checkInfo: azdata.CheckBoxCell = cellInfo as azdata.CheckBoxCell;
+			if (checkInfo) {
+				this._checkboxColumns[checkInfo.columnName].reactiveCheckboxCheck(checkInfo.row, checkInfo.checked);
+			}
 		});
 	}
 
@@ -372,11 +376,11 @@ export default class TableComponent extends ComponentBase implements IComponent,
 		this.setPropertyFromUI<azdata.RadioButtonProperties, boolean>((properties, value) => { properties.focused = value; }, newValue);
 	}
 
-	public get checked(): azdata.CheckBoxInfo[] {
-		return this.getPropertyOrDefault<azdata.TableComponentProperties, azdata.CheckBoxInfo[]>((props) => props.checked, undefined);
+	public get updateCells(): azdata.TableCell[] {
+		return this.getPropertyOrDefault<azdata.TableComponentProperties, azdata.TableCell[]>((props) => props.updateCells, undefined);
 	}
 
-	public set checked(newValue: azdata.CheckBoxInfo[]) {
-		this.setPropertyFromUI<azdata.TableComponentProperties, azdata.CheckBoxInfo[]>((properties, value) => { properties.checked = value; }, newValue);
+	public set updateCells(newValue: azdata.TableCell[]) {
+		this.setPropertyFromUI<azdata.TableComponentProperties, azdata.TableCell[]>((properties, value) => { properties.updateCells = value; }, newValue);
 	}
 }


### PR DESCRIPTION
Fixes #7157. Previously, the schema compare differences table wasn't updating the inclusion state of other differences that were affected by the checking/unchecking of a different row. This fixes that by updating the checkboxes of affected dependencies and also resetting the checkbox state if the include/exclude request failed.

![includeExcludeFix](https://user-images.githubusercontent.com/31145923/67610112-7d63b000-f745-11e9-8912-99767cc79e40.gif)
