### PR TITLE
deprecate the card component

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2477,6 +2477,9 @@ declare module 'azdata' {
 		flexContainer(): FlexBuilder;
 		splitViewContainer(): SplitViewBuilder;
 		dom(): ComponentBuilder<DomComponent>;
+		/**
+		 * @deprecated please use radioCardGroup component.
+		 */
 		card(): ComponentBuilder<CardComponent>;
 		inputBox(): ComponentBuilder<InputBoxComponent>;
 		checkBox(): ComponentBuilder<CheckBoxComponent>;

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -79,7 +79,12 @@ class ModelBuilderImpl implements azdata.ModelBuilder {
 		return container;
 	}
 
+	private cardDeprecationMessagePrinted = false;
 	card(): azdata.ComponentBuilder<azdata.CardComponent> {
+		if (!this.cardDeprecationMessagePrinted) {
+			console.warn(`Extension '${this._extension.identifier.value}' is using card component which has been replaced by radioCardGroup. the card component will be removed in a future release.`);
+			this.cardDeprecationMessagePrinted = true;
+		}
 		let id = this.getNextComponentId();
 		let builder: ComponentBuilderImpl<azdata.CardComponent> = this.getComponentBuilder(new CardWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);


### PR DESCRIPTION
data virtualization is the only extension I've seen using the card component, I will go and modify it.

this is just to follow the process of deprecating the API
<img width="1429" alt="Screen Shot 2019-12-03 at 9 07 00 PM" src="https://user-images.githubusercontent.com/13777222/70114353-132a0f00-1611-11ea-9837-80beba1510fe.png">

