### PR TITLE
Added check for the last null row

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/gridParentComponent.ts
+++ b/src/sql/workbench/contrib/editData/browser/gridParentComponent.ts
@@ -391,22 +391,24 @@ export abstract class GridParentComponent {
 		}
 
 		let rowIndex = grid.getCellFromEvent(event).row;
+		if (rowIndex !== grid.getDataLength() - 1) {
+			let actionContext: IGridInfo = {
+				batchIndex: batchId,
+				resultSetNumber: resultId,
+				selection: selection,
+				gridIndex: index,
+				rowIndex: rowIndex
+			};
 
-		let actionContext: IGridInfo = {
-			batchIndex: batchId,
-			resultSetNumber: resultId,
-			selection: selection,
-			gridIndex: index,
-			rowIndex: rowIndex
-		};
+			let anchor = { x: event.pageX + 1, y: event.pageY };
 
-		let anchor = { x: event.pageX + 1, y: event.pageY };
-		this.contextMenuService.showContextMenu({
-			getAnchor: () => anchor,
-			getActions: () => this.actionProvider.getGridActions(),
-			getKeyBinding: (action) => this._keybindingFor(action),
-			getActionsContext: () => (actionContext)
-		});
+			this.contextMenuService.showContextMenu({
+				getAnchor: () => anchor,
+				getActions: () => this.actionProvider.getGridActions(),
+				getKeyBinding: (action) => this._keybindingFor(action),
+				getActionsContext: () => (actionContext)
+			});
+		}
 	}
 
 	/**


### PR DESCRIPTION
Added a simple check to make sure that the context menu doesn't open for the last row (which is the null row) for the data in editdata, this was tested using an empty grid with only the null row, and a table with several rows.

This PR addresses #478
