### PR TITLE
Fix refresh action

### DIFF
--- a/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
@@ -330,7 +330,8 @@ CommandsRegistry.registerCommand({
 				logService.error(`Could not find tree node for node ${args.nodeInfo.label}`);
 			}
 		}
-	});
+	}
+});
 //#endregion
 
 //#region -- explorer widget

--- a/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
@@ -311,6 +311,7 @@ CommandsRegistry.registerCommand({
 CommandsRegistry.registerCommand({
 	id: OE_REFRESH_COMMAND_ID,
 	handler: async (accessor, args: ObjectExplorerActionsContext): Promise<void> => {
+		const connectionManagementService = accessor.get(IConnectionManagementService);
 		const capabilitiesService = accessor.get(ICapabilitiesService);
 		const objectExplorerService = accessor.get(IObjectExplorerService);
 		const logService = accessor.get(ILogService);

--- a/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
@@ -20,7 +20,6 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
 import { TreeSelectionHandler } from 'sql/workbench/contrib/objectExplorer/browser/treeSelectionHandler';
 import { TreeUpdateUtils } from 'sql/workbench/contrib/objectExplorer/browser/treeUpdateUtils';
-import Severity from 'vs/base/common/severity';
 import { TreeNode } from 'sql/workbench/contrib/objectExplorer/common/treeNode';
 import { VIEWLET_ID } from 'sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet';
 import { ILogService } from 'vs/platform/log/common/log';


### PR DESCRIPTION
Initially started off just fixing a dangling promise but found a bug here - in line 321 we were fetching the treeNode if we hadn't retrieved it previously. But this was done in an async function - and so the calling code would continue on and check again if treeNode was undefined on line 326 even though the async function may not have completed by that point and so would silently fail to refresh the node. 

Did slightly change the behavior to show an error message if an error occurred during the collapse/expand as well (since it's unlikely to happen and having it be more obvious when that happened should be a good thing)