### PR TITLE
Tab trap for modal (closes #5930)

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -334,8 +334,8 @@ export abstract class Modal extends Disposable implements IThemable {
 		// Try to find focusable element in dialog pane rather than overall container. _modalBodySection contains items in the pane for a wizard.
 		// This ensures that we are setting the focus on a useful element in the form when possible.
 		let focusableElements = this._modalBodySection ?
-		this._modalBodySection.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]') :
-		this._bodyContainer.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]');
+			this._modalBodySection.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]') :
+			this._bodyContainer.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]');
 
 		this._focusedElementBeforeOpen = <HTMLElement>document.activeElement;
 

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -84,9 +84,8 @@ export abstract class Modal extends Disposable implements IThemable {
 	private _messageDetailText: string;
 
 	private _spinnerElement: HTMLElement;
-	private _focusableElements: NodeListOf<Element>;
-	private _firstFocusableElement: HTMLElement;
-	private _lastFocusableElement: HTMLElement;
+	private _firstTabbableElement: HTMLElement; // The first element in the dialog the user could tab to
+	private _lastTabbableElement: HTMLElement; // The last element in the dialog the user could tab to
 	private _focusedElementBeforeOpen: HTMLElement;
 
 	private _dialogForeground?: Color;
@@ -269,16 +268,18 @@ export abstract class Modal extends Disposable implements IThemable {
 	}
 
 	private handleBackwardTab(e: KeyboardEvent) {
-		if (this._firstFocusableElement && this._lastFocusableElement && document.activeElement === this._firstFocusableElement) {
+		this.setFirstLastTabbableElement(); // called every time to get the current elements
+		if (this._firstTabbableElement && this._lastTabbableElement && document.activeElement === this._firstTabbableElement) {
 			e.preventDefault();
-			this._lastFocusableElement.focus();
+			this._lastTabbableElement.focus();
 		}
 	}
 
 	private handleForwardTab(e: KeyboardEvent) {
-		if (this._firstFocusableElement && this._lastFocusableElement && document.activeElement === this._lastFocusableElement) {
+		this.setFirstLastTabbableElement(); // called everytime to get the current elements
+		if (this._firstTabbableElement && this._lastTabbableElement && document.activeElement === this._lastTabbableElement) {
 			e.preventDefault();
-			this._firstFocusableElement.focus();
+			this._firstTabbableElement.focus();
 		}
 	}
 
@@ -316,29 +317,30 @@ export abstract class Modal extends Disposable implements IThemable {
 	}
 
 	/**
-	 * Set focusable elements in the modal dialog
+	 * Figures out the first and last elements which the user can tab to in the dialog
 	 */
-	public setFocusableElements() {
-		// try to find focusable element in dialog pane rather than overall container
-		this._focusableElements = this._modalBodySection ?
-			this._modalBodySection.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]') :
-			this._bodyContainer.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]');
-		if (this._focusableElements && this._focusableElements.length > 0) {
-			this._firstFocusableElement = <HTMLElement>this._focusableElements[0];
-			this._lastFocusableElement = <HTMLElement>this._focusableElements[this._focusableElements.length - 1];
+	public setFirstLastTabbableElement() {
+		let tabbableElements = this._bodyContainer.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]');
+		if (tabbableElements && tabbableElements.length > 0) {
+			this._firstTabbableElement = <HTMLElement>tabbableElements[0];
+			this._lastTabbableElement = <HTMLElement>tabbableElements[tabbableElements.length - 1];
 		}
-
-		this._focusedElementBeforeOpen = <HTMLElement>document.activeElement;
-		this.focus();
 	}
 
 	/**
-	 * Focuses the modal
-	 * Default behavior: focus the first focusable element
+	 * Set focusable elements in the modal dialog
 	 */
-	protected focus() {
-		if (this._firstFocusableElement) {
-			this._firstFocusableElement.focus();
+	public setFocusableElements() {
+		// Try to find focusable element in dialog pane rather than overall container. _modalBodySection contains items in the pane for a wizard.
+		// This ensures that we are setting the focus on a useful element in the form when possible.
+		let focusableElements = this._modalBodySection ?
+		this._modalBodySection.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]') :
+		this._bodyContainer.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]');
+
+		this._focusedElementBeforeOpen = <HTMLElement>document.activeElement;
+
+		if (focusableElements[0]) {
+			(<HTMLElement>focusableElements[0]).focus();
 		}
 	}
 

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -330,7 +330,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	/**
 	 * Set focusable elements in the modal dialog
 	 */
-	public setFocusableElements() {
+	public setInitialFocusedElement() {
 		// Try to find focusable element in dialog pane rather than overall container. _modalBodySection contains items in the pane for a wizard.
 		// This ensures that we are setting the focus on a useful element in the form when possible.
 		let focusableElements = this._modalBodySection ?
@@ -339,7 +339,7 @@ export abstract class Modal extends Disposable implements IThemable {
 
 		this._focusedElementBeforeOpen = <HTMLElement>document.activeElement;
 
-		if (focusableElements[0]) {
+		if (focusableElements && focusableElements.length > 0) {
 			(<HTMLElement>focusableElements[0]).focus();
 		}
 	}
@@ -350,7 +350,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	protected show() {
 		this._modalShowingContext.get()!.push(this._staticKey);
 		DOM.append(this.layoutService.container, this._bodyContainer);
-		this.setFocusableElements();
+		this.setInitialFocusedElement();
 
 		this._keydownListener = DOM.addDisposableListener(document, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
 			let context = this._modalShowingContext.get()!;

--- a/src/sql/workbench/services/backup/browser/backupUiService.ts
+++ b/src/sql/workbench/services/backup/browser/backupUiService.ts
@@ -108,7 +108,7 @@ export class BackupUiService implements IBackupUiService {
 	public onShowBackupDialog() {
 		let backupDialog = this._backupDialogs[this._currentProvider];
 		if (backupDialog) {
-			backupDialog.setFocusableElements();
+			backupDialog.setInitialFocusedElement();
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #5930. The modal dialog in ADS has the logic for trapping the tab. However it was not comparing against the right first and last tabbable elements. As a result the tab order could bleed into elements in the background in ADS, outside of the modal dialog. This fix includes the following:
- Find first and last tabbable element on the _bodyContainer, which includes all items in the dialog. This gets the code back in the state it was in August.
- Determine the first and last element on every tab press. The contents of the dialog can change. Just remembering the elements in the beginning does not help.
- Separate the logic for setting the focus on the most logical element in a wizard. This executes once for the dialog. And does not conflict with the tab trapping logic for modal dialogs.

Also fixes #6031 . 
