### PR TITLE
Only package external extensions on Linux in the pipelines

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -65,13 +65,13 @@ steps:
 
   - script: |
       set -e
-      yarn gulp vscode-darwin
-    displayName: Build
+      yarn gulp install-sqltoolsservice
+    displayName: Install sqltoolsservice
 
   - script: |
       set -e
-      yarn gulp install-sqltoolsservice
-    displayName: Install sqltoolsservice
+      yarn gulp vscode-darwin
+    displayName: Build
 
   - task: ArchiveFiles@2 # WHY ARE WE DOING THIS?
     displayName: 'Archive build scripts source'

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -79,6 +79,11 @@ steps:
 
   - script: |
       set -e
+      yarn gulp package-extensions
+    displayName: Build
+
+  - script: |
+      set -e
       yarn gulp install-sqltoolsservice
     displayName: Install sqltoolsservice
 
@@ -134,6 +139,12 @@ steps:
       SourceFolder: '$(Build.SourcesDirectory)/.build/linux/rpm/x86_64/'
       Contents: '*.rpm'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)/vsix'
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)/../vsix'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/vsix'
 
   - script: | # WHY ARE WE DOING THIS?
       set -e

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -89,6 +89,11 @@ steps:
 
   - script: |
       set -e
+      yarn gulp compile-extensions
+    displayName: Compile Extensions
+
+  - script: |
+      set -e
       yarn gulp package-extensions
     displayName: Package extensions
 

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -94,8 +94,8 @@ steps:
 
   - script: |
       set -e
-      yarn gulp package-extensions
-    displayName: Package extensions
+      yarn gulp package-external-extensions
+    displayName: Package External extensions
 
   - task: ArchiveFiles@2 # WHY ARE WE DOING THIS?
     displayName: 'Archive build scripts source'

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -74,6 +74,16 @@ steps:
 
   - script: |
       set -e
+      yarn gulp install-sqltoolsservice
+    displayName: Install sqltoolsservice
+
+  - script: |
+      set -e
+      yarn gulp install-ssmsmin
+    displayName: Install ssmsmin
+
+  - script: |
+      set -e
       yarn gulp vscode-linux-x64
     displayName: Build
 
@@ -81,11 +91,6 @@ steps:
       set -e
       yarn gulp package-extensions
     displayName: Package extensions
-
-  - script: |
-      set -e
-      yarn gulp install-sqltoolsservice
-    displayName: Install sqltoolsservice
 
   - task: ArchiveFiles@2 # WHY ARE WE DOING THIS?
     displayName: 'Archive build scripts source'

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -80,7 +80,7 @@ steps:
   - script: |
       set -e
       yarn gulp package-extensions
-    displayName: Build extensions
+    displayName: Package extensions
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -80,7 +80,7 @@ steps:
   - script: |
       set -e
       yarn gulp package-extensions
-    displayName: Build
+    displayName: Build extensions
 
   - script: |
       set -e

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -70,20 +70,14 @@ steps:
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { yarn gulp "vscode-win32-x64" }
-    displayName: Build
-
-  - powershell: |
-      . build/azure-pipelines/win32/exec.ps1
-      $ErrorActionPreference = "Stop"
       exec { yarn gulp "install-sqltoolsservice" }
     displayName: Install sqltoolsservice
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { yarn gulp "install-ssmsmin" }
-    displayName: Install ssmsmin
+      exec { yarn gulp "vscode-win32-x64" }
+    displayName: Build
 
   - task: ArchiveFiles@2 # WHY
     displayName: 'Archive build scripts source'

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -133,12 +133,6 @@ steps:
     condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
     displayName: Run unstable integration tests
 
-  - task: CopyFiles@2
-    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)/vsix'
-    inputs:
-      SourceFolder: '$(Build.SourcesDirectory)/../vsix'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)/vsix'
-
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'ESRP CodeSigning - Build files - sha256 only'
     inputs:

--- a/build/gulpfile.sql.js
+++ b/build/gulpfile.sql.js
@@ -17,6 +17,7 @@ const ext = require('./lib/extensions');
 const task = require('./lib/task');
 const glob = require('glob');
 const vsce = require('vsce');
+const mkdirp = require('mkdirp');
 
 gulp.task('clean-mssql-extension', util.rimraf('extensions/mssql/node_modules'));
 gulp.task('clean-credentials-extension', util.rimraf('extensions/credentials/node_modules'));
@@ -145,8 +146,9 @@ gulp.task('package-external-extensions', task.series(
 			return { name: extensionName, path: extensionPath };
 		}).map(element => {
 			const pkgJson = require(path.join(element.path, 'package.json'));
-			const visxDirectory = path.join(path.dirname(root), 'vsix');
-			const packagePath = path.join(visxDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
+			const vsixDirectory = path.join(path.dirname(root), 'vsix');
+			mkdirp.sync(vsixDirectory);
+			const packagePath = path.join(vsixDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
 			console.info('Creating vsix for ' + element.path + ' result:' + packagePath);
 			return vsce.createVSIX({
 				cwd: element.path,

--- a/build/gulpfile.sql.js
+++ b/build/gulpfile.sql.js
@@ -11,7 +11,7 @@ const es = require('event-stream');
 const filter = require('gulp-filter');
 const del = require('del');
 const serviceDownloader = require('service-downloader').ServiceDownloadProvider;
-const platform = require('service-downloader/out/platform');
+const platform = require('service-downloader/out/platform').PlatformInformation;
 const path = require('path');
 const ext = require('./lib/extensions');
 
@@ -94,7 +94,7 @@ const formatStagedFiles = () => {
 
 function installService() {
 	let config = require('../extensions/mssql/config.json');
-	return platform.platformInfo.getCurrent().then(p => {
+	return platform.getCurrent().then(p => {
 		let runtime = p.runtimeId;
 		// fix path since it won't be correct
 		config.installDirectory = path.join(__dirname, '../extensions/mssql/src', config.installDirectory);
@@ -116,7 +116,7 @@ gulp.task('install-sqltoolsservice', () => {
 
 gulp.task('install-ssmsmin', () => {
 	const config = require('../extensions/admin-tool-ext-win/config.json');
-	const runtime = platform.Runtime.Windows_64;
+	const runtime = 'Windows_64';
 	// fix path since it won't be correct
 	config.installDirectory = path.join(__dirname, '..', 'extensions', 'admin-tool-ext-win', config.installDirectory);
 	var installer = new serviceDownloader(config);

--- a/build/gulpfile.sql.js
+++ b/build/gulpfile.sql.js
@@ -131,6 +131,6 @@ gulp.task('install-ssmsmin', () => {
 	});
 });
 
-gulp.task('package-extensions', () => {
-	return ext.packageSQLExtensions();
+gulp.task('package-external-extensions', () => {
+	return ext.packageExternalExtensions();
 });

--- a/build/gulpfile.sql.js
+++ b/build/gulpfile.sql.js
@@ -116,7 +116,7 @@ gulp.task('install-sqltoolsservice', () => {
 
 gulp.task('install-ssmsmin', () => {
 	const config = require('../extensions/admin-tool-ext-win/config.json');
-	const runtime = 'Windows_64';
+	const runtime = 'Windows_64'; // admin-tool-ext is a windows only extension, and we only ship a 64 bit version, so locking the binaries as such
 	// fix path since it won't be correct
 	config.installDirectory = path.join(__dirname, '..', 'extensions', 'admin-tool-ext-win', config.installDirectory);
 	var installer = new serviceDownloader(config);

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -29,7 +29,6 @@ const packageJson = require('../package.json');
 const product = require('../product.json');
 const crypto = require('crypto');
 const i18n = require('./lib/i18n');
-const ext = require('./lib/extensions'); // {{SQL CARBON EDIT}}
 const deps = require('./dependencies');
 const { config } = require('./lib/electron');
 const createAsar = require('./lib/asar').createAsar;
@@ -196,9 +195,6 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 		const src = gulp.src(out + '/**', { base: '.' })
 			.pipe(rename(function (path) { path.dirname = path.dirname.replace(new RegExp('^' + out), 'out'); }))
 			.pipe(util.setExecutableBit(['**/*.sh']));
-
-		// {{SQL CARBON EDIT}}
-		ext.packageSQLExtensions();
 
 		const extensions = gulp.src(['.build/extensions/**', '!.build/extensions/node_modules/**'], { base: '.build', dot: true }); // {{SQL CARBON EDIT}} - don't package the node_modules directory
 

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -250,22 +250,13 @@ function packageSQLExtensions() {
             return fromLocal(extension.path)
                 .pipe(rename(p => p.dirname = `extensions/${extension.name}/${p.dirname}`));
         }).map(p => p.pipe(gulp.dest('.build/external')))).on('end', () => {
-            const visxDirectory = path.join(path.dirname(root), 'vsix');
-            try {
-                if (!fs.existsSync(visxDirectory)) {
-                    fs.mkdirSync(visxDirectory);
-                }
-            }
-            catch (err) {
-                // don't fail the build if the output directory already exists
-                console.warn(err);
-            }
             resolve(Promise.all(glob.sync('.build/external/extensions/*/package.json').map(manifestPath => {
                 const extensionPath = path.dirname(path.join(root, manifestPath));
                 const extensionName = path.basename(extensionPath);
                 return { name: extensionName, path: extensionPath };
             }).map(element => {
-                let pkgJson = JSON.parse(fs.readFileSync(path.join(element.path, 'package.json'), { encoding: 'utf8' }));
+                const pkgJson = require(path.join(element.path, 'package.json'));
+                const visxDirectory = path.join(path.dirname(root), 'vsix');
                 const packagePath = path.join(visxDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
                 console.info('Creating vsix for ' + element.path + ' result:' + packagePath);
                 return vsce.createVSIX({

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -235,38 +235,19 @@ function packageMarketplaceExtensionsStream() {
         .pipe(util2.setExecutableBit(['**/*.sh']));
 }
 exports.packageMarketplaceExtensionsStream = packageMarketplaceExtensionsStream;
-function packageExternalExtensions() {
-    return new Promise((resolve) => {
-        const extenalExtensionDescriptions = glob.sync('extensions/*/package.json')
-            .map(manifestPath => {
-            const extensionPath = path.dirname(path.join(root, manifestPath));
-            const extensionName = path.basename(extensionPath);
-            return { name: extensionName, path: extensionPath };
-        })
-            .filter(({ name }) => externalExtensions.indexOf(name) >= 0);
-        const builtExtensions = extenalExtensionDescriptions.map(extension => {
-            return fromLocal(extension.path)
-                .pipe(rename(p => p.dirname = `extensions/${extension.name}/${p.dirname}`));
-        }).map(p => p.pipe(gulp.dest('.build/external')));
-        es.merge(builtExtensions).on('end', () => {
-            const vsixes = glob.sync('.build/external/extensions/*/package.json').map(manifestPath => {
-                const extensionPath = path.dirname(path.join(root, manifestPath));
-                const extensionName = path.basename(extensionPath);
-                return { name: extensionName, path: extensionPath };
-            }).map(element => {
-                const pkgJson = require(path.join(element.path, 'package.json'));
-                const visxDirectory = path.join(path.dirname(root), 'vsix');
-                const packagePath = path.join(visxDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
-                console.info('Creating vsix for ' + element.path + ' result:' + packagePath);
-                return vsce.createVSIX({
-                    cwd: element.path,
-                    packagePath: packagePath,
-                    useYarn: true
-                });
-            });
-            resolve(Promise.all(vsixes).then());
-        });
+function packageExternalExtensionsStream() {
+    const extenalExtensionDescriptions = glob.sync('extensions/*/package.json')
+        .map(manifestPath => {
+        const extensionPath = path.dirname(path.join(root, manifestPath));
+        const extensionName = path.basename(extensionPath);
+        return { name: extensionName, path: extensionPath };
+    })
+        .filter(({ name }) => externalExtensions.indexOf(name) >= 0);
+    const builtExtensions = extenalExtensionDescriptions.map(extension => {
+        return fromLocal(extension.path)
+            .pipe(rename(p => p.dirname = `extensions/${extension.name}/${p.dirname}`));
     });
+    return es.merge(builtExtensions);
 }
-exports.packageExternalExtensions = packageExternalExtensions;
+exports.packageExternalExtensionsStream = packageExternalExtensionsStream;
 // {{SQL CARBON EDIT}} - End

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -235,7 +235,7 @@ function packageMarketplaceExtensionsStream() {
         .pipe(util2.setExecutableBit(['**/*.sh']));
 }
 exports.packageMarketplaceExtensionsStream = packageMarketplaceExtensionsStream;
-function packageSQLExtensions() {
+function packageExternalExtensions() {
     return new Promise((resolve, reject) => {
         const extenalExtensionDescriptions = glob.sync('extensions/*/package.json')
             .map(manifestPath => {
@@ -267,5 +267,5 @@ function packageSQLExtensions() {
         });
     });
 }
-exports.packageSQLExtensions = packageSQLExtensions;
+exports.packageExternalExtensions = packageExternalExtensions;
 // {{SQL CARBON EDIT}} - End

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -258,16 +258,16 @@ function packageSQLExtensions() {
         // don't fail the build if the output directory already exists
         console.warn(err);
     }
-    sqlBuiltInLocalExtensionDescriptions.forEach(element => {
+    return Promise.all(sqlBuiltInLocalExtensionDescriptions.map(element => {
         let pkgJson = JSON.parse(fs.readFileSync(path.join(element.path, 'package.json'), { encoding: 'utf8' }));
         const packagePath = path.join(visxDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
         console.info('Creating vsix for ' + element.path + ' result:' + packagePath);
-        vsce.createVSIX({
+        return vsce.createVSIX({
             cwd: element.path,
             packagePath: packagePath,
             useYarn: true
         });
-    });
+    })).then();
 }
 exports.packageSQLExtensions = packageSQLExtensions;
 function packageExtensionTask(extensionName, platform, arch) {

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -236,7 +236,7 @@ function packageMarketplaceExtensionsStream() {
 }
 exports.packageMarketplaceExtensionsStream = packageMarketplaceExtensionsStream;
 function packageExternalExtensions() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
         const extenalExtensionDescriptions = glob.sync('extensions/*/package.json')
             .map(manifestPath => {
             const extensionPath = path.dirname(path.join(root, manifestPath));
@@ -249,7 +249,7 @@ function packageExternalExtensions() {
                 .pipe(rename(p => p.dirname = `extensions/${extension.name}/${p.dirname}`));
         }).map(p => p.pipe(gulp.dest('.build/external')));
         es.merge(builtExtensions).on('end', () => {
-            resolve(Promise.all(glob.sync('.build/external/extensions/*/package.json').map(manifestPath => {
+            const vsixes = glob.sync('.build/external/extensions/*/package.json').map(manifestPath => {
                 const extensionPath = path.dirname(path.join(root, manifestPath));
                 const extensionName = path.basename(extensionPath);
                 return { name: extensionName, path: extensionPath };
@@ -262,8 +262,9 @@ function packageExternalExtensions() {
                     cwd: element.path,
                     packagePath: packagePath,
                     useYarn: true
-                }).then(() => console.log('Finished vsix for ' + element.path + ' result:' + packagePath));
-            })).then(undefined, reject));
+                });
+            });
+            resolve(Promise.all(vsixes).then());
         });
     });
 }

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -225,7 +225,7 @@ const excludedExtensions = [
 ];
 
 // {{SQL CARBON EDIT}}
-const sqlExtensions = [
+const externalExtensions = [
 	// This is the list of SQL extensions which the source code is included in this repository, but
 	// they get packaged separately. Adding extension name here, will make the build to create
 	// a separate vsix package for the extension and the extension will be excluded from the main package.
@@ -263,7 +263,7 @@ export function packageLocalExtensionsStream(): NodeJS.ReadWriteStream {
 		})
 		.filter(({ name }) => excludedExtensions.indexOf(name) === -1)
 		.filter(({ name }) => builtInExtensions.every(b => b.name !== name))
-		.filter(({ name }) => sqlExtensions.indexOf(name) === -1); // {{SQL CARBON EDIT}} Remove SQL Extensions with separate package
+		.filter(({ name }) => externalExtensions.indexOf(name) === -1); // {{SQL CARBON EDIT}} Remove external Extensions with separate package
 
 	const nodeModules = gulp.src('extensions/node_modules/**', { base: '.' });
 	const localExtensions = localExtensionDescriptions.map(extension => {
@@ -287,20 +287,20 @@ export function packageMarketplaceExtensionsStream(): NodeJS.ReadWriteStream {
 
 export function packageSQLExtensions(): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
-		const sqlBuiltInLocalExtensionDescriptions = (<string[]>glob.sync('extensions/*/package.json'))
+		const extenalExtensionDescriptions = (<string[]>glob.sync('extensions/*/package.json'))
 			.map(manifestPath => {
 				const extensionPath = path.dirname(path.join(root, manifestPath));
 				const extensionName = path.basename(extensionPath);
 				return { name: extensionName, path: extensionPath };
 			})
-			.filter(({ name }) => excludedExtensions.indexOf(name) === -1)
-			.filter(({ name }) => builtInExtensions.every(b => b.name !== name))
-			.filter(({ name }) => sqlExtensions.indexOf(name) >= 0);
+			.filter(({ name }) => externalExtensions.indexOf(name) >= 0);
 
-		es.merge(sqlBuiltInLocalExtensionDescriptions.map(extension => {
+		const builtExtensions = extenalExtensionDescriptions.map(extension => {
 			return fromLocal(extension.path)
 				.pipe(rename(p => p.dirname = `extensions/${extension.name}/${p.dirname}`));
-		}).map(p => p.pipe(gulp.dest('.build/external')))).on('end', () => {
+		}).map(p => p.pipe(gulp.dest('.build/external')));
+
+		es.merge(builtExtensions).on('end', () => {
 			resolve(Promise.all(glob.sync('.build/external/extensions/*/package.json').map(manifestPath => {
 				const extensionPath = path.dirname(path.join(root, manifestPath));
 				const extensionName = path.basename(extensionPath);
@@ -314,7 +314,7 @@ export function packageSQLExtensions(): Promise<void> {
 					cwd: element.path,
 					packagePath: packagePath,
 					useYarn: true
-				});
+				}).then(() => console.log('Finished vsix for ' + element.path + ' result:' + packagePath));
 			})).then(undefined, reject));
 		});
 	});

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -289,7 +289,7 @@ export function packageMarketplaceExtensionsStream(): NodeJS.ReadWriteStream {
 import * as _ from 'underscore';
 import * as vfs from 'vinyl-fs';
 
-export function packageSQLExtensions() {
+export function packageSQLExtensions(): Promise<void> {
 
 	// Create package for local SQL extensions
 	//
@@ -311,16 +311,16 @@ export function packageSQLExtensions() {
 		// don't fail the build if the output directory already exists
 		console.warn(err);
 	}
-	sqlBuiltInLocalExtensionDescriptions.forEach(element => {
+	return Promise.all(sqlBuiltInLocalExtensionDescriptions.map(element => {
 		let pkgJson = JSON.parse(fs.readFileSync(path.join(element.path, 'package.json'), { encoding: 'utf8' }));
 		const packagePath = path.join(visxDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
 		console.info('Creating vsix for ' + element.path + ' result:' + packagePath);
-		vsce.createVSIX({
+		return vsce.createVSIX({
 			cwd: element.path,
 			packagePath: packagePath,
 			useYarn: true
 		});
-	});
+	})).then();
 }
 
 export function packageExtensionTask(extensionName: string, platform: string, arch: string) {

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -286,7 +286,7 @@ export function packageMarketplaceExtensionsStream(): NodeJS.ReadWriteStream {
 }
 
 export function packageExternalExtensions(): Promise<void> {
-	return new Promise<void>((resolve, reject) => {
+	return new Promise<void>((resolve) => {
 		const extenalExtensionDescriptions = (<string[]>glob.sync('extensions/*/package.json'))
 			.map(manifestPath => {
 				const extensionPath = path.dirname(path.join(root, manifestPath));
@@ -301,7 +301,7 @@ export function packageExternalExtensions(): Promise<void> {
 		}).map(p => p.pipe(gulp.dest('.build/external')));
 
 		es.merge(builtExtensions).on('end', () => {
-			resolve(Promise.all(glob.sync('.build/external/extensions/*/package.json').map(manifestPath => {
+			const vsixes = glob.sync('.build/external/extensions/*/package.json').map(manifestPath => {
 				const extensionPath = path.dirname(path.join(root, manifestPath));
 				const extensionName = path.basename(extensionPath);
 				return { name: extensionName, path: extensionPath };
@@ -314,8 +314,10 @@ export function packageExternalExtensions(): Promise<void> {
 					cwd: element.path,
 					packagePath: packagePath,
 					useYarn: true
-				}).then(() => console.log('Finished vsix for ' + element.path + ' result:' + packagePath));
-			})).then(undefined, reject));
+				});
+			});
+
+			resolve(Promise.all(vsixes).then());
 		});
 	});
 }

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -285,7 +285,7 @@ export function packageMarketplaceExtensionsStream(): NodeJS.ReadWriteStream {
 		.pipe(util2.setExecutableBit(['**/*.sh']));
 }
 
-export function packageSQLExtensions(): Promise<void> {
+export function packageExternalExtensions(): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
 		const extenalExtensionDescriptions = (<string[]>glob.sync('extensions/*/package.json'))
 			.map(manifestPath => {

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -286,7 +286,6 @@ export function packageMarketplaceExtensionsStream(): NodeJS.ReadWriteStream {
 }
 
 export function packageSQLExtensions(): Promise<void> {
-
 	return new Promise<void>((resolve, reject) => {
 		const sqlBuiltInLocalExtensionDescriptions = (<string[]>glob.sync('extensions/*/package.json'))
 			.map(manifestPath => {
@@ -302,22 +301,13 @@ export function packageSQLExtensions(): Promise<void> {
 			return fromLocal(extension.path)
 				.pipe(rename(p => p.dirname = `extensions/${extension.name}/${p.dirname}`));
 		}).map(p => p.pipe(gulp.dest('.build/external')))).on('end', () => {
-			const visxDirectory = path.join(path.dirname(root), 'vsix');
-			try {
-				if (!fs.existsSync(visxDirectory)) {
-					fs.mkdirSync(visxDirectory);
-				}
-			} catch (err) {
-				// don't fail the build if the output directory already exists
-				console.warn(err);
-			}
-
-			resolve(Promise.all((<string[]>glob.sync('.build/external/extensions/*/package.json')).map(manifestPath => {
+			resolve(Promise.all(glob.sync('.build/external/extensions/*/package.json').map(manifestPath => {
 				const extensionPath = path.dirname(path.join(root, manifestPath));
 				const extensionName = path.basename(extensionPath);
 				return { name: extensionName, path: extensionPath };
 			}).map(element => {
-				let pkgJson = JSON.parse(fs.readFileSync(path.join(element.path, 'package.json'), { encoding: 'utf8' }));
+				const pkgJson = require(path.join(element.path, 'package.json'));
+				const visxDirectory = path.join(path.dirname(root), 'vsix');
 				const packagePath = path.join(visxDirectory, `${pkgJson.name}-${pkgJson.version}.vsix`);
 				console.info('Creating vsix for ' + element.path + ' result:' + packagePath);
 				return vsce.createVSIX({


### PR DESCRIPTION
Currently we are creating vsix's for our external extensions on every os in the pipelines since it is built into the packaging task. This breaks it out as it's own gulp task and only runs it on the linux (since its the fastest build time).

This only has an impact on the admin-tools-win extensions since it is windows only. But it seems if we just hard code in the windows platform when it downloads the binaries, everything else should be platform agnostic. @Charles-Gagnon let me know if you think there is an issue here. All the other extensions are already platform independent so only building from linux shouldn't be a problem.

Also fixes an issue where we weren't returning the promises the vsix creator was returning so the gulp task never knew about them. This wasn't an issue since they always finished before the rest of the package task, but was still a functional bug.

Eventually we should automate the publishing of these extensions as well.