### PR TITLE
Ensure cwd matches notebook path

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -333,6 +333,8 @@ export class JupyterSession implements nb.ISession {
 	private async setEnvironmentVars(skip: boolean = false): Promise<void> {
 		if (!skip && this.sessionImpl) {
 			let allCode: string = '';
+			// Ensure cwd matches notebook path (this follows Jupyter behavior)
+			allCode += `%cd ${path.dirname(this.path)}${EOL}`;
 			for (let i = 0; i < Object.keys(process.env).length; i++) {
 				let key = Object.keys(process.env)[i];
 				if (key.toLowerCase() === 'path' && this._pythonEnvVarPath) {

--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -334,7 +334,9 @@ export class JupyterSession implements nb.ISession {
 		if (!skip && this.sessionImpl) {
 			let allCode: string = '';
 			// Ensure cwd matches notebook path (this follows Jupyter behavior)
-			allCode += `%cd ${path.dirname(this.path)}${EOL}`;
+			if (this.path && path.dirname(this.path)) {
+				allCode += `%cd ${path.dirname(this.path)}${EOL}`;
+			}
 			for (let i = 0; i < Object.keys(process.env).length; i++) {
 				let key = Object.keys(process.env)[i];
 				if (key.toLowerCase() === 'path' && this._pythonEnvVarPath) {

--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -347,7 +347,9 @@ export class JupyterSession implements nb.ISession {
 				}
 			}
 			let future = this.sessionImpl.kernel.requestExecute({
-				code: allCode
+				code: allCode,
+				silent: true,
+				store_history: false
 			}, true);
 			await future.done;
 		}


### PR DESCRIPTION
In notebooks, the current working directory is by default the directory where the server was started, instead of the directory where the notebook lives (or the home dir in the case of untitled files).

To match Jupyter behavior, we should be setting the cwd to the folder of the current notebook.

Jupyter allows customization of the cwd by the %cd magic. We can just add that command to the other commands that we run when starting a session.