### PR TITLE
Fixes for broken notebook experience

### DIFF
--- a/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -458,7 +458,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 		};
 		let isUntitled: boolean = uri.scheme === Schemas.untitled;
 
-		const fileInput = isUntitled ? this._untitledEditorService.create({ associatedResource: uri, mode: 'notebook', initialValue: options.initialContent }) :
+		const fileInput = isUntitled ? this._untitledEditorService.create({ mode: 'notebook', initialValue: options.initialContent }) :
 			this._editorService.createInput({ resource: uri, mode: 'notebook' });
 		let input: NotebookInput;
 		if (isUntitled) {

--- a/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -458,7 +458,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 		};
 		let isUntitled: boolean = uri.scheme === Schemas.untitled;
 
-		const fileInput = isUntitled ? this._untitledEditorService.create({ mode: 'notebook', initialValue: options.initialContent }) :
+		const fileInput = isUntitled ? this._untitledEditorService.create({ untitledResource: uri, mode: 'notebook', initialValue: options.initialContent }) :
 			this._editorService.createInput({ resource: uri, mode: 'notebook' });
 		let input: NotebookInput;
 		if (isUntitled) {

--- a/src/vs/workbench/services/workingCopy/common/workingCopyService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyService.ts
@@ -138,6 +138,10 @@ export class WorkingCopyService extends Disposable implements IWorkingCopyServic
 	registerWorkingCopy(workingCopy: IWorkingCopy): IDisposable {
 		const disposables = new DisposableStore();
 
+		if (workingCopy.resource.path.includes('notebook-editor-') && workingCopy.resource.scheme === 'untitled') {
+			return disposables;
+		}
+
 		// Registry
 		let workingCopiesForResource = this.mapResourceToWorkingCopy.get(workingCopy.resource.toString());
 		if (!workingCopiesForResource) {

--- a/src/vs/workbench/services/workingCopy/common/workingCopyService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyService.ts
@@ -138,6 +138,7 @@ export class WorkingCopyService extends Disposable implements IWorkingCopyServic
 	registerWorkingCopy(workingCopy: IWorkingCopy): IDisposable {
 		const disposables = new DisposableStore();
 
+		// {{SQL CARBON EDIT}} @chlafreniere need to block working copies of notebook editors from being tracked
 		if (workingCopy.resource.path.includes('notebook-editor-') && workingCopy.resource.scheme === 'untitled') {
 			return disposables;
 		}

--- a/src/vs/workbench/services/workingCopy/common/workingCopyService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyService.ts
@@ -10,7 +10,7 @@ import { URI } from 'vs/base/common/uri';
 import { Disposable, IDisposable, toDisposable, DisposableStore, dispose } from 'vs/base/common/lifecycle';
 import { TernarySearchTree, values } from 'vs/base/common/map';
 import { ISaveOptions, IRevertOptions } from 'vs/workbench/common/editor';
-import { Schemas } from 'vs/base/common/network';
+import { Schemas } from 'vs/base/common/network'; // {{SQL CARBON EDIT}} @chlafreniere need to block working copies of notebook editors from being tracked
 
 export const enum WorkingCopyCapabilities {
 

--- a/src/vs/workbench/services/workingCopy/common/workingCopyService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyService.ts
@@ -10,6 +10,7 @@ import { URI } from 'vs/base/common/uri';
 import { Disposable, IDisposable, toDisposable, DisposableStore, dispose } from 'vs/base/common/lifecycle';
 import { TernarySearchTree, values } from 'vs/base/common/map';
 import { ISaveOptions, IRevertOptions } from 'vs/workbench/common/editor';
+import { Schemas } from 'vs/base/common/network';
 
 export const enum WorkingCopyCapabilities {
 
@@ -139,7 +140,7 @@ export class WorkingCopyService extends Disposable implements IWorkingCopyServic
 		const disposables = new DisposableStore();
 
 		// {{SQL CARBON EDIT}} @chlafreniere need to block working copies of notebook editors from being tracked
-		if (workingCopy.resource.path.includes('notebook-editor-') && workingCopy.resource.scheme === 'untitled') {
+		if (workingCopy.resource.path.includes('notebook-editor-') && workingCopy.resource.scheme === Schemas.untitled) {
 			return disposables;
 		}
 


### PR DESCRIPTION
We had 2 problems related to #8936:
- Untitled notebooks opened a notebook window upon reopening ADS with no cells, and a query editor would open with the json representation of the notebook
- Each cell in a notebook was being opened as its own editor tab

Since this issue is quite impactful, I have this PR that mitigates this issue.

1st issue:
For new untitled editors, providing an associatedResource now results in the untitledTextFileInput's hasAssociatedFilePath returning true, which means, on rehydration, a notebook editor with a URI of scheme 'file' was being opened. Not including associatedResource fixes this particular issue.

2nd issue:
The WorkingCopyService now keeps track of every contentChange event of every editor input. The BackupTracker then subscribes to these events, and adds all of these editors (i.e. every cell) to the backupFileService, which then looks to rehydrate all of the editors on reload. Exiting the registration method early gets around this... But if there's a better way to do this, I'm 100% all ears 😄 