### PR TITLE
Changed class name for manage packages extension

### DIFF
--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -133,7 +133,7 @@ export function createActionViewItem(action: IAction, keybindingService: IKeybin
 	return undefined;
 }
 
-const ids = new IdGenerator('icon-menu-item-');
+const ids = new IdGenerator('menu-item-action-item-icon-');
 
 // {{SQL CARBON EDIT}} - This is here to use the 'ids' generator above
 // General Menu Entry Action Item, may or may not be labeled.

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -133,7 +133,7 @@ export function createActionViewItem(action: IAction, keybindingService: IKeybin
 	return undefined;
 }
 
-const ids = new IdGenerator('menu-item-action-item-icon-');
+const ids = new IdGenerator('icon-menu-item-');
 
 export class MenuEntryActionViewItem extends ActionViewItem {
 
@@ -262,17 +262,17 @@ export class MenuEntryActionViewItem extends ActionViewItem {
 					iconClass = MenuEntryActionViewItem.ICON_PATH_TO_CSS_RULES.get(iconPathMapKey)!;
 				} else {
 					iconClass = ids.nextId();
-					createCSSRule(`.icon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.light || item.icon.dark)}`);
-					createCSSRule(`.vs-dark .icon.${iconClass}, .hc-black .icon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.dark)}`);
+					createCSSRule(`.codicon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.light || item.icon.dark)}`);
+					createCSSRule(`.vs-dark .codicon.${iconClass}, .hc-black .codicon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.dark)}`);
 					MenuEntryActionViewItem.ICON_PATH_TO_CSS_RULES.set(iconPathMapKey, iconClass);
 				}
 
 				if (this.label) {
 
-					addClasses(this.label, 'icon', iconClass);
+					addClasses(this.label, 'codicon', iconClass);
 					this._itemClassDispose.value = toDisposable(() => {
 						if (this.label) {
-							removeClasses(this.label, 'icon', iconClass);
+							removeClasses(this.label, 'codicon', iconClass);
 						}
 					});
 				}
@@ -333,13 +333,13 @@ export class LabeledMenuItemActionItem extends MenuEntryActionViewItem {
 				iconClass = MenuEntryActionViewItem.ICON_PATH_TO_CSS_RULES.get(iconPathMapKey)!;
 			} else {
 				iconClass = ids.nextId();
-				createCSSRule(`.icon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.light || item.icon.dark)}`);
-				createCSSRule(`.vs-dark .icon.${iconClass}, .hc-black .icon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.dark)}`);
+				createCSSRule(`.codicon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.light || item.icon.dark)}`);
+				createCSSRule(`.vs-dark .codicon.${iconClass}, .hc-black .codicon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.dark)}`);
 				MenuEntryActionViewItem.ICON_PATH_TO_CSS_RULES.set(iconPathMapKey, iconClass);
 			}
 
-			addClasses(this.label, 'icon', iconClass, this._defaultCSSClassToAdd);
-			this._labeledItemClassDispose = toDisposable(() => removeClasses(this.label, 'icon', iconClass, this._defaultCSSClassToAdd));
+			addClasses(this.label, 'codicon', this._defaultCSSClassToAdd, iconClass);
+			this._labeledItemClassDispose = toDisposable(() => removeClasses(this.label, 'codicon', this._defaultCSSClassToAdd, iconClass));
 		}
 	}
 

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -135,8 +135,7 @@ export function createActionViewItem(action: IAction, keybindingService: IKeybin
 
 const ids = new IdGenerator('menu-item-action-item-icon-');
 
-// {{SQL CARBON EDIT}} - This is here to use the 'ids' generator above
-// General Menu Entry Action Item, may or may not be labeled.
+
 export class MenuEntryActionViewItem extends ActionViewItem {
 
 	static readonly ICON_PATH_TO_CSS_RULES: Map<string /* path*/, string /* CSS rule */> = new Map<string, string>();

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -135,6 +135,8 @@ export function createActionViewItem(action: IAction, keybindingService: IKeybin
 
 const ids = new IdGenerator('icon-menu-item-');
 
+// {{SQL CARBON EDIT}} - This is here to use the 'ids' generator above
+// General Menu Entry Action Item, may or may not be labeled.
 export class MenuEntryActionViewItem extends ActionViewItem {
 
 	static readonly ICON_PATH_TO_CSS_RULES: Map<string /* path*/, string /* CSS rule */> = new Map<string, string>();
@@ -262,17 +264,17 @@ export class MenuEntryActionViewItem extends ActionViewItem {
 					iconClass = MenuEntryActionViewItem.ICON_PATH_TO_CSS_RULES.get(iconPathMapKey)!;
 				} else {
 					iconClass = ids.nextId();
-					createCSSRule(`.codicon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.light || item.icon.dark)}`);
-					createCSSRule(`.vs-dark .codicon.${iconClass}, .hc-black .codicon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.dark)}`);
+					createCSSRule(`.icon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.light || item.icon.dark)}`);
+					createCSSRule(`.vs-dark .icon.${iconClass}, .hc-black .icon.${iconClass}`, `background-image: ${asCSSUrl(item.icon.dark)}`);
 					MenuEntryActionViewItem.ICON_PATH_TO_CSS_RULES.set(iconPathMapKey, iconClass);
 				}
 
 				if (this.label) {
 
-					addClasses(this.label, 'codicon', iconClass);
+					addClasses(this.label, 'icon', iconClass);
 					this._itemClassDispose.value = toDisposable(() => {
 						if (this.label) {
-							removeClasses(this.label, 'codicon', iconClass);
+							removeClasses(this.label, 'icon', iconClass);
 						}
 					});
 				}

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -135,7 +135,6 @@ export function createActionViewItem(action: IAction, keybindingService: IKeybin
 
 const ids = new IdGenerator('menu-item-action-item-icon-');
 
-
 export class MenuEntryActionViewItem extends ActionViewItem {
 
 	static readonly ICON_PATH_TO_CSS_RULES: Map<string /* path*/, string /* CSS rule */> = new Map<string, string>();

--- a/src/vs/workbench/browser/style.ts
+++ b/src/vs/workbench/browser/style.ts
@@ -18,6 +18,7 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	const iconForegroundColor = theme.getColor(iconForeground);
 	if (iconForegroundColor) {
 		collector.addRule(`.monaco-workbench .codicon { color: ${iconForegroundColor}; }`);
+		collector.addRule(`.monaco-workbench .icon { color: ${iconForegroundColor}; }`);
 	}
 
 	// Foreground

--- a/src/vs/workbench/browser/style.ts
+++ b/src/vs/workbench/browser/style.ts
@@ -18,7 +18,6 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	const iconForegroundColor = theme.getColor(iconForeground);
 	if (iconForegroundColor) {
 		collector.addRule(`.monaco-workbench .codicon { color: ${iconForegroundColor}; }`);
-		collector.addRule(`.monaco-workbench .icon { color: ${iconForegroundColor}; }`);
 	}
 
 	// Foreground


### PR DESCRIPTION
Since the manage packages extension class name is .icon instead of .codicon, the style rules need to account for this as well (changing the class name to .codicon breaks the icon image so its not recommended)
This PR fixes #8721
