### PR TITLE
Remove externals for some azure deps

### DIFF
--- a/extensions/azurecore/extension.webpack.config.js
+++ b/extensions/azurecore/extension.webpack.config.js
@@ -15,8 +15,6 @@ module.exports = withDefaults({
 		extension: './src/extension.ts'
 	},
 	externals: {
-		'@azure/ms-rest-azure-js': 'commonjs @azure/ms-rest-azure-js',
-		'@azure/ms-rest-js': 'commonjs @azure/ms-rest-js',
 		'request': 'commonjs request'
 	}
 });


### PR DESCRIPTION
These don't need to be externals since webpack handles them without errors.