### PR TITLE
Notebooks: Fix Cancel for Connection Dialog to Actually Close Window

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -360,7 +360,7 @@ export class AttachToDropdown extends SelectBox {
 					connectionType: ConnectionType.temporary,
 					providers: this.model.getApplicableConnectionProviderIds(this.model.clientSession.kernel.name)
 				},
-				useProfile ? this.model.connectionProfile : undefined, undefined);
+				useProfile ? this.model.connectionProfile : undefined);
 
 			let attachToConnections = this.values;
 			if (!connection) {

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -360,12 +360,14 @@ export class AttachToDropdown extends SelectBox {
 					connectionType: ConnectionType.temporary,
 					providers: this.model.getApplicableConnectionProviderIds(this.model.clientSession.kernel.name)
 				},
-				useProfile ? this.model.connectionProfile : undefined);
+				useProfile ? this.model.connectionProfile : undefined, undefined);
 
 			let attachToConnections = this.values;
 			if (!connection) {
-				this.loadAttachToDropdown(this.model, this.getKernelDisplayName());
-				this.doChangeContext(undefined, true);
+				// If there is no connection, we should choose the previous connection,
+				// which will always be the first item in the list. Either "Select Connection"
+				// or a real connection name
+				this.select(0);
 				return false;
 			}
 			let connectionUri = this._connectionManagementService.getConnectionUri(connection);


### PR DESCRIPTION
Fixes #8612.

When clicking cancel, we were unnecessarily calling a couple of methods, when we really should have been doing nothing to the attach to dropdown and leaving the state as it was before the user chose Change Connnection.