### PR TITLE
Add enabled property and make default account option empty

### DIFF
--- a/extensions/resource-deployment/src/interfaces.ts
+++ b/extensions/resource-deployment/src/interfaces.ts
@@ -169,7 +169,8 @@ export interface FieldInfo {
 	fontStyle?: FontStyle;
 	labelFontWeight?: FontWeight;
 	links?: azdata.LinkArea[];
-	editable?: boolean; // for editable dropdown
+	editable?: boolean; // for editable dropdown,
+	enabled?: boolean;
 }
 
 export interface AzureAccountFieldInfo extends FieldInfo {

--- a/extensions/resource-deployment/src/localizedConstants.ts
+++ b/extensions/resource-deployment/src/localizedConstants.ts
@@ -11,4 +11,3 @@ export const account = localize('azure.account', "Azure Account");
 export const subscription = localize('azure.account.subscription', "Subscription");
 export const resourceGroup = localize('azure.account.resourceGroup', "Resource Group");
 export const location = localize('azure.account.location', "Azure Location");
-export const localDeploy = localize('azure.account.localDeploy', "Local Deploy");

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -66,14 +66,15 @@ interface CreateContext {
 	onNewInputComponentCreated: (name: string, component: azdata.InputBoxComponent | azdata.DropDownComponent | azdata.CheckBoxComponent, inputValueTransformer?: InputValueTransformer) => void;
 }
 
-export function createTextInput(view: azdata.ModelView, inputInfo: { defaultValue?: string, ariaLabel: string, required?: boolean, placeHolder?: string, width?: string }): azdata.InputBoxComponent {
+export function createTextInput(view: azdata.ModelView, inputInfo: { defaultValue?: string, ariaLabel: string, required?: boolean, placeHolder?: string, width?: string, enabled?: boolean }): azdata.InputBoxComponent {
 	return view.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
 		value: inputInfo.defaultValue,
 		ariaLabel: inputInfo.ariaLabel,
 		inputType: 'text',
 		required: inputInfo.required,
 		placeHolder: inputInfo.placeHolder,
-		width: inputInfo.width
+		width: inputInfo.width,
+		enabled: inputInfo.enabled
 	}).component();
 }
 
@@ -326,7 +327,8 @@ function processTextField(context: FieldContext): void {
 		ariaLabel: context.fieldInfo.label,
 		required: context.fieldInfo.required,
 		placeHolder: context.fieldInfo.placeHolder,
-		width: context.fieldInfo.inputWidth
+		width: context.fieldInfo.inputWidth,
+		enabled: context.fieldInfo.enabled
 	});
 	context.onNewInputComponentCreated(context.fieldInfo.variableName!, input);
 	addLabelInputPairToContainer(context.view, context.components, label, input, context.fieldInfo.labelPosition);
@@ -437,7 +439,7 @@ function processAzureAccountField(context: AzureAccountFieldContext): void {
 		handleSelectedAccountChanged(context, selectedAccount, subscriptionDropdown, subscriptionValueToSubscriptionMap, resourceGroupDropdown, locationDropdown);
 	});
 	azdata.accounts.getAllAccounts().then((accounts: azdata.Account[]) => {
-		accountDropdown.values = [loc.localDeploy].concat(accounts.map(account => {
+		accountDropdown.values = [''].concat(accounts.map(account => {
 			const displayName = `${account.displayInfo.displayName} (${account.displayInfo.userId})`;
 			accountValueToAccountMap.set(displayName, account);
 			return displayName;

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -439,7 +439,9 @@ function processAzureAccountField(context: AzureAccountFieldContext): void {
 		handleSelectedAccountChanged(context, selectedAccount, subscriptionDropdown, subscriptionValueToSubscriptionMap, resourceGroupDropdown, locationDropdown);
 	});
 	azdata.accounts.getAllAccounts().then((accounts: azdata.Account[]) => {
-		accountDropdown.values = [''].concat(accounts.map(account => {
+		// Append a blank value for the "default" option if the field isn't required, this will clear all the dropdowns when selected
+		const dropdownValues = context.fieldInfo.required ? [] : [''];
+		accountDropdown.values = dropdownValues.concat(accounts.map(account => {
 			const displayName = `${account.displayInfo.displayName} (${account.displayInfo.userId})`;
 			accountValueToAccountMap.set(displayName, account);
 			return displayName;


### PR DESCRIPTION
Enhancements for the Arc deployment - let a text field be disabled for values that aren't currently editable (but we still want to look consistent so using readonly_text isn't appropriate for).

Also make default option for account blank per feedback - the fields are optional so leaving them blank is better consistency. 