### PR TITLE
Fix null ref error in query history

### DIFF
--- a/src/sql/platform/queryHistory/common/queryHistoryServiceImpl.ts
+++ b/src/sql/platform/queryHistory/common/queryHistoryServiceImpl.ts
@@ -52,7 +52,7 @@ export class QueryHistoryService extends Disposable implements IQueryHistoryServ
 				const uri: URI = URI.parse(e.uri);
 				// VS Range is 1 based so offset values by 1. The endLine we get back from SqlToolsService is incremented
 				// by 1 from the original input range sent in as well so take that into account and don't modify
-				const text: string = e.queryInfo.selection.length > 0 ?
+				const text: string = e.queryInfo.selection && e.queryInfo.selection.length > 0 ?
 					_modelService.getModel(uri).getValueInRange(new Range(
 						e.queryInfo.selection[0].startLine + 1,
 						e.queryInfo.selection[0].startColumn + 1,

--- a/src/sql/platform/queryHistory/common/queryHistoryServiceImpl.ts
+++ b/src/sql/platform/queryHistory/common/queryHistoryServiceImpl.ts
@@ -52,11 +52,14 @@ export class QueryHistoryService extends Disposable implements IQueryHistoryServ
 				const uri: URI = URI.parse(e.uri);
 				// VS Range is 1 based so offset values by 1. The endLine we get back from SqlToolsService is incremented
 				// by 1 from the original input range sent in as well so take that into account and don't modify
-				const text: string = _modelService.getModel(uri).getValueInRange(new Range(
-					e.queryInfo.selection[0].startLine + 1,
-					e.queryInfo.selection[0].startColumn + 1,
-					e.queryInfo.selection[0].endLine,
-					e.queryInfo.selection[0].endColumn + 1));
+				const text: string = e.queryInfo.selection.length > 0 ?
+					_modelService.getModel(uri).getValueInRange(new Range(
+						e.queryInfo.selection[0].startLine + 1,
+						e.queryInfo.selection[0].startColumn + 1,
+						e.queryInfo.selection[0].endLine,
+						e.queryInfo.selection[0].endColumn + 1)) :
+					// If no specific selection get the entire text
+					_modelService.getModel(uri).getValue();
 
 				const newInfo = new QueryHistoryInfo(text, _connectionManagementService.getConnectionProfile(e.uri), new Date(), QueryStatus.Succeeded);
 


### PR DESCRIPTION
Fixes #8284

If a query is ran without a specific selection the selection array is empty - in that case just get the entire text.

Opened #8303 as a related issue (we probably shouldn't be collecting queries from internal implementations of features)