### PR TITLE
regex to encode & correctly

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown.ts
@@ -5,7 +5,6 @@
 import * as path from 'vs/base/common/path';
 
 import { URI } from 'vs/base/common/uri';
-
 import { IMarkdownString, removeMarkdownEscapes } from 'vs/base/common/htmlContent';
 import { IMarkdownRenderResult } from 'vs/editor/contrib/markdown/markdownRenderer';
 import * as marked from 'vs/base/common/marked/marked';
@@ -128,7 +127,7 @@ export class NotebookMarkdownRenderer {
 
 			} else {
 				// HTML Encode href
-				href = href.replace(/&/g, '&amp;')
+				href = href.replace(/&(?!amp;)/g, '&amp;')
 					.replace(/</g, '&lt;')
 					.replace(/>/g, '&gt;')
 					.replace(/"/g, '&quot;')


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
Ampersand has been encoded twice due to which on decode, url still has &amp when it should only have &.
Updated the regex to update & to &amp; only when it's not already encoded to &amp

This PR fixes #8093 
