### PR TITLE
Fix missing action buttons with single view

### DIFF
--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet.ts
@@ -134,10 +134,6 @@ export class DataExplorerViewPaneContainer extends ViewPaneContainer {
 		return 400;
 	}
 
-	getActions(): IAction[] {
-		return [];
-	}
-
 	getSecondaryActions(): IAction[] {
 		let menu = this.menuService.createMenu(MenuId.DataExplorerAction, this.contextKeyService);
 		let actions = [];


### PR DESCRIPTION
Fixes #8588

The base ViewPaneContainer has [logic](https://github.com/microsoft/azuredatastudio/blob/master/src/vs/workbench/browser/parts/views/viewPaneContainer.ts#L402) to display the actions of the view when there's only a single one showing which we were overriding. 

Normal (2+ views showing)

![image](https://user-images.githubusercontent.com/28519865/70868098-cfe56f80-1f31-11ea-81c5-70fcad608711.png)

Only one view showing

![image](https://user-images.githubusercontent.com/28519865/70868110-f60b0f80-1f31-11ea-8d08-d3be57fbab56.png)


