### PR TITLE
getter for markdown editor on edit mode

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -117,7 +117,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	 */
 	getEditor(): BaseTextEditor | undefined {
 		if (this.markdowncodeCell.length > 0) {
-			return this.markdowncodeCell.toArray()[0].getEditor();
+			return this.markdowncodeCell.first.getEditor();
 		}
 		return undefined;
 	}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -6,7 +6,7 @@ import 'vs/css!./textCell';
 import 'vs/css!./media/markdown';
 import 'vs/css!./media/highlight';
 
-import { OnInit, Component, Input, Inject, forwardRef, ElementRef, ChangeDetectorRef, ViewChild, OnChanges, SimpleChange, HostListener } from '@angular/core';
+import { OnInit, Component, Input, Inject, forwardRef, ElementRef, ChangeDetectorRef, ViewChild, OnChanges, SimpleChange, HostListener, ViewChildren, QueryList } from '@angular/core';
 
 import { localize } from 'vs/nls';
 import { IColorTheme, IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
@@ -25,6 +25,8 @@ import { NotebookModel } from 'sql/workbench/contrib/notebook/browser/models/not
 import { ISanitizer, defaultSanitizer } from 'sql/workbench/contrib/notebook/browser/outputs/sanitizer';
 import { CellToggleMoreActions } from 'sql/workbench/contrib/notebook/browser/cellToggleMoreActions';
 import { NotebookRange } from 'sql/workbench/contrib/notebook/find/notebookFindDecorations';
+import { CodeComponent } from 'sql/workbench/contrib/notebook/browser/cellViews/code.component';
+import { BaseTextEditor } from 'vs/workbench/browser/parts/editor/textEditor';
 
 export const TEXT_SELECTOR: string = 'text-cell-component';
 const USER_SELECT_CLASS = 'actionselect';
@@ -37,6 +39,8 @@ const USER_SELECT_CLASS = 'actionselect';
 export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	@ViewChild('preview', { read: ElementRef }) private output: ElementRef;
 	@ViewChild('moreactions', { read: ElementRef }) private moreActionsElementRef: ElementRef;
+	@ViewChildren(CodeComponent) private markdowncodeCell: QueryList<CodeComponent>;
+
 	@Input() cellModel: ICellModel;
 
 	@Input() set model(value: NotebookModel) {
@@ -107,6 +111,15 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 
 	get activeCellId(): string {
 		return this._activeCellId;
+	}
+	/**
+	 * Returns the code editor of makrdown cell in edit mode.
+	 */
+	getEditor(): BaseTextEditor | undefined {
+		if (this.markdowncodeCell.length > 0) {
+			return this.markdowncodeCell.toArray()[0].getEditor();
+		}
+		return undefined;
 	}
 
 	private setLoading(isLoading: boolean): void {

--- a/src/sql/workbench/contrib/notebook/find/notebookFindDecorations.ts
+++ b/src/sql/workbench/contrib/notebook/find/notebookFindDecorations.ts
@@ -128,7 +128,7 @@ export class NotebookFindDecorations implements IDisposable {
 
 	private removePrevDecorations(): void {
 		if (this._currentMatch && this._currentMatch.cell) {
-			let pevEditor = this._editor.getCellEditor(this._currentMatch.cell.cellGuid);
+			let pevEditor = this._currentMatch.cell.cellType === 'markdown' ? undefined : this._editor.getCellEditor(this._currentMatch.cell.cellGuid);
 			if (pevEditor) {
 				pevEditor.getControl().changeDecorations((changeAccessor: IModelDecorationsChangeAccessor) => {
 					changeAccessor.removeDecoration(this._rangeHighlightDecorationId);
@@ -153,7 +153,7 @@ export class NotebookFindDecorations implements IDisposable {
 	}
 
 	public checkValidEditor(range: NotebookRange): boolean {
-		return range && range.cell && !!(this._editor.getCellEditor(range.cell.cellGuid));
+		return range && range.cell && range.cell.cellType === 'code' && !!(this._editor.getCellEditor(range.cell.cellGuid));
 	}
 
 	public set(findMatches: NotebookFindMatch[], findScope: NotebookRange | null): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

Implemented getEditor for textCell component which returns undefined normally and in edit mode returns the code editor. (This aids Rajesh for his split cell work.)