### PR TITLE
Don't instrument any test code for coverage

### DIFF
--- a/test/coverage.js
+++ b/test/coverage.js
@@ -17,8 +17,7 @@ const REPO_PATH = toUpperDriveLetter(path.join(__dirname, '..'));
 exports.initialize = function (loaderConfig) {
 	const instrumenter = iLibInstrument.createInstrumenter();
 	loaderConfig.nodeInstrumenter = function (contents, source) {
-		if (minimatch(source, '**/test/**/*.test.js')) {
-			// tests don't get instrumented
+		if (minimatch(source, '**/test/**')) { // {{SQL CARBON EDIT}} Don't instrument test helper stuff either
 			return contents;
 		}
 		// Try to find a .map file


### PR DESCRIPTION
We were instrumenting helper classes too such as stub services, this shouldn't be necessary for getting accurate code coverage numbers. 

(only a very slight increase, ~1%, in coverage from this but an increase is an increase!)