### PR TITLE
Update NewDatabase extension to remove warnings

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -934,14 +934,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.0.3",
-							"lastUpdated": "11/27/2018",
+							"version": "1.0.0",
+							"lastUpdated": "10/28/2019",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/kevcunnane/azuredatastudio-newdatabase/releases/tag/0.0.3"
+									"source": "https://github.com/kevcunnane/azuredatastudio-newdatabase/releases/tag/1.0.0"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -977,7 +977,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": "preview"
+					"flags": ""
 				},
 				{
 					"extensionId": "28",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -934,14 +934,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.0.3",
-							"lastUpdated": "11/27/2018",
+							"version": "1.0.0",
+							"lastUpdated": "10/28/2019",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/kevcunnane/azuredatastudio-newdatabase/releases/tag/0.0.3"
+									"source": "https://github.com/kevcunnane/azuredatastudio-newdatabase/releases/tag/1.0.0"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -977,7 +977,7 @@
 						}
 					],
 					"statistics": [],
-					"flags": "preview"
+					"flags": ""
 				},
 				{
 					"extensionId": "28",


### PR DESCRIPTION
- Warnings were caused by use of sqlops APIs
- Updated to azdata and moved up to 1.0 since it's stable

Feel free to publish this whenever suits - happy to wait and have this batched with other extension updates.