### PR TITLE
Adding an activation event for opening the dashboard

### DIFF
--- a/src/sql/workbench/api/browser/mainThreadDashboard.ts
+++ b/src/sql/workbench/api/browser/mainThreadDashboard.ts
@@ -7,6 +7,7 @@ import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { SqlMainContext, MainThreadDashboardShape, ExtHostDashboardShape, SqlExtHostContext } from 'sql/workbench/api/common/sqlExtHost.protocol';
 import { IExtHostContext } from 'vs/workbench/api/common/extHost.protocol';
 import { IDashboardService } from 'sql/platform/dashboard/browser/dashboardService';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadDashboard)
 export class MainThreadDashboard implements MainThreadDashboardShape {
@@ -14,10 +15,12 @@ export class MainThreadDashboard implements MainThreadDashboardShape {
 
 	constructor(
 		context: IExtHostContext,
+		@IExtensionService extensionService: IExtensionService,
 		@IDashboardService dashboardService: IDashboardService
 	) {
 		this._proxy = context.getProxy(SqlExtHostContext.ExtHostDashboard);
 		dashboardService.onDidChangeToDashboard(e => {
+			extensionService.activateByEvent('onDashboardOpen');
 			this._proxy.$onDidChangeToDashboard(e);
 		});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

In my new extension I need to activate the extension when dashboard is opened. I didn't find any activation event for that so I added one. Please let me know if there's a better way to do it. 
