### PR TITLE
Fix for table name not showing up on the header.

### DIFF
--- a/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
@@ -89,6 +89,8 @@ export class QueryEditorService implements IQueryEditorService {
 		// Create a sql document pane with accoutrements
 		const fileInput = this._untitledEditorService.create({ associatedResource: docUri, mode: 'sql' });
 		const m = await fileInput.resolve();
+		//when associatedResource editor is created it is dirty, this must be set to false to be able to detect changes to the editor.
+		m.setDirty(false);
 		// Create an EditDataInput for editing
 		const resultsInput: EditDataResultsInput = this._instantiationService.createInstance(EditDataResultsInput, docUri.toString());
 		let editDataInput: EditDataInput = this._instantiationService.createInstance(EditDataInput, docUri, schemaName, tableName, fileInput, sqlContent, resultsInput);

--- a/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/browser/queryEditorService.ts
@@ -87,7 +87,7 @@ export class QueryEditorService implements IQueryEditorService {
 		let docUri: URI = URI.from({ scheme: Schemas.untitled, path: filePath });
 
 		// Create a sql document pane with accoutrements
-		const fileInput = this._untitledEditorService.create({ untitledResource: docUri, mode: 'sql' });
+		const fileInput = this._untitledEditorService.create({ associatedResource: docUri, mode: 'sql' });
 		const m = await fileInput.resolve();
 		// Create an EditDataInput for editing
 		const resultsInput: EditDataResultsInput = this._instantiationService.createInstance(EditDataResultsInput, docUri.toString());


### PR DESCRIPTION
An EditData editor created with an untitledResource will not have the name of the table on the top of the head. However, if we use an associatedResource which displays the title, the editor is initialized as dirty by default, and changes to the dirty state will not be detected at all for the editor. To fix this, the dirty state must be manually set to false upon creating the editor, so to detect when the editor has changed.

This PR fixes #9006
