### PR TITLE
Set encoding to true (Bug fix for flavor)

### DIFF
--- a/src/sql/workbench/common/sqlWorkbenchUtils.ts
+++ b/src/sql/workbench/common/sqlWorkbenchUtils.ts
@@ -34,7 +34,7 @@ export function getEditorUri(input: IEditorInput): string {
 	}
 
 	if (uri) {
-		return uri.toString();
+		return uri.toString(true);
 	}
 	return undefined;
 }


### PR DESCRIPTION
For offline scripts it shows the flavor as “Choose SQL Language”, this is because in flavorStatus.ts line 150 when we compare (uri === currentUri), the value of current Uri is "file:///d%3A/GitHub/PGExtension/TestDatabase/1ae730a9.sql" whereas the value for uri is "file:///d:/GitHub/PGExtension/TestDatabase/1ae730a9.sql" which ends up returning label ‘Choose SQL Language’.

In queryInput.ts we set public get uri(): string { return this.getResource().toString(true); }
This is the variable that we use in doChangeLanguageFlavor. And as we compare this with getEditorUri() later in flavorStatus.ts, it does not match. So enabling encoding here as well to get the encoded string in both the cases.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #8077
