### PR TITLE
Don't show dialog cancelled errors for mount

### DIFF
--- a/extensions/big-data-cluster/src/extension.ts
+++ b/extensions/big-data-cluster/src/extension.ts
@@ -15,6 +15,7 @@ import { BdcDashboard } from './bigDataCluster/dialog/bdcDashboard';
 import { BdcDashboardModel, BdcDashboardOptions } from './bigDataCluster/dialog/bdcDashboardModel';
 import { MountHdfsDialogModel as MountHdfsModel, MountHdfsProperties, MountHdfsDialog, DeleteMountDialog, DeleteMountModel, RefreshMountDialog, RefreshMountModel } from './bigDataCluster/dialog/mountHdfsDialog';
 import { getControllerEndpoint } from './bigDataCluster/utils';
+import { HdfsDialogCancelledError } from './bigDataCluster/dialog/hdfsDialogBase';
 
 const localize = nls.loadMessageBundle();
 
@@ -92,7 +93,14 @@ async function mountHdfs(explorerContext?: azdata.ObjectExplorerContext): Promis
 	const mountProps = await getMountProps(explorerContext);
 	if (mountProps) {
 		const dialog = new MountHdfsDialog(new MountHdfsModel(mountProps));
-		await dialog.showDialog();
+		try {
+			await dialog.showDialog();
+		} catch (error) {
+			if (!(error instanceof HdfsDialogCancelledError)) {
+				throw error;
+			}
+		}
+
 	}
 }
 


### PR DESCRIPTION
Fixes #8270

There's something to be said for not having the dialog reject if it's cancelled (instead just returning undefined) - but in the BDC dashboard I use this error to show a different string indicating the user needs to enter a connection and I'd rather not refactor it since this doesn't seem that terrible to have as is. 