### PR TITLE
Fix tree refresh

### DIFF
--- a/src/sql/workbench/contrib/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/connectionTreeAction.ts
@@ -56,7 +56,6 @@ export class RefreshAction extends Action {
 
 		if (treeNode) {
 			try {
-				await this._tree.collapse(this.element);
 				try {
 					await this._objectExplorerService.refreshTreeNode(treeNode.getSession(), treeNode);
 				} catch (error) {
@@ -64,7 +63,6 @@ export class RefreshAction extends Action {
 					return true;
 				}
 				await this._tree.refresh(this.element);
-				return this._tree.expand(this.element);
 			} catch (ex) {
 				this._logService.error(ex);
 				return true;

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeActionProvider.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeActionProvider.ts
@@ -187,7 +187,7 @@ export class ServerTreeActionProvider extends ContributableActionProvider {
 
 		// Contribute refresh action for scriptable objects via contribution
 		if (!this.isScriptableObject(context)) {
-			actions.push(this._instantiationService.createInstance(RefreshAction, RefreshAction.ID, RefreshAction.LABEL, context.tree, context.profile));
+			actions.push(this._instantiationService.createInstance(RefreshAction, RefreshAction.ID, RefreshAction.LABEL, context.tree, context.treeNode || context.profile));
 		}
 
 		return actions;

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/connectionTreeActions.test.ts
@@ -428,7 +428,6 @@ suite('SQL Connection Tree Action tests', () => {
 			objectExplorerService.verify(x => x.getObjectExplorerNode(TypeMoq.It.isAny()), TypeMoq.Times.atLeastOnce());
 			objectExplorerService.verify(x => x.refreshTreeNode(TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.atLeastOnce());
 			tree.verify(x => x.refresh(TypeMoq.It.isAny()), TypeMoq.Times.atLeastOnce());
-			tree.verify(x => x.expand(TypeMoq.It.isAny()), TypeMoq.Times.atLeastOnce());
 		}).then(() => done(), (err) => {
 			done(err);
 		});

--- a/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
@@ -326,10 +326,8 @@ CommandsRegistry.registerCommand({
 			if (treeNode) {
 				const tree = objectExplorerService.getServerTreeView().tree;
 				try {
-					await tree.collapse(treeNode);
 					await objectExplorerService.refreshTreeNode(treeNode.getSession(), treeNode);
 					await tree.refresh(treeNode);
-					await tree.expand(treeNode);
 				} catch (err) {
 					// Display message to the user but also log the entire error to the console for the stack trace
 					notificationService.error(localize('refreshError', "An error occurred refreshing node '{0}': {1}", args.nodeInfo.label, getErrorMessage(err)));

--- a/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
@@ -311,32 +311,18 @@ CommandsRegistry.registerCommand({
 CommandsRegistry.registerCommand({
 	id: OE_REFRESH_COMMAND_ID,
 	handler: async (accessor, args: ObjectExplorerActionsContext): Promise<void> => {
-		const connectionManagementService = accessor.get(IConnectionManagementService);
-		const capabilitiesService = accessor.get(ICapabilitiesService);
 		const objectExplorerService = accessor.get(IObjectExplorerService);
 		const logService = accessor.get(ILogService);
 		const notificationService = accessor.get(INotificationService);
-		const connection = new ConnectionProfile(capabilitiesService, args.connectionProfile);
-		if (connectionManagementService.isConnected(undefined, connection)) {
-			let treeNode = await getTreeNode(args, objectExplorerService);
-			if (!treeNode) {
-				await objectExplorerService.updateObjectExplorerNodes(connection.toIConnectionProfile());
-				treeNode = objectExplorerService.getObjectExplorerNode(connection);
-			}
-			if (treeNode) {
-				const tree = objectExplorerService.getServerTreeView().tree;
-				try {
-					await objectExplorerService.refreshTreeNode(treeNode.getSession(), treeNode);
-					await tree.refresh(treeNode);
-				} catch (err) {
-					// Display message to the user but also log the entire error to the console for the stack trace
-					notificationService.error(localize('refreshError', "An error occurred refreshing node '{0}': {1}", args.nodeInfo.label, getErrorMessage(err)));
-					logService.error(err);
-				}
-
-			} else {
-				logService.error(`Could not find tree node for node ${args.nodeInfo.label}`);
-			}
+		const treeNode = await getTreeNode(args, objectExplorerService);
+		const tree = objectExplorerService.getServerTreeView().tree;
+		try {
+			await objectExplorerService.refreshTreeNode(treeNode.getSession(), treeNode);
+			await tree.refresh(treeNode);
+		} catch (err) {
+			// Display message to the user but also log the entire error to the console for the stack trace
+			notificationService.error(localize('refreshError', "An error occurred refreshing node '{0}': {1}", args.nodeInfo.label, getErrorMessage(err)));
+			logService.error(err);
 		}
 	}
 });


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/8512
Fixes https://github.com/microsoft/azuredatastudio/issues/8455
Fixes https://github.com/microsoft/azuredatastudio/issues/7420
Fixes https://github.com/microsoft/azuredatastudio/issues/6787

2 main issues being fixed here :

1. **Refreshing nodes was collapsing the tree up to the server level in OE** 

   For non-server nodes we were passing in the ConnectionProfile, which would then be turned into a URI for looking up whether a node was connected. But because we were using the connection to get the node it was always getting the server node and refreshing that instead of the specific node being requested - and thus would refresh the entire tree. The fix is to pass in the TreeNode instead directly if we have it (which we should always) so that it refreshes just that node specifically.

1. **Scriptable nodes (tables, views, etc.) weren't refreshing at all**
   This was because of an issue with the lookup for isConnected. We were taking the IConnectionProfile from the args and turning that into a ConnectionProfile. But during this process the databaseDisplayName option was added, and thus when we turned that into the URI for looking up whether it was an active connection the actual connection (which didn't have the databaseDisplayName option) would fail to match and thus it would skip the entire refresh logic. 

   This is an indication of the bigger issue we have with using URIs for identifiers across the product, but in this case I was able to fix it by just removing that logic to check that it's connected. Scriptable nodes should always have a connection regardless - that's what we assume in all the other actions - and so I just made the refresh action look more similar to the other scriptable objects actions.

In addition there's one additional change I made to remove the collapse/expand calls we were during around refreshes. I don't see any reason for having them - the tree updates just fine without it and it doesn't look very good to have the tree collapse briefly while the refresh is happening (causes a "flicker" effect). There isn't an actual bug here that I can tell though so I can split this into its own review if we want to do a design review of the change first. 

I'm in the process of writing some tests for these (especially the scriptable object actions which didn't have any before) that I'll add to this PR later. I wanted to get this out for early review though.