### PR TITLE
Revert timeout changes for integration tests.

### DIFF
--- a/extensions/integration-tests/src/index.ts
+++ b/extensions/integration-tests/src/index.ts
@@ -12,7 +12,7 @@ const suite = getSuiteType();
 const options: any = {
 	ui: 'tdd',
 	useColors: true,
-	timeout: 10000
+	timeout: 600000
 };
 
 if (suite === SuiteType.Stress) {

--- a/extensions/notebook/src/integrationTest/index.ts
+++ b/extensions/notebook/src/integrationTest/index.ts
@@ -11,7 +11,7 @@ const suite = 'notebook Extension Integration Tests';
 const options: any = {
 	ui: 'bdd',
 	useColors: true,
-	timeout: 10000
+	timeout: 600000
 };
 
 // set relevant mocha options from the environment


### PR DESCRIPTION
Some of our integration tests started timing out after the timeouts were decreased in https://github.com/microsoft/azuredatastudio/commit/7ecb6b442716dd43d080c3c09a2749b9ff63570d

This PR reverts the timeout changes just for the integration tests.