### PR TITLE
Add stale pr config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 {
-  perform: true,
+  perform: false,
   label: 'Stale PR',
   daysSinceLastUpdate: 7,
   ignoredLabels: ['Do Not Merge']

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,6 @@
+{
+  perform: true,
+  label: 'Stale PR',
+  daysSinceLastUpdate: 7,
+  ignoredLabels: ['Do Not Merge', ]
+}

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,5 +2,5 @@
   perform: true,
   label: 'Stale PR',
   daysSinceLastUpdate: 7,
-  ignoredLabels: ['Do Not Merge', ]
+  ignoredLabels: ['Do Not Merge']
 }


### PR DESCRIPTION
Adds config for the probot to label and unlabel pr's for stale. Initally not performing as I want to verify it is doing the right thing first. Already tested on test repo.