### PR TITLE
Change deploy string from connections viewlet/welcome page

### DIFF
--- a/extensions/resource-deployment/package.nls.json
+++ b/extensions/resource-deployment/package.nls.json
@@ -1,7 +1,7 @@
 {
 	"extension-displayName": "SQL Server Deployment extension for Azure Data Studio",
 	"extension-description": "Provides a notebook-based experience to deploy Microsoft SQL Server",
-	"deploy-resource-command-name": "Deploy SQL Server…",
+	"deploy-resource-command-name": "New Deployment…",
 	"deploy-resource-command-category": "Deployment",
 	"resource-type-sql-image-display-name": "SQL Server container image",
 	"resource-type-sql-image-description": "Run SQL Server container image with docker",

--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -28,7 +28,7 @@ export default () => `
 				<div class="section deploy">
 					<h2 class="caption">${escape(localize('welcomePage.deploy', "Deploy"))}</h2>
 					<ul>
-						<li><a href="command:azdata.resource.deploy">${escape(localize('welcomePage.DeploySQLServer', "Deploy SQL Server…"))}</a></li>
+						<li><a href="command:azdata.resource.deploy">${escape(localize('welcomePage.newDeployment', "New Deployment…"))}</a></li>
 					</ul>
 				</div>
 				<div class="section recent">


### PR DESCRIPTION
Per UX and PM feedback, changing option from "Deploy SQL Server..." to "New Deployment..." in both connections viewlet and welcome page

![image](https://user-images.githubusercontent.com/40371649/70673119-53ebde80-1c36-11ea-9f37-d56dfaf9f8f3.png)

![image](https://user-images.githubusercontent.com/40371649/70673303-0459e280-1c37-11ea-8b33-cb976ad48bbc.png)
