### PR TITLE
Only show find when modal is loaded

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -334,8 +334,10 @@ export class NotebookEditor extends BaseEditor implements IFindNotebookControlle
 		this._currentMatch = range;
 	}
 	public toggleSearch(): void {
+		// reveal only when the model is loaded
+		let isRevealed: boolean = !this._findState.isRevealed && this._notebookModel ? !this._findState.isRevealed : false;
 		this._findState.change({
-			isRevealed: !this._findState.isRevealed
+			isRevealed: isRevealed
 		}, false);
 		if (this._findState.isRevealed) {
 			this._finder.focusFindInput();

--- a/src/sql/workbench/contrib/notebook/find/notebookFindDecorations.ts
+++ b/src/sql/workbench/contrib/notebook/find/notebookFindDecorations.ts
@@ -144,6 +144,8 @@ export class NotebookFindDecorations implements IDisposable {
 
 	private _revealRangeInCenterIfOutsideViewport(match: NotebookRange): void {
 		let matchEditor = this._editor.getCellEditor(match.cell.cellGuid);
+		// expand the cell if it's collapsed and scroll into view
+		match.cell.isCollapsed = false;
 		if (matchEditor) {
 			matchEditor.getContainer().scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 			matchEditor.getControl().revealRangeInCenterIfOutsideViewport(match, ScrollType.Smooth);

--- a/src/sql/workbench/contrib/notebook/find/notebookFindModel.ts
+++ b/src/sql/workbench/contrib/notebook/find/notebookFindModel.ts
@@ -649,9 +649,10 @@ abstract class SettingsCommand extends Command {
 
 class SearchNotebookCommand extends SettingsCommand {
 
-	public runCommand(accessor: ServicesAccessor, args: any): void {
+	public async runCommand(accessor: ServicesAccessor, args: any): Promise<void> {
 		const notebookEditor = this.getNotebookEditor(accessor);
 		if (notebookEditor) {
+			await notebookEditor.setNotebookModel();
 			notebookEditor.toggleSearch();
 		}
 	}


### PR DESCRIPTION
Fixes the below two issues:
1. On ctr+f show find only when the notebook modal is loaded. Currently the find widget shows no results if it's launched before the notebook modal load.
2. If the find result is in a collapsed cell, it doesn't expand the cell and the user is clueless about it.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #8754 
