### PR TITLE
add installation search path to system before tools discovery is done every time

### DIFF
--- a/extensions/resource-deployment/src/services/tools/toolBase.ts
+++ b/extensions/resource-deployment/src/services/tools/toolBase.ts
@@ -180,7 +180,6 @@ export abstract class ToolBase implements ITool {
 		try {
 			this.status = ToolStatus.Installing;
 			await this.installCore();
-			await this.addInstallationSearchPathsToSystemPath();
 			this.startVersionAndStatusUpdate();
 			await this._pendingVersionAndStatusUpdate;
 		} catch (error) {
@@ -222,7 +221,7 @@ export abstract class ToolBase implements ITool {
 	}
 
 	protected async addInstallationSearchPathsToSystemPath(): Promise<void> {
-		const searchPaths = [...await this.getSearchPaths(), this.storagePath].filter(path => !!path);
+		const searchPaths = [...(new Set<string>([...await this.getSearchPaths(), this.storagePath].filter(path => !!path))).values()]; // collect all unique installation search paths
 		this.logToOutputChannel(localize('toolBase.addInstallationSearchPathsToSystemPath.SearchPaths', "Search Paths for tool '{0}': {1}", this.displayName, JSON.stringify(searchPaths, undefined, '\t'))); //this.displayName is localized and searchPaths are OS filesystem paths.
 		searchPaths.forEach(searchPath => {
 			if (process.env.PATH) {
@@ -237,9 +236,6 @@ export abstract class ToolBase implements ITool {
 
 	public async loadInformation(): Promise<void> {
 		await this._pendingVersionAndStatusUpdate;
-		if (this.status === ToolStatus.NotInstalled) {
-			await this.addInstallationSearchPathsToSystemPath();
-		}
 	}
 
 	private startVersionAndStatusUpdate() {
@@ -248,6 +244,7 @@ export abstract class ToolBase implements ITool {
 
 	private async updateVersionAndStatus(): Promise<void> {
 		this._statusDescription = '';
+		await this.addInstallationSearchPathsToSystemPath();
 		const commandOutput = await this._platformService.runCommand(
 			this.versionCommand.command,
 			{


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
This change fixes 2 things:
1. Moves the code to add possible installation location of the tools to system path to the call that discovers the version of tools intalled so that every time we try to discover these tools, we check to see if these know installation locations are in path and add them to system path if they are not.

2. Make a change so that we eliminate duplicate installation paths.

This PR fixes #8685
