### PR TITLE
Use a single button for expanding and collapsing a notebook cell.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component.html
@@ -6,5 +6,4 @@
 -->
 <div style="width: 100%; height: fit-content; display: flex; flex-flow: column">
 	<button #collapseCellButton (click)="toggleCollapsed($event)" class="hide-component-button"></button>
-	<button #expandCellButton (click)="toggleCollapsed($event)" style="display:none" class="hide-component-button icon-show-cell"></button>
 </div>

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component.ts
@@ -50,7 +50,6 @@ export class CollapseComponent extends CellView implements OnInit, OnChanges {
 
 	private handleCellCollapse(isCollapsed: boolean): void {
 		let collapseButton = <HTMLElement>this.collapseCellButtonElement.nativeElement;
-
 		if (isCollapsed) {
 			collapseButton.classList.remove(this.collapseButtonClass);
 			collapseButton.classList.add(this.expandButtonClass);

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/collapse.component.ts
@@ -18,7 +18,12 @@ export const COLLAPSE_SELECTOR: string = 'collapse-component';
 
 export class CollapseComponent extends CellView implements OnInit, OnChanges {
 	@ViewChild('collapseCellButton', { read: ElementRef }) private collapseCellButtonElement: ElementRef;
-	@ViewChild('expandCellButton', { read: ElementRef }) private expandCellButtonElement: ElementRef;
+
+	private readonly expandButtonTitle = localize('expandCellContents', "Expand code cell contents");
+	private readonly expandButtonClass = 'icon-show-cell';
+
+	private readonly collapseButtonTitle = localize('collapseCellContents', "Collapse code cell contents");
+	private readonly collapseButtonClass = 'icon-hide-cell';
 
 	@Input() cellModel: ICellModel;
 	@Input() activeCellId: string;
@@ -28,8 +33,6 @@ export class CollapseComponent extends CellView implements OnInit, OnChanges {
 	}
 
 	ngOnInit() {
-		this.collapseCellButtonElement.nativeElement.title = localize('collapseCellContents', "Collapse code cell contents");
-		this.expandCellButtonElement.nativeElement.title = localize('expandCellContents', "Expand code cell contents");
 	}
 
 	ngOnChanges(changes: { [propKey: string]: SimpleChange }) {
@@ -47,13 +50,15 @@ export class CollapseComponent extends CellView implements OnInit, OnChanges {
 
 	private handleCellCollapse(isCollapsed: boolean): void {
 		let collapseButton = <HTMLElement>this.collapseCellButtonElement.nativeElement;
-		let expandButton = <HTMLElement>this.expandCellButtonElement.nativeElement;
+
 		if (isCollapsed) {
-			collapseButton.style.display = 'none';
-			expandButton.style.display = 'block';
+			collapseButton.classList.remove(this.collapseButtonClass);
+			collapseButton.classList.add(this.expandButtonClass);
+			collapseButton.title = this.expandButtonTitle;
 		} else {
-			collapseButton.style.display = 'block';
-			expandButton.style.display = 'none';
+			collapseButton.classList.remove(this.expandButtonClass);
+			collapseButton.classList.add(this.collapseButtonClass);
+			collapseButton.title = this.collapseButtonTitle;
 		}
 	}
 
@@ -74,11 +79,12 @@ export class CollapseComponent extends CellView implements OnInit, OnChanges {
 
 	public toggleIconVisibility(isActiveOrHovered: boolean) {
 		let collapseButton = <HTMLElement>this.collapseCellButtonElement.nativeElement;
-		let buttonClass = 'icon-hide-cell';
-		if (isActiveOrHovered) {
-			collapseButton.classList.add(buttonClass);
-		} else {
-			collapseButton.classList.remove(buttonClass);
+		if (collapseButton.title === this.collapseButtonTitle) {
+			if (isActiveOrHovered) {
+				collapseButton.classList.add(this.collapseButtonClass);
+			} else {
+				collapseButton.classList.remove(this.collapseButtonClass);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/8634