### PR TITLE
Add error messages to BDC dashboard page

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/constants.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/constants.ts
@@ -71,6 +71,7 @@ export namespace cssStyles {
 	export const selectedTabDiv = { 'border-bottom': '2px solid #000' };
 	export const unselectedTabDiv = { 'border-bottom': '1px solid #ccc' };
 	export const lastUpdatedText = { ...text, 'color': '#595959' };
+	export const errorText = { ...text, 'color': 'red' };
 }
 
 export type AuthType = 'integrated' | 'basic';

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboard.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboard.ts
@@ -34,6 +34,7 @@ export class BdcDashboard {
 	private modelView: azdata.ModelView;
 	private mainAreaContainer: azdata.FlexContainer;
 	private navContainer: azdata.FlexContainer;
+	private overviewPage: BdcDashboardOverviewPage;
 
 	private currentTab: NavTab;
 	private currentPage: azdata.FlexContainer;
@@ -44,7 +45,7 @@ export class BdcDashboard {
 
 	constructor(private title: string, private model: BdcDashboardModel) {
 		this.model.onDidUpdateBdcStatus(bdcStatus => this.handleBdcStatusUpdate(bdcStatus));
-		this.model.onError(error => this.handleError(error));
+		this.model.onGeneralError(error => this.handleError(error));
 	}
 
 	public showDashboard(): void {
@@ -75,6 +76,7 @@ export class BdcDashboard {
 				}).component();
 
 			this.refreshButton.onDidClick(async () => {
+				this.overviewPage.onRefreshStarted();
 				await this.doRefresh();
 			});
 
@@ -130,18 +132,19 @@ export class BdcDashboard {
 			const overviewNavItemText = modelView.modelBuilder.text().withProperties({ value: localize('bdc.dashboard.overviewNavTitle', "Big data cluster overview") }).component();
 			overviewNavItemText.updateCssStyles(selectedTabCss);
 			overviewNavItemDiv.addItem(overviewNavItemText, { CSSStyles: { 'user-select': 'text' } });
-			const overviewPage = new BdcDashboardOverviewPage(this, this.model).create(modelView);
-			this.currentPage = overviewPage;
+			this.overviewPage = new BdcDashboardOverviewPage(this, this.model);
+			const overviewContainer: azdata.FlexContainer = this.overviewPage.create(modelView);
+			this.currentPage = overviewContainer;
 			this.currentTab = { serviceName: undefined, div: overviewNavItemDiv, dot: undefined, text: overviewNavItemText };
-			this.mainAreaContainer.addItem(overviewPage, { flex: '0 0 100%', CSSStyles: { 'margin': '0 20px 0 20px' } });
+			this.mainAreaContainer.addItem(overviewContainer, { flex: '0 0 100%', CSSStyles: { 'margin': '0 20px 0 20px' } });
 
 			overviewNavItemDiv.onDidClick(() => {
 				if (this.currentTab) {
 					this.currentTab.text.updateCssStyles(unselectedTabCss);
 				}
 				this.mainAreaContainer.removeItem(this.currentPage);
-				this.mainAreaContainer.addItem(overviewPage, { flex: '0 0 100%', CSSStyles: { 'margin': '0 20px 0 20px' } });
-				this.currentPage = overviewPage;
+				this.mainAreaContainer.addItem(overviewContainer, { flex: '0 0 100%', CSSStyles: { 'margin': '0 20px 0 20px' } });
+				this.currentPage = overviewContainer;
 				this.currentTab = { serviceName: undefined, div: overviewNavItemDiv, dot: undefined, text: overviewNavItemText };
 				this.currentTab.text.updateCssStyles(selectedTabCss);
 			});

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboard.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboard.ts
@@ -8,7 +8,7 @@
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import { BdcDashboardModel, getTroubleshootNotebookUrl } from './bdcDashboardModel';
+import { BdcDashboardModel, getTroubleshootNotebookUrl, BdcErrorEvent } from './bdcDashboardModel';
 import { IconPathHelper, cssStyles } from '../constants';
 import { BdcServiceStatusPage } from './bdcServiceStatusPage';
 import { BdcDashboardOverviewPage } from './bdcDashboardOverviewPage';
@@ -45,7 +45,7 @@ export class BdcDashboard {
 
 	constructor(private title: string, private model: BdcDashboardModel) {
 		this.model.onDidUpdateBdcStatus(bdcStatus => this.handleBdcStatusUpdate(bdcStatus));
-		this.model.onGeneralError(error => this.handleError(error));
+		this.model.onBdcError(errorEvent => this.handleError(errorEvent));
 	}
 
 	public showDashboard(): void {
@@ -170,11 +170,14 @@ export class BdcDashboard {
 		this.updateServiceNavTabs(bdcStatus.services);
 	}
 
-	private handleError(error: Error): void {
+	private handleError(errorEvent: BdcErrorEvent): void {
+		if (errorEvent.errorType !== 'general') {
+			return;
+		}
 		// We don't want to show an error for the connection dialog being
 		// canceled since that's a normal case.
-		if (!(error instanceof HdfsDialogCancelledError)) {
-			showErrorMessage(error.message);
+		if (!(errorEvent.error instanceof HdfsDialogCancelledError)) {
+			showErrorMessage(errorEvent.error.message);
 		}
 	}
 

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
@@ -62,8 +62,6 @@ export class BdcDashboardModel {
 		return this._endpointsLastUpdated;
 	}
 
-	private firstStatus = true;
-	private firstEndpoints = true;
 	public async refresh(): Promise<void> {
 		try {
 			if (!this._clusterController) {
@@ -73,19 +71,11 @@ export class BdcDashboardModel {
 
 			await Promise.all([
 				this._clusterController.getBdcStatus(true).then(response => {
-					if (this.firstStatus) {
-						this.firstStatus = false;
-						throw new Error('This is a BDC status error');
-					}
 					this._bdcStatus = response.bdcStatus;
 					this._bdcStatusLastUpdated = new Date();
 					this._onDidUpdateBdcStatus.fire(this.bdcStatus);
 				}).catch(error => this._onBdcStatusError.fire(error)),
 				this._clusterController.getEndPoints(true).then(response => {
-					if (this.firstEndpoints) {
-						this.firstEndpoints = false;
-						throw new Error('This is a BDC endpoints error');
-					}
 					this._endpoints = response.endPoints || [];
 					fixEndpoints(this._endpoints);
 					this._endpointsLastUpdated = new Date();

--- a/extensions/big-data-cluster/src/bigDataCluster/utils.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/utils.ts
@@ -269,3 +269,7 @@ export function getControllerEndpoint(serverInfo: azdata.ServerInfo): string | u
 	}
 	return undefined;
 }
+
+export function getBdcStatusErrorMessage(error: Error): string {
+	return localize('endpointsError', "Unexpected error retrieving BDC Endpoints: {0}", error.message);
+}

--- a/src/sql/workbench/browser/modelComponents/divContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/divContainer.component.ts
@@ -23,7 +23,7 @@ class DivItem {
 
 @Component({
 	template: `
-		<div #divContainer *ngIf="items" class="divContainer" [style.height]="height" [style.width]="width"  (click)="onClick()" (keyup)="onKey($event)">
+		<div #divContainer *ngIf="items" class="divContainer" [style.height]="height" [style.width]="width" [style.display]="display" (click)="onClick()" (keyup)="onKey($event)">
 			<div *ngFor="let item of items" [style.order]="getItemOrder(item)" [ngStyle]="getItemStyles(item)">
 				<model-component-wrapper [descriptor]="item.descriptor" [modelStore]="modelStore">
 				</model-component-wrapper>

--- a/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
+++ b/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
@@ -17,13 +17,11 @@ import * as nls from 'vs/nls';
 @Component({
 	selector: 'modelview-loadingComponent',
 	template: `
-		<div [style.display]="display">
-			<div class="modelview-loadingComponent-container" role="alert" aria-busy="true" *ngIf="loading">
-				<div class="modelview-loadingComponent-spinner" *ngIf="loading" [title]=_loadingTitle #spinnerElement></div>
-			</div>
-			<model-component-wrapper #childElement [descriptor]="_component" [modelStore]="modelStore" *ngIf="_component" [ngClass]="{'modelview-loadingComponent-content-loading': loading}">
-			</model-component-wrapper>
+		<div class="modelview-loadingComponent-container" role="alert" aria-busy="true" *ngIf="loading">
+			<div class="modelview-loadingComponent-spinner" *ngIf="loading" [title]=_loadingTitle #spinnerElement></div>
 		</div>
+		<model-component-wrapper #childElement [descriptor]="_component" [modelStore]="modelStore" *ngIf="_component" [ngClass]="{'modelview-loadingComponent-content-loading': loading}">
+		</model-component-wrapper>
 	`
 })
 export default class LoadingComponent extends ComponentBase implements IComponent, OnDestroy, AfterViewInit {

--- a/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
+++ b/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
@@ -17,11 +17,13 @@ import * as nls from 'vs/nls';
 @Component({
 	selector: 'modelview-loadingComponent',
 	template: `
-		<div class="modelview-loadingComponent-container" role="alert" aria-busy="true" *ngIf="loading">
-			<div class="modelview-loadingComponent-spinner" *ngIf="loading" [title]=_loadingTitle #spinnerElement></div>
+		<div [style.display]="display">
+			<div class="modelview-loadingComponent-container" role="alert" aria-busy="true" *ngIf="loading">
+				<div class="modelview-loadingComponent-spinner" *ngIf="loading" [title]=_loadingTitle #spinnerElement></div>
+			</div>
+			<model-component-wrapper #childElement [descriptor]="_component" [modelStore]="modelStore" *ngIf="_component" [ngClass]="{'modelview-loadingComponent-content-loading': loading}">
+			</model-component-wrapper>
 		</div>
-		<model-component-wrapper #childElement [descriptor]="_component" [modelStore]="modelStore" *ngIf="_component" [ngClass]="{'modelview-loadingComponent-content-loading': loading}">
-		</model-component-wrapper>
 	`
 })
 export default class LoadingComponent extends ComponentBase implements IComponent, OnDestroy, AfterViewInit {


### PR DESCRIPTION
For #7721

Add error messages when service calls for BDC dashboard fail or user cancels out of connect dialog.

![screen](https://user-images.githubusercontent.com/28519865/67817905-8b2e7380-fa6c-11e9-856a-30f58ba2cea9.gif)
