### PR TITLE
Add triggers for devops ci

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,7 @@
+trigger:
+  - master
+  - release/*
+
 jobs:
 - job: Windows
   pool:


### PR DESCRIPTION
I noticed after my previous change that ci now triggers for all commits pushed to any branch. So I added back the triggers for the CI.