### PR TITLE
Increase timeouts

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -130,7 +130,7 @@ steps:
             "toolVersion": "1.0"
           }
         ]
-      SessionTimeout: 60
+      SessionTimeout: 125
     condition: and(succeeded(), eq(variables['signed'], true))
 
   - script: |

--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -20,6 +20,7 @@ jobs:
   - Compile
   steps:
   - template: darwin/sql-product-build-darwin.yml
+  timeoutInMinutes: 180
 
 - job: Linux
   condition: eq(variables['VSCODE_BUILD_LINUX'], 'true')


### PR DESCRIPTION
This increases the timeouts for signing and building.

It's based on their SLA of 120 minutes for signing of 50-150 MB packages with large number of files.

We're also going to need to raise this for notarization as well.