### PR TITLE
Add WS as a dep of notebooks

### DIFF
--- a/extensions/notebook/extension.webpack.config.js
+++ b/extensions/notebook/extension.webpack.config.js
@@ -11,16 +11,15 @@ const withDefaults = require('../shared.webpack.config');
 const fs = require('fs');
 const path = require('path');
 
-const yarnrcPath = path.join(__dirname, '.yarnrc');
-
 const externals = {
 	'node-fetch': 'commonjs node-fetch'
 };
 
 // conditionally add ws if we are going to be running in a node environment
+const yarnrcPath = path.join(__dirname, '.yarnrc');
 if (fs.existsSync(yarnrcPath)) {
 	const yarnrc = fs.readFileSync(yarnrcPath).toString();
-	const properties = yarnrc.split('\\n').map(r => r.split(' '));
+	const properties = yarnrc.split(/\r?\n/).map(r => r.split(' '));
 	if (properties.find(r => r[0] === 'runtime')[1] === '"node"') {
 		externals['ws'] = 'commonjs ws';
 	}

--- a/extensions/notebook/extension.webpack.config.js
+++ b/extensions/notebook/extension.webpack.config.js
@@ -8,13 +8,28 @@
 'use strict';
 
 const withDefaults = require('../shared.webpack.config');
+const fs = require('fs');
+const path = require('path');
+
+const yarnrcPath = path.join(__dirname, '.yarnrc');
+
+const externals = {
+	'node-fetch': 'commonjs node-fetch'
+};
+
+// conditionally add ws if we are going to be running in a node environment
+if (fs.existsSync(yarnrcPath)) {
+	const yarnrc = fs.readFileSync(yarnrcPath).toString();
+	const properties = yarnrc.split('\\n').map(r => r.split(' '));
+	if (properties.find(r => r[0] === 'runtime')[1] === '"node"') {
+		externals['ws'] = 'commonjs ws';
+	}
+}
 
 module.exports = withDefaults({
 	context: __dirname,
 	entry: {
 		extension: './src/extension.ts'
 	},
-	externals: {
-		'node-fetch': 'commonjs node-fetch'
-	}
+	externals: externals
 });

--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -469,8 +469,5 @@
     "typemoq": "^2.1.0",
     "vscode": "1.1.5"
   },
-  "enableProposedApi": true,
-  "optionalDependencies": {
-    "ws": "^7.2.0"
-  }
+  "enableProposedApi": true
 }

--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -448,7 +448,8 @@
     "request": "^2.88.0",
     "temp-write": "^3.4.0",
     "vscode-languageclient": "^5.3.0-next.1",
-    "vscode-nls": "^4.0.0"
+    "vscode-nls": "^4.0.0",
+    "ws": "^7.2.0"
   },
   "devDependencies": {
     "@types/decompress": "^4.2.3",

--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -468,5 +468,8 @@
     "typemoq": "^2.1.0",
     "vscode": "1.1.5"
   },
-  "enableProposedApi": true
+  "enableProposedApi": true,
+  "optionalDependencies": {
+    "ws": "^7.2.0"
+  }
 }

--- a/extensions/notebook/yarn.lock
+++ b/extensions/notebook/yarn.lock
@@ -339,6 +339,11 @@ assert@^1.4.1:
   dependencies:
     util "0.10.3"
 
+async-limiter@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2679,6 +2684,13 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+ws@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.0.tgz#422eda8c02a4b5dba7744ba66eebbd84bcef0ec7"
+  integrity sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==
+  dependencies:
+    async-limiter "^1.0.0"
 
 xml@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
When running in node environments, ws is a required dependency, where as in electron, ws is built into the runtime.

Therefore adding ws as an optional for when we run in node environments instead of electron environments.

I'm investigating if this has any impact on package size at the moment.