### PR TITLE
Bump SQL Tools to 2.0.0-release.35 for SMO update

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "2.0.0-release.30",
+	"version": "2.0.0-release.35",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",


### PR DESCRIPTION
Pickup a new SMO with 1.1.0 of MS.Data.SqlClient.  The SQL Tools release is still publishing so the CI builds may fail.