### PR TITLE
Import "fromPromise" so Observables work correctly

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -43,6 +43,7 @@ const nodeModules = [
 	'electron',
 	'original-fs',
 	'rxjs/Observable',
+	'rxjs/add/observable/fromPromise',
 	'rxjs/Subject',
 	'rxjs/Observer',
 	'slickgrid/lib/jquery.event.drag-2.3.0',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuredatastudio",
   "version": "1.15.0",
-  "distro": "b9cf7cc558c3c0b1178a13f8d973debfaffdd14c",
+  "distro": "922d292f69c5d36ab6f0dbbd94a63c81219afaaf",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuredatastudio",
   "version": "1.15.0",
-  "distro": "b71b4af5016533d971958cc37e25b43b9c3754a5",
+  "distro": "b9cf7cc558c3c0b1178a13f8d973debfaffdd14c",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/bootstrap-window.js
+++ b/src/bootstrap-window.js
@@ -111,6 +111,7 @@ exports.load = function (modulePaths, resultCallback, options) {
 		'@angular/platform-browser-dynamic',
 		'@angular/router',
 		'rxjs/Observable',
+		'rxjs/add/observable/fromPromise',
 		'rxjs/Subject',
 		'rxjs/Observer',
 		'slickgrid/lib/jquery.event.drag-2.3.0',

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component.ts
@@ -8,6 +8,7 @@ import {
 	ComponentFactoryResolver, ViewChild, ChangeDetectorRef, Injector
 } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/fromPromise';
 
 import { DashboardWidget, IDashboardWidget, WIDGET_CONFIG, WidgetConfig } from 'sql/workbench/contrib/dashboard/browser/core/dashboardWidget';
 import { CommonServiceInterface } from 'sql/workbench/services/bootstrap/browser/commonServiceInterface.service';

--- a/src/sql/workbench/services/bootstrap/browser/commonServiceInterface.service.ts
+++ b/src/sql/workbench/services/bootstrap/browser/commonServiceInterface.service.ts
@@ -6,6 +6,7 @@
 /* Node Modules */
 import { Injectable, Inject } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/fromPromise';
 
 /* SQL imports */
 import { IDefaultComponentParams, IBootstrapParams } from 'sql/workbench/services/bootstrap/common/bootstrapParams';

--- a/test/all.js
+++ b/test/all.js
@@ -63,6 +63,7 @@ function main() {
 			'angular2-grid',
 			'ng2-charts',
 			'rxjs/add/observable/of',
+			'rxjs/add/observable/fromPromise',
 			'rxjs/Observable',
 			'rxjs/Subject',
 			'rxjs/Observer'

--- a/test/electron/renderer.js
+++ b/test/electron/renderer.js
@@ -51,6 +51,7 @@ function initLoader(opts) {
 			'angular2-grid',
 			'ng2-charts',
 			'rxjs/add/observable/of',
+			'rxjs/add/observable/fromPromise',
 			'rxjs/Observable',
 			'rxjs/Subject',
 			'rxjs/Observer'


### PR DESCRIPTION
This PR fixes #9003.  At some point, the `fromPromise` calls stopped working in packaged builds, raising a null ref.  Apparently importing this additional `add` module is needed now.
