### PR TITLE
Fix race conditions with BDC dashboard init

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboard.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboard.ts
@@ -3,8 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
@@ -15,6 +13,7 @@ import { BdcDashboardOverviewPage } from './bdcDashboardOverviewPage';
 import { BdcStatusModel, ServiceStatusModel } from '../controller/apiGenerated';
 import { getHealthStatusDot, getServiceNameDisplayText, showErrorMessage } from '../utils';
 import { HdfsDialogCancelledError } from './hdfsDialogBase';
+import { BdcDashboardPage } from './bdcDashboardPage';
 
 const localize = nls.loadMessageBundle();
 
@@ -25,11 +24,9 @@ const unselectedTabCss = { 'font-weight': '' };
 
 type NavTab = { serviceName: string, div: azdata.DivContainer, dot: azdata.TextComponent, text: azdata.TextComponent };
 
-export class BdcDashboard {
+export class BdcDashboard extends BdcDashboardPage {
 
 	private dashboard: azdata.workspace.ModelViewEditor;
-
-	private initialized: boolean = false;
 
 	private modelView: azdata.ModelView;
 	private mainAreaContainer: azdata.FlexContainer;
@@ -44,8 +41,9 @@ export class BdcDashboard {
 	private serviceTabPageMapping = new Map<string, { navTab: NavTab, servicePage: azdata.FlexContainer }>();
 
 	constructor(private title: string, private model: BdcDashboardModel) {
-		this.model.onDidUpdateBdcStatus(bdcStatus => this.handleBdcStatusUpdate(bdcStatus));
-		this.model.onBdcError(errorEvent => this.handleError(errorEvent));
+		super();
+		this.model.onDidUpdateBdcStatus(bdcStatus => this.eventuallyRunOnInitialized(() => this.handleBdcStatusUpdate(bdcStatus)));
+		this.model.onBdcError(errorEvent => this.eventuallyRunOnInitialized(() => this.handleError(errorEvent)));
 	}
 
 	public showDashboard(): void {
@@ -163,10 +161,6 @@ export class BdcDashboard {
 	}
 
 	private handleBdcStatusUpdate(bdcStatus: BdcStatusModel): void {
-		if (!this.initialized || !bdcStatus) {
-			return;
-		}
-
 		this.updateServiceNavTabs(bdcStatus.services);
 	}
 
@@ -213,7 +207,7 @@ export class BdcDashboard {
 	 * Helper to update the navigation tabs for the services when we get a status update
 	 */
 	private updateServiceNavTabs(services?: ServiceStatusModel[]): void {
-		if (this.initialized && services) {
+		if (services) {
 			// Add a nav item for each service
 			services.forEach(s => {
 				const existingTabPage = this.serviceTabPageMapping[s.serviceName];

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboard.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboard.ts
@@ -160,7 +160,10 @@ export class BdcDashboard extends BdcDashboardPage {
 		});
 	}
 
-	private handleBdcStatusUpdate(bdcStatus: BdcStatusModel): void {
+	private handleBdcStatusUpdate(bdcStatus?: BdcStatusModel): void {
+		if (!bdcStatus) {
+			return;
+		}
 		this.updateServiceNavTabs(bdcStatus.services);
 	}
 

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
@@ -212,7 +212,10 @@ export class BdcDashboardOverviewPage extends BdcDashboardPage {
 		this.endpointsDisplayContainer.display = undefined;
 	}
 
-	private handleBdcStatusUpdate(bdcStatus: BdcStatusModel): void {
+	private handleBdcStatusUpdate(bdcStatus?: BdcStatusModel): void {
+		if (!bdcStatus) {
+			return;
+		}
 		this.lastUpdatedLabel.value =
 			localize('bdc.dashboard.lastUpdated', "Last Updated : {0}",
 				this.model.bdcStatusLastUpdated ?

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardPage.ts
@@ -31,8 +31,7 @@ export abstract class BdcDashboardPage {
 	 */
 	protected eventuallyRunOnInitialized(action: () => void): void {
 		if (!this._initialized) {
-			// tslint:disable-next-line:no-floating-promises Currently we don't have any need to wait for the result
-			this.onInitializedPromise.promise.then(() => action());
+			this.onInitializedPromise.promise.then(() => action()).catch(error => console.error(`Unexpected error running onInitialized action for BDC Page : ${error}`));
 		} else {
 			action();
 		}

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardPage.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Deferred } from '../../common/promise';
+
+export abstract class BdcDashboardPage {
+
+	private _initialized: boolean = false;
+
+	private onInitializedPromise: Deferred<void> = new Deferred();
+
+	constructor() { }
+
+	protected get initialized(): boolean {
+		return this._initialized;
+	}
+
+	protected set initialized(value: boolean) {
+		if (!this._initialized && value) {
+			this._initialized = true;
+			this.onInitializedPromise.resolve();
+		}
+	}
+
+	/**
+	 * Runs the specified action when the component is initialized. If already initialized just runs
+	 * the action immediately.
+	 * @param action The action to be ran when the page is initialized
+	 */
+	protected eventuallyRunOnInitialized(action: () => void): void {
+		if (!this._initialized) {
+			this.onInitializedPromise.promise.then(() => action());
+		} else {
+			action();
+		}
+	}
+}
+

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardPage.ts
@@ -31,6 +31,7 @@ export abstract class BdcDashboardPage {
 	 */
 	protected eventuallyRunOnInitialized(action: () => void): void {
 		if (!this._initialized) {
+			// tslint:disable-next-line:no-floating-promises Currently we don't have any need to wait for the result
 			this.onInitializedPromise.promise.then(() => action());
 		} else {
 			action();

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
@@ -138,7 +138,10 @@ export class BdcDashboardResourceStatusPage extends BdcDashboardPage {
 		return rootContainer;
 	}
 
-	private handleBdcStatusUpdate(bdcStatus: BdcStatusModel): void {
+	private handleBdcStatusUpdate(bdcStatus?: BdcStatusModel): void {
+		if (!bdcStatus) {
+			return;
+		}
 		const service = bdcStatus.services ? bdcStatus.services.find(s => s.serviceName === this.serviceName) : undefined;
 		const resource = service ? service.resources.find(r => r.resourceName === this.resourceName) : undefined;
 

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
@@ -12,6 +11,7 @@ import { getHealthStatusDisplayText, getHealthStatusIcon, getStateDisplayText, S
 import { cssStyles } from '../constants';
 import { isNullOrUndefined } from 'util';
 import { createViewDetailsButton } from './commonControls';
+import { BdcDashboardPage } from './bdcDashboardPage';
 
 const localize = nls.loadMessageBundle();
 
@@ -39,17 +39,16 @@ const metricsAndLogsLogsColumnWidth = 75;
 const viewText = localize('bdc.dashboard.viewHyperlink', "View");
 const notAvailableText = localize('bdc.dashboard.notAvailable', "N/A");
 
-export class BdcDashboardResourceStatusPage {
+export class BdcDashboardResourceStatusPage extends BdcDashboardPage {
 
 	private rootContainer: azdata.FlexContainer;
 	private instanceHealthStatusRowsContainer: azdata.FlexContainer;
 	private metricsAndLogsRowsContainer: azdata.FlexContainer;
 	private lastUpdatedLabel: azdata.TextComponent;
-	private sqlMetricsComponents: azdata.Component[];
-	private initialized: boolean = false;
 
 	constructor(private model: BdcDashboardModel, private modelView: azdata.ModelView, private serviceName: string, private resourceName: string) {
-		this.model.onDidUpdateBdcStatus(bdcStatus => this.handleBdcStatusUpdate(bdcStatus));
+		super();
+		this.model.onDidUpdateBdcStatus(bdcStatus => this.eventuallyRunOnInitialized(() => this.handleBdcStatusUpdate(bdcStatus)));
 		this.rootContainer = this.createContainer(modelView);
 	}
 
@@ -143,7 +142,7 @@ export class BdcDashboardResourceStatusPage {
 		const service = bdcStatus.services ? bdcStatus.services.find(s => s.serviceName === this.serviceName) : undefined;
 		const resource = service ? service.resources.find(r => r.resourceName === this.resourceName) : undefined;
 
-		if (!this.initialized || !resource || isNullOrUndefined(resource.instances)) {
+		if (!resource || isNullOrUndefined(resource.instances)) {
 			return;
 		}
 

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcServiceStatusPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcServiceStatusPage.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-'use strict';
 
 import * as azdata from 'azdata';
 import { BdcStatusModel, ResourceStatusModel } from '../controller/apiGenerated';
@@ -10,12 +9,11 @@ import { BdcDashboardResourceStatusPage } from './bdcDashboardResourceStatusPage
 import { BdcDashboardModel } from './bdcDashboardModel';
 import { getHealthStatusDot } from '../utils';
 import { cssStyles } from '../constants';
+import { BdcDashboardPage } from './bdcDashboardPage';
 
 type ServiceTab = { div: azdata.DivContainer, dot: azdata.TextComponent, text: azdata.TextComponent };
 
-export class BdcServiceStatusPage {
-
-	private initialized: boolean = false;
+export class BdcServiceStatusPage extends BdcDashboardPage {
 
 	private currentTab: { tab: ServiceTab, index: number };
 	private currentTabPage: azdata.FlexContainer;
@@ -25,7 +23,8 @@ export class BdcServiceStatusPage {
 	private createdTabs: Map<string, ServiceTab> = new Map<string, ServiceTab>();
 
 	constructor(private serviceName: string, private model: BdcDashboardModel, private modelView: azdata.ModelView) {
-		this.model.onDidUpdateBdcStatus(bdcStatus => this.handleBdcStatusUpdate(bdcStatus));
+		super();
+		this.model.onDidUpdateBdcStatus(bdcStatus => this.eventuallyRunOnInitialized(() => this.handleBdcStatusUpdate(bdcStatus)));
 		this.createPage();
 	}
 
@@ -57,10 +56,6 @@ export class BdcServiceStatusPage {
 	}
 
 	private handleBdcStatusUpdate(bdcStatus: BdcStatusModel): void {
-		if (!this.initialized || !bdcStatus) {
-			return;
-		}
-
 		const service = bdcStatus.services.find(s => s.serviceName === this.serviceName);
 		if (service && service.resources) {
 			this.createResourceNavTabs(service.resources);
@@ -79,49 +74,47 @@ export class BdcServiceStatusPage {
 	 * Helper to create the navigation tabs for the resources
 	 */
 	private createResourceNavTabs(resources: ResourceStatusModel[]) {
-		if (this.initialized) {
-			let tabIndex = this.createdTabs.size;
-			resources.forEach(resource => {
-				const existingTab: ServiceTab = this.createdTabs[resource.resourceName];
-				if (existingTab) {
-					// We already created this tab so just update the status
-					existingTab.dot.value = getHealthStatusDot(resource.healthStatus);
-				} else {
-					// New tab - create and add to the end of the container
-					const currentIndex = tabIndex++;
-					const resourceHeaderTab = createResourceHeaderTab(this.modelView.modelBuilder, resource);
-					this.createdTabs[resource.resourceName] = resourceHeaderTab;
-					const resourceStatusPage: azdata.FlexContainer = new BdcDashboardResourceStatusPage(this.model, this.modelView, this.serviceName, resource.resourceName).container;
-					resourceHeaderTab.div.onDidClick(() => {
-						// Don't need to do anything if this is already the currently selected tab
-						if (this.currentTab.index === currentIndex) {
-							return;
-						}
-						if (this.currentTab) {
-							this.currentTab.tab.text.updateCssStyles(cssStyles.unselectedResourceHeaderTab);
-							this.resourceHeader.removeItem(this.currentTab.tab.div);
-							this.resourceHeader.insertItem(this.currentTab.tab.div, this.currentTab.index, { flex: '0 0 auto', CSSStyles: cssStyles.unselectedTabDiv });
-						}
-						this.changeSelectedTabPage(resourceStatusPage);
-						this.currentTab = { tab: resourceHeaderTab, index: currentIndex };
-						this.currentTab.tab.text.updateCssStyles(cssStyles.selectedResourceHeaderTab);
+		let tabIndex = this.createdTabs.size;
+		resources.forEach(resource => {
+			const existingTab: ServiceTab = this.createdTabs[resource.resourceName];
+			if (existingTab) {
+				// We already created this tab so just update the status
+				existingTab.dot.value = getHealthStatusDot(resource.healthStatus);
+			} else {
+				// New tab - create and add to the end of the container
+				const currentIndex = tabIndex++;
+				const resourceHeaderTab = createResourceHeaderTab(this.modelView.modelBuilder, resource);
+				this.createdTabs[resource.resourceName] = resourceHeaderTab;
+				const resourceStatusPage: azdata.FlexContainer = new BdcDashboardResourceStatusPage(this.model, this.modelView, this.serviceName, resource.resourceName).container;
+				resourceHeaderTab.div.onDidClick(() => {
+					// Don't need to do anything if this is already the currently selected tab
+					if (this.currentTab.index === currentIndex) {
+						return;
+					}
+					if (this.currentTab) {
+						this.currentTab.tab.text.updateCssStyles(cssStyles.unselectedResourceHeaderTab);
 						this.resourceHeader.removeItem(this.currentTab.tab.div);
-						this.resourceHeader.insertItem(this.currentTab.tab.div, this.currentTab.index, { flex: '0 0 auto', CSSStyles: cssStyles.selectedTabDiv });
-					});
-					// Set initial page
-					if (!this.currentTabPage) {
-						this.changeSelectedTabPage(resourceStatusPage);
-						this.currentTab = { tab: resourceHeaderTab, index: currentIndex };
-						this.currentTab.tab.text.updateCssStyles(cssStyles.selectedResourceHeaderTab);
-						this.resourceHeader.addItem(resourceHeaderTab.div, { flex: '0 0 auto', CSSStyles: cssStyles.selectedTabDiv });
+						this.resourceHeader.insertItem(this.currentTab.tab.div, this.currentTab.index, { flex: '0 0 auto', CSSStyles: cssStyles.unselectedTabDiv });
 					}
-					else {
-						resourceHeaderTab.text.updateCssStyles(cssStyles.unselectedResourceHeaderTab);
-						this.resourceHeader.addItem(resourceHeaderTab.div, { flex: '0 0 auto', CSSStyles: cssStyles.unselectedTabDiv });
-					}
+					this.changeSelectedTabPage(resourceStatusPage);
+					this.currentTab = { tab: resourceHeaderTab, index: currentIndex };
+					this.currentTab.tab.text.updateCssStyles(cssStyles.selectedResourceHeaderTab);
+					this.resourceHeader.removeItem(this.currentTab.tab.div);
+					this.resourceHeader.insertItem(this.currentTab.tab.div, this.currentTab.index, { flex: '0 0 auto', CSSStyles: cssStyles.selectedTabDiv });
+				});
+				// Set initial page
+				if (!this.currentTabPage) {
+					this.changeSelectedTabPage(resourceStatusPage);
+					this.currentTab = { tab: resourceHeaderTab, index: currentIndex };
+					this.currentTab.tab.text.updateCssStyles(cssStyles.selectedResourceHeaderTab);
+					this.resourceHeader.addItem(resourceHeaderTab.div, { flex: '0 0 auto', CSSStyles: cssStyles.selectedTabDiv });
 				}
-			});
-		}
+				else {
+					resourceHeaderTab.text.updateCssStyles(cssStyles.unselectedResourceHeaderTab);
+					this.resourceHeader.addItem(resourceHeaderTab.div, { flex: '0 0 auto', CSSStyles: cssStyles.unselectedTabDiv });
+				}
+			}
+		});
 	}
 }
 

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcServiceStatusPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcServiceStatusPage.ts
@@ -56,6 +56,9 @@ export class BdcServiceStatusPage extends BdcDashboardPage {
 	}
 
 	private handleBdcStatusUpdate(bdcStatus: BdcStatusModel): void {
+		if (!bdcStatus) {
+			return;
+		}
 		const service = bdcStatus.services.find(s => s.serviceName === this.serviceName);
 		if (service && service.resources) {
 			this.createResourceNavTabs(service.resources);


### PR DESCRIPTION
Fixes #8128

The model events weren't always correctly checking the initialized state correctly which could cause issues if they were called before the page was initialized. To fix this I refactored the pages to queue actions for running after a page is initialized which is a much cleaner design and ensures that we don't lose events if the page isn't initialized. 