### PR TITLE
Fix/open relative on dev

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -59,7 +59,7 @@ export class NotebookMarkdownRenderer {
 		let signalInnerHTML: () => void;
 		const withInnerHTML = new Promise(c => signalInnerHTML = c);
 
-		let notebookFolder = path.dirname(this._notebookURI.fsPath) + '/';
+		let notebookFolder = this._notebookURI ? path.dirname(this._notebookURI.fsPath) + '/' : '';
 		if (!this._baseUrls.some(x => x === notebookFolder)) {
 			this._baseUrls.push(notebookFolder);
 		}
@@ -207,7 +207,7 @@ export class NotebookMarkdownRenderer {
 			href = this.resolveUrl(base, href);
 		}
 		try {
-			href = encodeURI(href).replace(/%5C/g, '\\').replace(/%25/g, '%');
+			href = encodeURI(href).replace(/%5C/g, '\\').replace(/%25/g, '%').replace(/%7C/g, '|');
 		} catch (e) {
 			return null;
 		}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -59,7 +59,7 @@ export class NotebookMarkdownRenderer {
 		let signalInnerHTML: () => void;
 		const withInnerHTML = new Promise(c => signalInnerHTML = c);
 
-		let notebookFolder = this._notebookURI ? path.dirname(this._notebookURI.fsPath) + path.sep : '';
+		let notebookFolder = this._notebookURI ? path.join(path.dirname(this._notebookURI.fsPath), path.sep)  : '';
 		if (!this._baseUrls.some(x => x === notebookFolder)) {
 			this._baseUrls.push(notebookFolder);
 		}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -113,6 +113,7 @@ export class NotebookMarkdownRenderer {
 			title = removeMarkdownEscapes(title);
 			// only remove escaped characters if it's a hyperlink, filepath usually can start with .{}_
 			// and the below function escapes them if it encounters in the path.
+			// using path.isAbsolute instead of isPathLocal since the latter accepts resolver (IRenderMime.IResolver) to check isLocal
 			if (!path.isAbsolute(href)) {
 				href = removeMarkdownEscapes(href);
 			}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -111,9 +111,9 @@ export class NotebookMarkdownRenderer {
 				text = removeMarkdownEscapes(text);
 			}
 			title = removeMarkdownEscapes(title);
-			// only remove escaped characters if it's a hyperlink, filepath usually can start with .{}_
+			// only remove markdown escapes if it's a hyperlink, filepath usually can start with .{}_
 			// and the below function escapes them if it encounters in the path.
-			// using path.isAbsolute instead of isPathLocal since the latter accepts resolver (IRenderMime.IResolver) to check isLocal
+			// dev note: using path.isAbsolute instead of isPathLocal since the latter accepts resolver (IRenderMime.IResolver) to check isLocal
 			if (!path.isAbsolute(href)) {
 				href = removeMarkdownEscapes(href);
 			}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -59,7 +59,7 @@ export class NotebookMarkdownRenderer {
 		let signalInnerHTML: () => void;
 		const withInnerHTML = new Promise(c => signalInnerHTML = c);
 
-		let notebookFolder = this._notebookURI ? path.dirname(this._notebookURI.fsPath) + '/' : '';
+		let notebookFolder = this._notebookURI ? path.dirname(this._notebookURI.fsPath) + path.sep : '';
 		if (!this._baseUrls.some(x => x === notebookFolder)) {
 			this._baseUrls.push(notebookFolder);
 		}
@@ -207,7 +207,7 @@ export class NotebookMarkdownRenderer {
 			href = this.resolveUrl(base, href);
 		}
 		try {
-			href = encodeURI(href).replace(/%5C/g, '\\').replace(/%25/g, '%').replace(/%7C/g, '|');
+			href = encodeURI(href).replace(/%5C/g, '\\').replace(/%7C/g, '|').replace(/%25/g, '%');
 		} catch (e) {
 			return null;
 		}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -111,7 +111,12 @@ export class NotebookMarkdownRenderer {
 				text = removeMarkdownEscapes(text);
 			}
 			title = removeMarkdownEscapes(title);
-			href = removeMarkdownEscapes(href);
+			// only remove escaped characters if it's a hyperlink, filepath usually can start with .{}_
+			// and the below function escapes them if it encounters in the path.
+			if (!path.isAbsolute(href)) {
+
+				href = removeMarkdownEscapes(href);
+			}
 			if (
 				!href
 				|| !markdown.isTrusted

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -114,7 +114,6 @@ export class NotebookMarkdownRenderer {
 			// only remove escaped characters if it's a hyperlink, filepath usually can start with .{}_
 			// and the below function escapes them if it encounters in the path.
 			if (!path.isAbsolute(href)) {
-
 				href = removeMarkdownEscapes(href);
 			}
 			if (

--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -59,7 +59,7 @@ export class NotebookMarkdownRenderer {
 		let signalInnerHTML: () => void;
 		const withInnerHTML = new Promise(c => signalInnerHTML = c);
 
-		let notebookFolder = this._notebookURI ? path.join(path.dirname(this._notebookURI.fsPath), path.sep)  : '';
+		let notebookFolder = this._notebookURI ? path.join(path.dirname(this._notebookURI.fsPath), path.sep) : '';
 		if (!this._baseUrls.some(x => x === notebookFolder)) {
 			this._baseUrls.push(notebookFolder);
 		}

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as marked from 'vs/base/common/marked/marked';
+import { NotebookMarkdownRenderer } from '../../browser/outputs/notebookMarkdown';
+
+suite('NotebookMarkdownRenderer', () => {
+	let notebookMarkdownRenderer = new NotebookMarkdownRenderer();
+	test('image rendering conforms to default', () => {
+		const markdown = { value: `![image](someimageurl 'caption')` };
+		const result: HTMLElement = notebookMarkdownRenderer.renderMarkdown(markdown);
+		const renderer = new marked.Renderer();
+		const imageFromMarked = marked(markdown.value, {
+			sanitize: true,
+			renderer
+		}).trim();
+		assert.strictEqual(result.innerHTML, imageFromMarked);
+	});
+
+	test('image rendering conforms to default without title', () => {
+		const markdown = { value: `![image](someimageurl)` };
+		const result: HTMLElement = notebookMarkdownRenderer.renderMarkdown(markdown);
+		const renderer = new marked.Renderer();
+		const imageFromMarked = marked(markdown.value, {
+			sanitize: true,
+			renderer
+		}).trim();
+		assert.strictEqual(result.innerHTML, imageFromMarked);
+	});
+
+	test('image width from title params', () => {
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![image](someimageurl|width=100 'caption')` });
+		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" width="100"></p>`);
+	});
+
+	test('image height from title params', () => {
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![image](someimageurl|height=100 'caption')` });
+		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" height="100"></p>`);
+	});
+
+	test('image width and height from title params', () => {
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `![image](someimageurl|height=200,width=100 'caption')` });
+		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" width="100" height="200"></p>`);
+	});
+
+	test('link from local file path', () => {
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[Link to File Path](someFileurl)`, isTrusted: true });
+		assert.strictEqual(result.innerHTML, `<p><a href="someFileurl" data-href="someFileurl" title="someFileurl">Link to File Path</a></p>`);
+	});
+
+	test('link from relative path', () => {
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[Link to relative path](/test/.build/someimageurl)`, isTrusted: true });
+		assert.strictEqual(result.innerHTML, `<p><a href="/test/.build/someimageurl" data-href="/test/.build/someimageurl" title="/test/.build/someimageurl">Link to relative path</a></p>`);
+	});
+});

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert';
 import * as marked from 'vs/base/common/marked/marked';
 import { NotebookMarkdownRenderer } from '../../browser/outputs/notebookMarkdown';
+import { URI } from 'vs/base/common/uri';
 
 suite('NotebookMarkdownRenderer', () => {
 	let notebookMarkdownRenderer = new NotebookMarkdownRenderer();
@@ -52,7 +53,12 @@ suite('NotebookMarkdownRenderer', () => {
 	});
 
 	test('link from relative path', () => {
-		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[Link to relative path](/test/.build/someimageurl)`, isTrusted: true });
-		assert.strictEqual(result.innerHTML, `<p><a href="/test/.build/someimageurl" data-href="/test/.build/someimageurl" title="/test/.build/someimageurl">Link to relative path</a></p>`);
+		notebookMarkdownRenderer.setNotebookURI(URI.parse('maddy/temp/file1.txt'));
+		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[Link to relative path](../test/.build/someimageurl)`, isTrusted: true });
+		if (process.platform === 'win32') {
+			assert.strictEqual(result.innerHTML, `<p><a href="\\maddy\\test\\.build\\someimageurl" data-href="\\maddy\\test\\.build\\someimageurl" title="\\maddy\\test\\.build\\someimageurl">Link to relative path</a></p>`);
+		} else {
+			assert.strictEqual(result.innerHTML, `<p><a href="/maddy/test/.build/someimageurl" data-href="/maddy/test/.build/someimageurl" title="/maddy/test/.build/someimageurl">Link to relative path</a></p>`);
+		}
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookMarkdown.test.ts
@@ -52,7 +52,7 @@ suite('NotebookMarkdownRenderer', () => {
 		assert.strictEqual(result.innerHTML, `<p><a href="someFileurl" data-href="someFileurl" title="someFileurl">Link to File Path</a></p>`);
 	});
 
-	test('link from relative path', () => {
+	test('link from relative file path', () => {
 		notebookMarkdownRenderer.setNotebookURI(URI.parse('maddy/temp/file1.txt'));
 		let result: HTMLElement = notebookMarkdownRenderer.renderMarkdown({ value: `[Link to relative path](../test/.build/someimageurl)`, isTrusted: true });
 		if (process.platform === 'win32') {


### PR DESCRIPTION
When formatting the links on the markdown, we're calling removeMarkdownEscapes which removes the any matching the following regex: /\\([\\`*_{}[\]()#+\-.!])/
So if the path is below: (it's getting rid of the \\. before build in the path)
$localdrive\git\azuredatastudio\\.build\builtInExtensions\Microsoft.sqlservernotebook\books\sqlserver2019\content\common\sop007-get-key-version-information.ipynb

This PR fixes #8147 
