### PR TITLE
Prevent Markdown Cells from Collapsing

### DIFF
--- a/src/sql/workbench/parts/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/parts/notebook/browser/models/cell.ts
@@ -108,6 +108,9 @@ export class CellModel implements ICellModel {
 	}
 
 	public set isCollapsed(value: boolean) {
+		if (this.cellType !== CellTypes.Code) {
+			return;
+		}
 		let stateChanged = this._isCollapsed !== value;
 		this._isCollapsed = value;
 
@@ -603,7 +606,7 @@ export class CellModel implements ICellModel {
 		this._source = this.getMultilineSource(cell.source);
 		this._metadata = cell.metadata || {};
 
-		if (this._metadata.tags && this._metadata.tags.some(x => x === HideInputTag)) {
+		if (this._metadata.tags && this._metadata.tags.some(x => x === HideInputTag) && this._cellType === CellTypes.Code) {
 			this._isCollapsed = true;
 		} else {
 			this._isCollapsed = false;

--- a/src/sql/workbench/parts/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/parts/notebook/test/electron-browser/cell.test.ts
@@ -335,6 +335,34 @@ suite('Cell Model', function (): void {
 		assert(!isCollapsed);
 	});
 
+	test('Should not allow markdown cells to be collapsible', async function (): Promise<void> {
+		let mdCellData: nb.ICellContents = {
+			cell_type: CellTypes.Markdown,
+			source: 'some *markdown*',
+			outputs: [],
+			metadata: { language: 'python' }
+		};
+		let cell = factory.createCell(mdCellData, undefined);
+		assert(cell.isCollapsed === false);
+		cell.isCollapsed = true;
+		// The typescript compiler will complain if we don't ignore the error from the following line,
+		// claiming that cell.isCollapsed will return true. It doesn't.
+		// @ts-ignore
+		assert(cell.isCollapsed === false);
+
+		let codeCellData: nb.ICellContents = {
+			cell_type: CellTypes.Code,
+			source: '1+1',
+			outputs: [],
+			metadata: { language: 'python' },
+			execution_count: 1
+		};
+		cell = factory.createCell(codeCellData, undefined);
+		assert(cell.isCollapsed === false);
+		cell.isCollapsed = true;
+		assert(cell.isCollapsed === true);
+	});
+
 	suite('Model Future handling', function (): void {
 		let future: TypeMoq.Mock<EmptyFuture>;
 		let cell: ICellModel;


### PR DESCRIPTION
Fixes #8286. We weren't checking for CellType when setting the _isCollapsed property, which meant that if a user collapsed all cells, they would see the markdown editor in a collapsed state and only be able to see one line.

Also added a test.