### PR TITLE
Fix Notebook Scrolling by Setting alwaysConsumeMouseWheel to False

### DIFF
--- a/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
@@ -71,6 +71,9 @@ export class QueryTextEditor extends BaseTextEditor {
 			options.minimap = {
 				enabled: false
 			};
+			options.scrollbar = {
+				alwaysConsumeMouseWheel: false
+			};
 			options.overviewRulerLanes = 0;
 			options.overviewRulerBorder = false;
 			options.hideCursorInOverviewRuler = true;
@@ -82,9 +85,6 @@ export class QueryTextEditor extends BaseTextEditor {
 			if (this._hideLineNumbers) {
 				options.lineNumbers = 'off';
 			}
-			options.scrollbar = {
-				alwaysConsumeMouseWheel: false;
-			};
 		}
 		return options;
 	}

--- a/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
@@ -82,6 +82,9 @@ export class QueryTextEditor extends BaseTextEditor {
 			if (this._hideLineNumbers) {
 				options.lineNumbers = 'off';
 			}
+			options.scrollbar = {
+				alwaysConsumeMouseWheel: false;
+			};
 		}
 		return options;
 	}


### PR DESCRIPTION
Fixes #8675.

In https://github.com/microsoft/vscode/commit/185d71b615e529b154c76907764bfda9270cb42f an alwaysConsumeMouseWheel option was added (and defaulted to true): https://github.com/microsoft/vscode/blob/185d71b615e529b154c76907764bfda9270cb42f/src/vs/editor/common/config/editorOptions.ts#L2328

For a document with 1 editor, this seems reasonable. However, when trying to scroll between editors for notebooks, this was breaking us, as events weren't getting propogated properly. Setting this to false for notebooks fixes this issue.