### PR TITLE
fix unstable tests

### DIFF
--- a/extensions/integration-tests/src/cms.test.ts
+++ b/extensions/integration-tests/src/cms.test.ts
@@ -45,7 +45,7 @@ if (isTestSetupCompleted()) {
 			}
 		});
 
-		test('Create CMS Server @UNSTABLE@ @REL@', async function () {
+		test('Create CMS Server @REL@', async function () {
 			// Should fail
 			await utils.assertThrowsAsync(
 				async () => await cmsService.createCmsServer(undefined, 'test_description', undefined, ownerUri),
@@ -66,7 +66,7 @@ if (isTestSetupCompleted()) {
 			await cmsService.createCmsServer(TEST_CMS_NAME, 'test_description', connection, ownerUri);
 		});
 
-		test('Add and delete registered group to/from CMS server @UNSTABLE@ @REL@', async function () {
+		test('Add and delete registered group to/from CMS server @REL@', async function () {
 			await utils.assertThrowsAsync(
 				async () => await cmsService.addServerGroup(ownerUri, '', undefined, 'test_description'),
 				'Cannot add a server group without a name');
@@ -95,7 +95,7 @@ if (isTestSetupCompleted()) {
 				`The server group ${TEST_CMS_GROUP} was not removed successfully. Groups : [${cmsResources.registeredServerGroups.map(g => g.name).join(', ')}]`);
 		});
 
-		test('Add and delete registered server to/from CMS server @UNSTABLE@ @REL@', async function () {
+		test('Add and delete registered server to/from CMS server @REL@', async function () {
 
 			await utils.assertThrowsAsync(
 				async () => cmsService.addRegisteredServer(ownerUri, '', undefined, 'test_description', undefined),
@@ -128,7 +128,7 @@ if (isTestSetupCompleted()) {
 			assert(deleteResult === true, `Registered server ${TEST_CMS_SERVER} was not removed correctly`);
 		});
 
-		test('Add and delete registered server to/from server group @UNSTABLE@ @REL@', async function () {
+		test('Add and delete registered server to/from server group @REL@', async function () {
 
 			// Should create a server group
 			let result = await cmsService.addServerGroup(ownerUri, '', TEST_CMS_GROUP, 'test_description');

--- a/extensions/integration-tests/src/cms.test.ts
+++ b/extensions/integration-tests/src/cms.test.ts
@@ -45,7 +45,7 @@ if (isTestSetupCompleted()) {
 			}
 		});
 
-		test('Create CMS Server @REL@', async function () {
+		test('Create CMS Server', async function () {
 			// Should fail
 			await utils.assertThrowsAsync(
 				async () => await cmsService.createCmsServer(undefined, 'test_description', undefined, ownerUri),
@@ -66,7 +66,7 @@ if (isTestSetupCompleted()) {
 			await cmsService.createCmsServer(TEST_CMS_NAME, 'test_description', connection, ownerUri);
 		});
 
-		test('Add and delete registered group to/from CMS server @REL@', async function () {
+		test('Add and delete registered group to/from CMS server', async function () {
 			await utils.assertThrowsAsync(
 				async () => await cmsService.addServerGroup(ownerUri, '', undefined, 'test_description'),
 				'Cannot add a server group without a name');
@@ -95,7 +95,7 @@ if (isTestSetupCompleted()) {
 				`The server group ${TEST_CMS_GROUP} was not removed successfully. Groups : [${cmsResources.registeredServerGroups.map(g => g.name).join(', ')}]`);
 		});
 
-		test('Add and delete registered server to/from CMS server @REL@', async function () {
+		test('Add and delete registered server to/from CMS server', async function () {
 
 			await utils.assertThrowsAsync(
 				async () => cmsService.addRegisteredServer(ownerUri, '', undefined, 'test_description', undefined),
@@ -128,7 +128,7 @@ if (isTestSetupCompleted()) {
 			assert(deleteResult === true, `Registered server ${TEST_CMS_SERVER} was not removed correctly`);
 		});
 
-		test('Add and delete registered server to/from server group @REL@', async function () {
+		test('Add and delete registered server to/from server group', async function () {
 
 			// Should create a server group
 			let result = await cmsService.addServerGroup(ownerUri, '', TEST_CMS_GROUP, 'test_description');

--- a/extensions/integration-tests/src/dacpac.test.ts
+++ b/extensions/integration-tests/src/dacpac.test.ts
@@ -73,7 +73,7 @@ if (isTestSetupCompleted()) {
 		// Tracking bug https://github.com/microsoft/azuredatastudio/issues/7323
 
 		const bacpac1: string = path.join(__dirname, '..', 'testData', 'Database1.bacpac');
-		test('Import and export bacpac', async function () {
+		test('Import and export bacpac @UNSTABLE@', async function () {
 			const server = await getStandaloneServer();
 			await utils.connectToServer(server);
 

--- a/extensions/integration-tests/src/dacpac.test.ts
+++ b/extensions/integration-tests/src/dacpac.test.ts
@@ -24,7 +24,7 @@ if (isTestSetupCompleted()) {
 			console.log(`Start dacpac tests`);
 		});
 
-		test('Deploy and extract dacpac @UNSTABLE@ @REL@', async function () {
+		test('Deploy and extract dacpac @REL@', async function () {
 			const server = await getStandaloneServer();
 			await utils.connectToServer(server);
 
@@ -41,8 +41,17 @@ if (isTestSetupCompleted()) {
 				// Deploy dacpac
 				const deployResult = await dacfxService.deployDacpac(dacpac1, databaseName, false, ownerUri, azdata.TaskExecutionMode.execute);
 				await utils.assertDatabaseCreationResult(databaseName, ownerUri, retryCount);
-				await utils.assertTableCreationResult(databaseName, 'dbo', 'Table1', ownerUri, retryCount);
-				await utils.assertTableCreationResult(databaseName, 'dbo', 'Table2', ownerUri, retryCount);
+				const dbConnectionId = await utils.connectToServer({
+					serverName: server.serverName,
+					database: databaseName,
+					userName: server.userName,
+					password: server.password,
+					authenticationTypeName: server.authenticationTypeName,
+					providerName: server.providerName
+				});
+				const dbConnectionOwnerUri = await azdata.connection.getUriForConnection(dbConnectionId);
+				await utils.assertTableCreationResult('dbo', 'Table1', dbConnectionOwnerUri, retryCount);
+				await utils.assertTableCreationResult('dbo', 'Table2', dbConnectionOwnerUri, retryCount);
 				assert(deployResult.success === true && deployResult.errorMessage === '', `Deploy dacpac should succeed Expected: there should be no error. Actual Error message: "${deployResult.errorMessage}"`);
 
 				// Extract dacpac
@@ -64,7 +73,7 @@ if (isTestSetupCompleted()) {
 		// Tracking bug https://github.com/microsoft/azuredatastudio/issues/7323
 
 		const bacpac1: string = path.join(__dirname, '..', 'testData', 'Database1.bacpac');
-		test('Import and export bacpac @UNSTABLE@', async function () {
+		test('Import and export bacpac', async function () {
 			const server = await getStandaloneServer();
 			await utils.connectToServer(server);
 
@@ -81,8 +90,17 @@ if (isTestSetupCompleted()) {
 				// Import bacpac
 				const importResult = await dacfxService.importBacpac(bacpac1, databaseName, ownerUri, azdata.TaskExecutionMode.execute);
 				await utils.assertDatabaseCreationResult(databaseName, ownerUri, retryCount);
-				await utils.assertTableCreationResult(databaseName, 'dbo', 'Table1', ownerUri, retryCount, true);
-				await utils.assertTableCreationResult(databaseName, 'dbo', 'Table2', ownerUri, retryCount, true);
+				const dbConnectionId = await utils.connectToServer({
+					serverName: server.serverName,
+					database: databaseName,
+					userName: server.userName,
+					password: server.password,
+					authenticationTypeName: server.authenticationTypeName,
+					providerName: server.providerName
+				});
+				const dbConnectionOwnerUri = await azdata.connection.getUriForConnection(dbConnectionId);
+				await utils.assertTableCreationResult('dbo', 'Table1', dbConnectionOwnerUri, retryCount, true);
+				await utils.assertTableCreationResult('dbo', 'Table2', dbConnectionOwnerUri, retryCount, true);
 				assert(importResult.success === true && importResult.errorMessage === '', `Expected: Import bacpac should succeed and there should be no error. Actual Error message: "${importResult.errorMessage}"`);
 
 				// Export bacpac

--- a/extensions/integration-tests/src/dacpac.test.ts
+++ b/extensions/integration-tests/src/dacpac.test.ts
@@ -24,7 +24,7 @@ if (isTestSetupCompleted()) {
 			console.log(`Start dacpac tests`);
 		});
 
-		test('Deploy and extract dacpac @UNSTABLE@', async function () {
+		test('Deploy and extract dacpac', async function () {
 			const server = await getStandaloneServer();
 			await utils.connectToServer(server);
 
@@ -73,7 +73,7 @@ if (isTestSetupCompleted()) {
 		// Tracking bug https://github.com/microsoft/azuredatastudio/issues/7323
 
 		const bacpac1: string = path.join(__dirname, '..', 'testData', 'Database1.bacpac');
-		test('Import and export bacpac @UNSTABLE@', async function () {
+		test('Import and export bacpac', async function () {
 			const server = await getStandaloneServer();
 			await utils.connectToServer(server);
 

--- a/extensions/integration-tests/src/dacpac.test.ts
+++ b/extensions/integration-tests/src/dacpac.test.ts
@@ -24,7 +24,7 @@ if (isTestSetupCompleted()) {
 			console.log(`Start dacpac tests`);
 		});
 
-		test('Deploy and extract dacpac @REL@', async function () {
+		test('Deploy and extract dacpac @UNSTABLE@ @REL@', async function () {
 			const server = await getStandaloneServer();
 			await utils.connectToServer(server);
 

--- a/extensions/integration-tests/src/dacpac.test.ts
+++ b/extensions/integration-tests/src/dacpac.test.ts
@@ -24,7 +24,7 @@ if (isTestSetupCompleted()) {
 			console.log(`Start dacpac tests`);
 		});
 
-		test('Deploy and extract dacpac @UNSTABLE@ @REL@', async function () {
+		test('Deploy and extract dacpac @UNSTABLE@', async function () {
 			const server = await getStandaloneServer();
 			await utils.connectToServer(server);
 

--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -19,16 +19,16 @@ if (isTestSetupCompleted()) {
 		test('Standalone instance node label test', async function () {
 			return await (new ObjectExplorerTester()).standaloneNodeLabelTest();
 		});
-		test('Azure SQL DB instance node label test @UNSTABLE@', async function () {
+		test('Azure SQL DB instance node label test', async function () {
 			return await (new ObjectExplorerTester()).sqlDbNodeLabelTest();
 		});
 		test.skip('BDC instance context menu test', async function () {
 			return await (new ObjectExplorerTester()).bdcContextMenuTest();
 		});
-		test('Azure SQL DB context menu test @UNSTABLE@', async function () {
+		test('Azure SQL DB context menu test', async function () {
 			return await (new ObjectExplorerTester()).sqlDbContextMenuTest();
 		});
-		test('Standalone database context menu test @UNSTABLE@', async function () {
+		test('Standalone database context menu test', async function () {
 			return await (new ObjectExplorerTester()).standaloneContextMenuTest();
 		});
 	});
@@ -152,7 +152,7 @@ class ObjectExplorerTester {
 			const serverNode = nodes[index];
 			const children = await serverNode.getChildren();
 
-			assert(children[0].label.toLocaleLowerCase === 'Databases'.toLocaleLowerCase, `Expected Databases node. Actual ${children[0].label}`);
+			assert(children[0].label === 'Databases', `Expected Databases node. Actual ${children[0].label}`);
 			const databasesFolder = children[0];
 
 			const databases = await databasesFolder.getChildren();

--- a/extensions/integration-tests/src/objectExplorer.test.ts
+++ b/extensions/integration-tests/src/objectExplorer.test.ts
@@ -19,7 +19,7 @@ if (isTestSetupCompleted()) {
 		test('Standalone instance node label test', async function () {
 			return await (new ObjectExplorerTester()).standaloneNodeLabelTest();
 		});
-		test('Azure SQL DB instance node label test', async function () {
+		test('Azure SQL DB instance node label test @UNSTABLE@', async function () {
 			return await (new ObjectExplorerTester()).sqlDbNodeLabelTest();
 		});
 		test.skip('BDC instance context menu test', async function () {

--- a/extensions/integration-tests/src/schemaCompare.test.ts
+++ b/extensions/integration-tests/src/schemaCompare.test.ts
@@ -44,7 +44,7 @@ if (isTestSetupCompleted()) {
 		test('Schema compare dacpac to dacpac comparison and scmp', async function () {
 			await schemaCompareTester.SchemaCompareDacpacToDacpac();
 		});
-		test('Schema compare database to database comparison, script generation, and scmp @UNSTABLE@', async function () {
+		test('Schema compare database to database comparison, script generation, and scmp', async function () {
 			await schemaCompareTester.SchemaCompareDatabaseToDatabase();
 		});
 		// TODO: figure out why this is failing with Error: This editor is not connected to a database Parameter name: OwnerUri

--- a/extensions/integration-tests/src/testConfig.ts
+++ b/extensions/integration-tests/src/testConfig.ts
@@ -67,7 +67,15 @@ export const EnvironmentVariable_STANDALONE_SERVER_2019: string = 'STANDALONE_SQ
 export const EnvironmentVariable_STANDALONE_USERNAME_2019: string = 'STANDALONE_SQL_USERNAME_2019';
 export const EnvironmentVariable_STANDALONE_PASSWORD_2019: string = 'STANDALONE_SQL_PWD_2019';
 
-export class TestServerProfile {
+export interface TestConnectionInfo {
+	readonly serverName: string;
+	readonly database: string;
+	readonly userName: string;
+	readonly password: string;
+	readonly providerName: string;
+	readonly authenticationTypeName: string;
+}
+export class TestServerProfile implements TestConnectionInfo {
 	constructor(private _profile: ITestServerProfile) { }
 	public get serverName(): string { return this._profile.serverName; }
 	public get userName(): string { return this._profile.userName; }

--- a/extensions/integration-tests/src/utils.ts
+++ b/extensions/integration-tests/src/utils.ts
@@ -7,26 +7,26 @@ import * as assert from 'assert';
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import { TestServerProfile } from './testConfig';
+import { TestServerProfile, TestConnectionInfo } from './testConfig';
 import { isNullOrUndefined } from 'util';
 
 // default server connection timeout
 export const DefaultConnectTimeoutInMs: number = 10000;
 
 /**
- * @param server test connection profile
+ * @param connectionInfo test connection profile
  * @param timeout optional timeout parameter
  * Returns connection id for a new connection
  */
-export async function connectToServer(server: TestServerProfile, timeout: number = DefaultConnectTimeoutInMs): Promise<string> {
+export async function connectToServer(connectionInfo: TestConnectionInfo, timeout: number = DefaultConnectTimeoutInMs): Promise<string> {
 	let connectionProfile: azdata.IConnectionProfile = {
-		serverName: server.serverName,
-		databaseName: server.database,
-		authenticationType: server.authenticationTypeName,
-		providerName: server.providerName,
+		serverName: connectionInfo.serverName,
+		databaseName: connectionInfo.database,
+		authenticationType: connectionInfo.authenticationTypeName,
+		providerName: connectionInfo.providerName,
 		connectionName: '',
-		userName: server.userName,
-		password: server.password,
+		userName: connectionInfo.userName,
+		password: connectionInfo.password,
 		savePassword: false,
 		groupFullName: undefined,
 		saveProfile: true,
@@ -182,16 +182,22 @@ export async function assertDatabaseCreationResult(databaseName: string, ownerUr
 	let result: azdata.SimpleExecuteResult;
 	while (retryCount > 0) {
 		--retryCount;
-
-		let query = `BEGIN TRY
-				SELECT name FROM master.dbo.sysdatabases WHERE name='${databaseName}'
+		// add state=0 to the query to make sure the database is online
+		const query = `BEGIN TRY
+				SELECT name FROM sys.databases WHERE name='${databaseName}' AND state=0
 			END TRY
 			BEGIN CATCH
 				SELECT ERROR_MESSAGE() AS ErrorMessage;
 			END CATCH`;
-		result = await runQuery(query, ownerUri);
-		if (result.rowCount > 0) {
-			break;
+		try {
+			result = await runQuery(query, ownerUri);
+			if (result.rowCount > 0) {
+				break;
+			}
+		}
+		catch {
+			// exception will be thrown by the SQL Tools Service if no results is returned
+			// ignore it.
 		}
 
 		await sleep(5000);
@@ -222,7 +228,6 @@ export async function assertFileGenerationResult(filepath: string, retryCount: n
 
 /**
  *
- * @param databaseName name of database where to look for table
  * @param tableName table to look for
  * @param schema schema to look for
  * @param ownerUri owner uri
@@ -230,12 +235,11 @@ export async function assertFileGenerationResult(filepath: string, retryCount: n
  * @param checkForData whether or not to check if the table has data
  * Checks for table existing
  */
-export async function assertTableCreationResult(databaseName: string, schema: string, tableName: string, ownerUri: string, retryCount: number, checkForData?: boolean): Promise<void> {
+export async function assertTableCreationResult(schema: string, tableName: string, ownerUri: string, retryCount: number, checkForData?: boolean): Promise<void> {
 	let result: azdata.SimpleExecuteResult;
 	while (retryCount > 0) {
 		--retryCount;
 		let query = `BEGIN TRY
-				USE ${databaseName}
 				SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '${schema}' AND TABLE_NAME = '${tableName}'
 			END TRY
 			BEGIN CATCH
@@ -254,7 +258,6 @@ export async function assertTableCreationResult(databaseName: string, schema: st
 	if (checkForData) {
 		while (retryCount > 0) {
 			let query = `BEGIN TRY
-					USE ${databaseName}
 					SELECT * FROM ${tableName}
 				END TRY
 				BEGIN CATCH

--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "2.0.0-release.40",
+	"version": "2.0.0-release.42",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",


### PR DESCRIPTION
1. fix the 'editor is not connected' error, the root cause is we were switching database context of the underlying connection, the fix is to use a new dedicated connection to the desired database. (leaving it as unstable due to new errors were discovered, @kisantia made changes in SQL Tools Service to fix the new issue). 
2. remove the unstable tag for the test cases that are passing consistently.

see the test runs
![Screen Shot 2020-01-02 at 3 54 12 PM](https://user-images.githubusercontent.com/13777222/71700258-44187380-2d78-11ea-8e27-b4e190f72525.png)
