### PR TITLE
Add level to dialog titles and form component titles

### DIFF
--- a/src/sql/workbench/browser/modelComponents/formContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/formContainer.component.ts
@@ -46,10 +46,10 @@ class FormItem {
 			</div>
 			<div class="form-row" *ngIf="isFormComponent(item)" [style.height]="getRowHeight(item)">
 					<ng-container *ngIf="isHorizontal(item)">
-						<div *ngIf="hasItemTitle(item)" class="form-cell form-cell-title" [style.font-size]="getItemTitleFontSize(item)"  role="heading" aria-level="2" [ngClass]="{'form-group-item': isInGroup(item)}">
+						<h2 *ngIf="hasItemTitle(item)" class="form-cell form-cell-title" [style.font-size]="getItemTitleFontSize(item)" [ngClass]="{'form-group-item': isInGroup(item)}">
 							{{getItemTitle(item)}}<span class="form-required" *ngIf="isItemRequired(item)">*</span>
 							<span class="codicon help form-info" *ngIf="itemHasInfo(item)" [title]="getItemInfo(item)"></span>
-						</div>
+						</h2>
 						<div class="form-cell">
 							<div class="form-component-container">
 								<div [style.width]="getComponentWidth(item)" [ngClass]="{'form-input-flex': !getComponentWidth(item)}">
@@ -66,10 +66,10 @@ class FormItem {
 						</div>
 					</ng-container>
 					<div class="form-vertical-container" *ngIf="isVertical(item)" [style.height]="getRowHeight(item)" [ngClass]="{'form-group-item': isInGroup(item)}">
-						<div class="form-item-row" [style.font-size]="getItemTitleFontSize(item)" role="heading" aria-level="2">
+						<h2 class="form-item-row" [style.font-size]="getItemTitleFontSize(item)">
 							{{getItemTitle(item)}}<span class="form-required" *ngIf="isItemRequired(item)">*</span>
 							<span class="codicon help form-info" *ngIf="itemHasInfo(item)" [title]="getItemInfo(item)"></span>
-						</div>
+						</h2>
 						<div class="form-item-row" [style.width]="getComponentWidth(item)" [style.height]="getRowHeight(item)">
 							<model-component-wrapper [descriptor]="item.descriptor" [modelStore]="modelStore" [style.width]="getComponentWidth(item)" [style.height]="getRowHeight(item)">
 							</model-component-wrapper>

--- a/src/sql/workbench/browser/modelComponents/formContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/formContainer.component.ts
@@ -45,9 +45,8 @@ class FormItem {
 				</div>
 			</div>
 			<div class="form-row" *ngIf="isFormComponent(item)" [style.height]="getRowHeight(item)">
-
 					<ng-container *ngIf="isHorizontal(item)">
-						<div *ngIf="hasItemTitle(item)" class="form-cell form-cell-title" [style.font-size]="getItemTitleFontSize(item)" [ngClass]="{'form-group-item': isInGroup(item)}">
+						<div *ngIf="hasItemTitle(item)" class="form-cell form-cell-title" [style.font-size]="getItemTitleFontSize(item)"  role="heading" aria-level="2" [ngClass]="{'form-group-item': isInGroup(item)}">
 							{{getItemTitle(item)}}<span class="form-required" *ngIf="isItemRequired(item)">*</span>
 							<span class="codicon help form-info" *ngIf="itemHasInfo(item)" [title]="getItemInfo(item)"></span>
 						</div>
@@ -67,7 +66,7 @@ class FormItem {
 						</div>
 					</ng-container>
 					<div class="form-vertical-container" *ngIf="isVertical(item)" [style.height]="getRowHeight(item)" [ngClass]="{'form-group-item': isInGroup(item)}">
-						<div class="form-item-row" [style.font-size]="getItemTitleFontSize(item)">
+						<div class="form-item-row" [style.font-size]="getItemTitleFontSize(item)" role="heading" aria-level="2">
 							{{getItemTitle(item)}}<span class="form-required" *ngIf="isItemRequired(item)">*</span>
 							<span class="codicon help form-info" *ngIf="itemHasInfo(item)" [title]="getItemInfo(item)"></span>
 						</div>

--- a/src/sql/workbench/services/dialog/browser/dialogContainer.component.ts
+++ b/src/sql/workbench/services/dialog/browser/dialogContainer.component.ts
@@ -28,7 +28,7 @@ export interface DialogComponentParams extends IBootstrapParams {
 	template: `
 		<div class="dialogContainer" *ngIf="_dialogPane && _dialogPane.displayPageTitle">
 			<div class="dialogModal-wizardHeader" *ngIf="_dialogPane && _dialogPane.displayPageTitle">
-				<div *ngIf="_dialogPane.pageNumber" class="wizardPageNumber">Step {{_dialogPane.pageNumber}}</div>
+				<div *ngIf="_dialogPane.pageNumber" class="wizardPageNumber" role="heading" aria-level="1">Step {{_dialogPane.pageNumber}}</div>
 				<h1 class="wizardPageTitle" role="alert">{{_dialogPane.title}}</h1>
 				<div *ngIf="_dialogPane.description">{{_dialogPane.description}}</div>
 			</div>

--- a/src/sql/workbench/services/dialog/browser/dialogContainer.component.ts
+++ b/src/sql/workbench/services/dialog/browser/dialogContainer.component.ts
@@ -28,7 +28,7 @@ export interface DialogComponentParams extends IBootstrapParams {
 	template: `
 		<div class="dialogContainer" *ngIf="_dialogPane && _dialogPane.displayPageTitle">
 			<div class="dialogModal-wizardHeader" *ngIf="_dialogPane && _dialogPane.displayPageTitle">
-				<div *ngIf="_dialogPane.pageNumber" class="wizardPageNumber" role="heading" aria-level="1">Step {{_dialogPane.pageNumber}}</div>
+				<h1 *ngIf="_dialogPane.pageNumber" class="wizardPageNumber">Step {{_dialogPane.pageNumber}}</h1>
 				<h1 class="wizardPageTitle" role="alert">{{_dialogPane.title}}</h1>
 				<div *ngIf="_dialogPane.description">{{_dialogPane.description}}</div>
 			</div>

--- a/src/sql/workbench/services/dialog/browser/media/dialogModal.css
+++ b/src/sql/workbench/services/dialog/browser/media/dialogModal.css
@@ -71,6 +71,13 @@
 	font-weight: bold;
 }
 
+.dialogContainer .dialogModal-wizardHeader h1.wizardPageNumber {
+	margin-block-start: 0px;
+	margin-block-end: 0px;
+	font-weight: normal;
+	font-size: 11px;
+}
+
 .dialogContainer {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Fixes #6072

The simplistic "fix" here is to add a heading level 1 for the top-level "title" components for a page. And then have form items (regardless of where they are) use h2 for the titles of the components.

With more complex layouts this may not be enough (for example if a form was nested under a h2 itself), but I don't know of anywhere we currently have that so as a cheap fix this seems fine. And talking with the a11y folks there's some controversy over the use of heading levels for titles anyways so they said something like this should be fine.

I went through a bunch of dialogs to make sure my changes didn't affect the look/layout and things seem fine. Let me know if there's a dialog you'd like me to verify though.

Original 
![image](https://user-images.githubusercontent.com/28519865/68256098-f1bf0e80-ffe3-11e9-9c3f-aa2d3e2772d4.png)

New
![image](https://user-images.githubusercontent.com/28519865/68256254-65611b80-ffe4-11e9-8447-e20a146568f2.png)

Agent Notebook Job (info help button)

Original
![image](https://user-images.githubusercontent.com/28519865/68256168-25019d80-ffe4-11e9-9b50-9cfb2799fb13.png)

New
![image](https://user-images.githubusercontent.com/28519865/68256282-7f026300-ffe4-11e9-9053-22418e4832d8.png)

Deploy DacPac (horizontal item layout)

Original
![image](https://user-images.githubusercontent.com/28519865/68256209-42cf0280-ffe4-11e9-9f5b-9316687ed09d.png)

New
![image](https://user-images.githubusercontent.com/28519865/68256304-92adc980-ffe4-11e9-8d48-79f12c823ad6.png)
