### PR TITLE
Bug fix to return authType as undefined if displayName is not set

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -915,6 +915,9 @@ export class ConnectionWidget extends lifecycle.Disposable {
 	}
 
 	private getMatchingAuthType(displayName: string): AuthenticationType {
+		if (!displayName) {
+			return undefined;
+		}
 		return find(ConnectionWidget._authTypes, authType => this.getAuthTypeDisplayName(authType) === displayName);
 	}
 


### PR DESCRIPTION
We noticed that if displayName is undefined this method would return the first auth type it found as getAuthTypeDisplayName() would return undefined.
If the displayName is undefined, we would not have a matchingTYpe and it should be undefined.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #8714

