### PR TITLE
allow extension to contribute top level dashboard tab

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -139,6 +139,9 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		// Before separating tabs into pinned / shown, ensure that the home tab is always set up as expected
 		allTabs = this.setAndRemoveHomeTab(allTabs, homeWidgets);
 
+		this.loadNewTabs(allTabs.filter((tab) => tab.isTopLevelTab));
+		this.addExtensionsTabGroup();
+
 		// If preview features are disabled only show the home tab
 		const extensionTabsEnabled = this.configurationService.getValue('workbench')['enablePreviewFeatures'];
 		if (!extensionTabsEnabled) {
@@ -148,7 +151,7 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		// Load tab setting configs
 		this._tabSettingConfigs = this.dashboardService.getSettings<Array<TabSettingConfig>>([this.context, 'tabs'].join('.'));
 
-		this.loadNewTabs(allTabs);
+		this.loadNewTabs(allTabs.filter((tab) => !tab.isTopLevelTab));
 
 		this.panelActions = [];
 
@@ -167,6 +170,21 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		this._tabsDispose.push(this.dashboardService.onAddNewTabs(e => {
 			this.loadNewTabs(e, true);
 		}));
+	}
+
+	private addExtensionsTabGroup(): void {
+		this.addNewTab({
+			id: 'extensionGroupHeader',
+			provider: Constants.anyProviderName,
+			originalConfig: [],
+			publisher: undefined,
+			title: nls.localize('dashboard.extensionGroupHeader', "Extensions"),
+			context: this.context,
+			type: 'group-header',
+			editable: false,
+			canClose: false,
+			actions: []
+		});
 	}
 
 	private setAndRemoveHomeTab(allTabs: IDashboardTab[], homeWidgets: WidgetConfig[]): IDashboardTab[] {
@@ -192,18 +210,6 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 			homeTabConfig.container = tabConfig.container;
 		}
 		this.addNewTab(homeTabConfig);
-		this.addNewTab({
-			id: 'extensionGroupHeader',
-			provider: Constants.anyProviderName,
-			originalConfig: [],
-			publisher: undefined,
-			title: nls.localize('dashboard.extensionGroupHeader', "Extensions"),
-			context: this.context,
-			type: 'group-header',
-			editable: false,
-			canClose: false,
-			actions: []
-		});
 		return allTabs;
 	}
 

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution.ts
@@ -25,6 +25,7 @@ export interface IDashboardTabContrib {
 	description?: string;
 	alwaysShow?: boolean;
 	isHomeTab?: boolean;
+	isTopLevelTab?: boolean;
 }
 
 const tabSchema: IJSONSchema = {
@@ -63,6 +64,10 @@ const tabSchema: IJSONSchema = {
 		isHomeTab: {
 			description: localize('azdata.extension.contributes.dashboard.tab.isHomeTab', "Whether or not this tab should be used as the Home tab for a connection type."),
 			type: 'boolean'
+		},
+		isTopLevelTab: {
+			description: localize('azdata.extension.contributes.dashboard.tab.isTopLevelTab', "Whether or not this tab should be next to Home tab, if not it will be shown under Extensions group."),
+			type: 'boolean'
 		}
 	}
 };
@@ -81,12 +86,18 @@ const tabContributionSchema: IJSONSchema = {
 ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabContrib[]>({ extensionPoint: 'dashboard.tabs', jsonSchema: tabContributionSchema }).setHandler(extensions => {
 
 	function handleCommand(tab: IDashboardTabContrib, extension: IExtensionPointUser<any>) {
-		let { description, container, provider, title, when, id, alwaysShow, isHomeTab } = tab;
+		let { description, container, provider, title, when, id, alwaysShow, isHomeTab, isTopLevelTab } = tab;
 
 		// If always show is not specified, set it to true by default.
 		if (!types.isBoolean(alwaysShow)) {
 			alwaysShow = true;
 		}
+
+		// If isTopLevelTab is not specified, set it to true by default.
+		if (!types.isBoolean(isTopLevelTab)) {
+			isTopLevelTab = false;
+		}
+
 		const publisher = extension.description.publisher;
 		if (!title) {
 			extension.collector.error(localize('dashboardTab.contribution.noTitleError', "No title specified for extension."));
@@ -131,7 +142,7 @@ ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabCo
 		}
 
 		if (result) {
-			registerTab({ description, title, container, provider, when, id, alwaysShow, publisher, isHomeTab });
+			registerTab({ description, title, container, provider, when, id, alwaysShow, publisher, isHomeTab, isTopLevelTab });
 		}
 	}
 

--- a/src/sql/workbench/contrib/dashboard/browser/dashboardRegistry.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/dashboardRegistry.ts
@@ -29,6 +29,7 @@ export interface IDashboardTab {
 	when?: string;
 	alwaysShow?: boolean;
 	isHomeTab?: boolean;
+	isTopLevelTab?: boolean;
 }
 
 export interface IDashboardRegistry {


### PR DESCRIPTION
with the new dashboard design, all contributed tabs will appear under extensions group, add a flag to allow extensions to contribute a top level tab, for now this is designed for the big data cluster dashboard tab.

![Screen Shot 2020-01-13 at 12 00 21 PM](https://user-images.githubusercontent.com/13777222/72287772-7ccc0e80-35fc-11ea-88cc-b3018a129e63.png)

sample code:

in package.json's tab contribution section add
````JSON
      {
        "id": "test-modelview",
        "description": "bababa",
        "provider": "MSSQL",
        "title": "bababa",
        "when": "connectionProvider == 'MSSQL'",
        "isTopLevelTab": true,
        "container": {
          "modelview-container": {}
        }
      }
````

in extension code, register a model view provider
````TypeScript
	azdata.ui.registerModelViewProvider('test-modelview', async (view) => {
		const text = view.modelBuilder.text().withProperties<azdata.TextComponentProperties>({ value: 'my tab goes here' }).component();
		return view.initializeModel(text);
	});
````