### PR TITLE
Add validation error message for inputbox component

### DIFF
--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -7,7 +7,7 @@
   "preview": false,
   "engines": {
     "vscode": "^1.25.0",
-    "azdata": "*"
+    "azdata": ">=1.15.0"
   },
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",
   "icon": "images/sqlserver.png",

--- a/extensions/dacpac/src/wizard/api/basePage.ts
+++ b/extensions/dacpac/src/wizard/api/basePage.ts
@@ -14,6 +14,7 @@ export abstract class BasePage {
 	protected readonly wizardPage: azdata.window.WizardPage;
 	protected readonly model: DacFxDataModel;
 	protected readonly view: azdata.ModelView;
+	protected databaseValues: string[];
 
 	/**
 	 * This method constructs all the elements of the page.
@@ -105,30 +106,27 @@ export abstract class BasePage {
 		return values;
 	}
 
-	protected async getDatabaseValues(): Promise<{ displayName: string, name: string }[]> {
+	protected async getDatabaseValues(): Promise<string[]> {
 		let idx = -1;
 		let count = -1;
-		let values = (await azdata.connection.listDatabases(this.model.server.connectionId)).map(db => {
+		this.databaseValues = (await azdata.connection.listDatabases(this.model.server.connectionId)).map(db => {
 			count++;
 			if (this.model.database && db === this.model.database) {
 				idx = count;
 			}
 
-			return {
-				displayName: db,
-				name: db
-			};
+			return db;
 		});
 
 		if (idx >= 0) {
-			let tmp = values[0];
-			values[0] = values[idx];
-			values[idx] = tmp;
+			let tmp = this.databaseValues[0];
+			this.databaseValues[0] = this.databaseValues[idx];
+			this.databaseValues[idx] = tmp;
 		} else {
 			this.deleteDatabaseValues();
 		}
 
-		return values;
+		return this.databaseValues;
 	}
 
 	protected deleteServerValues() {

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import { DataTierApplicationWizard, Operation } from '../dataTierApplicationWizard';
 import { DacFxDataModel } from './models';
 import { BasePage } from './basePage';
-import { sanitizeStringForFilename, isValidBasename } from './utils';
+import { sanitizeStringForFilename, isValidBasename, isValidBasenameErrorMessage } from './utils';
 
 const localize = nls.loadMessageBundle();
 
@@ -163,9 +163,16 @@ export abstract class DacFxConfigPage extends BasePage {
 		)
 			.withProperties({
 				required: true,
-				validationErrorMessage: localize('dacfx.invalidFileNameErrorMessage', "Invalid file name"),
 				ariaLive: 'polite'
 			}).component();
+
+		// Set validation error message if file name is invalid
+		this.fileTextBox.onTextChanged(text => {
+			const errorMessage = isValidBasenameErrorMessage(text);
+			if (errorMessage) {
+				this.fileTextBox.updateProperty('validationErrorMessage', errorMessage);
+			}
+		});
 
 		this.fileTextBox.ariaLabel = localize('dacfx.fileLocationAriaLabel', "File Location");
 		this.fileButton = this.view.modelBuilder.button().withProperties({
@@ -204,7 +211,7 @@ export abstract class DacFxConfigPage extends BasePage {
 	// Compares database name with existing databases on the server
 	protected databaseNameExists(n: string): boolean {
 		for (let i = 0; i < this.databaseValues.length; ++i) {
-			if (this.databaseValues[i].toLocaleLowerCase() === n.toLocaleLowerCase()) {
+			if (this.databaseValues[i].toLowerCase() === n.toLowerCase()) {
 				// database name exists
 				return true;
 			}

--- a/extensions/dacpac/src/wizard/api/utils.ts
+++ b/extensions/dacpac/src/wizard/api/utils.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 import * as os from 'os';
 import * as path from 'path';
-
+import * as nls from 'vscode-nls';
 const WINDOWS_INVALID_FILE_CHARS = /[\\/:\*\?"<>\|]/g;
 const UNIX_INVALID_FILE_CHARS = /[\\/]/g;
 const isWindows = os.platform() === 'win32';
 const WINDOWS_FORBIDDEN_NAMES = /^(con|prn|aux|clock\$|nul|lpt[0-9]|com[0-9])$/i;
+const localize = nls.loadMessageBundle();
 
 /**
  * Determines if a given character is a valid filename character
@@ -88,4 +89,49 @@ export function isValidBasename(name: string | null | undefined): boolean {
 	}
 
 	return true;
+}
+
+/**
+ * Returns specific error message if file name is invalid
+ * Logic is copied from src\vs\base\common\extpath.ts
+ * @param name filename to check
+ */
+export function isValidBasenameErrorMessage(name: string | null | undefined): string {
+	const invalidFileChars = isWindows ? WINDOWS_INVALID_FILE_CHARS : UNIX_INVALID_FILE_CHARS;
+	if (!name) {
+		return localize('dacfx.undefinedFileNameErrorMessage', "Undefined name");
+	}
+
+	if (isWindows && name[name.length - 1] === '.') {
+		return localize('dacfx.fileNameEndingInPeriodErrorMessage', "File name cannot end with a period"); // Windows: file cannot end with a "."
+	}
+
+	let basename = path.parse(name).name;
+	if (!basename || basename.length === 0 || /^\s+$/.test(basename)) {
+		return localize('dacfx.whitespaceFilenameErrorMessage', "File name cannot be whitespace"); // require a name that is not just whitespace
+	}
+
+	invalidFileChars.lastIndex = 0;
+	if (invalidFileChars.test(basename)) {
+		return localize('dacfx.invalidFileCharsErrorMessage', "Invalid file characters"); // check for certain invalid file characters
+	}
+
+	if (isWindows && WINDOWS_FORBIDDEN_NAMES.test(basename)) {
+		console.error('here');
+		return localize('dacfx.reservedWindowsFileNameErrorMessage', "This file name is reserved for use by Windows. Choose another name and try again"); // check for certain invalid file names
+	}
+
+	if (basename === '.' || basename === '..') {
+		return localize('dacfx.reservedValueErrorMessage', "Reserved file name. Choose another name and try again"); // check for reserved values
+	}
+
+	if (isWindows && basename.length !== basename.trim().length) {
+		return localize('dacfx.trailingWhitespaceErrorMessage', "File name cannot end with a whitespace"); // Windows: file cannot end with a whitespace
+	}
+
+	if (basename.length > 255) {
+		return localize('dacfx.tooLongFileNameErrorMessage', "File name is over 255 characters"); // most file systems do not allow files > 255 length
+	}
+
+	return '';
 }

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -57,6 +57,8 @@ export class DeployConfigPage extends DacFxConfigPage {
 	async onPageEnter(): Promise<boolean> {
 		let r1 = await this.populateServerDropdown();
 		let r2 = await this.populateDeployDatabaseDropdown();
+		// get existing database values to verify if new database name is valid
+		await this.getDatabaseValues();
 		return r1 && r2;
 	}
 
@@ -191,7 +193,7 @@ export class DeployConfigPage extends DacFxConfigPage {
 
 		//set the database to the first dropdown value if upgrading, otherwise it should get set to the textbox value
 		if (this.model.upgradeExisting) {
-			this.model.database = values[0].name;
+			this.model.database = values[0];
 		}
 
 		this.databaseDropdown.updateProperties({

--- a/extensions/dacpac/src/wizard/pages/importConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/importConfigPage.ts
@@ -48,6 +48,8 @@ export class ImportConfigPage extends DacFxConfigPage {
 
 	async onPageEnter(): Promise<boolean> {
 		let r1 = await this.populateServerDropdown();
+		// get existing database values to verify if new database name is valid
+		await this.getDatabaseValues();
 		return r1;
 	}
 

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3094,6 +3094,7 @@ declare module 'azdata' {
 		 * means the event will propagate up to any parents that have handlers (such as validate on Dialogs)
 		 */
 		stopEnterPropagation?: boolean;
+		validationErrorMessage?: string;
 	}
 
 	export interface TableColumn {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3094,7 +3094,6 @@ declare module 'azdata' {
 		 * means the event will propagate up to any parents that have handlers (such as validate on Dialogs)
 		 */
 		stopEnterPropagation?: boolean;
-		validationErrorMessage?: string;
 	}
 
 	export interface TableColumn {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -194,4 +194,23 @@ declare module 'azdata' {
 
 	export interface ImageComponentProperties extends ComponentProperties, ComponentWithIconProperties {
 	}
+
+	export interface InputBoxProperties extends ComponentProperties {
+		value?: string;
+		ariaLive?: string;
+		placeHolder?: string;
+		inputType?: InputBoxInputType;
+		required?: boolean;
+		multiline?: boolean;
+		rows?: number;
+		columns?: number;
+		min?: number;
+		max?: number;
+		/**
+		 * Whether to stop key event propagation when enter is pressed in the input box. Leaving this as false
+		 * means the event will propagate up to any parents that have handlers (such as validate on Dialogs)
+		 */
+		stopEnterPropagation?: boolean;
+		validationErrorMessage?: string;
+	}
 }

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -196,21 +196,6 @@ declare module 'azdata' {
 	}
 
 	export interface InputBoxProperties extends ComponentProperties {
-		value?: string;
-		ariaLive?: string;
-		placeHolder?: string;
-		inputType?: InputBoxInputType;
-		required?: boolean;
-		multiline?: boolean;
-		rows?: number;
-		columns?: number;
-		min?: number;
-		max?: number;
-		/**
-		 * Whether to stop key event propagation when enter is pressed in the input box. Leaving this as false
-		 * means the event will propagate up to any parents that have handlers (such as validate on Dialogs)
-		 */
-		stopEnterPropagation?: boolean;
 		validationErrorMessage?: string;
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -158,12 +158,16 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 
 	public validate(): Thenable<boolean> {
 		return super.validate().then(valid => {
+			const otherErrorMsg = valid || this.inputElement.value === '' ? undefined : this.validationErrorMessage;
 			valid = valid && this.inputElement.validate();
 
 			// set aria label based on validity of input
 			if (valid) {
 				this.inputElement.setAriaLabel(this.ariaLabel);
 			} else {
+				if (otherErrorMsg) {
+					this.inputElement.showMessage({ type: MessageType.ERROR, content: otherErrorMsg }, true);
+				}
 				if (this.ariaLabel) {
 					this.inputElement.setAriaLabel(nls.localize('period', "{0}. {1}", this.ariaLabel, this.inputElement.inputElement.validationMessage));
 				} else {
@@ -328,5 +332,13 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 
 	public focus(): void {
 		this.inputElement.focus();
+	}
+
+	public get validationErrorMessage(): string {
+		return this.getPropertyOrDefault<azdata.InputBoxProperties, string>((props) => props.validationErrorMessage, '');
+	}
+
+	public set validationErrorMessage(newValue: string) {
+		this.setPropertyFromUI<azdata.InputBoxProperties, string>((props, value) => props.validationErrorMessage = value, newValue);
 	}
 }


### PR DESCRIPTION
This makes it so a validation error message now can show when input box validation is false. Previously in the dacpac wizard, invalid file names would just disable the Next button but no message would show why. 

![image](https://user-images.githubusercontent.com/31145923/72654828-1faac280-3946-11ea-9a4a-9fbd8fe40b62.png)

This also adds validation in the dacpac wizard to check if database names are unique when deploying dacpacs and importing bacpacs. Fixes #8124. 
![image](https://user-images.githubusercontent.com/31145923/72654695-811e6180-3945-11ea-9816-7149269c0478.png)

Still shows default message when inputbox is empty:
![image](https://user-images.githubusercontent.com/31145923/72654887-6ef0f300-3946-11ea-9fc0-6c14cfc9a304.png)
