### PR TITLE
Fix spacing for form layout

### DIFF
--- a/src/sql/workbench/browser/modelComponents/media/formLayout.css
+++ b/src/sql/workbench/browser/modelComponents/media/formLayout.css
@@ -17,6 +17,12 @@
 	display: table-row;
 }
 
+.form-row h2 {
+	margin-block-start: 0px;
+	margin-block-end: 0px;
+	font-weight: normal;
+}
+
 .form-item-row {
 	padding-bottom: 5px;
 }


### PR DESCRIPTION
A recent CSS change made the form titles an h2 instead of a div for accessibility reasons. But the default style for h2s is different, and so this PR is fixing it so they still look as they did before.

Current :
![image](https://user-images.githubusercontent.com/28519865/68725356-074baf80-0573-11ea-89f4-68cfa8979dba.png)

Fixed :
![image](https://user-images.githubusercontent.com/28519865/68725373-16326200-0573-11ea-9fb6-123618840d7e.png)
