### PR TITLE
BDC: Add another command for bdc extension activation events

### DIFF
--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -14,7 +14,8 @@
 	"activationEvents": [
     "onCommand:bigDataClusters.command.mount",
     "onCommand:bigDataClusters.command.refreshmount",
-    "onCommand:bigDataClusters.command.deletemount",
+	"onCommand:bigDataClusters.command.deletemount",
+	"onCommand:bigDataClusters.command.manageController",
     "onView:sqlBigDataCluster"
 	],
 	"repository": {

--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -17,7 +17,7 @@
     "onCommand:bigDataClusters.command.deletemount",
     "onCommand:bigDataClusters.command.addController",
     "onCommand:bigDataClusters.command.deleteController",
-	"onCommand:bigDataClusters.command.manageController",
+    "onCommand:bigDataClusters.command.manageController",
     "onCommand:bigDataClusters.command.refreshController",
     "onView:sqlBigDataCluster"
 	],

--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -14,8 +14,8 @@
 	"activationEvents": [
     "onCommand:bigDataClusters.command.mount",
     "onCommand:bigDataClusters.command.refreshmount",
-	"onCommand:bigDataClusters.command.deletemount",
-	"onCommand:bigDataClusters.command.manageController",
+    "onCommand:bigDataClusters.command.deletemount",
+    "onCommand:bigDataClusters.command.manageController",
     "onView:sqlBigDataCluster"
 	],
 	"repository": {

--- a/extensions/big-data-cluster/package.json
+++ b/extensions/big-data-cluster/package.json
@@ -15,7 +15,10 @@
     "onCommand:bigDataClusters.command.mount",
     "onCommand:bigDataClusters.command.refreshmount",
     "onCommand:bigDataClusters.command.deletemount",
-    "onCommand:bigDataClusters.command.manageController",
+    "onCommand:bigDataClusters.command.addController",
+    "onCommand:bigDataClusters.command.deleteController",
+	"onCommand:bigDataClusters.command.manageController",
+    "onCommand:bigDataClusters.command.refreshController",
     "onView:sqlBigDataCluster"
 	],
 	"repository": {


### PR DESCRIPTION
This is for #9049. Needed to add another activationEvent for the open cluster dashboard command. 