### PR TITLE
Fix node update in bdc dashboard on reconnect

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
@@ -311,7 +311,6 @@ export class ClusterController {
 						this._connectionPromise = this._dialog.showDialog();
 					}
 					const controller = await this._connectionPromise;
-					this._connectionPromise = undefined;
 					if (controller) {
 						this._username = controller._username;
 						this._password = controller._password;
@@ -325,6 +324,8 @@ export class ClusterController {
 			}
 		} catch (error) {
 			throw new ControllerError(error, errorMessage);
+		} finally {
+			this._connectionPromise = undefined;
 		}
 	}
 }

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
@@ -121,6 +121,13 @@ export class BdcDashboardModel {
 	 */
 	private async promptReconnect(): Promise<void> {
 		this._clusterController = await new ConnectControllerDialog(new ConnectControllerModel(this._options)).showDialog();
+		await this.updateController();
+	}
+
+	private async updateController(): Promise<void> {
+		if (!this._clusterController) {
+			return;
+		}
 		this._treeDataProvider.addOrUpdateController(
 			this._clusterController.url,
 			this._clusterController.authType,

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
@@ -12,7 +12,7 @@ import { AuthType } from '../constants';
 import { ConnectControllerDialog, ConnectControllerModel } from './connectControllerDialog';
 import { ControllerTreeDataProvider } from '../tree/controllerTreeDataProvider';
 
-export type BdcDashboardOptions = { url: string, auth: AuthType, username: string, password: string };
+export type BdcDashboardOptions = { url: string, auth: AuthType, username: string, password: string, rememberPassword: boolean };
 
 export type BdcErrorType = 'bdcStatus' | 'bdcEndpoints' | 'general';
 export type BdcErrorEvent = { error: Error, errorType: BdcErrorType };
@@ -126,7 +126,8 @@ export class BdcDashboardModel {
 			this._clusterController.authType,
 			this._clusterController.username,
 			this._clusterController.password,
-			/* Remember password */false);
+			this._options.rememberPassword);
+		this._treeDataProvider.saveControllers();
 	}
 }
 

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
@@ -127,7 +127,7 @@ export class BdcDashboardModel {
 			this._clusterController.username,
 			this._clusterController.password,
 			this._options.rememberPassword);
-		this._treeDataProvider.saveControllers();
+		await this._treeDataProvider.saveControllers();
 	}
 }
 

--- a/extensions/big-data-cluster/src/extension.ts
+++ b/extensions/big-data-cluster/src/extension.ts
@@ -62,9 +62,20 @@ function registerCommands(context: vscode.ExtensionContext, treeDataProvider: Co
 		treeDataProvider.notifyNodeChanged(node);
 	});
 
-	vscode.commands.registerCommand(ManageControllerCommand, async (info: ControllerNode | BdcDashboardOptions) => {
+	vscode.commands.registerCommand(ManageControllerCommand, async (info: ControllerNode | BdcDashboardOptions, addOrUpdateController: boolean = false) => {
 		const title: string = `${localize('bdc.dashboard.title', "Big Data Cluster Dashboard -")} ${ControllerNode.toIpAndPort(info.url)}`;
-		const dashboard: BdcDashboard = new BdcDashboard(title, new BdcDashboardModel(info, treeDataProvider));
+		if (addOrUpdateController) {
+			// The info may be wrong, but if it is then we'll prompt to reconnect when the dashboard is opened
+			// and update with the correct info then
+			treeDataProvider.addOrUpdateController(
+				info.url,
+				info.auth,
+				info.username,
+				info.password,
+				info.rememberPassword);
+			await treeDataProvider.saveControllers();
+		}
+		const dashboard: BdcDashboard = new BdcDashboard(title, new BdcDashboardModel(info, treeDataProvider, /*ignoreSslVerification*/true));
 		dashboard.showDashboard();
 	});
 

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -216,7 +216,8 @@ async function handleOpenClusterDashboardTask(profile: azdata.IConnectionProfile
 			url: controller.endpoint,
 			auth: profile.authenticationType === 'Integrated' ? AuthType.Integrated : AuthType.Basic,
 			username: 'admin', // Default to admin as a best-guess, we'll prompt for re-entering credentials if that fails
-			password: profile.password
+			password: profile.password,
+			rememberPassword: true
 		});
 }
 

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -218,7 +218,7 @@ async function handleOpenClusterDashboardTask(profile: azdata.IConnectionProfile
 			username: 'admin', // Default to admin as a best-guess, we'll prompt for re-entering credentials if that fails
 			password: profile.password,
 			rememberPassword: true
-		});
+		}, /*addOrUpdateController*/true);
 }
 
 // this method is called when your extension is deactivated

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -112,14 +112,14 @@ function activateSparkFeatures(appContext: AppContext): void {
 	let outputChannel: vscode.OutputChannel = mssqlOutputChannel;
 	extensionContext.subscriptions.push(new OpenSparkJobSubmissionDialogCommand(appContext, outputChannel));
 	extensionContext.subscriptions.push(new OpenSparkJobSubmissionDialogFromFileCommand(appContext, outputChannel));
-	apiWrapper.registerTaskHandler(Constants.mssqlClusterLivySubmitSparkJobTask, (profile: azdata.IConnectionProfile) => {
-		new OpenSparkJobSubmissionDialogTask(appContext, outputChannel).execute(profile);
+	apiWrapper.registerTaskHandler(Constants.mssqlClusterLivySubmitSparkJobTask, async (profile: azdata.IConnectionProfile) => {
+		await new OpenSparkJobSubmissionDialogTask(appContext, outputChannel).execute(profile);
 	});
-	apiWrapper.registerTaskHandler(Constants.mssqlClusterLivyOpenSparkHistory, (profile: azdata.IConnectionProfile) => {
-		new OpenSparkYarnHistoryTask(appContext).execute(profile, true);
+	apiWrapper.registerTaskHandler(Constants.mssqlClusterLivyOpenSparkHistory, async (profile: azdata.IConnectionProfile) => {
+		await new OpenSparkYarnHistoryTask(appContext).execute(profile, true);
 	});
-	apiWrapper.registerTaskHandler(Constants.mssqlClusterLivyOpenYarnHistory, (profile: azdata.IConnectionProfile) => {
-		new OpenSparkYarnHistoryTask(appContext).execute(profile, false);
+	apiWrapper.registerTaskHandler(Constants.mssqlClusterLivyOpenYarnHistory, async (profile: azdata.IConnectionProfile) => {
+		await new OpenSparkYarnHistoryTask(appContext).execute(profile, false);
 	});
 }
 


### PR DESCRIPTION
For #8102

We weren't calling saveControllers after updating the info in the dashboard model so while the info was updated for the current session if you closed ADS and tried to connect again we'd prompt for the password again. 

Also fixed it to use the actual value of the remember password option for the node so that we don't overwrite it to false each time. #8136 opened up to cover us not having remember password being an option in the connect controller dialog. 

And finally fixed issue where we weren't saving the controller node when opening from the SQL dashboard if the connection information was right. (If it was wrong then we'd prompt for connection and save it correctly there)