### PR TITLE
Fix options dropdown arrow alignment in options dialog

### DIFF
--- a/src/sql/workbench/browser/modal/media/optionsDialog.css
+++ b/src/sql/workbench/browser/modal/media/optionsDialog.css
@@ -5,13 +5,10 @@
 
 .optionsDialog-label {
 	width: 120px;
-	padding-bottom: 5px;
 }
 
 .optionsDialog-input {
 	width: 200px;
-	padding-bottom: 5px;
-	padding-right: 7px;
 }
 
 .options-dialog .select-box {
@@ -96,9 +93,6 @@
 
 .optionsDialog-table{
 	width:100%;
-	padding: 10px;
-}
-
-td.optionsDialog-input.select-container {
-	padding-right: 9px;
+	padding: 10px 19px 10px 10px;
+	border-spacing: 5px;
 }


### PR DESCRIPTION
Old :

![image](https://user-images.githubusercontent.com/28519865/70868946-a1b85d80-1f3a-11ea-891f-686a2fe23582.png)

Fixed : 

![image](https://user-images.githubusercontent.com/28519865/70868947-ab41c580-1f3a-11ea-9a78-bd1fb4c6abb2.png)
