### PR TITLE
Add config for ignoring SSL errors on BDC queries

### DIFF
--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -139,7 +139,18 @@
 				"command": "bigDataClusters.command.deletemount",
 				"title": "%command.deletemount.title%"
 			}
-		]
+		],
+		"configuration": {
+			"type": "object",
+			"title": "%bdc.configuration.title%",
+			"properties": {
+				"bigDataCluster.ignoreSslVerification": {
+					"type": "boolean",
+					"default": true,
+					"description": "%bdc.ignoreSslVerification.desc%"
+				}
+			}
+		}
 	},
 	"dependencies": {
 		"kerberos": "^1.1.3",

--- a/extensions/big-data-cluster/package.nls.json
+++ b/extensions/big-data-cluster/package.nls.json
@@ -9,5 +9,5 @@
 	"command.refreshmount.title" : "Refresh Mount",
 	"command.deletemount.title" : "Delete Mount",
 	"bdc.configuration.title" : "Big Data Cluster",
-	"bdc.ignoreSslVerification.desc" : "Whether to ignore SSL verification errors when running Big Data Cluster queries"
+	"bdc.ignoreSslVerification.desc" : "Ignore SSL verification errors against SQL Server Big Data Cluster endpoints such as HDFS, Spark, and Controller if true"
 }

--- a/extensions/big-data-cluster/package.nls.json
+++ b/extensions/big-data-cluster/package.nls.json
@@ -7,5 +7,7 @@
 	"command.manageController.title" : "Manage",
 	"command.mount.title" : "Mount HDFS",
 	"command.refreshmount.title" : "Refresh Mount",
-	"command.deletemount.title" : "Delete Mount"
+	"command.deletemount.title" : "Delete Mount",
+	"bdc.configuration.title" : "Big Data Cluster",
+	"bdc.ignoreSslVerification.desc" : "Whether to ignore SSL verification errors when running Big Data Cluster queries"
 }

--- a/extensions/big-data-cluster/src/bigDataCluster/constants.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/constants.ts
@@ -3,8 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as vscode from 'vscode';
 
 export enum BdcItemType {

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/addControllerDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/addControllerDialog.ts
@@ -70,7 +70,7 @@ export class AddControllerDialogModel {
 				}
 			}
 			// We pre-fetch the endpoints here to verify that the information entered is correct (the user is able to connect)
-			let controller = new ClusterController(url, auth, username, password, true);
+			let controller = new ClusterController(url, auth, username, password);
 			let response = await controller.getEndPoints();
 			if (response && response.endPoints) {
 				if (this._canceled) {

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardModel.ts
@@ -31,9 +31,9 @@ export class BdcDashboardModel {
 	public onDidUpdateBdcStatus = this._onDidUpdateBdcStatus.event;
 	public onBdcError = this._onBdcError.event;
 
-	constructor(private _options: BdcDashboardOptions, private _treeDataProvider: ControllerTreeDataProvider, ignoreSslVerification = true) {
+	constructor(private _options: BdcDashboardOptions, private _treeDataProvider: ControllerTreeDataProvider) {
 		try {
-			this._clusterController = new ClusterController(_options.url, _options.auth, _options.username, _options.password, ignoreSslVerification);
+			this._clusterController = new ClusterController(_options.url, _options.auth, _options.username, _options.password);
 			// tslint:disable-next-line:no-floating-promises
 			this.refresh();
 		} catch {

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/hdfsDialogBase.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/hdfsDialogBase.ts
@@ -80,7 +80,7 @@ export abstract class HdfsDialogModelBase<T extends HdfsDialogProperties, R> {
 	}
 
 	protected createController(): ClusterController {
-		return new ClusterController(this.props.url, this.props.auth, this.props.username, this.props.password, true);
+		return new ClusterController(this.props.url, this.props.auth, this.props.username, this.props.password);
 	}
 
 	protected async createAndVerifyControllerConnection(): Promise<ClusterController> {

--- a/extensions/big-data-cluster/src/bigDataCluster/utils.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/utils.ts
@@ -281,11 +281,11 @@ export const ignoreSslConfigName = 'ignoreSslVerification';
 export function getIgnoreSslVerificationConfigSetting(): boolean {
 	try {
 		const config = vscode.workspace.getConfiguration(bdcConfigSectionName);
-		return config.get<boolean>(ignoreSslConfigName) || false;
+		return config.get<boolean>(ignoreSslConfigName) || true;
 	} catch (error) {
 		console.error(`Unexpected error retrieving ${bdcConfigSectionName}.${ignoreSslConfigName} setting : ${error}`);
 	}
-	return false;
+	return true;
 }
 
 

--- a/extensions/big-data-cluster/src/bigDataCluster/utils.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/utils.ts
@@ -279,26 +279,13 @@ export const ignoreSslConfigName = 'ignoreSslVerification';
  * Retrieves the current setting for whether to ignore SSL verification errors
  */
 export function getIgnoreSslVerificationConfigSetting(): boolean {
-	return _ignoreSslVerification;
-}
-
-let _ignoreSslVerification = false;
-
-vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-	if (e.affectsConfiguration(`${bdcConfigSectionName}.${ignoreSslConfigName}`)) {
-		updateIgnoreSslConfigSetting();
-	}
-});
-
-function updateIgnoreSslConfigSetting(): void {
 	try {
 		const config = vscode.workspace.getConfiguration(bdcConfigSectionName);
-		_ignoreSslVerification = config.get<boolean>(ignoreSslConfigName) || false;
+		return config.get<boolean>(ignoreSslConfigName) || false;
 	} catch (error) {
 		console.error(`Unexpected error retrieving ${bdcConfigSectionName}.${ignoreSslConfigName} setting : ${error}`);
 	}
+	return false;
 }
-
-updateIgnoreSslConfigSetting();
 
 

--- a/extensions/big-data-cluster/src/bigDataCluster/utils.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/utils.ts
@@ -3,13 +3,11 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
-const localize = nls.loadMessageBundle();
 import * as constants from './constants';
+const localize = nls.loadMessageBundle();
 
 export enum Endpoint {
 	gateway = 'gateway',
@@ -273,3 +271,34 @@ export function getControllerEndpoint(serverInfo: azdata.ServerInfo): string | u
 export function getBdcStatusErrorMessage(error: Error): string {
 	return localize('endpointsError', "Unexpected error retrieving BDC Endpoints: {0}", error.message);
 }
+
+export const bdcConfigSectionName = 'bigDataCluster';
+export const ignoreSslConfigName = 'ignoreSslVerification';
+
+/**
+ * Retrieves the current setting for whether to ignore SSL verification errors
+ */
+export function getIgnoreSslVerificationConfigSetting(): boolean {
+	return _ignoreSslVerification;
+}
+
+let _ignoreSslVerification = false;
+
+vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
+	if (e.affectsConfiguration(`${bdcConfigSectionName}.${ignoreSslConfigName}`)) {
+		updateIgnoreSslConfigSetting();
+	}
+});
+
+function updateIgnoreSslConfigSetting(): void {
+	try {
+		const config = vscode.workspace.getConfiguration(bdcConfigSectionName);
+		_ignoreSslVerification = config.get<boolean>(ignoreSslConfigName) || false;
+	} catch (error) {
+		console.error(`Unexpected error retrieving ${bdcConfigSectionName}.${ignoreSslConfigName} setting : ${error}`);
+	}
+}
+
+updateIgnoreSslConfigSetting();
+
+

--- a/extensions/big-data-cluster/src/extension.ts
+++ b/extensions/big-data-cluster/src/extension.ts
@@ -75,7 +75,7 @@ function registerCommands(context: vscode.ExtensionContext, treeDataProvider: Co
 				info.rememberPassword);
 			await treeDataProvider.saveControllers();
 		}
-		const dashboard: BdcDashboard = new BdcDashboard(title, new BdcDashboardModel(info, treeDataProvider, /*ignoreSslVerification*/true));
+		const dashboard: BdcDashboard = new BdcDashboard(title, new BdcDashboardModel(info, treeDataProvider));
 		dashboard.showDashboard();
 	});
 

--- a/extensions/mssql/src/hdfs/webhdfs.ts
+++ b/extensions/mssql/src/hdfs/webhdfs.ts
@@ -780,10 +780,6 @@ export class WebHDFS {
 				stream.pipe(upload);
 				stream.resume();
 			}
-			if (error && !response) {
-				// request failed, and req is not accessible in this case.
-				throw this.parseError(undefined, undefined, error);
-			}
 			if (error || this.isError(response)) {
 				emitError(req, this.parseError(response, body, error));
 			}

--- a/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
@@ -18,6 +18,7 @@ import { WebHDFS, HdfsError } from '../hdfs/webhdfs';
 import { PermissionStatus } from '../hdfs/aclEntry';
 import { Mount, MountStatus } from '../hdfs/mount';
 import { FileStatus, hdfsFileTypeToFileType } from '../hdfs/fileStatus';
+import { getIgnoreSslVerificationConfigSetting } from '../util/auth';
 
 const localize = nls.loadMessageBundle();
 
@@ -143,12 +144,11 @@ export class FileSourceFactory {
 		options = options && options.host ? FileSourceFactory.removePortFromHost(options) : options;
 		let requestParams: IRequestParams = options.requestParams ? options.requestParams : {};
 		if (requestParams.auth || requestParams.isKerberos) {
-			// TODO Remove handling of unsigned cert once we have real certs in our Knox service
 			let agentOptions = {
 				host: options.host,
 				port: options.port,
 				path: constants.hdfsRootPath,
-				rejectUnauthorized: false
+				rejectUnauthorized: !getIgnoreSslVerificationConfigSetting()
 			};
 			let agent = new https.Agent(agentOptions);
 			requestParams['agent'] = agent;

--- a/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkJobSubmissionService.ts
+++ b/extensions/mssql/src/sparkFeature/dialog/sparkJobSubmission/sparkJobSubmissionService.ts
@@ -37,8 +37,7 @@ export class SparkJobSubmissionService {
 				uri: livyUrl,
 				method: 'POST',
 				json: true,
-				// TODO, change it back after service's authentication changed.
-				rejectUnauthorized: false,
+				rejectUnauthorized: !auth.getIgnoreSslVerificationConfigSetting(),
 				body: {
 					file: submissionArgs.sparkFile,
 					proxyUser: submissionArgs.user,
@@ -114,7 +113,7 @@ export class SparkJobSubmissionService {
 				uri: livyUrl,
 				method: 'GET',
 				json: true,
-				rejectUnauthorized: false,
+				rejectUnauthorized: !auth.getIgnoreSslVerificationConfigSetting(),
 				// authentication headers
 				headers: headers
 			};

--- a/extensions/mssql/src/util/auth.ts
+++ b/extensions/mssql/src/util/auth.ts
@@ -28,10 +28,10 @@ const ignoreSslConfigName = 'ignoreSslVerification';
 export function getIgnoreSslVerificationConfigSetting(): boolean {
 	try {
 		const config = vscode.workspace.getConfiguration(bdcConfigSectionName);
-		return config.get<boolean>(ignoreSslConfigName) || false;
+		return config.get<boolean>(ignoreSslConfigName) || true;
 	} catch (error) {
 		console.error(`Unexpected error retrieving ${bdcConfigSectionName}.${ignoreSslConfigName} setting : ${error}`);
 	}
-	return false;
+	return true;
 }
 

--- a/extensions/mssql/src/util/auth.ts
+++ b/extensions/mssql/src/util/auth.ts
@@ -26,25 +26,12 @@ const ignoreSslConfigName = 'ignoreSslVerification';
  * Retrieves the current setting for whether to ignore SSL verification errors
  */
 export function getIgnoreSslVerificationConfigSetting(): boolean {
-	return _ignoreSslVerification;
-}
-
-let _ignoreSslVerification = false;
-
-vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-	if (e.affectsConfiguration(`${bdcConfigSectionName}.${ignoreSslConfigName}`)) {
-		updateIgnoreSslConfigSetting();
-	}
-});
-
-function updateIgnoreSslConfigSetting(): void {
 	try {
 		const config = vscode.workspace.getConfiguration(bdcConfigSectionName);
-		_ignoreSslVerification = config.get<boolean>(ignoreSslConfigName) || false;
+		return config.get<boolean>(ignoreSslConfigName) || false;
 	} catch (error) {
 		console.error(`Unexpected error retrieving ${bdcConfigSectionName}.${ignoreSslConfigName} setting : ${error}`);
 	}
+	return false;
 }
-
-updateIgnoreSslConfigSetting();
 

--- a/extensions/mssql/src/util/auth.ts
+++ b/extensions/mssql/src/util/auth.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as kerberos from 'kerberos';
+import * as vscode from 'vscode';
 
 export enum AuthType {
 	Integrated = 'integrated',
@@ -17,3 +18,33 @@ export async function authenticateKerberos(hostname: string): Promise<string> {
 	let response = await client.step('');
 	return response;
 }
+
+const bdcConfigSectionName = 'bigDataCluster';
+const ignoreSslConfigName = 'ignoreSslVerification';
+
+/**
+ * Retrieves the current setting for whether to ignore SSL verification errors
+ */
+export function getIgnoreSslVerificationConfigSetting(): boolean {
+	return _ignoreSslVerification;
+}
+
+let _ignoreSslVerification = false;
+
+vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
+	if (e.affectsConfiguration(`${bdcConfigSectionName}.${ignoreSslConfigName}`)) {
+		updateIgnoreSslConfigSetting();
+	}
+});
+
+function updateIgnoreSslConfigSetting(): void {
+	try {
+		const config = vscode.workspace.getConfiguration(bdcConfigSectionName);
+		_ignoreSslVerification = config.get<boolean>(ignoreSslConfigName) || false;
+	} catch (error) {
+		console.error(`Unexpected error retrieving ${bdcConfigSectionName}.${ignoreSslConfigName} setting : ${error}`);
+	}
+}
+
+updateIgnoreSslConfigSetting();
+

--- a/extensions/notebook/resources/jupyter_config/sparkmagic_config.json
+++ b/extensions/notebook/resources/jupyter_config/sparkmagic_config.json
@@ -11,7 +11,6 @@
 		"url": "",
 		"auth": "None"
 	},
-	"ignore_ssl_errors": true,
 	"logging_config": {
 		"version": 1,
 		"formatters": {

--- a/extensions/notebook/src/common/utils.ts
+++ b/extensions/notebook/src/common/utils.ts
@@ -256,9 +256,9 @@ const ignoreSslConfigName = 'ignoreSslVerification';
 export function getIgnoreSslVerificationConfigSetting(): boolean {
 	try {
 		const config = vscode.workspace.getConfiguration(bdcConfigSectionName);
-		return config.get<boolean>(ignoreSslConfigName) || false;
+		return config.get<boolean>(ignoreSslConfigName) || true;
 	} catch (error) {
 		console.error(`Unexpected error retrieving ${bdcConfigSectionName}.${ignoreSslConfigName} setting : ${error}`);
 	}
-	return false;
+	return true;
 }

--- a/extensions/notebook/src/common/utils.ts
+++ b/extensions/notebook/src/common/utils.ts
@@ -246,3 +246,32 @@ export async function exists(path: string): Promise<boolean> {
 		return false;
 	}
 }
+
+const bdcConfigSectionName = 'bigDataCluster';
+const ignoreSslConfigName = 'ignoreSslVerification';
+
+/**
+ * Retrieves the current setting for whether to ignore SSL verification errors
+ */
+export function getIgnoreSslVerificationConfigSetting(): boolean {
+	return _ignoreSslVerification;
+}
+
+let _ignoreSslVerification = false;
+
+vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
+	if (e.affectsConfiguration(`${bdcConfigSectionName}.${ignoreSslConfigName}`)) {
+		updateIgnoreSslConfigSetting();
+	}
+});
+
+function updateIgnoreSslConfigSetting(): void {
+	try {
+		const config = vscode.workspace.getConfiguration(bdcConfigSectionName);
+		_ignoreSslVerification = config.get<boolean>(ignoreSslConfigName) || false;
+	} catch (error) {
+		console.error(`Unexpected error retrieving ${bdcConfigSectionName}.${ignoreSslConfigName} setting : ${error}`);
+	}
+}
+
+updateIgnoreSslConfigSetting();

--- a/extensions/notebook/src/common/utils.ts
+++ b/extensions/notebook/src/common/utils.ts
@@ -254,24 +254,11 @@ const ignoreSslConfigName = 'ignoreSslVerification';
  * Retrieves the current setting for whether to ignore SSL verification errors
  */
 export function getIgnoreSslVerificationConfigSetting(): boolean {
-	return _ignoreSslVerification;
-}
-
-let _ignoreSslVerification = false;
-
-vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
-	if (e.affectsConfiguration(`${bdcConfigSectionName}.${ignoreSslConfigName}`)) {
-		updateIgnoreSslConfigSetting();
-	}
-});
-
-function updateIgnoreSslConfigSetting(): void {
 	try {
 		const config = vscode.workspace.getConfiguration(bdcConfigSectionName);
-		_ignoreSslVerification = config.get<boolean>(ignoreSslConfigName) || false;
+		return config.get<boolean>(ignoreSslConfigName) || false;
 	} catch (error) {
 		console.error(`Unexpected error retrieving ${bdcConfigSectionName}.${ignoreSslConfigName} setting : ${error}`);
 	}
+	return false;
 }
-
-updateIgnoreSslConfigSetting();

--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -26,9 +26,6 @@ const configBase = {
 	'kernel_r_credentials': {
 		'url': ''
 	},
-
-	'ignore_ssl_errors': true,
-
 	'logging_config': {
 		'version': 1,
 		'formatters': {
@@ -308,6 +305,7 @@ export class JupyterSession implements nb.ISession {
 		config.kernel_scala_credentials = creds;
 		config.kernel_r_credentials = creds;
 		config.logging_config.handlers.magicsHandler.home_path = homePath;
+		config.ignore_ssl_errors = utils.getIgnoreSslVerificationConfigSetting();
 	}
 
 	private getKnoxPortOrDefault(connectionProfile: IConnectionProfile): string {

--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -168,6 +168,7 @@ export class JupyterSession implements nb.ISession {
 	private _messagesComplete: Deferred<void> = new Deferred<void>();
 
 	constructor(private sessionImpl: Session.ISession, skipSettingEnvironmentVars?: boolean, private _pythonEnvVarPath?: string) {
+		// tslint:disable-next-line:no-floating-promises This is handled by use of a deferred promise for callers to await on
 		this.setEnvironmentVars(skipSettingEnvironmentVars);
 	}
 

--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -168,8 +168,12 @@ export class JupyterSession implements nb.ISession {
 	private _messagesComplete: Deferred<void> = new Deferred<void>();
 
 	constructor(private sessionImpl: Session.ISession, skipSettingEnvironmentVars?: boolean, private _pythonEnvVarPath?: string) {
-		// tslint:disable-next-line:no-floating-promises This is handled by use of a deferred promise for callers to await on
-		this.setEnvironmentVars(skipSettingEnvironmentVars);
+		this.setEnvironmentVars(skipSettingEnvironmentVars).catch(error => {
+			console.error(`Unexpected exception setting Jupyter Session variables : ${error}`);
+			// We don't want callers to hang forever waiting - it's better to continue on even if we weren't
+			// able to set environment variables
+			this._messagesComplete.resolve();
+		});
 	}
 
 	public get canChangeKernels(): boolean {


### PR DESCRIPTION
For #8129

Things tested :

- OE HDFS node expansion
- Notebook PySpark kernel executions
- BDC Dashboard
- Spark Submission
- Manage Access dialog
- New Directory
- Upload files
- Mount HDFS

Note that the SQL Dashboard continues to list endpoints because it queries those from SQL directly. 

I also fixed up a small issue with creating a write stream - we were throwing an exception which was causing an unhandled promise rejection. The correct way is to emit an error and handle that error by the calling code. 