### PR TITLE
Increase code signing timeout for Mac builds.

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -130,7 +130,7 @@ steps:
             "toolVersion": "1.0"
           }
         ]
-      SessionTimeout: 20
+      SessionTimeout: 60
     condition: and(succeeded(), eq(variables['signed'], true))
 
   - script: |


### PR DESCRIPTION
We've been hitting a lot of signing timeouts in the Mac builds today, so hopefully increasing the timeout will help. We already use a 600 minute timeout for the Windows signing step, so using 60 minutes here isn't too outrageous.