### PR TITLE
Pull integration test connection string variables from secret store

### DIFF
--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -104,12 +104,12 @@ steps:
     condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
     displayName: Run unstable tests
 
-- task: AzureKeyVault@1
-  displayName: 'Azure Key Vault: SqlToolsSecretStore'
-  inputs:
-    azureSubscription: 'ClientToolsInfra_670062 (88d5392f-a34f-4769-b405-f597fc533613)'
-    KeyVaultName: SqlToolsSecretStore
-    SecretsFilter: 'ads-integration-test-azure-server,ads-integration-test-azure-server-password,ads-integration-test-azure-server-username,ads-integration-test-bdc-server,ads-integration-test-bdc-server-password,ads-integration-test-bdc-server-username,ads-integration-test-standalone-server,ads-integration-test-standalone-server-password,ads-integration-test-standalone-server-username'
+  - task: AzureKeyVault@1
+    displayName: 'Azure Key Vault: SqlToolsSecretStore'
+    inputs:
+      azureSubscription: 'ClientToolsInfra_670062 (88d5392f-a34f-4769-b405-f597fc533613)'
+      KeyVaultName: SqlToolsSecretStore
+      SecretsFilter: 'ads-integration-test-azure-server,ads-integration-test-azure-server-password,ads-integration-test-azure-server-username,ads-integration-test-bdc-server,ads-integration-test-bdc-server-password,ads-integration-test-bdc-server-username,ads-integration-test-standalone-server,ads-integration-test-standalone-server-password,ads-integration-test-standalone-server-username'
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -104,7 +104,6 @@ steps:
     condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
     displayName: Run unstable tests
 
-steps:
 - task: AzureKeyVault@1
   displayName: 'Azure Key Vault: SqlToolsSecretStore'
   inputs:

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -139,7 +139,6 @@ steps:
     env:
       ADS_TEST_GREP: (.*@REL@|integration test setup)
       ADS_TEST_INVERT_GREP: 0
-    env:
       BDC_BACKEND_USERNAME: $(ads-integration-test-bdc-server-username)
       BDC_BACKEND_PWD: $(ads-integration-test-bdc-server-password)
       BDC_BACKEND_HOSTNAME: $(ads-integration-test-bdc-server)
@@ -157,6 +156,16 @@ steps:
     continueOnError: true
     condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
     displayName: Run unstable integration tests
+    env:
+      BDC_BACKEND_USERNAME: $(ads-integration-test-bdc-server-username)
+      BDC_BACKEND_PWD: $(ads-integration-test-bdc-server-password)
+      BDC_BACKEND_HOSTNAME: $(ads-integration-test-bdc-server)
+      STANDALONE_SQL_USERNAME: $(ads-integration-test-standalone-server-username)
+      STANDALONE_SQL_PWD: $(ads-integration-test-standalone-server-password)
+      STANDALONE_SQL: $(ads-integration-test-standalone-server)
+      AZURE_SQL_USERNAME: $(ads-integration-test-azure-server-username)
+      AZURE_SQL_PWD: $(ads-integration-test-azure-server-password)
+      AZURE_SQL: $(ads-integration-test-azure-server)
 
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'Sign out code'
@@ -212,16 +221,6 @@ steps:
       MaxConcurrency: 5
       MaxRetryAttempts: 20
     condition: and(succeeded(), eq(variables['signed'], true))
-      env:
-      BDC_BACKEND_USERNAME: $(ads-integration-test-bdc-server-username)
-      BDC_BACKEND_PWD: $(ads-integration-test-bdc-server-password)
-      BDC_BACKEND_HOSTNAME: $(ads-integration-test-bdc-server)
-      STANDALONE_SQL_USERNAME: $(ads-integration-test-standalone-server-username)
-      STANDALONE_SQL_PWD: $(ads-integration-test-standalone-server-password)
-      STANDALONE_SQL: $(ads-integration-test-standalone-server)
-      AZURE_SQL_USERNAME: $(ads-integration-test-azure-server-username)
-      AZURE_SQL_PWD: $(ads-integration-test-azure-server-password)
-      AZURE_SQL: $(ads-integration-test-azure-server)
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -104,6 +104,14 @@ steps:
     condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
     displayName: Run unstable tests
 
+steps:
+- task: AzureKeyVault@1
+  displayName: 'Azure Key Vault: SqlToolsSecretStore'
+  inputs:
+    azureSubscription: 'ClientToolsInfra_670062 (88d5392f-a34f-4769-b405-f597fc533613)'
+    KeyVaultName: SqlToolsSecretStore
+    SecretsFilter: 'ads-integration-test-azure-server,ads-integration-test-azure-server-password,ads-integration-test-azure-server-username,ads-integration-test-bdc-server,ads-integration-test-bdc-server-password,ads-integration-test-bdc-server-username,ads-integration-test-standalone-server,ads-integration-test-standalone-server-password,ads-integration-test-standalone-server-username'
+
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
@@ -111,6 +119,16 @@ steps:
     continueOnError: true
     condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
     displayName: Run stable tests
+    env:
+      BDC_BACKEND_USERNAME: $(ads-integration-test-bdc-server-username)
+      BDC_BACKEND_PWD: $(ads-integration-test-bdc-server-password)
+      BDC_BACKEND_HOSTNAME: $(ads-integration-test-bdc-server)
+      STANDALONE_SQL_USERNAME: $(ads-integration-test-standalone-server-username)
+      STANDALONE_SQL_PWD: $(ads-integration-test-standalone-server-password)
+      STANDALONE_SQL: $(ads-integration-test-standalone-server)
+      AZURE_SQL_USERNAME: $(ads-integration-test-azure-server-username)
+      AZURE_SQL_PWD: $(ads-integration-test-azure-server-password)
+      AZURE_SQL: $(ads-integration-test-azure-server)
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
@@ -122,6 +140,16 @@ steps:
     env:
       ADS_TEST_GREP: (.*@REL@|integration test setup)
       ADS_TEST_INVERT_GREP: 0
+    env:
+      BDC_BACKEND_USERNAME: $(ads-integration-test-bdc-server-username)
+      BDC_BACKEND_PWD: $(ads-integration-test-bdc-server-password)
+      BDC_BACKEND_HOSTNAME: $(ads-integration-test-bdc-server)
+      STANDALONE_SQL_USERNAME: $(ads-integration-test-standalone-server-username)
+      STANDALONE_SQL_PWD: $(ads-integration-test-standalone-server-password)
+      STANDALONE_SQL: $(ads-integration-test-standalone-server)
+      AZURE_SQL_USERNAME: $(ads-integration-test-azure-server-username)
+      AZURE_SQL_PWD: $(ads-integration-test-azure-server-password)
+      AZURE_SQL: $(ads-integration-test-azure-server)
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
@@ -185,6 +213,16 @@ steps:
       MaxConcurrency: 5
       MaxRetryAttempts: 20
     condition: and(succeeded(), eq(variables['signed'], true))
+      env:
+      BDC_BACKEND_USERNAME: $(ads-integration-test-bdc-server-username)
+      BDC_BACKEND_PWD: $(ads-integration-test-bdc-server-password)
+      BDC_BACKEND_HOSTNAME: $(ads-integration-test-bdc-server)
+      STANDALONE_SQL_USERNAME: $(ads-integration-test-standalone-server-username)
+      STANDALONE_SQL_PWD: $(ads-integration-test-standalone-server-password)
+      STANDALONE_SQL: $(ads-integration-test-standalone-server)
+      AZURE_SQL_USERNAME: $(ads-integration-test-azure-server-username)
+      AZURE_SQL_PWD: $(ads-integration-test-azure-server-password)
+      AZURE_SQL: $(ads-integration-test-azure-server)
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #8390 

1. This change hooks up to the AzureKeyVault to pull into pipeline variables the set of various connection string secrets necessary for the execution of integration tests.
2. Sets the environment variables that the execution of integration tests need from pipeline variables.