### PR TITLE
Improve performance of tools table painting for bdc deployment tools

### DIFF
--- a/extensions/resource-deployment/src/services/tools/toolBase.ts
+++ b/extensions/resource-deployment/src/services/tools/toolBase.ts
@@ -303,7 +303,7 @@ export abstract class ToolBase implements ITool {
 		return !version || (this._version ? SemVerCompare(this._version, version) >= 0 : false);
 	}
 
-	private _pendingVersionAndStatusUpdate: Promise<void> = Promise.reject();
+	private _pendingVersionAndStatusUpdate!: Promise<void>;
 	private _status: ToolStatus = ToolStatus.NotInstalled;
 	private _version?: SemVer;
 	private _statusDescription?: string;

--- a/extensions/resource-deployment/src/services/tools/toolBase.ts
+++ b/extensions/resource-deployment/src/services/tools/toolBase.ts
@@ -41,6 +41,7 @@ export const messageByDependencyType: Map<dependencyType, string> = new Map<depe
 
 export abstract class ToolBase implements ITool {
 	constructor(private _platformService: IPlatformService) {
+		this.startVersionAndStatusUpdate();
 	}
 
 	abstract name: string;
@@ -180,7 +181,8 @@ export abstract class ToolBase implements ITool {
 			this.status = ToolStatus.Installing;
 			await this.installCore();
 			await this.addInstallationSearchPathsToSystemPath();
-			this.status = await this.updateVersionAndGetStatus();
+			this.startVersionAndStatusUpdate();
+			await this._pendingVersionAndStatusUpdate;
 		} catch (error) {
 			const errorMessage = getErrorMessage(error);
 			this._statusDescription = localize('toolBase.InstallError', "Error installing tool '{0}' [ {1} ].{2}Error: {3}{2}See output channel '{4}' for more details", this.displayName, this.homePage, EOL, errorMessage, this.outputChannelName);
@@ -190,7 +192,7 @@ export abstract class ToolBase implements ITool {
 
 		// Since we just completed installation, the status should be ToolStatus.Installed
 		// but if it is ToolStatus.NotInstalled then it means that installation failed with 0 exit code.
-		if (this.status === ToolStatus.NotInstalled) {
+		if ((this.status as ToolStatus) === ToolStatus.NotInstalled) {
 			this._statusDescription = localize('toolBase.InstallFailed', "Installation commands completed but version of tool '{0}' could not be detected so our installation attempt has failed. Detection Error: {1}{2}Cleaning up previous installations would help.", this.displayName, this._statusDescription, EOL);
 			if (this.uninstallCommand) {
 				this._statusDescription += localize('toolBase.ManualUninstallCommand', " A possibly way to uninstall is using this command:{0}   >{1}", EOL, this.uninstallCommand);
@@ -234,13 +236,17 @@ export abstract class ToolBase implements ITool {
 	}
 
 	public async loadInformation(): Promise<void> {
+		await this._pendingVersionAndStatusUpdate;
 		if (this.status === ToolStatus.NotInstalled) {
 			await this.addInstallationSearchPathsToSystemPath();
-			this.status = await this.updateVersionAndGetStatus();
 		}
 	}
 
-	private async updateVersionAndGetStatus(): Promise<ToolStatus> {
+	private startVersionAndStatusUpdate() {
+		this._pendingVersionAndStatusUpdate = this.updateVersionAndStatus();
+	}
+
+	private async updateVersionAndStatus(): Promise<void> {
 		this._statusDescription = '';
 		const commandOutput = await this._platformService.runCommand(
 			this.versionCommand.command,
@@ -257,11 +263,11 @@ export abstract class ToolBase implements ITool {
 				// discover and set the installationPath
 				await this.setInstallationPath();
 			}
-			return ToolStatus.Installed;
+			this.status = ToolStatus.Installed;
 		}
 		else {
 			this._statusDescription = localize('deployCluster.GetToolVersionError', "Error retrieving version information.{0}Invalid output received, get version command output: '{1}' ", EOL, commandOutput);
-			return ToolStatus.NotInstalled;
+			this.status = ToolStatus.NotInstalled;
 		}
 	}
 
@@ -297,6 +303,7 @@ export abstract class ToolBase implements ITool {
 		return !version || (this._version ? SemVerCompare(this._version, version) >= 0 : false);
 	}
 
+	private _pendingVersionAndStatusUpdate: Promise<void> = Promise.reject();
 	private _status: ToolStatus = ToolStatus.NotInstalled;
 	private _version?: SemVer;
 	private _statusDescription?: string;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
This change starts to populate each tool's status and version as soon as the tool is constructed. This improves user-perceived performance because, by the time the user clicks on respective cards that need to display these tools, the information is already populated.

This PR fixes #8526 
