### PR TITLE
Book/untitled file name updates

### DIFF
--- a/extensions/notebook/src/book/bookModel.ts
+++ b/extensions/notebook/src/book/bookModel.ts
@@ -207,8 +207,8 @@ export class BookModel implements azdata.nb.NavigationProvider {
 		if (notebook) {
 			result = {
 				hasNavigation: true,
-				previous: notebook.previousUri ? this.openAsUntitled ? this.getPlatformSpecificUri(notebook.previousUri) : vscode.Uri.file(notebook.previousUri) : undefined,
-				next: notebook.nextUri ? this.openAsUntitled ? this.getPlatformSpecificUri(notebook.nextUri) : vscode.Uri.file(notebook.nextUri) : undefined
+				previous: notebook.previousUri ? this.openAsUntitled ? this.getUntitledUri(notebook.previousUri) : vscode.Uri.file(notebook.previousUri) : undefined,
+				next: notebook.nextUri ? this.openAsUntitled ? this.getUntitledUri(notebook.nextUri) : vscode.Uri.file(notebook.nextUri) : undefined
 			};
 		} else {
 			result = {
@@ -220,12 +220,7 @@ export class BookModel implements azdata.nb.NavigationProvider {
 		return Promise.resolve(result);
 	}
 
-	getPlatformSpecificUri(resource: string): vscode.Uri {
-		if (process.platform === 'win32') {
-			return vscode.Uri.parse(`untitled:${resource}`);
-		}
-		else {
-			return vscode.Uri.parse(resource).with({ scheme: 'untitled' });
-		}
+	getUntitledUri(resource: string): vscode.Uri {
+		return vscode.Uri.parse(`untitled:${resource}`);
 	}
 }

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -285,13 +285,8 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 
 	getUntitledNotebookUri(resource: string): vscode.Uri {
 		let untitledFileName: vscode.Uri;
-		if (process.platform === 'win32') {
-			let title = path.join(path.dirname(resource), this.findNextUntitledFileName(resource));
-			untitledFileName = vscode.Uri.parse(`untitled:${title}`);
-		}
-		else {
-			untitledFileName = vscode.Uri.parse(resource).with({ scheme: 'untitled' });
-		}
+		let nextTitle: string = this.findNextUntitledFileName(resource);
+		untitledFileName = vscode.Uri.parse(`untitled:${nextTitle}`);
 		if (!this.currentBook.getAllBooks().get(untitledFileName.fsPath) && !this.currentBook.getAllBooks().get(path.basename(untitledFileName.fsPath))) {
 			let notebook = this.currentBook.getAllBooks().get(resource);
 			this.currentBook.getAllBooks().set(path.basename(untitledFileName.fsPath), notebook);

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -39,7 +39,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		this._openAsUntitled = openAsUntitled;
 		this._extensionContext = extensionContext;
 		this.books = [];
-		this.initialize(workspaceFolders.map(a => a.uri.fsPath));
+		this.initialize(workspaceFolders.map(a => a.uri.fsPath)).catch(e => console.error(e));
 		this.viewId = view;
 		this.prompter = new CodeAdapter();
 
@@ -72,14 +72,14 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			// Check if the book is already open in viewlet.
 			if (books.length > 0 && books[0].bookItems) {
 				this.currentBook = books[0];
-				this.showPreviewFile(urlToOpen);
+				await this.showPreviewFile(urlToOpen);
 			}
 			else {
 				await this.initialize([bookPath]);
 				let bookViewer = vscode.window.createTreeView(this.viewId, { showCollapseAll: true, treeDataProvider: this });
 				this.currentBook = this.books.filter(book => book.bookPath === bookPath)[0];
 				bookViewer.reveal(this.currentBook.bookItems[0], { expand: vscode.TreeItemCollapsibleState.Expanded, focus: true, select: true });
-				this.showPreviewFile(urlToOpen);
+				await this.showPreviewFile(urlToOpen);
 			}
 		} catch (e) {
 			vscode.window.showErrorMessage(localize('openBookError', "Open book {0} failed: {1}",
@@ -99,7 +99,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				this.openMarkdown(sectionToOpenMarkdown);
 			}
 			else if (await fs.pathExists(sectionToOpenNotebook)) {
-				this.openNotebook(sectionToOpenNotebook);
+				await this.openNotebook(sectionToOpenNotebook);
 			}
 		}
 	}

--- a/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -718,7 +718,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 				let result = await this._proxy.$getNavigation(handle, uri);
 				if (result) {
 					if (result.next.scheme === Schemas.untitled) {
-						let untitledNbName: URI = URI.parse(`untitled:${result.next.path}`);
+						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.next.path)}`);
 						let content = await this._fileService.readFile(URI.file(result.next.path));
 						await this.doOpenEditor(untitledNbName, { initialContent: content.value.toString(), initialDirtyState: false });
 					}
@@ -731,7 +731,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 				let result = await this._proxy.$getNavigation(handle, uri);
 				if (result) {
 					if (result.previous.scheme === Schemas.untitled) {
-						let untitledNbName: URI = URI.parse(`untitled:${result.previous.path}`);
+						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.previous.path)}`);
 						let content = await this._fileService.readFile(URI.file(result.previous.path));
 						await this.doOpenEditor(untitledNbName, { initialContent: content.value.toString(), initialDirtyState: false });
 					}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
Following changes:
1. When book files are opened as untitled files, the name of the book currently has the entire path as it's name. Made changes here to only have the filename instead of the path.
2. Previously untitled schema needed to applied differently on each platform but after the previous vscode merge this has not been the case.

