### PR TITLE
fix the missing icon issue of expand/collapse btn

### DIFF
--- a/src/sql/workbench/parts/profiler/browser/profilerActions.ts
+++ b/src/sql/workbench/parts/profiler/browser/profilerActions.ts
@@ -197,7 +197,7 @@ export class ProfilerCollapsablePanelAction extends Action {
 	private _collapsed: boolean;
 
 	constructor(id: string, label: string) {
-		super(id, label, 'minimize-panel-action');
+		super(id, label, 'codicon-chevron-down');
 	}
 
 	public run(input: ProfilerInput): Promise<boolean> {
@@ -212,7 +212,7 @@ export class ProfilerCollapsablePanelAction extends Action {
 
 	set collapsed(val: boolean) {
 		this._collapsed = val === false ? false : true;
-		this._setClass(this._collapsed ? 'maximize-panel-action' : 'minimize-panel-action');
+		this._setClass(this._collapsed ? 'codicon-chevron-up' : 'codicon-chevron-down');
 	}
 }
 


### PR DESCRIPTION
vscode renamed the icon, update the code to use the new name.

I tried to have this icon in our own code to remove this dependency, but I couldn't find such svg files in our own icons folder. let me know if you guys think we should not have this dependency.

This PR fixes #8130 
