### PR TITLE
Add repository field for extensions

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -13,6 +13,10 @@
     "*"
   ],
   "main": "./out/extension",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/azuredatastudio.git"
+  },
   "contributes": {
     "configuration": [
       {

--- a/extensions/liveshare/package.json
+++ b/extensions/liveshare/package.json
@@ -10,6 +10,10 @@
     "vscode": "*"
   },
   "main": "./out/main",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/azuredatastudio.git"
+  },
   "extensionDependencies": [
     "vscode.sql"
   ],


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/8070

The reason was that it was failing in the extension packaging task, where it would error out because a couple of extensions didn't have the `repository` field in its `package.json` file
