### PR TITLE
Change typo for monaco-pane-view

### DIFF
--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -231,7 +231,6 @@ export class OptionsDialog extends Modal {
 
 			let viewSize = this._optionCategoryPadding + serviceOptions.length * this._optionRowSize;
 			let categoryView = this._instantiationService.createInstance(CategoryView, bodyContainer, viewSize, { title: category, ariaHeaderLabel: category, id: category });
-			categoryView.headerVisible = true;
 			this.splitview.addView(categoryView, viewSize);
 			categoryView.render();
 			attachPanelStyler(categoryView, this._themeService);

--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -123,7 +123,7 @@ export class OptionsDialog extends Modal {
 
 		this._dividerBuilder = append(this._body, $('div'));
 
-		this._optionGroups = append(this._body, $('div.optionsDialog-options-groups.monaco-panel-view'));
+		this._optionGroups = append(this._body, $('div.optionsDialog-options-groups.monaco-pane-view'));
 		this.splitview = new ScrollableSplitView(this._optionGroups, { enableResizing: false, scrollDebounce: 0 });
 
 		const descriptionContainer = append(this._body, $('div.optionsDialog-description'));
@@ -231,6 +231,7 @@ export class OptionsDialog extends Modal {
 
 			let viewSize = this._optionCategoryPadding + serviceOptions.length * this._optionRowSize;
 			let categoryView = this._instantiationService.createInstance(CategoryView, bodyContainer, viewSize, { title: category, ariaHeaderLabel: category, id: category });
+			categoryView.headerVisible = true;
 			this.splitview.addView(categoryView, viewSize);
 			categoryView.render();
 			attachPanelStyler(categoryView, this._themeService);

--- a/src/sql/workbench/services/insights/browser/insightsDialogView.ts
+++ b/src/sql/workbench/services/insights/browser/insightsDialogView.ts
@@ -204,7 +204,7 @@ export class InsightsDialogView extends Modal {
 
 	protected renderBody(container: HTMLElement) {
 		this._container = container;
-		container.classList.add('monaco-panel-view');
+		container.classList.add('monaco-pane-view');
 
 		this._splitView = new SplitView(container);
 


### PR DESCRIPTION
This PR fixes #8624
Both use the wrong name, it should be .monaco-pane-view instead of .monaco-panel-view (this spelling does not have any CSS files that use it)

Made changes to both optionsDialog and insightDialogView as they are both paneview(lets) (should fix issues related to .monaco-pane-view rules in css files).