### PR TITLE
Fix for null shift-tab/focus

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editData.component.ts
+++ b/src/sql/workbench/contrib/editData/browser/editData.component.ts
@@ -172,7 +172,6 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 			let returnVal = '';
 			// replace the line breaks with space since the edit text control cannot
 			// render line breaks and strips them, updating the value.
-
 			/* tslint:disable:no-null-keyword */
 			let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && value.isNull);
 			if (!valueMissing && Services.DBCellValue.isDBCellValue(value)) {

--- a/src/sql/workbench/contrib/editData/browser/editData.component.ts
+++ b/src/sql/workbench/contrib/editData/browser/editData.component.ts
@@ -174,13 +174,15 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 			// render line breaks and strips them, updating the value.
 			/* tslint:disable:no-null-keyword */
 			let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && value.isNull);
-			if (!valueMissing && Services.DBCellValue.isDBCellValue(value)) {
-				returnVal = this.spacefyLinebreaks(value.displayValue);
-			} else if (typeof value === 'string') {
-				returnVal = this.spacefyLinebreaks(value);
-			} else if (valueMissing) {
+			if (valueMissing) {
 				/* tslint:disable:no-null-keyword */
 				returnVal = null;
+			}
+			else if (Services.DBCellValue.isDBCellValue(value)) {
+				returnVal = this.spacefyLinebreaks(value.displayValue);
+			}
+			else if (typeof value === 'string') {
+				returnVal = this.spacefyLinebreaks(value);
 			}
 			return returnVal;
 		};
@@ -732,35 +734,26 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 	}
 
 	/*Formatter for Column*/
-	private getColumnFormatter(row, cell, value, columnDef, dataContext) {
+	private getColumnFormatter(row: number | undefined, cell: any | undefined, value: any, columnDef: any | undefined, dataContext: any | undefined): string {
 		let valueToDisplay = '';
 		let cellClasses = 'grid-cell-value-container';
 		/* tslint:disable:no-null-keyword */
-		let valueMissing = value === undefined || value === null;
-
-		if (!valueMissing) {
-			if (Services.DBCellValue.isDBCellValue(value)) {
-				valueToDisplay = 'NULL';
-				if (!value.isNull) {
-					valueToDisplay = (value.displayValue + '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-					valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
-				} else {
-					cellClasses += ' missing-value';
-				}
-			}
-
-			if (typeof value === 'string' || (value && value.text)) {
-				if (value.text) {
-					valueToDisplay = value.text;
-				} else {
-					valueToDisplay = value;
-				}
-				valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
-			}
-		}
+		let valueMissing = value === undefined || value === null || (Services.DBCellValue.isDBCellValue(value) && value.isNull);
 		if (valueMissing) {
 			valueToDisplay = 'NULL';
 			cellClasses += ' missing-value';
+		}
+		else if (Services.DBCellValue.isDBCellValue(value)) {
+			valueToDisplay = (value.displayValue + '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+			valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
+		}
+		else if (typeof value === 'string' || (value && value.text)) {
+			if (value.text) {
+				valueToDisplay = value.text;
+			} else {
+				valueToDisplay = value;
+			}
+			valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
 		}
 		return '<span title="' + valueToDisplay + '" class="' + cellClasses + '">' + valueToDisplay + '</span>';
 	}


### PR DESCRIPTION
Here are the primary changes listed:

On Line 378 in editdatagridpanel.ts: changed the formatter in the columnDefinitions to use a custom formatter in the class, instead of one in tables.

On Line 171 and 739: NULL is used to indicate a null row as the loading of cell values is handled primarily by slick.grid api which only recognizes NULL, and not undefined, as empty (not counting empty strings)

slick.grid api is called first when a cell is clicked and loads the value in before it can be processed by the main code. The code cannot determine whether a cell has been changed or not because of this.

This PR fixes #8889 
