### PR TITLE
Undo codicon change to fix modelview images

### DIFF
--- a/src/sql/workbench/browser/modelComponents/image.component.ts
+++ b/src/sql/workbench/browser/modelComponents/image.component.ts
@@ -55,7 +55,7 @@ export default class ImageComponent extends ComponentWithIconBase implements ICo
 		if (this.iconPath) {
 			if (!this._iconClass) {
 				super.updateIcon();
-				DOM.addClasses(this.imageContainer.nativeElement, this._iconClass, 'codicon');
+				DOM.addClasses(this.imageContainer.nativeElement, this._iconClass, 'icon');
 			} else {
 				super.updateIcon();
 			}

--- a/src/sql/workbench/browser/modelComponents/media/image.css
+++ b/src/sql/workbench/browser/modelComponents/media/image.css
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-modelview-image div.codicon {
+modelview-image div.icon {
 	background-repeat: no-repeat;
 	background-position: center;
 	background-size: contain;


### PR DESCRIPTION
Fixes #8200
This fixes an issue caused by https://github.com/microsoft/azuredatastudio/pull/7837 - the ModelView image component was updated to use the codicon class but the underlying ComponentWithIcon base wasn't and so the CSS styles weren't being applied correctly.

Given that the ModelView stuff isn't using any of the codicon fonts (instead it only supports external image files currently) this doesn't need to use codicon and so I'm reverting it back to just use the icon class. At some point we should consider adding codicon support to this component since that'd potentially be useful, but that be a later enhancement if that feature is needed at some point.

![image](https://user-images.githubusercontent.com/28519865/68091149-0909ca80-fe31-11e9-8f91-c19f6ebd9797.png)
