### PR TITLE
Fix alignment of select dropdown in modal dialogs

### DIFF
--- a/src/sql/workbench/browser/modal/media/modal.css
+++ b/src/sql/workbench/browser/modal/media/modal.css
@@ -96,7 +96,7 @@
 /* Add space in the bottom to separate each input elements */
 .modal.flyout-dialog .input-divider {
 	width: 100%;
-	padding-bottom: 20px;
+	margin-bottom: 20px;
 }
 
 .modal.flyout-dialog .input {


### PR DESCRIPTION
(noticed in backup dialog, but would affect any dialog with a select dropdown)

Previous :

![image](https://user-images.githubusercontent.com/28519865/70839853-b8887400-1dc3-11ea-8ee2-08ba4686523a.png)

After fix :

![image](https://user-images.githubusercontent.com/28519865/70839862-c3430900-1dc3-11ea-8ca5-d66455561105.png)
