### PR TITLE
Fix #8159 Mount HDFS broken against latest cluster

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
@@ -301,7 +301,7 @@ export class ClusterController {
 	private async withConnectRetry<T>(f: (...args: any[]) => Promise<T>, promptConnect: boolean, errorMessage: string, ...args: any[]): Promise<T> {
 		try {
 			try {
-				return await f(this, args);
+				return await f(this, ...args);
 			} catch (error) {
 				if (promptConnect) {
 					// We don't want to open multiple dialogs here if multiple calls come in the same time so check


### PR DESCRIPTION
connectWithRetry needed to pass as ... so each arg was set correctly,
instead of having 1st param be an array of the input arguments
