### PR TITLE
Add publish scripts to source

### DIFF
--- a/build/azure-pipelines/darwin/sql-publish.ps1
+++ b/build/azure-pipelines/darwin/sql-publish.ps1
@@ -1,0 +1,19 @@
+Param(
+	[string]$sourcesDir,
+	[string]$artifactsDir,
+	[string]$storageKey,
+	[string]$documentDbKey
+)
+
+$env:AZURE_STORAGE_ACCESS_KEY_2 = $storageKey
+$env:AZURE_DOCUMENTDB_MASTERKEY = $documentDbKey
+
+$VersionJson = Get-Content -Raw -Path "$artifactsDir\version.json" | ConvertFrom-Json
+$Version = $VersionJson.version
+$Quality = $VersionJson.quality
+$CommitId = $VersionJson.commit
+
+$ZipName = "azuredatastudio-darwin.zip"
+$Zip = "$artifactsDir\$ZipName"
+
+node $sourcesDir\build\azure-pipelines\common\publish.js $Quality darwin archive $ZipName $Version true $Zip $CommitId

--- a/build/azure-pipelines/linux/sql-publish.ps1
+++ b/build/azure-pipelines/linux/sql-publish.ps1
@@ -1,0 +1,36 @@
+Param(
+	[string]$sourcesDir,
+	[string]$artifactsDir,
+	[string]$storageKey,
+	[string]$documentDbKey
+)
+
+$env:AZURE_STORAGE_ACCESS_KEY_2 = $storageKey
+$env:AZURE_DOCUMENTDB_MASTERKEY = $documentDbKey
+
+$VersionJson = Get-Content -Raw -Path "$artifactsDir\version.json" | ConvertFrom-Json
+$Version = $VersionJson.version
+$Quality = $VersionJson.quality
+$CommitId = $VersionJson.commit
+$Arch = "x64"
+
+# Publish tarball
+$PlatformLinux = "linux-$Arch"
+$TarballFilename = "azuredatastudio-linux-$Arch.tar.gz"
+$TarballPath = "$artifactsDir\$TarballFilename"
+
+node $sourcesDir\build\azure-pipelines\common\publish.js $Quality $PlatformLinux archive-unsigned $TarballFilename $Version true $TarballPath $CommitId
+
+# Publish DEB
+$PlatformDeb = "linux-deb-$Arch"
+$DebFilename = "$(Get-ChildItem -File -Name $artifactsDir\*.deb)"
+$DebPath = "$artifactsDir\$DebFilename"
+
+node $sourcesDir\build\azure-pipelines\common\publish.js $Quality $PlatformDeb package $DebFilename $Version true $DebPath $CommitId
+
+# Publish RPM
+$PlatformRpm = "linux-rpm-$Arch"
+$RpmFilename = "$(Get-ChildItem -File -Name $artifactsDir\*.rpm)"
+$RpmPath = "$artifactsDir\$RpmFilename"
+
+node $sourcesDir\build\azure-pipelines\common\publish.js $Quality $PlatformRpm package $RpmFilename $Version true $RpmPath $CommitId

--- a/build/azure-pipelines/win32/sql-publish.ps1
+++ b/build/azure-pipelines/win32/sql-publish.ps1
@@ -1,0 +1,29 @@
+Param(
+	[string]$sourcesDir,
+	[string]$artifactsDir,
+	[string]$storageKey,
+	[string]$documentDbKey
+)
+
+$env:AZURE_STORAGE_ACCESS_KEY_2 = $storageKey
+$env:AZURE_DOCUMENTDB_MASTERKEY = $documentDbKey
+
+$ExeName = "AzureDataStudioSetup.exe"
+$SystemExe = "$artifactsDir\$ExeName"
+$UserExe = "$artifactsDir\user-setup\$ExeName"
+$UserExeName = "AzureDataStudioUserSetup.exe"
+$ZipName = "azuredatastudio-windows.zip"
+$Zip = "$artifactsDir\$ZipName"
+
+$VersionJson = Get-Content -Raw -Path "$artifactsDir\version.json" | ConvertFrom-Json
+$Version = $VersionJson.version
+$Quality = $VersionJson.quality
+$CommitId = $VersionJson.commit
+
+$assetPlatform = "win32-x64"
+
+node $sourcesDir/build/azure-pipelines/common/publish.js $Quality "$assetPlatform-archive" archive $ZipName $Version true $Zip $CommitId
+
+node $sourcesDir/build/azure-pipelines/common/publish.js $Quality "$assetPlatform" setup $ExeName $Version true $SystemExe $CommitId
+
+node $sourcesDir/build/azure-pipelines/common/publish.js $Quality "$assetPlatform-user" setup $UserExeName $Version true $UserExe $CommitId


### PR DESCRIPTION
Since our build pipeline is now source controlled, it makes sense for our publishing scripts to also be source controlled.

I have made no changes here, this is just copy pasted.