### PR TITLE
Fix missing icon and add test

### DIFF
--- a/src/sql/base/test/node/ui/codicon.test.ts
+++ b/src/sql/base/test/node/ui/codicon.test.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { readFile } from 'vs/base/node/pfs';
+import { join } from 'vs/base/common/path';
+import { URI } from 'vs/base/common/uri';
+
+const icons: string[] = [
+	'codicon-chevron-down',
+	'codicon-chevron-up',
+	'codicon-clear-all',
+	'codicon-debug-pause',
+	'codicon-play'
+];
+
+suite('codicon css', () => {
+	test('codicon.css contains expected icons', async () => {
+		assert.fail(__dirname);
+		const codiconFile = await readFile(join(URI.parse(__dirname).fsPath, '..', '..', '..', '..', '..', 'vs', 'base', 'browser', 'ui', 'codiconLabel', 'codicon', 'codicon.css'));
+		icons.forEach(icon => {
+			assert.ok(codiconFile.includes(icon), `codicon.css did not contain expected icon ${icon}`);
+		});
+	});
+});
+

--- a/src/sql/base/test/node/ui/codicon.test.ts
+++ b/src/sql/base/test/node/ui/codicon.test.ts
@@ -18,7 +18,6 @@ const icons: string[] = [
 
 suite('codicon css', () => {
 	test('codicon.css contains expected icons', async () => {
-		assert.fail(__dirname);
 		const codiconFile = await readFile(join(URI.parse(__dirname).fsPath, '..', '..', '..', '..', '..', 'vs', 'base', 'browser', 'ui', 'codiconLabel', 'codicon', 'codicon.css'));
 		icons.forEach(icon => {
 			assert.ok(codiconFile.includes(icon), `codicon.css did not contain expected icon ${icon}`);

--- a/src/sql/workbench/parts/queryHistory/browser/queryHistoryActions.ts
+++ b/src/sql/workbench/parts/queryHistory/browser/queryHistoryActions.ts
@@ -127,7 +127,7 @@ export class ToggleQueryHistoryCaptureAction extends Action {
 
 	private setClassAndLabel(enabled: boolean) {
 		if (enabled) {
-			this.class = 'toggle-query-history-capture-action codicon-pause';
+			this.class = 'toggle-query-history-capture-action codicon-debug-pause';
 			this.label = localize('queryHistory.disableCapture', "Pause Query History Capture");
 		} else {
 			this.class = 'toggle-query-history-capture-action codicon-play';


### PR DESCRIPTION
This icon was removed in https://github.com/microsoft/azuredatastudio/pull/7880

Added test to read the codicon.css file and check that the icons we use are in there as a basic smoke test. 

![image](https://user-images.githubusercontent.com/28519865/68642297-8fbe4780-04c2-11ea-8a4c-26d690a1f991.png)
