### PR TITLE
Books: Ensure associatedResource is Present for Untitled Notebooks that have a File Associated with them

### DIFF
--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -67,7 +67,8 @@ export class BookTreeItem extends vscode.TreeItem {
 
 	private setCommand() {
 		if (this.book.type === BookTreeItemType.Notebook) {
-			let pathToNotebook = path.join(this.book.root, 'content', this._uri.concat('.ipynb'));
+			// The Notebook editor expects a posix path for the resource (it will still resolve to the correct fsPath based on OS)
+			const pathToNotebook = path.posix.join(this.book.root, 'content', this._uri.concat('.ipynb'));
 			this.command = { command: this.book.isUntitled ? 'bookTreeView.openUntitledNotebook' : 'bookTreeView.openNotebook', title: loc.openNotebookCommand, arguments: [pathToNotebook], };
 		} else if (this.book.type === BookTreeItemType.Markdown) {
 			let pathToMarkdown = path.join(this.book.root, 'content', this._uri.concat('.md'));
@@ -81,8 +82,8 @@ export class BookTreeItem extends vscode.TreeItem {
 		let i = --index;
 		while (i > -1) {
 			if (this.book.tableOfContents.sections[i].url) {
-				// TODO: Currently only navigating to notebooks. Need to add logic for markdown.
-				let pathToNotebook = path.join(this.book.root, 'content', this.book.tableOfContents.sections[i].url.concat('.ipynb'));
+				// The Notebook editor expects a posix path for the resource (it will still resolve to the correct fsPath based on OS)
+				let pathToNotebook = path.posix.join(this.book.root, 'content', this.book.tableOfContents.sections[i].url.concat('.ipynb'));
 				// eslint-disable-next-line no-sync
 				if (fs.existsSync(pathToNotebook)) {
 					this._previousUri = pathToNotebook;
@@ -97,8 +98,8 @@ export class BookTreeItem extends vscode.TreeItem {
 		let i = ++index;
 		while (i < this.book.tableOfContents.sections.length) {
 			if (this.book.tableOfContents.sections[i].url) {
-				// TODO: Currently only navigating to notebooks. Need to add logic for markdown.
-				let pathToNotebook = path.join(this.book.root, 'content', this.book.tableOfContents.sections[i].url.concat('.ipynb'));
+				// The Notebook editor expects a posix path for the resource (it will still resolve to the correct fsPath based on OS)
+				let pathToNotebook = path.posix.join(this.book.root, 'content', this.book.tableOfContents.sections[i].url.concat('.ipynb'));
 				// eslint-disable-next-line no-sync
 				if (fs.existsSync(pathToNotebook)) {
 					this._nextUri = pathToNotebook;

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -297,8 +297,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	}
 
 	getUntitledNotebookUri(resource: string): vscode.Uri {
-		let untitledFileName: vscode.Uri;
-		untitledFileName = vscode.Uri.parse(`untitled:${resource}`);
+		let untitledFileName = vscode.Uri.parse(`untitled:${resource}`);
 		if (!this.currentBook.getAllBooks().get(untitledFileName.fsPath) && !this.currentBook.getAllBooks().get(path.basename(untitledFileName.fsPath))) {
 			let notebook = this.currentBook.getAllBooks().get(resource);
 			this.currentBook.getAllBooks().set(path.basename(untitledFileName.fsPath), notebook);

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -97,7 +97,8 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			const sectionToOpen = bookRoot.findChildSection(urlToOpen);
 			const urlPath = sectionToOpen ? sectionToOpen.url : bookRoot.tableOfContents.sections[0].url;
 			const sectionToOpenMarkdown: string = path.join(this.currentBook.bookPath, 'content', urlPath.concat('.md'));
-			const sectionToOpenNotebook: string = path.join(this.currentBook.bookPath, 'content', urlPath.concat('.ipynb'));
+			// The Notebook editor expects a posix path for the resource (it will still resolve to the correct fsPath based on OS)
+			const sectionToOpenNotebook: string = path.posix.join(this.currentBook.bookPath, 'content', urlPath.concat('.ipynb'));
 			if (await fs.pathExists(sectionToOpenMarkdown)) {
 				this.openMarkdown(sectionToOpenMarkdown);
 			}

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -10,7 +10,6 @@ import * as fs from 'fs-extra';
 import { IPrompter, QuestionTypes, IQuestion } from '../prompts/question';
 import CodeAdapter from '../prompts/adapter';
 import { BookTreeItem } from './bookTreeItem';
-import { isEditorTitleFree } from '../common/utils';
 import { BookModel } from './bookModel';
 import { Deferred } from '../common/promise';
 import * as loc from '../common/localizedConstants';
@@ -298,8 +297,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 
 	getUntitledNotebookUri(resource: string): vscode.Uri {
 		let untitledFileName: vscode.Uri;
-		let nextTitle: string = this.findNextUntitledFileName(resource);
-		untitledFileName = vscode.Uri.parse(`untitled:${nextTitle}`);
+		untitledFileName = vscode.Uri.parse(`untitled:${resource}`);
 		if (!this.currentBook.getAllBooks().get(untitledFileName.fsPath) && !this.currentBook.getAllBooks().get(path.basename(untitledFileName.fsPath))) {
 			let notebook = this.currentBook.getAllBooks().get(resource);
 			this.currentBook.getAllBooks().set(path.basename(untitledFileName.fsPath), notebook);
@@ -307,18 +305,6 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		return untitledFileName;
 	}
 
-	findNextUntitledFileName(filePath: string): string {
-		const baseName = path.basename(filePath);
-		let idx = 0;
-		let title;
-		do {
-			const suffix = idx === 0 ? '' : `-${idx}`;
-			title = `${baseName}${suffix}`;
-			idx++;
-		} while (!isEditorTitleFree(title));
-
-		return title;
-	}
 
 	//Confirmation message dialog
 	private async confirmReplace(): Promise<boolean> {

--- a/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -725,7 +725,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 				let result = await this._proxy.$getNavigation(handle, uri);
 				if (result) {
 					if (result.next.scheme === Schemas.untitled) {
-						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.next.path)}`);
+						let untitledNbName: URI = URI.parse(`untitled:${result.next.path}`);
 						let content = await this._fileService.readFile(URI.file(result.next.path));
 						await this.doOpenEditor(untitledNbName, { initialContent: content.value.toString(), initialDirtyState: false });
 					}
@@ -738,7 +738,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 				let result = await this._proxy.$getNavigation(handle, uri);
 				if (result) {
 					if (result.previous.scheme === Schemas.untitled) {
-						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.previous.path)}`);
+						let untitledNbName: URI = URI.parse(`untitled:${result.previous.path}`);
 						let content = await this._fileService.readFile(URI.file(result.previous.path));
 						await this.doOpenEditor(untitledNbName, { initialContent: content.value.toString(), initialDirtyState: false });
 					}

--- a/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -458,8 +458,13 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 		};
 		let isUntitled: boolean = uri.scheme === Schemas.untitled;
 
-		const fileInput = isUntitled ? this._untitledEditorService.create({ untitledResource: uri, mode: 'notebook', initialValue: options.initialContent }) :
-			this._editorService.createInput({ resource: uri, mode: 'notebook' });
+		let fileInput;
+		if (isUntitled && path.isAbsolute(uri.fsPath)) {
+			fileInput = this._untitledEditorService.create({ associatedResource: uri, mode: 'notebook', initialValue: options.initialContent });
+		} else {
+			fileInput = isUntitled ? this._untitledEditorService.create({ untitledResource: uri, mode: 'notebook', initialValue: options.initialContent }) :
+				this._editorService.createInput({ resource: uri, mode: 'notebook' });
+		}
 		let input: NotebookInput;
 		if (isUntitled) {
 			input = this._instantiationService.createInstance(UntitledNotebookInput, path.basename(uri.fsPath), uri, fileInput as UntitledTextEditorInput);


### PR DESCRIPTION
Fixes #9008.

2 very related issues:
- Conditionally add associatedResource (instead of untitledResource) if the file exists on disk already
- Don't use same untitled numbering logic as other untitled notebooks and use the resource as-is (either the full path uri or the untitled:Notebook-x format)

I've tested the following scenarios:
- Opening saved notebooks + rehydrating
- Untitled new notebooks + rehydrating
- Opening notebook from unsaved books viewlet + clicking relative link (note: rehydration does not work in this case, which is not a regression)
- Opening notebook from saved books viewlet + clicking relative link (rehydration succeeds)

If anyone has any spare cycles and can test, would love any help that you can provide 😄 