### PR TITLE
Change error to info for declining python install

### DIFF
--- a/extensions/notebook/src/dialog/configurePythonDialog.ts
+++ b/extensions/notebook/src/dialog/configurePythonDialog.ts
@@ -59,7 +59,7 @@ export class ConfigurePythonDialog {
 		this.dialog.cancelButton.label = this.CancelButtonText;
 		this.dialog.cancelButton.onClick(() => {
 			if (rejectOnCancel) {
-				this.setupComplete.reject(localize('configurePython.pythonInstallDeclined', "Python installation was declined."));
+				this.setupComplete.reject('INFO: '.concat(localize('configurePython.pythonInstallDeclined', "Python installation was declined.")));
 			} else {
 				this.setupComplete.resolve();
 			}

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookModel.ts
@@ -430,8 +430,8 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		this._activeCell = cell;
 	}
 
-	private notifyError(error: string): void {
-		this._onErrorEmitter.fire({ message: error, severity: Severity.Error });
+	private notifyError(error: string, severity: Severity = Severity.Error): void {
+		this._onErrorEmitter.fire({ message: error, severity: severity });
 	}
 
 	public async startSession(manager: INotebookManager, displayName?: string, setErrorStateOnFail?: boolean): Promise<void> {
@@ -628,7 +628,12 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			}
 		} catch (err) {
 			if (oldDisplayName && restoreOnFail) {
-				this.notifyError(localize('changeKernelFailedRetry', "Failed to change kernel. Kernel {0} will be used. Error was: {1}", oldDisplayName, getErrorMessage(err)));
+				let errorMessage = getErrorMessage(err);
+				if (errorMessage.startsWith('INFO:')) {
+					this.notifyError(localize('changeKernelFailedInfoRetry', "Failed to change kernel. Kernel {0} will be used.", oldDisplayName), Severity.Info);
+				} else {
+					this.notifyError(localize('changeKernelFailedRetry', "Failed to change kernel. Kernel {0} will be used. Error was: {1}", oldDisplayName, errorMessage));
+				}
 				// Clear out previous kernel
 				let failedProviderId = this.tryFindProviderForKernel(displayName, true);
 				let oldProviderId = this.tryFindProviderForKernel(oldDisplayName, true);


### PR DESCRIPTION
This addresses #6321. Since we only have so much to go by (an error message from a promise rejection), I don't have an amazing solution to distinguish between "real errors" and "things that we should notify users about that aren't really errors" (of which there is a grand total of 1 instance that fits into that bucket) besides parsing the message and looking for a well-known pattern.

If anyone has any other suggestions, totally open to anything here 😄 