### PR TITLE
Clear cell execution count when clearing output.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/cell.ts
@@ -586,7 +586,7 @@ export class CellModel implements ICellModel {
 			cellJson.metadata.language = this._language;
 			cellJson.metadata.tags = metadata.tags;
 			cellJson.outputs = this._outputs;
-			cellJson.execution_count = this.executionCount;
+			cellJson.execution_count = this.executionCount ? this.executionCount : null;
 		}
 		return cellJson as nb.ICellContents;
 	}

--- a/src/sql/workbench/contrib/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/cell.ts
@@ -418,6 +418,8 @@ export class CellModel implements ICellModel {
 	public clearOutputs(): void {
 		this._outputs = [];
 		this.fireOutputsChanged();
+
+		this.executionCount = undefined;
 	}
 
 	private fireOutputsChanged(shouldScroll: boolean = false): void {
@@ -584,7 +586,7 @@ export class CellModel implements ICellModel {
 			cellJson.metadata.language = this._language;
 			cellJson.metadata.tags = metadata.tags;
 			cellJson.outputs = this._outputs;
-			cellJson.execution_count = this.executionCount ? this.executionCount : 0;
+			cellJson.execution_count = this.executionCount;
 		}
 		return cellJson as nb.ICellContents;
 	}

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookEditorModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookEditorModel.test.ts
@@ -176,7 +176,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
 
 		assert(notebookEditorModel.lastEditFullReplacement);
@@ -197,7 +197,7 @@ suite('Notebook Editor Model', function (): void {
 		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
 		assert(notebookEditorModel.lastEditFullReplacement);
 
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
 
 		newCell.executionCount = 1;
 		contentChange = {
@@ -278,7 +278,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -324,7 +324,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '            ],');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(27), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(27), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(28), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -368,7 +368,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -432,7 +432,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -552,7 +552,7 @@ suite('Notebook Editor Model', function (): void {
 			}
 			assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10 + i * 21), '            ],');
 			assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14 + i * 21), '            "outputs": [');
-			assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25 + i * 21), '            "execution_count": 0');
+			assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25 + i * 21), '            "execution_count": null');
 			assert(startsWith(notebookEditorModel.editorModel.textEditorModel.getLineContent(26 + i * 21), '        }'));
 		}
 	});
@@ -589,7 +589,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(23), '                }, {');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(31), '}');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(32), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(33), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(33), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(34), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -628,7 +628,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '    "text": "[0em"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(27), '}');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(28), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(29), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(29), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(30), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -647,7 +647,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(32), '                    "text": "test test test"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(33), '                }');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(34), '            ],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(35), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(35), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(36), '        }');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(37), '    ]');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(38), '}');
@@ -690,7 +690,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(23), '}');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -832,7 +832,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '            ],');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(13), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "outputs": [],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(17), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -854,7 +854,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '            ],');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(13), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "outputs": [],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(17), '        }');
 
 		assert(!notebookEditorModel.lastEditFullReplacement);
@@ -914,7 +914,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [],');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "execution_count": 0');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(15), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '        }');
 	}
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -590,7 +590,7 @@ suite('Cell Model', function (): void {
 			assert(startsWith(contentSplit[4].trim(), '"azdata_cell_guid": "'));
 			assert(startsWith(contentSplit[5].trim(), '}'));
 			assert(startsWith(contentSplit[6].trim(), '"outputs": []'));
-			assert(startsWith(contentSplit[7].trim(), '"execution_count": 0'));
+			assert(startsWith(contentSplit[7].trim(), '"execution_count": null'));
 			assert(startsWith(contentSplit[8].trim(), '}'));
 		});
 	});


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/6159