### PR TITLE
Notebooks: Stop Firing Active Cell Changes when Active Cell Isn't Changing

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -183,8 +183,10 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		if (event) {
 			event.stopPropagation();
 		}
-		this.model.updateActiveCell(cell);
-		this.detectChanges();
+		if (!this.model.activeCell || this.model.activeCell.id !== cell.id) {
+			this.model.updateActiveCell(cell);
+			this.detectChanges();
+		}
 	}
 
 	//Saves scrollTop value on scroll change


### PR DESCRIPTION
This PR fixes #8328. We were always calling updateActiveCell() on the notebook model when selecting a cell (or, in this case, attempting to copy text from the output). From the cell model's active setter, fireExecutionStateChanged() was called, which the code component listened to and called setFocusAndScroll (thus stealing focus from the output component).

![image](https://user-images.githubusercontent.com/40371649/73330805-b6189700-4216-11ea-8294-53b40d48ce94.png)
