### PR TITLE
recommend datavirtualization instead of sql-vnext

### DIFF
--- a/product.json
+++ b/product.json
@@ -49,7 +49,7 @@
 		"Microsoft.powershell",
 		"Microsoft.profiler",
 		"Microsoft.schema-compare",
-		"Microsoft.sql-vnext",
+		"Microsoft.datavirtualization",
 		"Redgate.sql-search",
 		"IDERA.sqldm-performance-insights",
 		"SentryOne.plan-explorer"


### PR DESCRIPTION
In preparation for release, this is needed so the correct extension shows in the marketplace without searching.

This fixes #8173