### PR TITLE
updating DacPac and SC ext to latest versions

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1273,7 +1273,7 @@
 					"versions": [
 						{
 							"version": "1.0.0",
-							"lastUpdated": "10/10/2019",
+							"lastUpdated": "10/31/2019",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1314,7 +1314,8 @@
 							]
 						}
 					],
-					"statistics": []
+					"statistics": [],
+					"flags":""
 				},
 				{
 					"extensionId": "34",
@@ -1549,7 +1550,8 @@
 							]
 						}
 					],
-					"statistics": []
+					"statistics": [],
+					"flags":""
 				},
 				{
 					"extensionId": "38",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1272,14 +1272,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.8.0",
+							"version": "1.0.0",
 							"lastUpdated": "10/10/2019",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-0.8.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.0.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1314,8 +1314,7 @@
 							]
 						}
 					],
-					"statistics": [],
-					"flags": "preview"
+					"statistics": []
 				},
 				{
 					"extensionId": "34",
@@ -1504,14 +1503,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.8.0",
-							"lastUpdated": "10/10/2019",
+							"version": "1.0.0",
+							"lastUpdated": "10/31/2019",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-0.8.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-1.0.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1541,7 +1540,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.11.0"
+									"value": ">=1.13.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -1550,8 +1549,7 @@
 							]
 						}
 					],
-					"statistics": [],
-					"flags": "preview"
+					"statistics": []
 				},
 				{
 					"extensionId": "38",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1273,7 +1273,7 @@
 					"versions": [
 						{
 							"version": "1.0.0",
-							"lastUpdated": "9/9/2019",
+							"lastUpdated": "10/31/2019",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1314,7 +1314,8 @@
 							]
 						}
 					],
-					"statistics": []
+					"statistics": [],
+					"flags":""
 				},
 				{
 					"extensionId": "34",
@@ -1549,7 +1550,8 @@
 							]
 						}
 					],
-					"statistics": []
+					"statistics": [],
+					"flags":""
 				},
 				{
 					"extensionId": "38",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1272,14 +1272,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.6.0",
+							"version": "1.0.0",
 							"lastUpdated": "9/9/2019",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-0.6.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.0.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1314,8 +1314,7 @@
 							]
 						}
 					],
-					"statistics": [],
-					"flags": "preview"
+					"statistics": []
 				},
 				{
 					"extensionId": "34",
@@ -1504,14 +1503,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.6.0",
-							"lastUpdated": "8/26/2019",
+							"version": "1.0.0",
+							"lastUpdated": "10/31/2019",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-0.6.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-1.0.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -1541,7 +1540,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.11.0"
+									"value": ">=1.13.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",
@@ -1550,8 +1549,7 @@
 							]
 						}
 					],
-					"statistics": [],
-					"flags": "preview"
+					"statistics": []
 				},
 				{
 					"extensionId": "38",


### PR DESCRIPTION
This PR updates Dacpac and Schema compare ext. versions to latest (Jumps to 1.0.0) in gallery.