### PR TITLE
content tab group

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -437,6 +437,12 @@
         }
       ]
     },
+    "dashboard.tabGroups": [
+      {
+        "id": "contents",
+        "title": "%contents-tab-group-title%"
+      }
+    ],
     "dashboard.tabs": [
       {
         "id": "mssql-big-data-cluster",
@@ -481,6 +487,28 @@
                 "modelview": {
                   "id": "books-widget"
                 }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "databases-tab",
+        "description": "%databases-tab-description%",
+        "provider": "MSSQL",
+        "title": "%databases-tab-title%",
+        "when": "",
+        "group": "contents",
+        "container": {
+          "widgets-container": [
+            {
+              "name": "%databases-widget-title%",
+              "gridItemConfig": {
+                "sizex": 3,
+                "sizey": 3
+              },
+              "widget": {
+                "explorer-widget": {}
               }
             }
           ]

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -497,7 +497,7 @@
         "description": "%databases-tab-description%",
         "provider": "MSSQL",
         "title": "%databases-tab-title%",
-        "when": "",
+        "when": "dashboardContext == 'server'",
         "group": "contents",
         "container": {
           "widgets-container": [

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -131,5 +131,10 @@
 	"mssql.connectionOptions.packetSize.displayName": "Packet size",
 	"mssql.connectionOptions.packetSize.description": "Size in bytes of the network packets used to communicate with an instance of SQL Server",
 	"mssql.connectionOptions.typeSystemVersion.displayName": "Type system version",
-	"mssql.connectionOptions.typeSystemVersion.description": "Indicates which server type system then provider will expose through the DataReader"
+	"mssql.connectionOptions.typeSystemVersion.description": "Indicates which server type system then provider will expose through the DataReader",
+
+	"contents-tab-group-title" : "Contents",
+	"databases-tab-description": "Databases tab of server dashboard",
+	"databases-tab-title": "Databases",
+	"databases-widget-title": "Search"
 }

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -140,6 +140,8 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		allTabs = this.setAndRemoveHomeTab(allTabs, homeWidgets);
 
 		this.loadNewTabs(allTabs.filter((tab) => tab.isTopLevelTab));
+
+		this.addContentTabGroup();
 		this.addExtensionsTabGroup();
 
 		// If preview features are disabled only show the home tab
@@ -170,6 +172,32 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		this._tabsDispose.push(this.dashboardService.onAddNewTabs(e => {
 			this.loadNewTabs(e, true);
 		}));
+	}
+
+	private addContentTabGroup(): void {
+		const contentTabs = this.getContentTabs();
+		if (contentTabs) {
+			this.addNewTab({
+				id: 'contentGroupHeader',
+				provider: Constants.anyProviderName,
+				originalConfig: [],
+				publisher: undefined,
+				title: nls.localize('dashboard.contentsGroupHeader', "Contents"),
+				context: this.context,
+				type: 'group-header',
+				editable: false,
+				canClose: false,
+				actions: []
+			});
+			contentTabs.forEach((tab) => {
+				this.addNewTab(tab);
+			});
+		}
+	}
+
+
+	protected getContentTabs(): TabConfig[] | undefined {
+		return undefined;
 	}
 
 	private addExtensionsTabGroup(): void {

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -154,8 +154,6 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		this.addCustomTabGroups(allTabs);
 		this.addExtensionsTabGroup(allTabs);
 
-		this.loadNewTabs(allTabs.filter((tab) => !tab.group));
-
 		this.panelActions = [];
 
 		this._cd.detectChanges();

--- a/src/sql/workbench/contrib/dashboard/browser/dashboardRegistry.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/dashboardRegistry.ts
@@ -29,19 +29,27 @@ export interface IDashboardTab {
 	when?: string;
 	alwaysShow?: boolean;
 	isHomeTab?: boolean;
-	isTopLevelTab?: boolean;
+	group?: string;
+}
+
+export interface IDashboardTabGroup {
+	id: string;
+	title: string;
 }
 
 export interface IDashboardRegistry {
 	registerDashboardProvider(id: string, properties: ProviderProperties): void;
 	getProperties(id: string): ProviderProperties;
 	registerTab(tab: IDashboardTab): void;
+	registerTabGroup(tabGroup: IDashboardTabGroup): void;
 	tabs: Array<IDashboardTab>;
+	tabGroups: Array<IDashboardTabGroup>;
 }
 
 class DashboardRegistry implements IDashboardRegistry {
 	private _properties = new Map<string, ProviderProperties>();
 	private _tabs = new Array<IDashboardTab>();
+	private _tabGroups = new Array<IDashboardTabGroup>();
 	private _configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtension.Configuration);
 
 	/**
@@ -73,8 +81,18 @@ class DashboardRegistry implements IDashboardRegistry {
 		}
 	}
 
+	registerTabGroup(tabGroup: IDashboardTabGroup): void {
+		if (this.tabGroups.findIndex(group => group.id === tabGroup.id) === -1) {
+			this.tabGroups.push(tabGroup);
+		}
+	}
+
 	public get tabs(): Array<IDashboardTab> {
 		return this._tabs;
+	}
+
+	public get tabGroups(): Array<IDashboardTabGroup> {
+		return this._tabGroups;
 	}
 }
 
@@ -83,6 +101,10 @@ Registry.add(Extensions.DashboardContributions, dashboardRegistry);
 
 export function registerTab(tab: IDashboardTab): void {
 	dashboardRegistry.registerTab(tab);
+}
+
+export function registerTabGroup(tabGroup: IDashboardTabGroup): void {
+	dashboardRegistry.registerTabGroup(tabGroup);
 }
 
 const dashboardPropertiesPropertyContrib: IJSONSchema = {

--- a/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
@@ -8,7 +8,7 @@ import { OnInit, Inject, forwardRef, ChangeDetectorRef, ElementRef } from '@angu
 import { DashboardPage } from 'sql/workbench/contrib/dashboard/browser/core/dashboardPage.component';
 import { BreadcrumbClass } from 'sql/workbench/contrib/dashboard/browser/services/breadcrumb.service';
 import { IBreadcrumbService } from 'sql/base/browser/ui/breadcrumb/interfaces';
-import { WidgetConfig } from 'sql/workbench/contrib/dashboard/browser/core/dashboardWidget';
+import { WidgetConfig, TabConfig } from 'sql/workbench/contrib/dashboard/browser/core/dashboardWidget';
 import { DashboardServiceInterface } from 'sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service';
 import { CommonServiceInterface } from 'sql/workbench/services/bootstrap/browser/commonServiceInterface.service';
 import { IAngularEventingService } from 'sql/platform/angularEventing/browser/angularEventingService';
@@ -18,7 +18,7 @@ import * as nls from 'vs/nls';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ILogService } from 'vs/platform/log/common/log';
-import { mssqlProviderName } from 'sql/platform/connection/common/constants';
+import { mssqlProviderName, anyProviderName } from 'sql/platform/connection/common/constants';
 
 export class ServerDashboardPage extends DashboardPage implements OnInit {
 	protected propertiesWidget: WidgetConfig = {
@@ -67,5 +67,33 @@ export class ServerDashboardPage extends DashboardPage implements OnInit {
 			this.init();
 			this._cd.detectChanges();
 		});
+	}
+
+	getContentTabs(): TabConfig[] {
+		return [{
+			id: 'databasesTab',
+			provider: anyProviderName,
+			publisher: undefined,
+			title: nls.localize('databasesTabName', "Databases"),
+			container: {
+				'widgets-container': [
+					{
+						name: nls.localize('explorerWidgetTitle', "Search"),
+						gridItemConfig: {
+							sizex: 3,
+							sizey: 3
+						},
+						widget: {
+							'explorer-widget': {}
+						}
+					}
+				]
+			},
+			context: this.context,
+			originalConfig: [],
+			editable: true,
+			canClose: false,
+			actions: []
+		}];
 	}
 }

--- a/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
@@ -8,7 +8,7 @@ import { OnInit, Inject, forwardRef, ChangeDetectorRef, ElementRef } from '@angu
 import { DashboardPage } from 'sql/workbench/contrib/dashboard/browser/core/dashboardPage.component';
 import { BreadcrumbClass } from 'sql/workbench/contrib/dashboard/browser/services/breadcrumb.service';
 import { IBreadcrumbService } from 'sql/base/browser/ui/breadcrumb/interfaces';
-import { WidgetConfig, TabConfig } from 'sql/workbench/contrib/dashboard/browser/core/dashboardWidget';
+import { WidgetConfig } from 'sql/workbench/contrib/dashboard/browser/core/dashboardWidget';
 import { DashboardServiceInterface } from 'sql/workbench/contrib/dashboard/browser/services/dashboardServiceInterface.service';
 import { CommonServiceInterface } from 'sql/workbench/services/bootstrap/browser/commonServiceInterface.service';
 import { IAngularEventingService } from 'sql/platform/angularEventing/browser/angularEventingService';
@@ -18,7 +18,7 @@ import * as nls from 'vs/nls';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ILogService } from 'vs/platform/log/common/log';
-import { mssqlProviderName, anyProviderName } from 'sql/platform/connection/common/constants';
+import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 
 export class ServerDashboardPage extends DashboardPage implements OnInit {
 	protected propertiesWidget: WidgetConfig = {
@@ -67,33 +67,5 @@ export class ServerDashboardPage extends DashboardPage implements OnInit {
 			this.init();
 			this._cd.detectChanges();
 		});
-	}
-
-	getContentTabs(): TabConfig[] {
-		return [{
-			id: 'databasesTab',
-			provider: anyProviderName,
-			publisher: undefined,
-			title: nls.localize('databasesTabName', "Databases"),
-			container: {
-				'widgets-container': [
-					{
-						name: nls.localize('explorerWidgetTitle', "Search"),
-						gridItemConfig: {
-							sizex: 3,
-							sizey: 3
-						},
-						widget: {
-							'explorer-widget': {}
-						}
-					}
-				]
-			},
-			context: this.context,
-			originalConfig: [],
-			editable: true,
-			canClose: false,
-			actions: []
-		}];
 	}
 }

--- a/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution.ts
@@ -85,16 +85,6 @@ const defaultVal = [
 		}
 	},
 	{
-		name: 'Search',
-		gridItemConfig: {
-			sizex: 1,
-			sizey: 2
-		},
-		widget: {
-			'explorer-widget': {}
-		}
-	},
-	{
 		widget: {
 			'backup-history-server-insight': null
 		}


### PR DESCRIPTION
as per the mock up of new dashboard, we need databases tab under contents group of server dashboard. removed the databases widget from the home tab.

https://www.figma.com/proto/QRkuP8YG7sZr87LRoS210ldo/ADS_Framework_v0.03?node-id=3058%3A97242&scaling=min-zoom

![Screen Shot 2020-01-14 at 5 40 44 PM](https://user-images.githubusercontent.com/13777222/72397755-9d2bc400-36f5-11ea-87ba-ec5aac094a22.png)

