### PR TITLE
Initialize cell source to empty array if notebook file's source is undefined.

### DIFF
--- a/src/sql/workbench/parts/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/parts/notebook/browser/models/cell.ts
@@ -674,7 +674,7 @@ export class CellModel implements ICellModel {
 
 
 	private getMultilineSource(source: string | string[]): string | string[] {
-		if (!source) {
+		if (source === undefined) {
 			return [];
 		}
 		if (typeof source === 'string') {

--- a/src/sql/workbench/parts/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/parts/notebook/browser/models/cell.ts
@@ -675,7 +675,7 @@ export class CellModel implements ICellModel {
 
 	private getMultilineSource(source: string | string[]): string | string[] {
 		if (!source) {
-			return '';
+			return [];
 		}
 		if (typeof source === 'string') {
 			let sourceMultiline = source.split('\n');

--- a/src/sql/workbench/parts/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/parts/notebook/browser/models/cell.ts
@@ -674,6 +674,9 @@ export class CellModel implements ICellModel {
 
 
 	private getMultilineSource(source: string | string[]): string | string[] {
+		if (!source) {
+			return '';
+		}
 		if (typeof source === 'string') {
 			let sourceMultiline = source.split('\n');
 			// If source is one line (i.e. no '\n'), return it immediately


### PR DESCRIPTION
Ran into a situation earlier where a notebook had an undefined source field, which was causing errors to be thrown from locations that referenced cellModel.source, such as the onDidChangeContent handler in code.component.ts