### PR TITLE
Bump dacpac and schema compare extension versions and remove preview

### DIFF
--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -2,9 +2,9 @@
   "name": "dacpac",
   "displayName": "SQL Server Dacpac",
   "description": "SQL Server Dacpac for Azure Data Studio.",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "publisher": "Microsoft",
-  "preview": true,
+  "preview": false,
   "engines": {
     "vscode": "^1.25.0",
     "azdata": "*"

--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -7,7 +7,7 @@
   "preview": false,
   "engines": {
     "vscode": "^1.25.0",
-    "azdata": ">=1.11.0"
+    "azdata": ">=1.13.0"
   },
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/import/Microsoft_SQL_Server_Import_Extension_and_Tools_Import_Flat_File_Preview.docx",
   "icon": "images/sqlserver.png",

--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -2,9 +2,9 @@
   "name": "schema-compare",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "publisher": "Microsoft",
-  "preview": true,
+  "preview": false,
   "engines": {
     "vscode": "^1.25.0",
     "azdata": ">=1.11.0"


### PR DESCRIPTION
Dacpac and Schema Compare extensions are going to be GA so this bumps their versions to 1.0.0 and removes the preview. Will remove the preview flag in the extensionsGallery in another PR. Addresses #8085