### PR TITLE
added try catch aroud the json parse and bypassing the err by logging…

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -36,7 +36,7 @@ const msgSkipPythonInstall = localize('msgSkipPythonInstall', "Python already ex
 const msgWaitingForInstall = localize('msgWaitingForInstall', "Another Python installation is currently in progress. Waiting for it to complete.");
 function msgDependenciesInstallationFailed(errorMessage: string): string { return localize('msgDependenciesInstallationFailed', "Installing Notebook dependencies failed with error: {0}", errorMessage); }
 function msgDownloadPython(platform: string, pythonDownloadUrl: string): string { return localize('msgDownloadPython', "Downloading local python for platform: {0} to {1}", platform, pythonDownloadUrl); }
-function msgPackageRetrievalFailed(errorMessage: string, packageInfo: string): string { return localize('msgPackageRetrievalFailed', "Encountered an error when trying to retrieve list of installed packages: {0}\nPackage Info: {1}", errorMessage, packageInfo); }
+function msgPackageRetrievalFailed(errorMessage: string): string { return localize('msgPackageRetrievalFailed', "Encountered an error when trying to retrieve list of installed packages: {0}", errorMessage); }
 
 export class JupyterServerInstallation {
 	public apiWrapper: ApiWrapper;
@@ -520,19 +520,19 @@ export class JupyterServerInstallation {
 	}
 
 	public async getInstalledPipPackages(): Promise<PythonPkgDetails[]> {
-		let cmd = `"${this.pythonExecutable}" -m pip list --format=json`;
-		let packagesInfo = await this.executeBufferedCommand(cmd);
-
-		let packagesResult: PythonPkgDetails[] = [];
-		if (packagesInfo) {
-			try {
+		try {
+			let cmd = `"${this.pythonExecutable}" -m pip list --format=json`;
+			let packagesInfo = await this.executeBufferedCommand(cmd);
+			let packagesResult: PythonPkgDetails[] = [];
+			if (packagesInfo) {
 				packagesResult = <PythonPkgDetails[]>JSON.parse(packagesInfo);
 			}
-			catch (err) {
-				this.outputChannel.appendLine(msgPackageRetrievalFailed(utils.getErrorMessage(err), packagesInfo));
-			}
+			return packagesResult;
 		}
-		return packagesResult;
+		catch (err) {
+			this.outputChannel.appendLine(msgPackageRetrievalFailed(utils.getErrorMessage(err)));
+			return [];
+		}
 	}
 
 	public installPipPackages(packages: PythonPkgDetails[], useMinVersion: boolean): Promise<void> {
@@ -555,26 +555,25 @@ export class JupyterServerInstallation {
 	}
 
 	public async getInstalledCondaPackages(): Promise<PythonPkgDetails[]> {
-		let condaExe = this.getCondaExePath();
-		let cmd = `"${condaExe}" list --json`;
-		let packagesInfo = await this.executeBufferedCommand(cmd);
+		try {
+			let condaExe = this.getCondaExePath();
+			let cmd = `"${condaExe}" list --json`;
+			let packagesInfo = await this.executeBufferedCommand(cmd);
 
-		if (packagesInfo) {
-			let packagesResult = [];
-			try {
-				packagesResult = JSON.parse(packagesInfo);
+			if (packagesInfo) {
+				let packagesResult = JSON.parse(packagesInfo);
+				if (Array.isArray(packagesResult)) {
+					return packagesResult
+						.filter(pkg => pkg && pkg.channel && pkg.channel !== 'pypi')
+						.map(pkg => <PythonPkgDetails>{ name: pkg.name, version: pkg.version });
+				}
 			}
-			catch (err) {
-				this.outputChannel.appendLine(msgPackageRetrievalFailed(utils.getErrorMessage(err), packagesInfo));
-			}
-
-			if (Array.isArray(packagesResult)) {
-				return packagesResult
-					.filter(pkg => pkg && pkg.channel && pkg.channel !== 'pypi')
-					.map(pkg => <PythonPkgDetails>{ name: pkg.name, version: pkg.version });
-			}
+			return [];
 		}
-		return [];
+		catch (err) {
+			this.outputChannel.appendLine(msgPackageRetrievalFailed(utils.getErrorMessage(err)));
+			return [];
+		}
 	}
 
 	public installCondaPackages(packages: PythonPkgDetails[], useMinVersion: boolean): Promise<void> {

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -36,7 +36,7 @@ const msgSkipPythonInstall = localize('msgSkipPythonInstall', "Python already ex
 const msgWaitingForInstall = localize('msgWaitingForInstall', "Another Python installation is currently in progress. Waiting for it to complete.");
 function msgDependenciesInstallationFailed(errorMessage: string): string { return localize('msgDependenciesInstallationFailed', "Installing Notebook dependencies failed with error: {0}", errorMessage); }
 function msgDownloadPython(platform: string, pythonDownloadUrl: string): string { return localize('msgDownloadPython', "Downloading local python for platform: {0} to {1}", platform, pythonDownloadUrl); }
-function msgPackageRetrievalFailed(errorMessage: string): string { return localize('msgPackageRetrievalFailed', "Encountered an error when trying to retrieve list of installed packages: {0}", errorMessage); }
+function msgPackageRetrievalFailed(errorMessage: string, packageInfo: string): string { return localize('msgPackageRetrievalFailed', "Encountered an error when trying to retrieve list of installed packages: {0} /n Package Info: {1}", errorMessage, packageInfo); }
 
 export class JupyterServerInstallation {
 	public apiWrapper: ApiWrapper;
@@ -529,8 +529,7 @@ export class JupyterServerInstallation {
 				packagesResult = <PythonPkgDetails[]>JSON.parse(packagesInfo);
 			}
 			catch (err) {
-				let errorMsg = `Failed to parse package info, encountered following error: ${(utils.getErrorMessage(err))} \n PackageInfo: ${packagesInfo}`;
-				this.outputChannel.appendLine(msgPackageRetrievalFailed(errorMsg));
+				this.outputChannel.appendLine(msgPackageRetrievalFailed(utils.getErrorMessage(err), packagesInfo));
 			}
 		}
 		return packagesResult;
@@ -566,8 +565,7 @@ export class JupyterServerInstallation {
 				packagesResult = JSON.parse(packagesInfo);
 			}
 			catch (err) {
-				let errorMsg = `Failed to parse package info, encountered following error: ${(utils.getErrorMessage(err))} \n PackageInfo: ${packagesInfo}`;
-				this.outputChannel.appendLine(msgPackageRetrievalFailed(errorMsg));
+				this.outputChannel.appendLine(msgPackageRetrievalFailed(utils.getErrorMessage(err), packagesInfo));
 			}
 
 			if (Array.isArray(packagesResult)) {

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -528,7 +528,7 @@ export class JupyterServerInstallation {
 				packagesResult = <PythonPkgDetails[]>JSON.parse(packagesInfo);
 			}
 			catch (err) {
-				let errorMsg = msgDependenciesInstallationFailed(utils.getErrorMessage(err));
+				let errorMsg = `Failed to parse package info, encountered following error: ${(utils.getErrorMessage(err))} \n PackageInfo: ${packagesInfo}`;
 				this.outputChannel.appendLine(errorMsg);
 			}
 		}
@@ -565,7 +565,7 @@ export class JupyterServerInstallation {
 				packagesResult = JSON.parse(packagesInfo);
 			}
 			catch (err) {
-				let errorMsg = msgDependenciesInstallationFailed(utils.getErrorMessage(err));
+				let errorMsg = `Failed to parse package info, encountered following error: ${(utils.getErrorMessage(err))} \n PackageInfo: ${packagesInfo}`;
 				this.outputChannel.appendLine(errorMsg);
 			}
 

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -524,7 +524,13 @@ export class JupyterServerInstallation {
 
 		let packagesResult: PythonPkgDetails[] = [];
 		if (packagesInfo) {
-			packagesResult = <PythonPkgDetails[]>JSON.parse(packagesInfo);
+			try {
+				packagesResult = <PythonPkgDetails[]>JSON.parse(packagesInfo);
+			}
+			catch (err) {
+				let errorMsg = msgDependenciesInstallationFailed(utils.getErrorMessage(err));
+				this.outputChannel.appendLine(errorMsg);
+			}
 		}
 		return packagesResult;
 	}
@@ -554,7 +560,15 @@ export class JupyterServerInstallation {
 		let packagesInfo = await this.executeBufferedCommand(cmd);
 
 		if (packagesInfo) {
-			let packagesResult = JSON.parse(packagesInfo);
+			let packagesResult = [];
+			try {
+				packagesResult = JSON.parse(packagesInfo);
+			}
+			catch (err) {
+				let errorMsg = msgDependenciesInstallationFailed(utils.getErrorMessage(err));
+				this.outputChannel.appendLine(errorMsg);
+			}
+
 			if (Array.isArray(packagesResult)) {
 				return packagesResult
 					.filter(pkg => pkg && pkg.channel && pkg.channel !== 'pypi')

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -36,7 +36,7 @@ const msgSkipPythonInstall = localize('msgSkipPythonInstall', "Python already ex
 const msgWaitingForInstall = localize('msgWaitingForInstall', "Another Python installation is currently in progress. Waiting for it to complete.");
 function msgDependenciesInstallationFailed(errorMessage: string): string { return localize('msgDependenciesInstallationFailed', "Installing Notebook dependencies failed with error: {0}", errorMessage); }
 function msgDownloadPython(platform: string, pythonDownloadUrl: string): string { return localize('msgDownloadPython', "Downloading local python for platform: {0} to {1}", platform, pythonDownloadUrl); }
-function msgPackageRetrievalFailed(errorMessage: string, packageInfo: string): string { return localize('msgPackageRetrievalFailed', "Encountered an error when trying to retrieve list of installed packages: {0} /n Package Info: {1}", errorMessage, packageInfo); }
+function msgPackageRetrievalFailed(errorMessage: string, packageInfo: string): string { return localize('msgPackageRetrievalFailed', "Encountered an error when trying to retrieve list of installed packages: {0}\nPackage Info: {1}", errorMessage, packageInfo); }
 
 export class JupyterServerInstallation {
 	public apiWrapper: ApiWrapper;

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -36,6 +36,7 @@ const msgSkipPythonInstall = localize('msgSkipPythonInstall', "Python already ex
 const msgWaitingForInstall = localize('msgWaitingForInstall', "Another Python installation is currently in progress. Waiting for it to complete.");
 function msgDependenciesInstallationFailed(errorMessage: string): string { return localize('msgDependenciesInstallationFailed', "Installing Notebook dependencies failed with error: {0}", errorMessage); }
 function msgDownloadPython(platform: string, pythonDownloadUrl: string): string { return localize('msgDownloadPython', "Downloading local python for platform: {0} to {1}", platform, pythonDownloadUrl); }
+function msgPackageRetrievalFailed(errorMessage: string): string { return localize('msgPackageRetrievalFailed', "Encountered an error when trying to retrieve list of installed packages: {0}", errorMessage); }
 
 export class JupyterServerInstallation {
 	public apiWrapper: ApiWrapper;
@@ -529,7 +530,7 @@ export class JupyterServerInstallation {
 			}
 			catch (err) {
 				let errorMsg = `Failed to parse package info, encountered following error: ${(utils.getErrorMessage(err))} \n PackageInfo: ${packagesInfo}`;
-				this.outputChannel.appendLine(errorMsg);
+				this.outputChannel.appendLine(msgPackageRetrievalFailed(errorMsg));
 			}
 		}
 		return packagesResult;
@@ -566,7 +567,7 @@ export class JupyterServerInstallation {
 			}
 			catch (err) {
 				let errorMsg = `Failed to parse package info, encountered following error: ${(utils.getErrorMessage(err))} \n PackageInfo: ${packagesInfo}`;
-				this.outputChannel.appendLine(errorMsg);
+				this.outputChannel.appendLine(msgPackageRetrievalFailed(errorMsg));
 			}
 
 			if (Array.isArray(packagesResult)) {


### PR DESCRIPTION
… to console

Installing dependencies fail with the below error. As a fix, we're wrapping the parse step in try catch and bypassing the error by logging the it on console.

![image](https://user-images.githubusercontent.com/12754347/67990243-93182000-fbf2-11e9-9734-e6f6fd3c9287.png)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #8134 
