### PR TITLE
Remove labels from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: Bug
+labels: ''
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: Enhancement
+labels: ''
 assignees: ''
 
 ---


### PR DESCRIPTION
The issue bot won't attempt to operate on issues that are created with labels (by design). So if people used the issue templates, the issue bot would ignore them.

I don't think they are adding much benefit with DRI and the issue bot anyways.