### PR TITLE
Make dropdown update width immediately upon opening

### DIFF
--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -279,8 +279,12 @@ export class Dropdown extends Disposable {
 				return previous.value.length > current.value.length ? previous : current;
 			}, { value: '' });
 			this._widthControlElement.innerText = longestOption.value;
-			if (longestOption.value.length > 10) {
-				this._treeContainer.style.width = DOM.getTotalWidth(this._widthControlElement) + 'px';
+
+			const inputContainerWidth = DOM.getContentWidth(this._inputContainer);
+			if (longestOption.value.length > inputContainerWidth) {
+				this._treeContainer.style.width = `${DOM.getTotalWidth(this._widthControlElement)}px`;
+			} else {
+				this._treeContainer.style.width = `${inputContainerWidth}px`;
 			}
 			// Don't let it get too large
 			this._treeContainer.style.maxWidth = `500px`;

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -6,7 +6,7 @@
 import 'vs/css!./media/dropdownList';
 
 import { ToggleDropdownAction } from './actions';
-import { DropdownDataSource, DropdownFilter, DropdownModel, DropdownRenderer, DropdownController, Resource } from './dropdownTree';
+import { DropdownDataSource, DropdownFilter, DropdownModel, DropdownRenderer, DropdownController } from './dropdownTree';
 
 import { IContextViewProvider } from 'vs/base/browser/ui/contextview/contextview';
 import { mixin } from 'vs/base/common/objects';
@@ -275,7 +275,7 @@ export class Dropdown extends Disposable {
 	 */
 	private updateTreeWidth(): void {
 		if (this._dataSource && this._dataSource.options) {
-			const longestOption = this._dataSource.options.reduce((previous: Resource, current: Resource) => {
+			const longestOption = this._dataSource.options.reduce((previous, current) => {
 				return previous.value.length > current.value.length ? previous : current;
 			}, { value: '' });
 			this._widthControlElement.innerText = longestOption.value;

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -23,6 +23,7 @@ import { KeyCode } from 'vs/base/common/keyCodes';
 import { Tree } from 'vs/base/parts/tree/browser/treeImpl';
 import { ITree } from 'vs/base/parts/tree/browser/tree';
 import { onUnexpectedError } from 'vs/base/common/errors';
+import { clamp } from 'vs/base/common/numbers';
 
 export interface IDropdownOptions extends IDropdownStyles {
 	/**
@@ -281,13 +282,8 @@ export class Dropdown extends Disposable {
 			this._widthControlElement.innerText = longestOption.value;
 
 			const inputContainerWidth = DOM.getContentWidth(this._inputContainer);
-			if (longestOption.value.length > inputContainerWidth) {
-				this._treeContainer.style.width = `${DOM.getTotalWidth(this._widthControlElement)}px`;
-			} else {
-				this._treeContainer.style.width = `${inputContainerWidth}px`;
-			}
-			// Don't let it get too large
-			this._treeContainer.style.maxWidth = `500px`;
+			const longestOptionWidth = DOM.getTotalWidth(this._widthControlElement);
+			this._treeContainer.style.width = `${clamp(longestOptionWidth, inputContainerWidth, 500)}px`;
 		}
 
 	}


### PR DESCRIPTION
Fixes #8709

First some context - the main thing causing this issue is that we fetch the database list asynchronously. So when the dropdown is opened we start the query to get the latest database list but then immediately open with the ones that we know about.

This changes it so the dropdown calculates the width immediately upon opening - this makes it so if the longest database name doesn't change after it comes back with the new options then the width won't change.

This DOESN'T fix the issue though that if the query comes back with the longest name being different  it'll still change the size. But this isn't something we can really prevent unless we wanted to only set the size on first open and not when new values are set (so the user would need to close and reopen to see the corrected size). But I think the current behavior is fine since the reason we did this in the first place was that users wanted to be able to see the names more clearly. 