### PR TITLE
Update schema compare extension to support SQL Login

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -258,8 +258,12 @@ export class SchemaCompareMainWindow {
 			},
 		]);
 
-		// reset buttons to before comparison state
-		this.resetButtons(ResetButtonState.beforeCompareStart);
+		if (!this.sourceName || !this.targetName || this.sourceName === ' ' || this.targetName === ' ') {
+			this.resetButtons(ResetButtonState.noSourceTarget);
+		} else {
+			// reset buttons to before comparison state
+			this.resetButtons(ResetButtonState.beforeCompareStart);
+		}
 	}
 
 	// only for test
@@ -821,7 +825,6 @@ export class SchemaCompareMainWindow {
 
 	// reset state afer loading an scmp
 	private resetForNewCompare(): void {
-		this.resetButtons(ResetButtonState.beforeCompareStart);
 		this.flexModel.removeItem(this.splitView);
 		this.flexModel.removeItem(this.noDifferencesLabel);
 		this.flexModel.addItem(this.startText, { CSSStyles: { 'margin': 'auto' } });
@@ -943,17 +946,18 @@ export class SchemaCompareMainWindow {
 				return;
 			}
 
+			let ownerUri;
 			if (result.sourceEndpointInfo && result.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
 				// only set endpoint info if able to connect to the database
-				const ownerUri = await verifyConnectionAndGetOwnerUri(result.sourceEndpointInfo, SourceTitle);
-				if (ownerUri) {
-					this.sourceEndpointInfo = result.sourceEndpointInfo;
-					this.sourceEndpointInfo.ownerUri = ownerUri;
-				}
+				ownerUri = await verifyConnectionAndGetOwnerUri(result.sourceEndpointInfo, SourceTitle);
+			}
+			if (ownerUri) {
+				this.sourceEndpointInfo = result.sourceEndpointInfo;
+				this.sourceEndpointInfo.ownerUri = ownerUri;
 			} else {
 				// need to do this instead of just setting it to the result.sourceEndpointInfo because some fields are null which will cause an error when sending the compare request
 				this.sourceEndpointInfo = {
-					endpointType: mssql.SchemaCompareEndpointType.Dacpac,
+					endpointType: result.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database ? mssql.SchemaCompareEndpointType.Database : mssql.SchemaCompareEndpointType.Dacpac,
 					serverDisplayName: '',
 					serverName: '',
 					databaseName: '',
@@ -964,15 +968,16 @@ export class SchemaCompareMainWindow {
 			}
 
 			if (result.targetEndpointInfo && result.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
-				const ownerUri = await verifyConnectionAndGetOwnerUri(result.targetEndpointInfo, TargetTitle);
-				if (ownerUri) {
-					this.targetEndpointInfo = result.targetEndpointInfo;
-					this.targetEndpointInfo.ownerUri = ownerUri;
-				}
+				// only set endpoint info if able to connect to the database
+				ownerUri = await verifyConnectionAndGetOwnerUri(result.targetEndpointInfo, TargetTitle);
+			}
+			if (ownerUri) {
+				this.targetEndpointInfo = result.targetEndpointInfo;
+				this.targetEndpointInfo.ownerUri = ownerUri;
 			} else {
 				// need to do this instead of just setting it to the result.targetEndpointInfo because some fields are null which will cause an error when sending the compare request
 				this.targetEndpointInfo = {
-					endpointType: mssql.SchemaCompareEndpointType.Dacpac,
+					endpointType: result.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database ? mssql.SchemaCompareEndpointType.Database : mssql.SchemaCompareEndpointType.Dacpac,
 					serverDisplayName: '',
 					serverName: '',
 					databaseName: '',

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -23,6 +23,8 @@ const generateScriptNoChangesMessage = localize('schemaCompare.generateScriptNoC
 const applyEnabledMessage = localize('schemaCompare.applyButtonEnabledTitle', "Apply changes to target");
 const applyNoChangesMessage = localize('schemaCompare.applyNoChanges', "No changes to apply");
 const includeExcludeInfoMessage = localize('schemaCompare.includeExcludeInfoMessage', "Please note that include/exclude operations can take a moment to calculate affected dependencies");
+const SourceTitle: string = localize('schemaCompareDialog.SourceTitle', "Source");
+const TargetTitle: string = localize('schemaCompareDialog.TargetTitle', "Target");
 
 // Do not localize this, this is used to decide the icon for the editor.
 // TODO : In future icon should be decided based on language id (scmp) and not resource name
@@ -943,7 +945,7 @@ export class SchemaCompareMainWindow {
 
 			if (result.sourceEndpointInfo && result.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
 				// only set endpoint info if able to connect to the database
-				const ownerUri = await verifyConnectionAndGetOwnerUri(result.sourceEndpointInfo);
+				const ownerUri = await verifyConnectionAndGetOwnerUri(result.sourceEndpointInfo, SourceTitle);
 				if (ownerUri) {
 					this.sourceEndpointInfo = result.sourceEndpointInfo;
 					this.sourceEndpointInfo.ownerUri = ownerUri;
@@ -962,7 +964,7 @@ export class SchemaCompareMainWindow {
 			}
 
 			if (result.targetEndpointInfo && result.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
-				const ownerUri = await verifyConnectionAndGetOwnerUri(result.targetEndpointInfo);
+				const ownerUri = await verifyConnectionAndGetOwnerUri(result.targetEndpointInfo, TargetTitle);
 				if (ownerUri) {
 					this.targetEndpointInfo = result.targetEndpointInfo;
 					this.targetEndpointInfo.ownerUri = ownerUri;

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -23,8 +23,8 @@ const generateScriptNoChangesMessage = localize('schemaCompare.generateScriptNoC
 const applyEnabledMessage = localize('schemaCompare.applyButtonEnabledTitle', "Apply changes to target");
 const applyNoChangesMessage = localize('schemaCompare.applyNoChanges', "No changes to apply");
 const includeExcludeInfoMessage = localize('schemaCompare.includeExcludeInfoMessage', "Please note that include/exclude operations can take a moment to calculate affected dependencies");
-const SourceTitle: string = localize('schemaCompareDialog.SourceTitle', "Source");
-const TargetTitle: string = localize('schemaCompareDialog.TargetTitle', "Target");
+const sourceTitle = localize('schemaCompareDialog.SourceTitle', "Source");
+const targetTitle = localize('schemaCompareDialog.TargetTitle', "Target");
 
 // Do not localize this, this is used to decide the icon for the editor.
 // TODO : In future icon should be decided based on language id (scmp) and not resource name
@@ -946,46 +946,8 @@ export class SchemaCompareMainWindow {
 				return;
 			}
 
-			let ownerUri;
-			if (result.sourceEndpointInfo && result.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
-				// only set endpoint info if able to connect to the database
-				ownerUri = await verifyConnectionAndGetOwnerUri(result.sourceEndpointInfo, SourceTitle);
-			}
-			if (ownerUri) {
-				this.sourceEndpointInfo = result.sourceEndpointInfo;
-				this.sourceEndpointInfo.ownerUri = ownerUri;
-			} else {
-				// need to do this instead of just setting it to the result.sourceEndpointInfo because some fields are null which will cause an error when sending the compare request
-				this.sourceEndpointInfo = {
-					endpointType: result.sourceEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database ? mssql.SchemaCompareEndpointType.Database : mssql.SchemaCompareEndpointType.Dacpac,
-					serverDisplayName: '',
-					serverName: '',
-					databaseName: '',
-					ownerUri: '',
-					packageFilePath: result.sourceEndpointInfo.packageFilePath,
-					connectionDetails: undefined
-				};
-			}
-
-			if (result.targetEndpointInfo && result.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database) {
-				// only set endpoint info if able to connect to the database
-				ownerUri = await verifyConnectionAndGetOwnerUri(result.targetEndpointInfo, TargetTitle);
-			}
-			if (ownerUri) {
-				this.targetEndpointInfo = result.targetEndpointInfo;
-				this.targetEndpointInfo.ownerUri = ownerUri;
-			} else {
-				// need to do this instead of just setting it to the result.targetEndpointInfo because some fields are null which will cause an error when sending the compare request
-				this.targetEndpointInfo = {
-					endpointType: result.targetEndpointInfo.endpointType === mssql.SchemaCompareEndpointType.Database ? mssql.SchemaCompareEndpointType.Database : mssql.SchemaCompareEndpointType.Dacpac,
-					serverDisplayName: '',
-					serverName: '',
-					databaseName: '',
-					ownerUri: '',
-					packageFilePath: result.targetEndpointInfo.packageFilePath,
-					connectionDetails: undefined
-				};
-			}
+			this.sourceEndpointInfo = await this.constructEndpointInfo(result.sourceEndpointInfo, sourceTitle);
+			this.targetEndpointInfo = await this.constructEndpointInfo(result.targetEndpointInfo, targetTitle);
 
 			this.updateSourceAndTarget();
 			this.setDeploymentOptions(result.deploymentOptions);
@@ -1000,6 +962,31 @@ export class SchemaCompareMainWindow {
 				'elapsedTime:': (Date.now() - startTime).toString()
 			});
 		});
+	}
+
+	private async  constructEndpointInfo(endpoint: mssql.SchemaCompareEndpointInfo, caller: string): Promise<mssql.SchemaCompareEndpointInfo> {
+		let ownerUri;
+		let endpointInfo;
+		if (endpoint && endpoint.endpointType === mssql.SchemaCompareEndpointType.Database) {
+			// only set endpoint info if able to connect to the database
+			ownerUri = await verifyConnectionAndGetOwnerUri(endpoint, caller);
+		}
+		if (ownerUri) {
+			endpointInfo = endpoint;
+			endpointInfo.ownerUri = ownerUri;
+		} else {
+			// need to do this instead of just setting it to the endpoint because some fields are null which will cause an error when sending the compare request
+			endpointInfo = {
+				endpointType: endpoint.endpointType === mssql.SchemaCompareEndpointType.Database ? mssql.SchemaCompareEndpointType.Database : mssql.SchemaCompareEndpointType.Dacpac,
+				serverDisplayName: '',
+				serverName: '',
+				databaseName: '',
+				ownerUri: '',
+				packageFilePath: endpoint.packageFilePath,
+				connectionDetails: undefined
+			};
+		}
+		return endpointInfo;
 	}
 
 	private createSaveScmpButton(view: azdata.ModelView): void {

--- a/extensions/schema-compare/src/utils.ts
+++ b/extensions/schema-compare/src/utils.ts
@@ -3,10 +3,12 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 'use strict';
+import * as nls from 'vscode-nls';
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import * as mssql from '../../mssql';
 import * as os from 'os';
+const localize = nls.loadMessageBundle();
 
 export interface IPackageInfo {
 	name: string;
@@ -74,17 +76,44 @@ function connectionInfoToConnectionProfile(details: azdata.ConnectionInfo): azda
 	};
 }
 
-export async function verifyConnectionAndGetOwnerUri(endpoint: mssql.SchemaCompareEndpointInfo): Promise<string> {
+export async function verifyConnectionAndGetOwnerUri(endpoint: mssql.SchemaCompareEndpointInfo, caller: string): Promise<string> {
+	let ownerUri = undefined;
 	if (endpoint.endpointType === mssql.SchemaCompareEndpointType.Database && endpoint.connectionDetails) {
-		let connection = await azdata.connection.connect(connectionInfoToConnectionProfile(endpoint.connectionDetails), false, false);
+		let connectionProfile = await connectionInfoToConnectionProfile(endpoint.connectionDetails);
+		let connection = await azdata.connection.connect(connectionProfile, false, false);
+		if (connection) {
+			ownerUri = await azdata.connection.getUriForConnection(connection.connectionId);
+			if (!ownerUri) {
+				let connectionList = await azdata.connection.getActiveConnections();
+				let userConnection;
+				userConnection = connectionList.find(connection =>
+					(endpoint.connectionDetails['authenticationType'] === 'SqlLogin'
+						&& endpoint.connectionDetails['serverName'] === connection.options.server
+						&& endpoint.connectionDetails['userName'] === connection.options.user
+						&& (endpoint.connectionDetails['databaseName'].toLowerCase() === connection.options.database.toLowerCase()
+							|| connection.options.database.toLowerCase() === 'master')));
 
-		// show error message if the can't connect to the database
-		if (connection.errorMessage) {
-			vscode.window.showErrorMessage(connection.errorMessage);
+				if (userConnection === undefined) {
+					const getConnectionString = localize('schemaCompare.GetConnectionString', "Do you want to connect to {0}?", caller);
+					// need only yes button - since the modal dialog has a default cancel
+					const yesString = localize('schemaCompare.ApplyYes', "Yes");
+
+					let result = await vscode.window.showWarningMessage(getConnectionString, { modal: true }, yesString);
+					if (result === yesString) {
+						userConnection = await azdata.connection.openConnectionDialog(null, connectionProfile);
+					}
+				}
+
+				if (userConnection !== undefined) {
+					ownerUri = await azdata.connection.getUriForConnection(userConnection.connectionId);
+				}
+			}
+			if (!ownerUri && connection.errorMessage) {
+				vscode.window.showErrorMessage(connection.errorMessage);
+			}
 		}
-		return await azdata.connection.getUriForConnection(connection.connectionId);
 	}
-	return undefined;
+	return ownerUri;
 }
 
 /**

--- a/extensions/schema-compare/src/utils.ts
+++ b/extensions/schema-compare/src/utils.ts
@@ -108,7 +108,7 @@ export async function verifyConnectionAndGetOwnerUri(endpoint: mssql.SchemaCompa
 
 					let result = await vscode.window.showWarningMessage(getConnectionString, { modal: true }, yesString);
 					if (result === yesString) {
-						userConnection = await azdata.connection.openConnectionDialog(null, connectionProfile);
+						userConnection = await azdata.connection.openConnectionDialog(undefined, connectionProfile);
 					}
 				}
 

--- a/extensions/schema-compare/src/utils.ts
+++ b/extensions/schema-compare/src/utils.ts
@@ -84,7 +84,7 @@ export async function verifyConnectionAndGetOwnerUri(endpoint: mssql.SchemaCompa
 		if (connection) {
 			ownerUri = await azdata.connection.getUriForConnection(connection.connectionId);
 			if (!ownerUri) {
-				let connectionList = await azdata.connection.getActiveConnections();
+				let connectionList = await azdata.connection.getConnections(true);
 				let userConnection;
 				userConnection = connectionList.find(connection =>
 					(endpoint.connectionDetails['authenticationType'] === 'SqlLogin'

--- a/extensions/schema-compare/src/utils.ts
+++ b/extensions/schema-compare/src/utils.ts
@@ -52,7 +52,15 @@ export function getEndpointName(endpoint: mssql.SchemaCompareEndpointInfo): stri
 		if (!endpoint.serverName && endpoint.connectionDetails) {
 			endpoint.serverName = endpoint.connectionDetails['serverName'];
 		}
-		return `${endpoint.serverName}.${endpoint.databaseName}`;
+		if (!endpoint.databaseName && endpoint.connectionDetails) {
+			endpoint.databaseName = endpoint.connectionDetails['databaseName'];
+		}
+		if (endpoint.serverName && endpoint.databaseName) {
+			return `${endpoint.serverName}.${endpoint.databaseName}`;
+		} else {
+			return ' ';
+		}
+
 	} else {
 		return endpoint.packageFilePath;
 	}


### PR DESCRIPTION
This PR fixes the scenario where SchemaCompare can't reload an scmp where the source or target uses username/password to connect since the password is not persisted.
If the connection profile doesn't yield a connection Uri, the fix actually goes in and checks within the active connections list to get the connection details. If not, connection dialog opens up to get the connection information, upon approval.

This PR fixes #6833
