### PR TITLE
Create new row upon focus on last row

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -287,10 +287,10 @@ export class EditDataGridPanel extends GridParentComponent {
 			return;
 		}
 
-		if (this.isNullRow(this.currentCell.row)) {
-			self.addRow(this.currentCell.row);
-			self.refreshGrid();
-		}
+		// if (this.isNullRow(row)) {
+		// 	self.addRow(row);
+		// 	self.refreshGrid();
+		// }
 
 		let cellSelectTasks: Promise<void> = this.submitCurrentCellChange(
 			(result: EditUpdateCellResult) => {
@@ -547,9 +547,9 @@ export class EditDataGridPanel extends GridParentComponent {
 			if (this.isNullRow(this.currentCell.row)) {
 				refreshGrid = true;
 				// We've entered the "new row", so we need to add a row and jump to it
-				// updateCellPromise = updateCellPromise.then(() => {
-				// 	return self.addRow(this.currentCell.row);
-				// });
+				updateCellPromise = updateCellPromise.then(() => {
+					return self.addRow(this.currentCell.row);
+				});
 			}
 			// We're exiting a read/write cell after having changed the value, update the cell value in the service
 			updateCellPromise = updateCellPromise.then(() => {

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -287,10 +287,10 @@ export class EditDataGridPanel extends GridParentComponent {
 			return;
 		}
 
-		// if (this.isNullRow(row)) {
-		// 	self.addRow(row);
-		// 	self.refreshGrid();
-		// }
+		if (this.isNullRow(row)) {
+			self.addRow(row);
+			self.refreshGrid();
+		}
 
 		let cellSelectTasks: Promise<void> = this.submitCurrentCellChange(
 			(result: EditUpdateCellResult) => {
@@ -542,15 +542,7 @@ export class EditDataGridPanel extends GridParentComponent {
 	private submitCurrentCellChange(resultHandler, errorHandler): Promise<void> {
 		let self = this;
 		let updateCellPromise: Promise<void> = Promise.resolve();
-		let refreshGrid = false;
 		if (this.currentCell && this.currentCell.isEditable && this.currentEditCellValue !== undefined && !this.removingNewRow) {
-			if (this.isNullRow(this.currentCell.row)) {
-				refreshGrid = true;
-				// We've entered the "new row", so we need to add a row and jump to it
-				updateCellPromise = updateCellPromise.then(() => {
-					return self.addRow(this.currentCell.row);
-				});
-			}
 			// We're exiting a read/write cell after having changed the value, update the cell value in the service
 			updateCellPromise = updateCellPromise.then(() => {
 				// Use the mapped row ID if we're on that row
@@ -563,9 +555,6 @@ export class EditDataGridPanel extends GridParentComponent {
 				result => {
 					self.currentEditCellValue = undefined;
 					let refreshPromise: Thenable<void> = Promise.resolve();
-					if (refreshGrid) {
-						refreshPromise = self.refreshGrid();
-					}
 					return refreshPromise.then(() => {
 						return resultHandler(result);
 					});

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -287,6 +287,11 @@ export class EditDataGridPanel extends GridParentComponent {
 			return;
 		}
 
+		if (this.isNullRow(this.currentCell.row)) {
+			self.addRow(this.currentCell.row);
+			self.refreshGrid();
+		}
+
 		let cellSelectTasks: Promise<void> = this.submitCurrentCellChange(
 			(result: EditUpdateCellResult) => {
 				// Cell update was successful, update the flags
@@ -542,9 +547,9 @@ export class EditDataGridPanel extends GridParentComponent {
 			if (this.isNullRow(this.currentCell.row)) {
 				refreshGrid = true;
 				// We've entered the "new row", so we need to add a row and jump to it
-				updateCellPromise = updateCellPromise.then(() => {
-					return self.addRow(this.currentCell.row);
-				});
+				// updateCellPromise = updateCellPromise.then(() => {
+				// 	return self.addRow(this.currentCell.row);
+				// });
 			}
 			// We're exiting a read/write cell after having changed the value, update the cell value in the service
 			updateCellPromise = updateCellPromise.then(() => {

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -794,7 +794,7 @@ export class EditDataGridPanel extends GridParentComponent {
 				defaultFormatter: undefined,
 				editable: this.enableEditing,
 				autoEdit: this.enableEditing,
-				enableAddRow: true,
+				enableAddRow: false,
 				enableAsyncPostRender: false,
 				editorFactory: {
 					getEditor: (column: ISlickColumn<any>) => this.getColumnEditor(column)
@@ -974,7 +974,7 @@ export class EditDataGridPanel extends GridParentComponent {
 		this.enableEditing = enabled;
 		let options: any = this.table.grid.getOptions();
 		options.editable = enabled;
-		options.enableAddRow = true;
+		options.enableAddRow = false;
 		this.table.grid.setOptions(options);
 	}
 

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -794,7 +794,7 @@ export class EditDataGridPanel extends GridParentComponent {
 				defaultFormatter: undefined,
 				editable: this.enableEditing,
 				autoEdit: this.enableEditing,
-				enableAddRow: false,
+				enableAddRow: true,
 				enableAsyncPostRender: false,
 				editorFactory: {
 					getEditor: (column: ISlickColumn<any>) => this.getColumnEditor(column)
@@ -974,7 +974,7 @@ export class EditDataGridPanel extends GridParentComponent {
 		this.enableEditing = enabled;
 		let options: any = this.table.grid.getOptions();
 		options.editable = enabled;
-		options.enableAddRow = false;
+		options.enableAddRow = true;
 		this.table.grid.setOptions(options);
 	}
 


### PR DESCRIPTION
This makes it so that upon a new row cell is selected, a new row is automatically created below, instead of having the new row be created when the change is about to be submitted.

This PR fixes #9033 
