### PR TITLE
Ensure Screen Readers Read Notebook Expand/Collapse Button Names

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component.ts
@@ -7,6 +7,7 @@ import 'vs/css!./code';
 import { OnInit, Component, Input, ElementRef, ViewChild, SimpleChange, OnChanges } from '@angular/core';
 import { CellView } from 'sql/workbench/contrib/notebook/browser/cellViews/interfaces';
 import { ICellModel } from 'sql/workbench/contrib/notebook/browser/models/modelInterfaces';
+import { localize } from 'vs/nls';
 
 export const COLLAPSE_SELECTOR: string = 'collapse-component';
 
@@ -27,6 +28,8 @@ export class CollapseComponent extends CellView implements OnInit, OnChanges {
 	}
 
 	ngOnInit() {
+		this.collapseCellButtonElement.nativeElement.title = localize('collapseCellContents', "Collapse code cell contents");
+		this.expandCellButtonElement.nativeElement.title = localize('expandCellContents', "Expand code cell contents");
 	}
 
 	ngOnChanges(changes: { [propKey: string]: SimpleChange }) {


### PR DESCRIPTION
This hopefully addresses bug #7624. Before the fix, no screen readers would read anything when tabbing to the expand/collapse button in the notebook.

This component is defined as a button in the component html. If anyone feels strongly that we should be defining a couple of properties in the *component.ts and referencing those in the *.html file, more than happy to make that change.

After:

![image](https://user-images.githubusercontent.com/40371649/70466933-1e4dc680-1a79-11ea-9a46-c2d9cc8728ce.png)
![image](https://user-images.githubusercontent.com/40371649/70466954-24dc3e00-1a79-11ea-84c2-27521854e796.png)
