### PR TITLE
change order of tasks

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution.ts
@@ -2,10 +2,9 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-
+import { generateDashboardTabSchema, generateDashboardWidgetSchema } from 'sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import * as nls from 'vs/nls';
-import { generateDashboardWidgetSchema, generateDashboardTabSchema } from 'sql/workbench/contrib/dashboard/browser/pages/dashboardPageContribution';
 
 export interface IPropertiesConfig {
 	edition: number | Array<number>;
@@ -78,7 +77,7 @@ const defaultVal = [
 	{
 		name: 'Tasks',
 		widget: {
-			'tasks-widget': [{ name: 'restore', when: '!mssql:iscloud && mssql:engineedition != 11' }, 'configureDashboard', 'newQuery', 'mssqlCluster.task.newNotebook']
+			'tasks-widget': ['newQuery', 'mssqlCluster.task.newNotebook', { name: 'restore', when: '!mssql:iscloud && mssql:engineedition != 11' }, 'configureDashboard']
 		},
 		gridItemConfig: {
 			sizex: 1,


### PR DESCRIPTION
I am looking into the area recently and saw this issue, I didn't dig too much into the change history, it makes sense to have new query and new notebook appear first.

This PR fixes #8627 

with the changes:
![Screen Shot 2019-12-16 at 12 10 28 PM](https://user-images.githubusercontent.com/13777222/70939764-c9242e80-1ffd-11ea-9233-33ca531102bc.png)

