### PR TITLE
Refactor node loading logic for tree controllers

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/tree/controllerTreeDataProvider.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/tree/controllerTreeDataProvider.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as azdata from 'azdata';
+import * as nls from 'vscode-nls';
 import { TreeNode } from './treeNode';
 import { IControllerTreeChangeHandler } from './controllerTreeChangeHandler';
 import { AddControllerNode } from './addControllerNode';
@@ -12,6 +13,8 @@ import { ControllerRootNode, ControllerNode } from './controllerTreeNode';
 import { showErrorMessage } from '../utils';
 import { LoadingControllerNode } from './loadingControllerNode';
 import { AuthType } from '../constants';
+
+const localize = nls.loadMessageBundle();
 
 const CredentialNamespace = 'clusterControllerCredentials';
 
@@ -43,7 +46,9 @@ export class ControllerTreeDataProvider implements vscode.TreeDataProvider<TreeN
 			return this.root.getChildren();
 		}
 
-		await this.loadSavedControllers();
+		// Kick off loading the saved controllers but then immediately return the loading node so
+		// the user isn't left with an empty tree while we load the nodes
+		this.loadSavedControllers().catch(err => { vscode.window.showErrorMessage(localize('bdc.controllerTreeDataProvider.error', "Unexpected error loading saved controllers: {0}", err)); });
 		return [new LoadingControllerNode()];
 	}
 

--- a/extensions/cms/src/cmsResource/tree/treeProvider.ts
+++ b/extensions/cms/src/cmsResource/tree/treeProvider.ts
@@ -74,6 +74,8 @@ export class CmsResourceTreeProvider implements TreeDataProvider<TreeNode>, ICms
 
 	private async loadSavedServers(): Promise<void> {
 		try {
+			// Optimistically set to true so we don't double-load if something refreshes the tree while
+			// we're loading.
 			this.isSystemInitialized = true;
 			// Call to collect all locally saved CMS servers
 			// to determine whether the system has been initialized.

--- a/extensions/cms/src/cmsResource/tree/treeProvider.ts
+++ b/extensions/cms/src/cmsResource/tree/treeProvider.ts
@@ -31,30 +31,9 @@ export class CmsResourceTreeProvider implements TreeDataProvider<TreeNode>, ICms
 		}
 
 		if (!this.isSystemInitialized) {
-			try {
-				// Call to collect all locally saved CMS servers
-				// to determine whether the system has been initialized.
-				const cachedServers = this._appContext.cmsUtils.getSavedServers();
-				if (cachedServers && cachedServers.length > 0) {
-					const servers: CmsResourceTreeNode[] = [];
-					cachedServers.forEach(async (server) => {
-						servers.push(new CmsResourceTreeNode(
-							server.name,
-							server.description,
-							server.ownerUri,
-							server.connection,
-							this._appContext, this, null));
-						await this.appContext.cmsUtils.cacheRegisteredCmsServer(server.name, server.description,
-							server.ownerUri, server.connection);
-					});
-					return servers;
-				}
-				this.isSystemInitialized = true;
-				this._onDidChangeTreeData.fire(undefined);
-			} catch (error) {
-				// System not initialized yet
-				this.isSystemInitialized = false;
-			}
+			// Kick off loading the saved servers but then immediately return the loading node so
+			// the user isn't left with an empty tree while we load the nodes
+			this.loadSavedServers().catch(err => this._appContext.apiWrapper.showErrorMessage(localize('cms.resource.tree.treeProvider.loadError', "Unexpected error occured while loading saved servers {0}", err)));
 			return [CmsResourceMessageTreeNode.create(CmsResourceTreeProvider.loadingLabel, undefined)];
 		}
 		try {
@@ -91,6 +70,34 @@ export class CmsResourceTreeProvider implements TreeDataProvider<TreeNode>, ICms
 
 	public getTreeItem(element: TreeNode): TreeItem | Thenable<TreeItem> {
 		return element.getTreeItem();
+	}
+
+	private async loadSavedServers(): Promise<void> {
+		try {
+			this.isSystemInitialized = true;
+			// Call to collect all locally saved CMS servers
+			// to determine whether the system has been initialized.
+			const cachedServers = this._appContext.cmsUtils.getSavedServers();
+			if (cachedServers && cachedServers.length > 0) {
+				const servers: CmsResourceTreeNode[] = [];
+				for (let i = 0; i < cachedServers.length; ++i) {
+					const server = cachedServers[i];
+					servers.push(new CmsResourceTreeNode(
+						server.name,
+						server.description,
+						server.ownerUri,
+						server.connection,
+						this._appContext, this, null));
+					await this.appContext.cmsUtils.cacheRegisteredCmsServer(server.name, server.description,
+						server.ownerUri, server.connection);
+				}
+			}
+			this._onDidChangeTreeData.fire(undefined);
+		} catch (error) {
+			// Reset so we can try loading again
+			this.isSystemInitialized = false;
+			throw error; //re-throw and let caller handler error
+		}
 	}
 
 	public isSystemInitialized: boolean = false;


### PR DESCRIPTION
Fixes #8977

I'm not sure what changed here recently - this might have just been a race condition that we hadn't hit yet. But what would happen is that we'd finish the loading code before returning the "Loading..." node - which meant that the children returned didn't contain any of the actual nodes. And then at that point we'd be stuck unless something caused it to refresh the tree.

Noticed this issue for CMS tree as well so also fixed that up to have similar logic. 