### PR TITLE
Change test timeout for extension unit tests to 10sec

### DIFF
--- a/extensions/admin-tool-ext-win/src/test/index.ts
+++ b/extensions/admin-tool-ext-win/src/test/index.ts
@@ -11,7 +11,7 @@ const suite = 'admin-tool-ext-win Extension Tests';
 const options: any = {
 	ui: 'bdd',
 	useColors: true,
-	timeout: 600000
+	timeout: 10000
 };
 
 // set relevant mocha options from the environment

--- a/extensions/agent/src/test/index.ts
+++ b/extensions/agent/src/test/index.ts
@@ -11,7 +11,7 @@ const suite = 'agent Extension Tests';
 const options: any = {
 	ui: 'bdd',
 	useColors: true,
-	timeout: 600000
+	timeout: 10000
 };
 
 // set relevant mocha options from the environment

--- a/extensions/azurecore/src/test/index.ts
+++ b/extensions/azurecore/src/test/index.ts
@@ -11,7 +11,7 @@ const suite = 'azurecore Extension Tests';
 const options: any = {
 	ui: 'bdd',
 	useColors: true,
-	timeout: 60000
+	timeout: 10000
 };
 
 // set relevant mocha options from the environment

--- a/extensions/cms/src/test/index.ts
+++ b/extensions/cms/src/test/index.ts
@@ -11,7 +11,7 @@ const suite = 'cms Extension Tests';
 const options: any = {
 	ui: 'bdd',
 	useColors: true,
-	timeout: 60000
+	timeout: 10000
 };
 
 // set relevant mocha options from the environment

--- a/extensions/dacpac/src/test/index.ts
+++ b/extensions/dacpac/src/test/index.ts
@@ -11,7 +11,7 @@ const suite = 'dacpac Extension Tests';
 const testOptions: any = {
 	ui: 'bdd',
 	useColors: true,
-	timeout: 60000
+	timeout: 10000
 };
 
 // set relevant mocha options from the environment

--- a/extensions/integration-tests/src/index.ts
+++ b/extensions/integration-tests/src/index.ts
@@ -12,7 +12,7 @@ const suite = getSuiteType();
 const options: any = {
 	ui: 'tdd',
 	useColors: true,
-	timeout: 600000 	// 600 seconds
+	timeout: 10000
 };
 
 if (suite === SuiteType.Stress) {

--- a/extensions/machine-learning-services/src/test/index.ts
+++ b/extensions/machine-learning-services/src/test/index.ts
@@ -11,7 +11,7 @@ const suite = 'machine learning Extension Tests';
 const options: any = {
 	ui: 'bdd',
 	useColors: true,
-	timeout: 600000
+	timeout: 10000
 };
 
 // set relevant mocha options from the environment

--- a/extensions/notebook/src/integrationTest/index.ts
+++ b/extensions/notebook/src/integrationTest/index.ts
@@ -11,7 +11,7 @@ const suite = 'notebook Extension Integration Tests';
 const options: any = {
 	ui: 'bdd',
 	useColors: true,
-	timeout: 600000
+	timeout: 10000
 };
 
 // set relevant mocha options from the environment

--- a/extensions/notebook/src/test/index.ts
+++ b/extensions/notebook/src/test/index.ts
@@ -11,7 +11,7 @@ const suite = 'notebook Extension Tests';
 const options: any = {
 	ui: 'bdd',
 	useColors: true,
-	timeout: 600000
+	timeout: 10000
 };
 
 // set relevant mocha options from the environment

--- a/extensions/resource-deployment/src/test/index.ts
+++ b/extensions/resource-deployment/src/test/index.ts
@@ -11,7 +11,7 @@ const suite = 'resource-deployment Extension Tests';
 const testOptions: any = {
 	ui: 'tdd',
 	useColors: true,
-	timeout: 60000
+	timeout: 10000
 };
 
 // set relevant mocha options from the environment

--- a/extensions/schema-compare/src/test/index.ts
+++ b/extensions/schema-compare/src/test/index.ts
@@ -11,7 +11,7 @@ const suite = 'schema-compare Extension Tests';
 const options: any = {
 	ui: 'bdd',
 	useColors: true,
-	timeout: 60000
+	timeout: 10000
 };
 
 // set relevant mocha options from the environment


### PR DESCRIPTION
It was previously at 600sec which seems like a bit much for these tests and would mean any hanging test would slow down everything else as it waited for the huge timeout to be reached (and usually just end up hitting the build timeout or something in the lab). I see no reason these tests should be taking nearly that long so moving the timeout down to a more reasonable 10sec. 