### PR TITLE
Fix loading component not being removed

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
@@ -384,7 +384,10 @@ export class BdcDashboardOverviewPage extends BdcDashboardPage {
 		}
 	}
 
-	private handleEndpointsUpdate(endpoints: EndpointModel[]): void {
+	private handleEndpointsUpdate(endpoints?: EndpointModel[]): void {
+		if (!endpoints) {
+			return;
+		}
 		// Sort the endpoints. The sort method is that SQL Server Master is first - followed by all
 		// others in alphabetical order by endpoint
 		const sqlServerMasterEndpoints = endpoints.filter(e => e.name === Endpoint.sqlServerMaster);
@@ -406,7 +409,7 @@ export class BdcDashboardOverviewPage extends BdcDashboardPage {
 			copyValueCell.iconHeight = '14px';
 			copyValueCell.iconWidth = '14px';
 			return [getEndpointDisplayText(e.name, e.description),
-			createEndpointComponent(this.modelBuilder, e, this.model, hyperlinkedEndpoints.some(he => he === e.name)), //e.endpoint,
+			createEndpointComponent(this.modelBuilder, e, this.model, hyperlinkedEndpoints.some(he => he === e.name)),
 				copyValueCell];
 		});
 


### PR DESCRIPTION
The page was initializing from the model as soon as it finished setting up but because the endpoints array was set to be initialized as an empty array it couldn't tell if the model had actually gotten an empty list of endpoints back or hadn't yet finished the remote query. This resulted in us removing the loading component too quickly - which due to the other timing issues I'm working on with the ModelView stuff meant that it got "removed" before it was actually added to the container on the main thread side and thus never got correctly removed.

So this is more of a workaround fix in the meantime since it's essentially just adding a long enough delay so that the component has time to be added to the container before we remove it - but this is a better way to handle the logic anyways so isn't wasted effort even once I fix the timing issues. 