### PR TITLE
update govt cloud login endpoint

### DIFF
--- a/extensions/azurecore/src/account-provider/providerSettings.ts
+++ b/extensions/azurecore/src/account-provider/providerSettings.ts
@@ -45,7 +45,7 @@ const usGovAzureSettings: ProviderSettings = {
 		displayName: localize('usGovCloudDisplayName', "Azure (US Government)"),
 		id: 'usGovAzureCloud',
 		settings: {
-			host: 'https://login.microsoftonline.com/',
+			host: 'https://login.microsoftonline.us',
 			clientId: 'TBD',
 			signInResourceId: 'https://management.core.usgovcloudapi.net/',
 			graphResource: {


### PR DESCRIPTION
Updating the authentication endpoint for US government clouds.  Currently we have the public cloud endpoint and instead we should have the government cloud specific authentication endpoint.

We don't currently support connecting to government cloud fully as we are waiting on the client IDs to get approved so this is simply to make sure we have the right endpoint for government cloud once we have the client IDs.  
