### PR TITLE
Fix Jupyter Book notebook titles

### DIFF
--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -83,7 +83,7 @@ export class BookTreeItem extends vscode.TreeItem {
 		while (i > -1) {
 			if (this.book.tableOfContents.sections[i].url) {
 				// TODO: Currently only navigating to notebooks. Need to add logic for markdown.
-				let pathToNotebook = path.join(this.book.root, 'content', this.book.tableOfContents.sections[i].url.concat('.ipynb'));
+				let pathToNotebook = path.posix.join(this.book.root, 'content', this.book.tableOfContents.sections[i].url.concat('.ipynb'));
 				// eslint-disable-next-line no-sync
 				if (fs.existsSync(pathToNotebook)) {
 					this._previousUri = pathToNotebook;
@@ -99,7 +99,7 @@ export class BookTreeItem extends vscode.TreeItem {
 		while (i < this.book.tableOfContents.sections.length) {
 			if (this.book.tableOfContents.sections[i].url) {
 				// TODO: Currently only navigating to notebooks. Need to add logic for markdown.
-				let pathToNotebook = path.join(this.book.root, 'content', this.book.tableOfContents.sections[i].url.concat('.ipynb'));
+				let pathToNotebook = path.posix.join(this.book.root, 'content', this.book.tableOfContents.sections[i].url.concat('.ipynb'));
 				// eslint-disable-next-line no-sync
 				if (fs.existsSync(pathToNotebook)) {
 					this._nextUri = pathToNotebook;

--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -67,7 +67,8 @@ export class BookTreeItem extends vscode.TreeItem {
 
 	private setCommand() {
 		if (this.book.type === BookTreeItemType.Notebook) {
-			let pathToNotebook = path.join(this.book.root, 'content', this._uri.concat('.ipynb'));
+			// The Notebook editor expects a posix path for the resource (it will still resolve to the correct fsPath based on OS)
+			const pathToNotebook = path.posix.join(this.book.root, 'content', this._uri.concat('.ipynb'));
 			this.command = { command: this.book.isUntitled ? 'bookTreeView.openUntitledNotebook' : 'bookTreeView.openNotebook', title: loc.openNotebookCommand, arguments: [pathToNotebook], };
 		} else if (this.book.type === BookTreeItemType.Markdown) {
 			let pathToMarkdown = path.join(this.book.root, 'content', this._uri.concat('.md'));

--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -82,7 +82,7 @@ export class BookTreeItem extends vscode.TreeItem {
 		let i = --index;
 		while (i > -1) {
 			if (this.book.tableOfContents.sections[i].url) {
-				// TODO: Currently only navigating to notebooks. Need to add logic for markdown.
+				// The Notebook editor expects a posix path for the resource (it will still resolve to the correct fsPath based on OS)
 				let pathToNotebook = path.posix.join(this.book.root, 'content', this.book.tableOfContents.sections[i].url.concat('.ipynb'));
 				// eslint-disable-next-line no-sync
 				if (fs.existsSync(pathToNotebook)) {
@@ -98,7 +98,7 @@ export class BookTreeItem extends vscode.TreeItem {
 		let i = ++index;
 		while (i < this.book.tableOfContents.sections.length) {
 			if (this.book.tableOfContents.sections[i].url) {
-				// TODO: Currently only navigating to notebooks. Need to add logic for markdown.
+				// The Notebook editor expects a posix path for the resource (it will still resolve to the correct fsPath based on OS)
 				let pathToNotebook = path.posix.join(this.book.root, 'content', this.book.tableOfContents.sections[i].url.concat('.ipynb'));
 				// eslint-disable-next-line no-sync
 				if (fs.existsSync(pathToNotebook)) {

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -97,7 +97,8 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			const sectionToOpen = bookRoot.findChildSection(urlToOpen);
 			const urlPath = sectionToOpen ? sectionToOpen.url : bookRoot.tableOfContents.sections[0].url;
 			const sectionToOpenMarkdown: string = path.join(this.currentBook.bookPath, 'content', urlPath.concat('.md'));
-			const sectionToOpenNotebook: string = path.join(this.currentBook.bookPath, 'content', urlPath.concat('.ipynb'));
+			// The Notebook editor expects a posix path for the resource (it will still resolve to the correct fsPath based on OS)
+			const sectionToOpenNotebook: string = path.posix.join(this.currentBook.bookPath, 'content', urlPath.concat('.ipynb'));
 			if (await fs.pathExists(sectionToOpenMarkdown)) {
 				this.openMarkdown(sectionToOpenMarkdown);
 			}

--- a/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
+++ b/src/sql/workbench/api/browser/mainThreadNotebookDocumentsAndEditors.ts
@@ -725,7 +725,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 				let result = await this._proxy.$getNavigation(handle, uri);
 				if (result) {
 					if (result.next.scheme === Schemas.untitled) {
-						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.next.path)}`);
+						let untitledNbName: URI = URI.parse(`untitled:${result.next.path}`);
 						let content = await this._fileService.readFile(URI.file(result.next.path));
 						await this.doOpenEditor(untitledNbName, { initialContent: content.value.toString(), initialDirtyState: false });
 					}
@@ -738,7 +738,7 @@ export class MainThreadNotebookDocumentsAndEditors extends Disposable implements
 				let result = await this._proxy.$getNavigation(handle, uri);
 				if (result) {
 					if (result.previous.scheme === Schemas.untitled) {
-						let untitledNbName: URI = URI.parse(`untitled:${path.basename(result.previous.path)}`);
+						let untitledNbName: URI = URI.parse(`untitled:${result.previous.path}`);
 						let content = await this._fileService.readFile(URI.file(result.previous.path));
 						await this.doOpenEditor(untitledNbName, { initialContent: content.value.toString(), initialDirtyState: false });
 					}


### PR DESCRIPTION
This fixes it so the editor titles show the correct basename instead of the fully qualified path.

The issue comes down to the VS Code expects all resource URIs to be posix-like and so in https://github.com/microsoft/azuredatastudio/blob/master/src/vs/base/common/resources.ts#L72 hardcodes it to using posix.basename when getting the resource name for the editor title.

I've tested :

1. Opening book from viewlet (both saved and unsaved)
2. Opening book from command palette (2019 TSG)
3. Opening book from Troubleshooting link on BDC Dashboard