### PR TITLE
Fix wizard not displaying error messages

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -481,16 +481,20 @@ export abstract class Modal extends Disposable implements IThemable {
 				this._messageDetail.innerText = description;
 			}
 			DOM.removeNode(this._messageDetail);
-			if (this._messageSummaryText) {
-				if (this._useDefaultMessageBoxLocation) {
-					DOM.prepend(this._modalContent, (this._messageElement));
-				}
-			} else {
-				// Set the focus manually otherwise it'll escape the dialog to something behind it
-				this.setInitialFocusedElement();
-				DOM.removeNode(this._messageElement);
-			}
+			this.messagesElementVisible = !!this._messageSummaryText;
 			this.updateExpandMessageState();
+		}
+	}
+
+	protected set messagesElementVisible(visible: boolean) {
+		if (visible) {
+			if (this._useDefaultMessageBoxLocation) {
+				DOM.prepend(this._modalContent, (this._messageElement));
+			}
+		} else {
+			// Set the focus manually otherwise it'll escape the dialog to something behind it
+			this.setInitialFocusedElement();
+			DOM.removeNode(this._messageElement);
 		}
 	}
 

--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -36,6 +36,7 @@ export class WizardModal extends Modal {
 	private _body: HTMLElement;
 
 	private _pageContainer: HTMLElement;
+	private _mpContainer: HTMLElement;
 
 	// Buttons
 	private _previousButton: Button;
@@ -130,9 +131,8 @@ export class WizardModal extends Modal {
 
 		this.initializeNavigation(this._body);
 
-		const mpContainer = append(this._body, $('div.dialog-message-and-page-container'));
-		mpContainer.append(this._messageElement);
-		this._pageContainer = append(mpContainer, $('div.dialogModal-page-container'));
+		this._mpContainer = append(this._body, $('div.dialog-message-and-page-container'));
+		this._pageContainer = append(this._mpContainer, $('div.dialogModal-page-container'));
 
 		this._wizard.pages.forEach(page => {
 			this.registerPage(page);
@@ -150,6 +150,15 @@ export class WizardModal extends Modal {
 			dialogPane.dispose();
 		});
 		this.updatePageNumbers();
+	}
+
+	protected set messagesElementVisible(visible: boolean) {
+		if (visible) {
+			this._mpContainer.prepend(this._messageElement);
+		} else {
+			// Let base class handle it
+			super.messagesElementVisible = false;
+		}
 	}
 
 	private updatePageNumbers(): void {


### PR DESCRIPTION
Things using the custom message location need to also be able to handle showing/hiding the message element themselves. 

![image](https://user-images.githubusercontent.com/28519865/70100798-c8e06800-15e7-11ea-995f-0faf42241ca2.png)
