### PR TITLE
Fix modelview tables failing for number columns

### DIFF
--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -85,6 +85,9 @@ export function slickGridDataItemColumnValueExtractor(value: any, columnDef: any
  */
 export function slickGridDataItemColumnValueWithNoData(value: any, columnDef: any): { text: string; ariaLabel: string; } {
 	let displayValue = value[columnDef.field];
+	if (typeof displayValue === 'number') {
+		displayValue = displayValue.toString();
+	}
 	return {
 		text: displayValue,
 		ariaLabel: displayValue ? escape(displayValue) : ((displayValue !== undefined) ? localize("tableCell.NoDataAvailable", "no data available") : displayValue)


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/8554 and fixes https://github.com/microsoft/azuredatastudio/issues/8543

The `Table` component was failing for tables with numbers as columns. 