### PR TITLE
Make notebook cells selectable for tab navigation.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/cell.ts
@@ -56,8 +56,8 @@ export class CellModel implements ICellModel {
 	private _modelContentChangedEvent: IModelContentChangedEvent;
 	private readonly _ariaLabel: string;
 
-	private readonly codeCellLabel = localize('codeCellLabel', 'Code Cell');
-	private readonly textCellLabel = localize('textCellLabel', 'Text Cell');
+	private readonly codeCellLabel = localize('codeCellLabel', "Code Cell");
+	private readonly textCellLabel = localize('textCellLabel', "Text Cell");
 
 	constructor(cellData: nb.ICellContents,
 		private _options: ICellModelOptions,

--- a/src/sql/workbench/contrib/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/cell.ts
@@ -54,6 +54,10 @@ export class CellModel implements ICellModel {
 	private _isCollapsed: boolean;
 	private _onCollapseStateChanged = new Emitter<boolean>();
 	private _modelContentChangedEvent: IModelContentChangedEvent;
+	private readonly _ariaLabel: string;
+
+	private readonly codeCellLabel = localize('codeCellLabel', 'Code Cell');
+	private readonly textCellLabel = localize('textCellLabel', 'Text Cell');
 
 	constructor(cellData: nb.ICellContents,
 		private _options: ICellModelOptions,
@@ -67,6 +71,13 @@ export class CellModel implements ICellModel {
 			this._cellType = CellTypes.Code;
 			this._source = '';
 		}
+
+		if (this._cellType === CellTypes.Code) {
+			this._ariaLabel = this.codeCellLabel;
+		} else {
+			this._ariaLabel = this.textCellLabel;
+		}
+
 		this._isEditMode = this._cellType !== CellTypes.Markdown;
 		this._stdInVisible = false;
 		if (_options && _options.isTrusted) {
@@ -81,6 +92,10 @@ export class CellModel implements ICellModel {
 
 	public equals(other: ICellModel) {
 		return other !== undefined && other.id === this.id;
+	}
+
+	public get ariaLabel(): string {
+		return this._ariaLabel;
 	}
 
 	public get onCollapseStateChanged(): Event<boolean> {

--- a/src/sql/workbench/contrib/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/modelInterfaces.ts
@@ -543,6 +543,7 @@ export interface ICellModel {
 	readonly onCollapseStateChanged: Event<boolean>;
 	modelContentChangedEvent: IModelContentChangedEvent;
 	isEditMode: boolean;
+	readonly ariaLabel: string;
 }
 
 export interface FutureInternal extends nb.IFuture {

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.html
@@ -21,7 +21,12 @@
 			</button>
 		</div>
 		<div *ngFor="let cell of cells">
-			<div class="notebook-cell" (click)="selectCell(cell, $event)" [class.active]="cell.active">
+			<div class="notebook-cell"
+			(click)="selectCell(cell, $event)"
+			(focus)="selectCell(cell, $event)"
+			(focusout)="selectCell(undefined, $event)"
+			[class.active]="cell.active"
+			tabindex="0">
 				<code-cell-component *ngIf="cell.cellType === 'code'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">
 				</code-cell-component>
 				<text-cell-component *ngIf="cell.cellType === 'markdown'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.html
@@ -23,10 +23,10 @@
 		<div *ngFor="let cell of cells">
 			<div class="notebook-cell"
 			(click)="selectCell(cell, $event)"
-			(keyup.enter)="selectCell(cell, $event)"
 			(focus)="selectCell(cell, $event)"
 			(focusout)="selectCell(undefined, $event)"
 			[class.active]="cell.active"
+			[attr.aria-label]="cell.ariaLabel"
 			tabindex="0">
 				<code-cell-component *ngIf="cell.cellType === 'code'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">
 				</code-cell-component>

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.html
@@ -24,7 +24,6 @@
 			<div class="notebook-cell"
 			(click)="selectCell(cell, $event)"
 			(focus)="selectCell(cell, $event)"
-			(focusout)="selectCell(undefined, $event)"
 			[class.active]="cell.active"
 			[attr.aria-label]="cell.ariaLabel"
 			tabindex="0">

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.html
@@ -23,6 +23,7 @@
 		<div *ngFor="let cell of cells">
 			<div class="notebook-cell"
 			(click)="selectCell(cell, $event)"
+			(keyup.enter)="selectCell(cell, $event)"
 			(focus)="selectCell(cell, $event)"
 			(focusout)="selectCell(undefined, $event)"
 			[class.active]="cell.active"

--- a/src/sql/workbench/contrib/notebook/common/models/contracts.ts
+++ b/src/sql/workbench/contrib/notebook/common/models/contracts.ts
@@ -9,7 +9,6 @@ export type CellType = 'code' | 'markdown' | 'raw';
 export class CellTypes {
 	public static readonly Code = 'code';
 	public static readonly Markdown = 'markdown';
-	public static readonly Raw = 'raw';
 }
 
 // to do: add all mime types


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/7658

In the above accessibility issue, there was some confusion around the tab navigation ordering since we highlight the editor text first and then the More Actions button second, even though the button is technically higher in the view. This change makes the notebook cell itself selectable for tab navigation, so that it's more obvious what the ordering of the items is. We select the cell first, then go left to right from Run to Editor to More Actions. I also added an Aria label to announce the types of the cells.

Also removed the 'Raw' cell type, since it didn't seem to be used anywhere.