### PR TITLE
Add code coverage tests for cell.ts

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/cell.ts
@@ -191,15 +191,11 @@ export class CellModel implements ICellModel {
 	}
 
 	public get notebookModel(): NotebookModel {
-		return <NotebookModel>this.options.notebook;
+		return <NotebookModel>this._options.notebook;
 	}
 
 	public set cellUri(value: URI) {
 		this._cellUri = value;
-	}
-
-	public get options(): ICellModelOptions {
-		return this._options;
 	}
 
 	public get cellType(): CellType {
@@ -234,7 +230,7 @@ export class CellModel implements ICellModel {
 		if (this._language) {
 			return this._language;
 		}
-		return this.options.notebook.language;
+		return this._options.notebook.language;
 	}
 
 	public get cellGuid(): string {
@@ -370,7 +366,7 @@ export class CellModel implements ICellModel {
 	}
 
 	private async getOrStartKernel(notificationService: INotificationService): Promise<nb.IKernel> {
-		let model = this.options.notebook;
+		let model = this._options.notebook;
 		let clientSession = model && model.clientSession;
 		if (!clientSession) {
 			this.sendNotification(notificationService, Severity.Error, localize('notebookNotReady', "The session for this notebook is not yet ready"));
@@ -516,7 +512,7 @@ export class CellModel implements ICellModel {
 			try {
 				let result = output as nb.IDisplayResult;
 				if (result && result.data && result.data['text/html']) {
-					let model = (this as CellModel).options.notebook as NotebookModel;
+					let model = this._options.notebook as NotebookModel;
 					if (model.activeConnection) {
 						let gatewayEndpointInfo = this.getGatewayEndpoint(model.activeConnection);
 						if (gatewayEndpointInfo) {

--- a/src/sql/workbench/contrib/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/cell.ts
@@ -80,7 +80,7 @@ export class CellModel implements ICellModel {
 	}
 
 	public equals(other: ICellModel) {
-		return other && other.id === this.id;
+		return other !== undefined && other.id === this.id;
 	}
 
 	public get onCollapseStateChanged(): Event<boolean> {

--- a/src/sql/workbench/contrib/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/cell.ts
@@ -91,10 +91,6 @@ export class CellModel implements ICellModel {
 		return this._onOutputsChanged.event;
 	}
 
-	public get onCellModeChanged(): Event<boolean> {
-		return this._onCellModeChanged.event;
-	}
-
 	public get isEditMode(): boolean {
 		return this._isEditMode;
 	}
@@ -191,7 +187,7 @@ export class CellModel implements ICellModel {
 	}
 
 	public get notebookModel(): NotebookModel {
-		return <NotebookModel>this._options.notebook;
+		return this._options && <NotebookModel>this._options.notebook;
 	}
 
 	public set cellUri(value: URI) {

--- a/src/sql/workbench/contrib/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/modelInterfaces.ts
@@ -418,6 +418,8 @@ export interface INotebookModel {
 	 * @param cell New active cell
 	 */
 	updateActiveCell(cell: ICellModel);
+
+	requestConnection(): Promise<boolean>;
 }
 
 export interface NotebookContentChange {

--- a/src/sql/workbench/contrib/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/modelInterfaces.ts
@@ -491,6 +491,7 @@ export interface ICellModel {
 	isCollapsed: boolean;
 	readonly onCollapseStateChanged: Event<boolean>;
 	modelContentChangedEvent: IModelContentChangedEvent;
+	isEditMode: boolean;
 }
 
 export interface FutureInternal extends nb.IFuture {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -680,4 +680,34 @@ suite('Cell Model', function (): void {
 		result = cell.equals(otherCell);
 		assert.strictEqual(result, false, 'Cell should not be equal to a different cell');
 	});
+
+	suite('Run Cell tests', function (): void {
+		let cellOptions: ICellModelOptions;
+
+		setup(() => {
+			let notebookModel = new NotebookModelStub({
+				name: 'python',
+				version: '',
+				mimetype: ''
+			});
+			let mockNotebookModel = TypeMoq.Mock.ofInstance(notebookModel);
+
+			mockNotebookModel.setup(m => m.updateActiveCell(TypeMoq.It.isAny()));
+			mockNotebookModel.setup(m => m.requestConnection()).returns(() => Promise.resolve(true));
+
+			cellOptions = { notebook: mockNotebookModel.object, isTrusted: true };
+		});
+
+		test('Run markdown cell', async function (): Promise<void> {
+			let cellContents: nb.ICellContents = {
+				cell_type: CellTypes.Markdown,
+				source: 'some *markdown*',
+				outputs: [],
+				metadata: { language: 'python' }
+			};
+			let cell = factory.createCell(cellContents, cellOptions);
+			let result = await cell.runCell();
+			assert.strictEqual(result, false, 'Markdown cells should not be runnable');
+		});
+	});
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -697,7 +697,6 @@ suite('Cell Model', function (): void {
 			mockNotebookModel = TypeMoq.Mock.ofType<INotebookModel>(NotebookModelStub);
 			mockNotebookModel.setup(m => m.clientSession).returns(() => mockClientSession.object);
 			mockNotebookModel.setup(m => m.updateActiveCell(TypeMoq.It.isAny()));
-			mockNotebookModel.setup(m => m.requestConnection()).returns(() => Promise.resolve(true));
 
 			cellOptions = { notebook: mockNotebookModel.object, isTrusted: true };
 		});
@@ -729,7 +728,7 @@ suite('Cell Model', function (): void {
 			assert.strictEqual(result, false, 'Runing code cell without a kernel should fail');
 		});
 
-		test('Kernel fails to connect', async function (): Promise<void> {
+		test('Fails to connect', async function (): Promise<void> {
 			mockKernel.setup(k => k.requiresConnection).returns(() => true);
 			mockNotebookModel.setup(m => m.requestConnection()).returns(() => Promise.resolve(false));
 

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -734,8 +734,14 @@ suite('Cell Model', function (): void {
 		});
 
 		test('No Kernel provided', async function (): Promise<void> {
+			mockClientSession.reset();
 			mockClientSession.setup(s => s.kernel).returns(() => null);
+			mockClientSession.setup(s => s.isReady).returns(() => true);
+			mockNotebookModel.reset();
 			mockNotebookModel.setup(m => m.defaultKernel).returns(() => null);
+			mockNotebookModel.setup(m => m.clientSession).returns(() => mockClientSession.object);
+			mockNotebookModel.setup(m => m.updateActiveCell(TypeMoq.It.isAny()));
+			cellOptions.notebook = mockNotebookModel.object;
 
 			let cell = factory.createCell(codeCellContents, cellOptions);
 			let result = await cell.runCell();

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -698,7 +698,6 @@ suite('Cell Model', function (): void {
 
 			mockNotebookModel.setup(m => m.updateActiveCell(TypeMoq.It.isAny()));
 			mockNotebookModel.setup(m => m.requestConnection()).returns(() => Promise.resolve(true));
-			mockNotebookModel.setup(m => m.clientSession).returns(() => mockClientSession.object);
 
 			cellOptions = { notebook: mockNotebookModel.object, isTrusted: true };
 		});
@@ -716,7 +715,7 @@ suite('Cell Model', function (): void {
 		});
 
 		test('No Kernel provided', async function (): Promise<void> {
-			mockClientSession.setup(s => s.kernel).returns(() => undefined);
+			mockClientSession.setup(s => s.kernel).returns(() => null);
 
 			let cellContents: nb.ICellContents = {
 				cell_type: CellTypes.Code,

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -722,12 +722,24 @@ suite('Cell Model', function (): void {
 			assert.strictEqual(result, false, 'Markdown cells should not be runnable');
 		});
 
-		test('No Kernel provided', async function (): Promise<void> {
-			mockClientSession.setup(s => s.kernel).returns(() => null);
+		test('No client session provided', async function (): Promise<void> {
+			mockNotebookModel.reset();
+			mockNotebookModel.setup(m => m.clientSession).returns(() => undefined);
+			mockNotebookModel.setup(m => m.updateActiveCell(TypeMoq.It.isAny()));
+			cellOptions.notebook = mockNotebookModel.object;
 
 			let cell = factory.createCell(codeCellContents, cellOptions);
 			let result = await cell.runCell();
-			assert.strictEqual(result, false, 'Runing code cell without a kernel should fail');
+			assert.strictEqual(result, false, 'Running code cell without a client session should fail');
+		});
+
+		test('No Kernel provided', async function (): Promise<void> {
+			mockClientSession.setup(s => s.kernel).returns(() => null);
+			mockNotebookModel.setup(m => m.defaultKernel).returns(() => null);
+
+			let cell = factory.createCell(codeCellContents, cellOptions);
+			let result = await cell.runCell();
+			assert.strictEqual(result, false, 'Running code cell without a kernel should fail');
 		});
 
 		test('Kernel fails to connect', async function (): Promise<void> {
@@ -736,7 +748,7 @@ suite('Cell Model', function (): void {
 
 			let cell = factory.createCell(codeCellContents, cellOptions);
 			let result = await cell.runCell();
-			assert.strictEqual(result, false, 'Runing code cell should fail after connection fails');
+			assert.strictEqual(result, false, 'Running code cell should fail after connection fails');
 		});
 
 		test('Normal execute', async function (): Promise<void> {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -590,4 +590,21 @@ suite('Cell Model', function (): void {
 		});
 	});
 
+	test('Getters and setters test', async function (): Promise<void> {
+		// let cell = factory.createCell(undefined, undefined);
+	});
+
+	test('Equals test', async function (): Promise<void> {
+		let cell = factory.createCell(undefined, undefined);
+
+		let result = cell.equals(undefined);
+		assert.strictEqual(result, false, 'Cell should not be equal to undefined');
+
+		result = cell.equals(cell);
+		assert.strictEqual(result, true, 'Cell should be equal to itself');
+
+		let otherCell = factory.createCell(undefined, undefined);
+		result = cell.equals(otherCell);
+		assert.strictEqual(result, false, 'Cell should not be equal to a different cell');
+	});
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -11,9 +11,9 @@ import * as objects from 'vs/base/common/objects';
 
 import { CellTypes } from 'sql/workbench/contrib/notebook/common/models/contracts';
 import { ModelFactory } from 'sql/workbench/contrib/notebook/browser/models/modelFactory';
-import { NotebookModelStub, ClientSessionStub } from './common';
+import { NotebookModelStub, ClientSessionStub, KernelStub } from './common';
 import { EmptyFuture } from 'sql/workbench/services/notebook/browser/sessionManager';
-import { ICellModel, ICellModelOptions, IClientSession } from 'sql/workbench/contrib/notebook/browser/models/modelInterfaces';
+import { ICellModel, ICellModelOptions, IClientSession, INotebookModel } from 'sql/workbench/contrib/notebook/browser/models/modelInterfaces';
 import { Deferred } from 'sql/base/common/promise';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -684,18 +684,18 @@ suite('Cell Model', function (): void {
 	suite('Run Cell tests', function (): void {
 		let cellOptions: ICellModelOptions;
 		let mockClientSession: TypeMoq.Mock<IClientSession>;
+		let mockNotebookModel: TypeMoq.Mock<INotebookModel>;
+		let mockKernel: TypeMoq.Mock<nb.IKernel>;
 
 		setup(() => {
+			mockKernel = TypeMoq.Mock.ofType<nb.IKernel>(KernelStub);
+
 			mockClientSession = TypeMoq.Mock.ofType<IClientSession>(ClientSessionStub);
+			mockClientSession.setup(s => s.kernel).returns(() => mockKernel.object);
 			mockClientSession.setup(s => s.isReady).returns(() => true);
 
-			let notebookModel = new NotebookModelStub({
-				name: 'python',
-				version: '',
-				mimetype: ''
-			});
-			let mockNotebookModel = TypeMoq.Mock.ofInstance(notebookModel);
-
+			mockNotebookModel = TypeMoq.Mock.ofType<INotebookModel>(NotebookModelStub);
+			mockNotebookModel.setup(m => m.clientSession).returns(() => mockClientSession.object);
 			mockNotebookModel.setup(m => m.updateActiveCell(TypeMoq.It.isAny()));
 			mockNotebookModel.setup(m => m.requestConnection()).returns(() => Promise.resolve(true));
 
@@ -727,6 +727,22 @@ suite('Cell Model', function (): void {
 			let cell = factory.createCell(cellContents, cellOptions);
 			let result = await cell.runCell();
 			assert.strictEqual(result, false, 'Runing code cell without a kernel should fail');
+		});
+
+		test('Kernel fails to connect', async function (): Promise<void> {
+			mockKernel.setup(k => k.requiresConnection).returns(() => true);
+			mockNotebookModel.setup(m => m.requestConnection()).returns(() => Promise.resolve(false));
+
+			let cellContents: nb.ICellContents = {
+				cell_type: CellTypes.Code,
+				source: '1+1',
+				outputs: [],
+				metadata: { language: 'python' },
+				execution_count: 1
+			};
+			let cell = factory.createCell(cellContents, cellOptions);
+			let result = await cell.runCell();
+			assert.strictEqual(result, false, 'Runing code cell should fail after connection fails');
 		});
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
@@ -15,6 +15,9 @@ import { URI } from 'vs/workbench/workbench.web.api';
 import { RenderMimeRegistry } from 'sql/workbench/contrib/notebook/browser/outputs/registry';
 
 export class NotebookModelStub implements INotebookModel {
+	requestConnection(): Promise<boolean> {
+		throw new Error('Method not implemented.');
+	}
 	constructor(private _languageInfo?: nb.ILanguageInfo) {
 	}
 	public trustedMode: boolean;

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
@@ -350,22 +350,22 @@ export class FutureStub implements nb.IFuture {
 		return this._done;
 	}
 	setReplyHandler(handler: nb.MessageHandler<nb.IShellMessage>): void {
-		throw new Error('Method not implemented.');
+		return;
 	}
 	setStdInHandler(handler: nb.MessageHandler<nb.IStdinMessage>): void {
-		throw new Error('Method not implemented.');
+		return;
 	}
 	setIOPubHandler(handler: nb.MessageHandler<nb.IIOPubMessage>): void {
-		throw new Error('Method not implemented.');
+		return;
 	}
 	registerMessageHook(hook: (msg: nb.IIOPubMessage) => boolean | Thenable<boolean>): void {
-		throw new Error('Method not implemented.');
+		return;
 	}
 	removeMessageHook(hook: (msg: nb.IIOPubMessage) => boolean | Thenable<boolean>): void {
-		throw new Error('Method not implemented.');
+		return;
 	}
 	sendInputReply(content: nb.IInputReply): void {
-		throw new Error('Method not implemented.');
+		return;
 	}
 	dispose() {
 		return;

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
@@ -15,16 +15,13 @@ import { URI } from 'vs/workbench/workbench.web.api';
 import { RenderMimeRegistry } from 'sql/workbench/contrib/notebook/browser/outputs/registry';
 
 export class NotebookModelStub implements INotebookModel {
-	requestConnection(): Promise<boolean> {
-		throw new Error('Method not implemented.');
-	}
 	constructor(private _languageInfo?: nb.ILanguageInfo) {
 	}
-	public trustedMode: boolean;
+	trustedMode: boolean;
 	language: string;
 	standardKernels: IStandardKernelWithProvider[];
 
-	public get languageInfo(): nb.ILanguageInfo {
+	get languageInfo(): nb.ILanguageInfo {
 		return this._languageInfo;
 	}
 	onCellChange(cell: ICellModel, change: NotebookChangeType): void {
@@ -117,7 +114,9 @@ export class NotebookModelStub implements INotebookModel {
 	updateActiveCell(cell: ICellModel) {
 		throw new Error('Method not implemented.');
 	}
-
+	requestConnection(): Promise<boolean> {
+		throw new Error('Method not implemented.');
+	}
 }
 
 export class NotebookManagerStub implements INotebookManager {
@@ -128,12 +127,12 @@ export class NotebookManagerStub implements INotebookManager {
 }
 
 export class ServerManagerStub implements nb.ServerManager {
-	public onServerStartedEmitter = new Emitter<void>();
+	onServerStartedEmitter = new Emitter<void>();
 	onServerStarted: Event<void> = this.onServerStartedEmitter.event;
 	isStarted: boolean = false;
 	calledStart: boolean = false;
 	calledEnd: boolean = false;
-	public result: Promise<void> = undefined;
+	result: Promise<void> = undefined;
 
 	startServer(): Promise<void> {
 		this.calledStart = true;
@@ -207,25 +206,6 @@ export class NotebookServiceStub implements INotebookService {
 }
 
 export class ClientSessionStub implements IClientSession {
-	terminated: Event<void>;
-	kernelChanged: Event<nb.IKernelChangedArgs>;
-	statusChanged: Event<nb.ISession>;
-	iopubMessage: Event<nb.IMessage>;
-	unhandledMessage: Event<nb.IMessage>;
-	propertyChanged: Event<'path' | 'name' | 'type'>;
-	kernel: nb.IKernel;
-	notebookUri: URI;
-	name: string;
-	type: string;
-	status: nb.KernelStatus;
-	isReady: boolean;
-	isInErrorState: boolean;
-	errorMessage: string;
-	ready: Promise<void>;
-	kernelChangeCompleted: Promise<void>;
-	kernelPreference: IKernelPreference;
-	kernelDisplayName: string;
-	cachedKernelSpec: nb.IKernelSpec;
 	initialize(): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
@@ -260,6 +240,66 @@ export class ClientSessionStub implements IClientSession {
 		throw new Error('Method not implemented.');
 	}
 	dispose(): void {
+		throw new Error('Method not implemented.');
+	}
+	get terminated(): Event<void> {
+		throw new Error('Method not implemented.');
+	}
+	get kernelChanged(): Event<nb.IKernelChangedArgs> {
+		throw new Error('Method not implemented.');
+	}
+	get statusChanged(): Event<nb.ISession> {
+		throw new Error('Method not implemented.');
+	}
+	get iopubMessage(): Event<nb.IMessage> {
+		throw new Error('Method not implemented.');
+	}
+	get unhandledMessage(): Event<nb.IMessage> {
+		throw new Error('Method not implemented.');
+	}
+	get propertyChanged(): Event<'path' | 'name' | 'type'> {
+		throw new Error('Method not implemented.');
+	}
+	get kernel(): nb.IKernel | null {
+		throw new Error('Method not implemented.');
+	}
+	get notebookUri(): URI {
+		throw new Error('Method not implemented.');
+	}
+	get name(): string {
+		throw new Error('Method not implemented.');
+	}
+	get type(): string {
+		throw new Error('Method not implemented.');
+	}
+	get status(): nb.KernelStatus {
+		throw new Error('Method not implemented.');
+	}
+	get isReady(): boolean {
+		throw new Error('Method not implemented.');
+	}
+	get ready(): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	get kernelChangeCompleted(): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	get kernelPreference(): IKernelPreference {
+		throw new Error('Method not implemented.');
+	}
+	set kernelPreference(value: IKernelPreference) {
+		throw new Error('Method not implemented.');
+	}
+	get kernelDisplayName(): string {
+		throw new Error('Method not implemented.');
+	}
+	get errorMessage(): string {
+		throw new Error('Method not implemented.');
+	}
+	get isInErrorState(): boolean {
+		throw new Error('Method not implemented.');
+	}
+	get cachedKernelSpec(): nb.IKernelSpec {
 		throw new Error('Method not implemented.');
 	}
 }

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
@@ -303,3 +303,39 @@ export class ClientSessionStub implements IClientSession {
 		throw new Error('Method not implemented.');
 	}
 }
+
+export class KernelStub implements nb.IKernel {
+	get id(): string {
+		throw new Error('Method not implemented.');
+	}
+	get name(): string {
+		throw new Error('Method not implemented.');
+	}
+	get supportsIntellisense(): boolean {
+		throw new Error('Method not implemented.');
+	}
+	get requiresConnection(): boolean {
+		throw new Error('Method not implemented.');
+	}
+	get isReady(): boolean {
+		throw new Error('Method not implemented.');
+	}
+	get ready(): Thenable<void> {
+		throw new Error('Method not implemented.');
+	}
+	get info(): nb.IInfoReply {
+		throw new Error('Method not implemented.');
+	}
+	getSpec(): Thenable<nb.IKernelSpec> {
+		throw new Error('Method not implemented.');
+	}
+	requestExecute(content: nb.IExecuteRequest, disposeOnDone?: boolean): nb.IFuture {
+		throw new Error('Method not implemented.');
+	}
+	requestComplete(content: nb.ICompleteRequest): Thenable<nb.ICompleteReplyMsg> {
+		throw new Error('Method not implemented.');
+	}
+	interrupt(): Thenable<void> {
+		throw new Error('Method not implemented.');
+	}
+}

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
@@ -6,7 +6,7 @@
 import { nb, IConnectionProfile } from 'azdata';
 
 import { Event, Emitter } from 'vs/base/common/event';
-import { INotebookModel, ICellModel, IClientSession, IDefaultConnection, NotebookContentChange } from 'sql/workbench/contrib/notebook/browser/models/modelInterfaces';
+import { INotebookModel, ICellModel, IClientSession, IDefaultConnection, NotebookContentChange, IKernelPreference } from 'sql/workbench/contrib/notebook/browser/models/modelInterfaces';
 import { NotebookChangeType, CellType } from 'sql/workbench/contrib/notebook/common/models/contracts';
 import { INotebookManager, INotebookService, INotebookEditor, ILanguageMagic, INotebookProvider, INavigationProvider } from 'sql/workbench/services/notebook/browser/notebookService';
 import { ISingleNotebookEditOperation } from 'sql/workbench/api/common/sqlExtHostTypes';
@@ -202,6 +202,64 @@ export class NotebookServiceStub implements INotebookService {
 		throw new Error('Method not implemented.');
 	}
 	navigateTo(notebookUri: URI, sectionId: string): void {
+		throw new Error('Method not implemented.');
+	}
+}
+
+export class ClientSessionStub implements IClientSession {
+	terminated: Event<void>;
+	kernelChanged: Event<nb.IKernelChangedArgs>;
+	statusChanged: Event<nb.ISession>;
+	iopubMessage: Event<nb.IMessage>;
+	unhandledMessage: Event<nb.IMessage>;
+	propertyChanged: Event<'path' | 'name' | 'type'>;
+	kernel: nb.IKernel;
+	notebookUri: URI;
+	name: string;
+	type: string;
+	status: nb.KernelStatus;
+	isReady: boolean;
+	isInErrorState: boolean;
+	errorMessage: string;
+	ready: Promise<void>;
+	kernelChangeCompleted: Promise<void>;
+	kernelPreference: IKernelPreference;
+	kernelDisplayName: string;
+	cachedKernelSpec: nb.IKernelSpec;
+	initialize(): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	changeKernel(options: nb.IKernelSpec, oldKernel?: nb.IKernel): Promise<nb.IKernel> {
+		throw new Error('Method not implemented.');
+	}
+	configureKernel(options: nb.IKernelSpec): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	shutdown(): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	selectKernel(): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	restart(): Promise<boolean> {
+		throw new Error('Method not implemented.');
+	}
+	setPath(path: string): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	setName(name: string): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	setType(type: string): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	updateConnection(connection: IConnectionProfile): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	onKernelChanging(changeHandler: (kernel: nb.IKernelChangedArgs) => Promise<void>): void {
+		throw new Error('Method not implemented.');
+	}
+	dispose(): void {
 		throw new Error('Method not implemented.');
 	}
 }

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/common.ts
@@ -339,3 +339,35 @@ export class KernelStub implements nb.IKernel {
 		throw new Error('Method not implemented.');
 	}
 }
+
+export class FutureStub implements nb.IFuture {
+	constructor(private _msg: nb.IMessage, private _done: Thenable<nb.IShellMessage>) {
+	}
+	get msg(): nb.IMessage {
+		return this._msg;
+	}
+	get done(): Thenable<nb.IShellMessage> {
+		return this._done;
+	}
+	setReplyHandler(handler: nb.MessageHandler<nb.IShellMessage>): void {
+		throw new Error('Method not implemented.');
+	}
+	setStdInHandler(handler: nb.MessageHandler<nb.IStdinMessage>): void {
+		throw new Error('Method not implemented.');
+	}
+	setIOPubHandler(handler: nb.MessageHandler<nb.IIOPubMessage>): void {
+		throw new Error('Method not implemented.');
+	}
+	registerMessageHook(hook: (msg: nb.IIOPubMessage) => boolean | Thenable<boolean>): void {
+		throw new Error('Method not implemented.');
+	}
+	removeMessageHook(hook: (msg: nb.IIOPubMessage) => boolean | Thenable<boolean>): void {
+		throw new Error('Method not implemented.');
+	}
+	sendInputReply(content: nb.IInputReply): void {
+		throw new Error('Method not implemented.');
+	}
+	dispose() {
+		return;
+	}
+}


### PR DESCRIPTION
These tests bring code coverage for cell.ts to about 81%. I've been working on this for a while, so I wanted to merge in what tests I have for now. The only things left to cover are the rewriteUrl methods, and random one liners here and there.