### PR TITLE
Add focus function for modelview components

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/addControllerDialog.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/addControllerDialog.ts
@@ -180,6 +180,7 @@ export class AddControllerDialog {
 				}]).withLayout({ width: '100%' }).component();
 			this.onAuthChanged();
 			await view.initializeModel(formModel);
+			this.urlInputBox.focus();
 		});
 
 		this.dialog.registerCloseValidator(async () => await this.validate());

--- a/extensions/dacpac/src/wizard/pages/selectOperationpage.ts
+++ b/extensions/dacpac/src/wizard/pages/selectOperationpage.ts
@@ -38,10 +38,6 @@ export class SelectOperationPage extends BasePage {
 		let importComponent = await this.createImportRadioButton();
 		let exportComponent = await this.createExportRadioButton();
 
-		// default have the first radio button checked
-		this.deployRadioButton.checked = true;
-		this.deployRadioButton.focused = true;
-
 		this.form = this.view.modelBuilder.formContainer()
 			.withFormItems(
 				[
@@ -54,6 +50,7 @@ export class SelectOperationPage extends BasePage {
 			}).component();
 		await this.view.initializeModel(this.form);
 
+		this.deployRadioButton.focus();
 		this.instance.setDoneButton(Operation.deploy);
 		return true;
 	}
@@ -67,6 +64,7 @@ export class SelectOperationPage extends BasePage {
 			.withProperties({
 				name: 'selectedOperation',
 				label: localize('dacFx.deployRadioButtonLabel', "Deploy a data-tier application .dacpac file to an instance of SQL Server [Deploy Dacpac]"),
+				checked: true // Default to first radio button being selected
 			}).component();
 
 		this.deployRadioButton.onDidClick(() => {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3093,7 +3093,6 @@ declare module 'azdata' {
 		ariaRowCount?: number;
 		ariaColumnCount?: number;
 		ariaRole?: string;
-		focused?: boolean;
 		updateCells?: TableCell[];
 		moveFocusOutWithTab?: boolean; //accessibility requirement for tables with no actionable cells
 	}
@@ -3128,7 +3127,6 @@ declare module 'azdata' {
 		label?: string;
 		value?: string;
 		checked?: boolean;
-		focused?: boolean;
 	}
 
 	export interface TextComponentProperties extends ComponentProperties, TitledComponentProperties {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2646,6 +2646,11 @@ declare module 'azdata' {
 		 * Run the component's validations
 		 */
 		validate(): Thenable<boolean>;
+
+		/**
+		 * Focuses the component.
+		 */
+		focus(): Thenable<void>;
 	}
 
 	export interface FormComponent {

--- a/src/sql/platform/model/browser/modelViewService.ts
+++ b/src/sql/platform/model/browser/modelViewService.ts
@@ -31,4 +31,5 @@ export interface IModelView extends IView {
 	onEvent: Event<IModelViewEventArgs>;
 	validate(componentId: string): Thenable<boolean>;
 	readonly onDestroy: Event<void>;
+	focus(componentId: string): void;
 }

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -183,6 +183,11 @@ declare module 'sqlops' {
 		 * Run the component's validations
 		 */
 		validate(): Thenable<boolean>;
+
+		/**
+		 * Focuses the component.
+		 */
+		focus(): Thenable<void>;
 	}
 
 	export interface FormComponent {

--- a/src/sql/workbench/api/browser/mainThreadModelView.ts
+++ b/src/sql/workbench/api/browser/mainThreadModelView.ts
@@ -97,6 +97,10 @@ export class MainThreadModelView extends Disposable implements MainThreadModelVi
 		return new Promise(resolve => this.execModelViewAction(handle, (modelView) => resolve(modelView.validate(componentId))));
 	}
 
+	$focus(handle: number, componentId: string): Thenable<void> {
+		return new Promise(resolve => this.execModelViewAction(handle, (modelView) => resolve(modelView.focus(componentId))));
+	}
+
 	private runCustomValidations(handle: number, componentId: string): Thenable<boolean> {
 		return this._proxy.$runCustomValidations(handle, componentId);
 	}

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -711,6 +711,10 @@ class ComponentWrapper implements azdata.Component {
 	public get valid(): boolean {
 		return this._valid;
 	}
+
+	public focus() {
+		return this._proxy.$focus(this._handle, this._id);
+	}
 }
 
 class ComponentWithIconWrapper extends ComponentWrapper {

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1148,12 +1148,6 @@ class RadioButtonWrapper extends ComponentWrapper implements azdata.RadioButtonC
 	public set checked(v: boolean) {
 		this.setProperty('checked', v);
 	}
-	public get focused(): boolean {
-		return this.properties['focused'];
-	}
-	public set focused(v: boolean) {
-		this.setProperty('focused', v);
-	}
 
 	public get onDidClick(): vscode.Event<any> {
 		let emitter = this._emitterMap.get(ComponentEventType.onDidClick);
@@ -1268,13 +1262,6 @@ class TableComponentWrapper extends ComponentWrapper implements azdata.TableComp
 	}
 	public set moveFocusOutWithTab(v: boolean) {
 		this.setProperty('moveFocusOutWithTab', v);
-	}
-
-	public get focused(): boolean {
-		return this.properties['focused'];
-	}
-	public set focused(v: boolean) {
-		this.setProperty('focused', v);
 	}
 
 	public get updateCells(): azdata.TableCell[] {

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -736,6 +736,7 @@ export interface MainThreadModelViewShape extends IDisposable {
 	$validate(handle: number, componentId: string): Thenable<boolean>;
 	$setDataProvider(handle: number, componentId: string): Thenable<void>;
 	$refreshDataProvider(handle: number, componentId: string, item?: any): Thenable<void>;
+	$focus(handle: number, componentId: string): Thenable<void>;
 }
 
 export interface ExtHostObjectExplorerShape {

--- a/src/sql/workbench/browser/modelComponents/button.component.ts
+++ b/src/sql/workbench/browser/modelComponents/button.component.ts
@@ -125,6 +125,10 @@ export default class ButtonComponent extends ComponentWithIconBase implements IC
 		this._changeRef.detectChanges();
 	}
 
+	public focus(): void {
+		this._button.focus();
+	}
+
 	protected updateIcon() {
 		if (this.iconPath) {
 			if (!this._iconClass) {

--- a/src/sql/workbench/browser/modelComponents/checkbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/checkbox.component.ts
@@ -105,4 +105,8 @@ export default class CheckBoxComponent extends ComponentBase implements ICompone
 	private set label(newValue: string) {
 		this.setPropertyFromUI<azdata.CheckBoxProperties, string>((properties, label) => { properties.label = label; }, newValue);
 	}
+
+	public focus(): void {
+		this._input.focus();
+	}
 }

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -262,6 +262,12 @@ export abstract class ComponentBase extends Disposable implements IComponent, On
 		});
 	}
 
+	public focus(): void {
+		// Default is to just focus on the native element, components should override this if they
+		// want their own behavior (such as focusing a particular child element)
+		(<HTMLElement>this._el.nativeElement).focus();
+	}
+
 	protected onkeydown(domNode: HTMLElement, listener: (e: IKeyboardEvent) => void): void {
 		this._register(addDisposableListener(domNode, EventType.KEY_DOWN, (e: KeyboardEvent) => listener(new StandardKeyboardEvent(e))));
 	}

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -325,4 +325,8 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 	public set stopEnterPropagation(newValue: boolean) {
 		this.setPropertyFromUI<azdata.InputBoxProperties, boolean>((props, value) => props.stopEnterPropagation = value, newValue);
 	}
+
+	public focus(): void {
+		this.inputElement.focus();
+	}
 }

--- a/src/sql/workbench/browser/modelComponents/interfaces.ts
+++ b/src/sql/workbench/browser/modelComponents/interfaces.ts
@@ -27,6 +27,7 @@ export interface IComponent extends IDisposable {
 	validate(): Thenable<boolean>;
 	setDataProvider(handle: number, componentId: string, context: any): void;
 	refreshDataProvider(item: any): void;
+	focus(): void;
 }
 
 export const COMPONENT_CONFIG = new InjectionToken<IComponentConfig>('component_config');

--- a/src/sql/workbench/browser/modelComponents/radioButton.component.ts
+++ b/src/sql/workbench/browser/modelComponents/radioButton.component.ts
@@ -75,7 +75,6 @@ export default class RadioButtonComponent extends ComponentBase implements IComp
 		this._input.label = this.label;
 		this._input.enabled = this.enabled;
 		this._input.checked = this.checked;
-		this.focused ? this._input.focus() : this._input.blur();
 	}
 
 	// CSS-bound properties

--- a/src/sql/workbench/browser/modelComponents/radioButton.component.ts
+++ b/src/sql/workbench/browser/modelComponents/radioButton.component.ts
@@ -116,11 +116,8 @@ export default class RadioButtonComponent extends ComponentBase implements IComp
 		this.setPropertyFromUI<azdata.RadioButtonProperties, string>((properties, label) => { properties.name = label; }, newValue);
 	}
 
-	public get focused(): boolean {
-		return this.getPropertyOrDefault<azdata.RadioButtonProperties, boolean>((props) => props.focused, false);
+	public focus(): void {
+		this._input.focus();
 	}
 
-	public set focused(newValue: boolean) {
-		this.setPropertyFromUI<azdata.RadioButtonProperties, boolean>((properties, value) => { properties.focused = value; }, newValue);
-	}
 }

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -252,10 +252,6 @@ export default class TableComponent extends ComponentBase implements IComponent,
 			this._table.ariaRole = this.ariaRole;
 		}
 
-		if (this.focused) {
-			this._table.focus();
-		}
-
 		if (this.updateCells !== undefined) {
 			this.updateTableCells(this.updateCells);
 		}
@@ -366,14 +362,6 @@ export default class TableComponent extends ComponentBase implements IComponent,
 
 	public get moveFocusOutWithTab(): boolean {
 		return this.getPropertyOrDefault<azdata.TableComponentProperties, boolean>((props) => props.moveFocusOutWithTab, false);
-	}
-
-	public get focused(): boolean {
-		return this.getPropertyOrDefault<azdata.RadioButtonProperties, boolean>((props) => props.focused, false);
-	}
-
-	public set focused(newValue: boolean) {
-		this.setPropertyFromUI<azdata.RadioButtonProperties, boolean>((properties, value) => { properties.focused = value; }, newValue);
 	}
 
 	public get updateCells(): azdata.TableCell[] {

--- a/src/sql/workbench/browser/modelComponents/viewBase.ts
+++ b/src/sql/workbench/browser/modelComponents/viewBase.ts
@@ -146,4 +146,8 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 	public setDataProvider(handle: number, componentId: string, context: any): any {
 		return this.queueAction(componentId, (component) => component.setDataProvider(handle, componentId, context));
 	}
+
+	public focus(componentId: string): void {
+		return this.queueAction(componentId, (component) => component.focus());
+	}
 }


### PR DESCRIPTION
Fixes #7797

There's logic in the modal dialog to pick an initial element to focus - but this isn't working for modelview components. Since angular bootstrapping is done async'ly the elements don't exist in the DOM when that function is called and so aren't able to be correctly focused. 

The solutions I came up with as possibilities :
1. Wait until all the components are finished loading before 
   - This doesn't seem easily possible with how things are written
1. Rewrite modelview stuff to not use angular
   - A good idea at some point but beyond the scope of what I wanted to do for this fix
1. Let callers focus the element themselves
   - A bit more manual effort but in the end I chose this for its simplicity, general usefulness of the method and explicit control it gives to the dialog owner of what element should be receiving focus

