### PR TITLE
Re-enable windows test Job

### DIFF
--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -41,16 +41,15 @@ jobs:
   steps:
   - template: win32/sql-product-build-win32.yml
 
-# Temporarily disable Windows_Test job given build machine setup issues
-# - job: Windows_Test
-#   condition: and(succeeded(), eq(variables['VSCODE_BUILD_WIN32'], 'true'))
-#   pool:
-#     name: mssqltools
-#   dependsOn:
-#   - Linux
-#   - Windows
-#   steps:
-#   - template: win32/sql-product-test-win32.yml
+- job: Windows_Test
+  condition: and(succeeded(), eq(variables['VSCODE_BUILD_WIN32'], 'true'))
+  pool:
+    name: mssqltools
+  dependsOn:
+  - Linux
+  - Windows
+  steps:
+  - template: win32/sql-product-test-win32.yml
 
 - job: Release
   condition: and(succeeded(), or(eq(variables['VSCODE_RELEASE'], 'true'), and(eq(variables['VSCODE_QUALITY'], 'insider'), eq(variables['Build.Reason'], 'Schedule'))))
@@ -60,7 +59,7 @@ jobs:
   - macOS
   - Linux
   - Windows
-  # - Windows_Test
+  - Windows_Test
   steps:
   - template: sql-release.yml
 


### PR DESCRIPTION
Build machine configuration used for the Windows_Test Job has been updated to have the required pre-reqs and is succeeding again. Re-enabling again.