### PR TITLE
Fix aria label for form loading components

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3011,6 +3011,10 @@ declare module 'azdata' {
 		 */
 		display?: DisplayType;
 		/**
+		 * Corresponds to the aria-label accessibility attribute for this component
+		 */
+		ariaLabel?: string;
+		/**
 		 * Matches the CSS style key and its available values.
 		 */
 		CSSStyles?: { [key: string]: string };
@@ -3024,7 +3028,6 @@ declare module 'azdata' {
 
 	export interface InputBoxProperties extends ComponentProperties {
 		value?: string;
-		ariaLabel?: string;
 		ariaLive?: string;
 		placeHolder?: string;
 		inputType?: InputBoxInputType;
@@ -3147,7 +3150,6 @@ declare module 'azdata' {
 		values?: string[] | CategoryValue[];
 		editable?: boolean;
 		fireOnTextChange?: boolean;
-		ariaLabel?: string;
 		required?: boolean;
 	}
 
@@ -3226,10 +3228,6 @@ declare module 'azdata' {
 		 * The title for the button. This title will show when hovered over
 		 */
 		title?: string;
-		/**
-		 * The accessibility aria label for this component
-		 */
-		ariaLabel?: string;
 	}
 
 	export interface LoadingComponentProperties {

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -331,6 +331,9 @@ class FormContainerBuilder extends GenericContainerBuilder<azdata.FormContainer,
 		}
 		if (formComponent.title && componentWrapper) {
 			componentWrapper.ariaLabel = formComponent.title;
+			if (componentWrapper instanceof LoadingComponentWrapper) {
+				componentWrapper.component.ariaLabel = formComponent.title;
+			}
 		}
 		let actions: string[] = undefined;
 		if (formComponent.actions) {


### PR DESCRIPTION
Fixes #5970

This was partially fixed in https://github.com/microsoft/azuredatastudio/commit/bd15a96b836669ee2d481d1aa3730c9eef1ac469 but wasn't working for loading components since they're a bit special in that the loading component (that was having the aria-label attribute added) was being replaced with the actual child component when it finished loading and thus doesn't have the correct aria-label.

I chose to do this here instead of in the actual loading component class because in general I think it's appropriate for a loading component and its child component to have different labels. But in this case we want the title to apply to both so they're announced correctly regardless. 