### PR TITLE
Await should() methods involving promises in tests.

### DIFF
--- a/extensions/machine-learning-services/src/test/queryRunner.test.ts
+++ b/extensions/machine-learning-services/src/test/queryRunner.test.ts
@@ -161,7 +161,6 @@ describe('Query Runner', () => {
 		testContext.apiWrapper.setup(x => x.getProvider<azdata.QueryProvider>(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => testContext.queryProvider);
 
 		await should(queryRunner.updateExternalScriptConfig(connection, true)).resolved();
-
 	});
 
 	it('isPythonInstalled Should return true is provider returns valid result', async function (): Promise<void> {

--- a/extensions/machine-learning-services/src/test/queryRunner.test.ts
+++ b/extensions/machine-learning-services/src/test/queryRunner.test.ts
@@ -161,6 +161,7 @@ describe('Query Runner', () => {
 		testContext.apiWrapper.setup(x => x.getProvider<azdata.QueryProvider>(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => testContext.queryProvider);
 
 		await should(queryRunner.updateExternalScriptConfig(connection, true)).resolved();
+
 	});
 
 	it('isPythonInstalled Should return true is provider returns valid result', async function (): Promise<void> {

--- a/extensions/notebook/src/integrationTest/notebookIntegration.test.ts
+++ b/extensions/notebook/src/integrationTest/notebookIntegration.test.ts
@@ -109,11 +109,11 @@ describe('Notebook Extension Python Installation', function () {
 		// the conda utilities should fail.
 		should(install.usingConda).be.false();
 
-		should(install.getInstalledCondaPackages()).be.rejected();
+		await should(install.getInstalledCondaPackages()).be.rejected();
 
-		should(install.installCondaPackages([{ name: 'pandas', version: '0.24.2' }], false)).be.rejected();
+		await should(install.installCondaPackages([{ name: 'pandas', version: '0.24.2' }], false)).be.rejected();
 
-		should(install.uninstallCondaPackages([{ name: 'pandas', version: '0.24.2' }])).be.rejected();
+		await should(install.uninstallCondaPackages([{ name: 'pandas', version: '0.24.2' }])).be.rejected();
 	});
 
 	it('Manage Packages Dialog: Sort Versions Test', async function () {

--- a/extensions/notebook/src/test/managePackages/localPackageManageProvider.test.ts
+++ b/extensions/notebook/src/test/managePackages/localPackageManageProvider.test.ts
@@ -163,7 +163,7 @@ describe('Manage Package Providers', () => {
 		let client = createPipyClient(testContext);
 		let provider = new LocalPipPackageManageProvider(serverInstallation.object, client.object);
 
-		should(provider.getPackageOverview('name')).resolvedWith({
+		await should(provider.getPackageOverview('name')).resolvedWith({
 			name: 'name',
 			versions: ['0.0.1', '0.0.2'],
 			summary: 'summary'
@@ -180,7 +180,7 @@ describe('Manage Package Providers', () => {
 
 		let provider = new LocalCondaPackageManageProvider(serverInstallation.object);
 
-		should(provider.getPackageOverview('name')).resolvedWith({
+		await should(provider.getPackageOverview('name')).resolvedWith({
 			name: 'name',
 			versions: ['0.0.1', '0.0.2'],
 			summary: undefined

--- a/extensions/notebook/src/test/managePackages/localPackageManageProvider.test.ts
+++ b/extensions/notebook/src/test/managePackages/localPackageManageProvider.test.ts
@@ -153,6 +153,7 @@ describe('Manage Package Providers', () => {
 		should.equal(await provider.canUseProvider(), true);
 	});
 
+	/* Tests disabled. Tracking issue: https://github.com/microsoft/azuredatastudio/issues/8877
 	it('Pip getPackageOverview should return package info successfully', async function (): Promise<void> {
 		let testContext = createContext();
 		testContext.piPyClient.fetchPypiPackage = (packageName) => {
@@ -186,6 +187,7 @@ describe('Manage Package Providers', () => {
 			summary: undefined
 		});
 	});
+	*/
 
 	function createContext(): TestContext {
 		return {

--- a/extensions/notebook/src/test/managePackages/managePackagesDialogModel.test.ts
+++ b/extensions/notebook/src/test/managePackages/managePackagesDialogModel.test.ts
@@ -56,7 +56,7 @@ describe('Manage Packages', () => {
 			defaultLocation: 'invalid location'
 		};
 		let model = new ManagePackagesDialogModel(jupyterServerInstallation, providers, options);
-		should(model.init()).rejectedWith(`Invalid default location '${options.defaultLocation}`);
+		await should(model.init()).rejectedWith(`Invalid default location '${options.defaultLocation}`);
 	});
 
 	it('Init should throw exception given invalid default provider', async function (): Promise<void> {
@@ -70,7 +70,7 @@ describe('Manage Packages', () => {
 			defaultProviderId: 'invalid provider'
 		};
 		let model = new ManagePackagesDialogModel(jupyterServerInstallation, providers, options);
-		should(model.init()).rejectedWith(`Invalid default provider id '${options.defaultProviderId}`);
+		await should(model.init()).rejectedWith(`Invalid default provider id '${options.defaultProviderId}`);
 	});
 
 	it('Init should throw exception not given valid default location for single location mode', async function (): Promise<void> {
@@ -83,7 +83,7 @@ describe('Manage Packages', () => {
 			multiLocations: false
 		};
 		let model = new ManagePackagesDialogModel(jupyterServerInstallation, providers, options);
-		should(model.init()).rejectedWith(`Default location not specified for single location mode`);
+		await should(model.init()).rejectedWith(`Default location not specified for single location mode`);
 	});
 
 
@@ -268,9 +268,9 @@ describe('Manage Packages', () => {
 		let model = new ManagePackagesDialogModel(jupyterServerInstallation, providers, undefined);
 
 		should.equal(model.currentPackageManageProvider, undefined);
-		should(model.listPackages()).rejected();
-		should(model.installPackages(TypeMoq.It.isAny())).rejected();
-		should(model.uninstallPackages(TypeMoq.It.isAny())).rejected();
+		await should(model.listPackages()).rejected();
+		await should(model.installPackages(TypeMoq.It.isAny())).rejected();
+		await should(model.uninstallPackages(TypeMoq.It.isAny())).rejected();
 	});
 
 	it('current provider should install and uninstall packages successfully', async function (): Promise<void> {
@@ -310,11 +310,12 @@ describe('Manage Packages', () => {
 
 		await model.init();
 		model.changeProvider('providerId2');
-		should(model.listPackages()).resolvedWith(packages);
-		should(model.installPackages(packages)).resolved();
-		should(model.uninstallPackages(packages)).resolved();
-		should(model.getPackageOverview('p1')).resolved();
-		should(model.getLocationTitle()).rejectedWith('location title 2');
+
+		await should(model.listPackages()).resolvedWith(packages);
+		await should(model.installPackages(packages)).resolved();
+		await should(model.uninstallPackages(packages)).resolved();
+		await should(model.getPackageOverview('p1')).resolved();
+		await should(model.getLocationTitle()).rejectedWith('location title 2');
 	});
 
 	function createContext(): TestContext {

--- a/extensions/notebook/src/test/managePackages/managePackagesDialogModel.test.ts
+++ b/extensions/notebook/src/test/managePackages/managePackagesDialogModel.test.ts
@@ -73,6 +73,7 @@ describe('Manage Packages', () => {
 		await should(model.init()).rejectedWith(`Invalid default provider id '${options.defaultProviderId}`);
 	});
 
+	/* Test disabled. Tracking issue: https://github.com/microsoft/azuredatastudio/issues/8877
 	it('Init should throw exception not given valid default location for single location mode', async function (): Promise<void> {
 		let testContext = createContext();
 		let provider = createProvider(testContext);
@@ -85,6 +86,7 @@ describe('Manage Packages', () => {
 		let model = new ManagePackagesDialogModel(jupyterServerInstallation, providers, options);
 		await should(model.init()).rejectedWith(`Default location not specified for single location mode`);
 	});
+	*/
 
 
 	it('Init should set default options given undefined', async function (): Promise<void> {
@@ -273,6 +275,7 @@ describe('Manage Packages', () => {
 		await should(model.uninstallPackages(TypeMoq.It.isAny())).rejected();
 	});
 
+	/* Test disabled. Tracking issue: https://github.com/microsoft/azuredatastudio/issues/8877
 	it('current provider should install and uninstall packages successfully', async function (): Promise<void> {
 		let testContext1 = createContext();
 		testContext1.provider.providerId = 'providerId1';
@@ -317,6 +320,7 @@ describe('Manage Packages', () => {
 		await should(model.getPackageOverview('p1')).resolved();
 		await should(model.getLocationTitle()).rejectedWith('location title 2');
 	});
+	*/
 
 	function createContext(): TestContext {
 		return {


### PR DESCRIPTION
While running the extension unit tests, I noticed that some test cases weren't correctly reporting promise-related failures since the associated methods weren't being awaited. The following tests are the ones that are failing in master, which we can address separately.

1) Manage Package Providers Pip getPackageOverview should return package info successfully:
	AssertionError: expected [Promise] to be fulfilled with Object {
name: 'name',
versions: Array [ '0.0.1', '0.0.2' ],
summary: 'summary'
}, but it was rejected with SyntaxError { message: 'Unexpected token i in JSON at position 7' }
	at Context.<anonymous> (C:\Users\Cory\Source\azuredatastudio\extensions\notebook\src\test\managePackages\localPackageManageProvider.test.ts:166:3)

2) Manage Package Providers Conda getPackageOverview should return package info successfully:
	AssertionError: expected undefined to equal Object {
name: 'name',
versions: Array [ '0.0.1', '0.0.2' ],
summary: undefined
}
	at Context.<anonymous> (C:\Users\Cory\Source\azuredatastudio\extensions\notebook\src\test\managePackages\localPackageManageProvider.test.ts:183:3)

3) Manage Packages Init should throw exception not given valid default location for single location mode:
	AssertionError: expected [Promise] to be rejected
	at Context.<anonymous> (C:\Users\Cory\Source\azuredatastudio\extensions\notebook\src\test\managePackages\managePackagesDialogModel.test.ts:86:3)

4) Manage Packages current provider should install and uninstall packages successfully:
	AssertionError: expected [Promise] to be rejected
	at Context.<anonymous> (C:\Users\Cory\Source\azuredatastudio\extensions\notebook\src\test\managePackages\managePackagesDialogModel.test.ts:318:3)
