### PR TITLE
accept azdata eula

### DIFF
--- a/extensions/resource-deployment/src/services/notebookService.ts
+++ b/extensions/resource-deployment/src/services/notebookService.ts
@@ -79,6 +79,7 @@ export class NotebookService implements INotebookService {
 		const workingDirectory = this.platformService.storagePath();
 		const notebookFullPath = path.join(workingDirectory, fileName);
 		const outputFullPath = path.join(workingDirectory, `output-${fileName}`);
+		process.env['ACCEPT_EULA'] = 'yes';
 		try {
 			await this.platformService.saveTextFile(content, notebookFullPath);
 			await this.platformService.runCommand(`azdata notebook run --path "${notebookFullPath}" --output-path "${workingDirectory}" --timeout -1`,


### PR DESCRIPTION
the accept_eula env variable needs to be set for first time use of azdata. the scenario we are using azdata to execute the notebook already has the accept EULA checkbox.

this pr fixes #8112