### PR TITLE
fix the scroll issue of modal dialog and wizard

### DIFF
--- a/src/sql/workbench/parts/query/browser/modelViewTab/media/dialogModal.css
+++ b/src/sql/workbench/parts/query/browser/modelViewTab/media/dialogModal.css
@@ -49,7 +49,8 @@
 	background-image: url("loading.svg");
 }
 
-.vs-dark .footer-button .validating, .hc-black .footer-button .validating {
+.vs-dark .footer-button .validating,
+.hc-black .footer-button .validating {
 	background-image: url("loading_inverse.svg");
 }
 

--- a/src/sql/workbench/parts/query/browser/modelViewTab/media/dialogModal.css
+++ b/src/sql/workbench/parts/query/browser/modelViewTab/media/dialogModal.css
@@ -8,12 +8,6 @@
 	flex-direction: row;
 	height: 100%;
 	width: 100%;
-	min-width: 500px;
-	min-height: 600px;
-}
-
-.modal.wide .dialogModal-body {
-	min-width: 800px;
 }
 
 .dialog-message-and-page-container {
@@ -33,8 +27,8 @@
 	flex-direction: column;
 	width: 100%;
 	height: 100%;
-	overflow-x: hidden;
-	overflow-y: scroll;
+	overflow-x: auto;
+	overflow-y: auto;
 }
 
 .dialogModal-hidden {
@@ -55,8 +49,7 @@
 	background-image: url("loading.svg");
 }
 
-.vs-dark .footer-button .validating,
-.hc-black .footer-button .validating {
+.vs-dark .footer-button .validating, .hc-black .footer-button .validating {
 	background-image: url("loading_inverse.svg");
 }
 

--- a/src/sql/workbench/services/dialog/browser/media/dialogModal.css
+++ b/src/sql/workbench/services/dialog/browser/media/dialogModal.css
@@ -8,12 +8,6 @@
 	flex-direction: row;
 	height: 100%;
 	width: 100%;
-	min-width: 500px;
-	min-height: 600px;
-}
-
-.modal.wide .dialogModal-body {
-	min-width: 800px;
 }
 
 .dialog-message-and-page-container {
@@ -33,8 +27,8 @@
 	flex-direction: column;
 	width: 100%;
 	height: 100%;
-	overflow-x: hidden;
-	overflow-y: scroll;
+	overflow-x: auto;
+	overflow-y: auto;
 }
 
 .dialogModal-hidden {

--- a/src/sql/workbench/services/dialog/browser/media/wizardNavigation.css
+++ b/src/sql/workbench/services/dialog/browser/media/wizardNavigation.css
@@ -8,6 +8,7 @@
 	flex-direction: column;
 	width: 80px;
 	height: 100%;
+	overflow: auto;
 }
 
 .hc-black .wizardNavigation-container {


### PR DESCRIPTION
fixes #5964 
fixes #5784 
fixes #5674 
fixes #7664 

Notes: I didn't look into why do we have 2 copy of the same css file, I remembered @aaomidi mentioned in one PR that now we want to have components have their own css files instead of sharing. I am going to keep it that way and updating both files.

the min width and min height i removed in the PR caused the scroll to not show up or not able to scroll to the bottom of the view.  and the overflow-x: hidden results in no horizontal scrollbar when needed. I have tested with the following scenarios on both windows and macOS. 

**TOP vs Bottom = Before vs After**
![Nov-06-2019 10-08-34](https://user-images.githubusercontent.com/13777222/68327794-e242d280-0082-11ea-9bae-560d96ffcdc3.gif)

![Screen Shot 2019-11-06 at 10 02 33 AM](https://user-images.githubusercontent.com/13777222/68327565-706a8900-0082-11ea-8001-fbba0e055819.png)

![Screen Shot 2019-11-06 at 10 04 54 AM](https://user-images.githubusercontent.com/13777222/68327567-706a8900-0082-11ea-9c82-e0ffea5046c5.png)

![Screen Shot 2019-11-06 at 10 21 51 AM](https://user-images.githubusercontent.com/13777222/68327568-706a8900-0082-11ea-94bf-27a7280dba00.png)

![Screen Shot 2019-11-06 at 10 26 48 AM](https://user-images.githubusercontent.com/13777222/68327569-71031f80-0082-11ea-9a89-7c1ad66dfa1b.png)

![Screen Shot 2019-11-06 at 10 28 19 AM](https://user-images.githubusercontent.com/13777222/68327571-71031f80-0082-11ea-85b0-449c44ef55e2.png)

![Screen Shot 2019-11-06 at 10 32 21 AM](https://user-images.githubusercontent.com/13777222/68327572-71031f80-0082-11ea-9cdd-8c361ac5bd6d.png)

![Screen Shot 2019-11-06 at 10 33 15 AM](https://user-images.githubusercontent.com/13777222/68327573-71031f80-0082-11ea-862d-89f2a738c76d.png)