### PR TITLE
Fix Notebook Connection Profile Passing Bugs

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookModel.ts
@@ -449,7 +449,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			if (!this._activeClientSession) {
 				this.updateActiveClientSession(clientSession);
 			}
-			let profile = new ConnectionProfile(this._notebookOptions.capabilitiesService, this.connectionProfile);
+
+			// If a connection profile is passed in and _activeConnection isn't yet set, use that. Otherwise, use _activeConnection
+			let profile = this._activeConnection ? this._activeConnection : new ConnectionProfile(this._notebookOptions.capabilitiesService, this.connectionProfile);
 
 			if (this.isValidConnection(profile)) {
 				this._activeConnection = profile;

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -33,8 +33,6 @@ import { Deferred } from 'sql/base/common/promise';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { Taskbar } from 'sql/base/browser/ui/taskbar/taskbar';
 import { KernelsDropdown, AttachToDropdown, AddCellAction, TrustedAction, RunAllCellsAction, ClearAllOutputsAction, CollapseCellsAction } from 'sql/workbench/contrib/notebook/browser/notebookActions';
-import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
-import * as TaskUtilities from 'sql/workbench/browser/taskUtilities';
 import { ISingleNotebookEditOperation } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { IConnectionDialogService } from 'sql/workbench/services/connection/common/connectionDialogService';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
@@ -87,7 +85,6 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
 		@Inject(IWorkbenchThemeService) private themeService: IWorkbenchThemeService,
 		@Inject(IConnectionManagementService) private connectionManagementService: IConnectionManagementService,
-		@Inject(IObjectExplorerService) private objectExplorerService: IObjectExplorerService,
 		@Inject(IEditorService) private editorService: IEditorService,
 		@Inject(INotificationService) private notificationService: INotificationService,
 		@Inject(INotebookService) private notebookService: INotebookService,
@@ -112,21 +109,6 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 
 	private updateProfile(): void {
 		this.profile = this.notebookParams ? this.notebookParams.profile : undefined;
-		if (!this.profile) {
-			// Second use global connection if possible
-			let profile: IConnectionProfile = TaskUtilities.getCurrentGlobalConnection(this.objectExplorerService, this.connectionManagementService, this.editorService);
-
-			// TODO use generic method to match kernel with valid connection that's compatible. For now, we only have 1
-			if (profile && profile.providerName) {
-				this.profile = profile;
-			} else {
-				// if not, try 1st active connection that matches our filter
-				let activeProfiles = this.connectionManagementService.getActiveConnections();
-				if (activeProfiles && activeProfiles.length > 0) {
-					this.profile = activeProfiles[0];
-				}
-			}
-		}
 	}
 
 	ngOnInit() {


### PR DESCRIPTION
Fixes #8688.

Connection profile was getting set automatically for notebooks in the notebook component for some file->open scenarios.

In addition, a subtle bug where we were using this.connectionProfile when starting a new session instead of using this._activeConnection if it was already set.