### PR TITLE
listen to command a and select the active element.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -68,6 +68,14 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		this._model.updateActiveCell(undefined);
 	}
 
+	@HostListener('document:keydown.meta.a', ['$event'])
+	onkeydown(e) {
+		// use preventDefault() to avoid invoking the editors select all
+		// select the active .
+		e.preventDefault();
+		document.execCommand('selectAll');
+	}
+
 	private _content: string | string[];
 	private _lastTrustedMode: boolean;
 	private isEditMode: boolean;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -70,7 +70,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 
 	@HostListener('document:keydown.meta.a', ['$event'])
 	onkeydown(e) {
-		// use preventDefault() to avoid invoking the editors select all
+		// use preventDefault() to avoid invoking the editor's select all
 		// select the active .
 		e.preventDefault();
 		document.execCommand('selectAll');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #5023 

On windows, ctrl-A selects the html element but on Mac it invokes the editors select all action even when there is no editor. So added an event on textCell component to listen to cmd-A key event and prevent default behavior & select the active html element. 
