### PR TITLE
disable updateNameFromFirstLine from untitledTextEditorModel

### DIFF
--- a/src/sql/workbench/contrib/query/common/queryEditorInput.ts
+++ b/src/sql/workbench/contrib/query/common/queryEditorInput.ts
@@ -219,8 +219,10 @@ export abstract class QueryEditorInput extends EditorInput implements IConnectab
 			} else {
 				title += localize('disconnected', "disconnected");
 			}
+			console.log('title is ' + this._text.getName() + (longForm ? (' - ' + title) : ` - ${trimTitle(title)}`));
 			return this._text.getName() + (longForm ? (' - ' + title) : ` - ${trimTitle(title)}`);
 		} else {
+			console.log('title did not update');
 			return this._text.getName();
 		}
 	}

--- a/src/sql/workbench/contrib/query/common/queryEditorInput.ts
+++ b/src/sql/workbench/contrib/query/common/queryEditorInput.ts
@@ -219,10 +219,8 @@ export abstract class QueryEditorInput extends EditorInput implements IConnectab
 			} else {
 				title += localize('disconnected', "disconnected");
 			}
-			console.log('title is ' + this._text.getName() + (longForm ? (' - ' + title) : ` - ${trimTitle(title)}`));
 			return this._text.getName() + (longForm ? (' - ' + title) : ` - ${trimTitle(title)}`);
 		} else {
-			console.log('title did not update');
 			return this._text.getName();
 		}
 	}

--- a/src/vs/workbench/browser/labels.ts
+++ b/src/vs/workbench/browser/labels.ts
@@ -510,15 +510,15 @@ class ResourceLabelWidget extends IconLabel {
 		}
 
 		let label = this.label.name || '';
-		if (resource?.scheme === Schemas.untitled) {
-			// Untitled labels are very dynamic because they may change
-			// whenever the content changes. As such we always ask the
-			// text file service for the name of the untitled editor
-			const untitledName = this.textFileService.untitled.get(resource)?.getName();
-			if (untitledName) {
-				label = untitledName;
-			}
-		}
+		// if (resource?.scheme === Schemas.untitled) {	 // {{SQL CARBON EDIT}} - For Query Editor, untitled editor query must use same label.
+		// 	// Untitled labels are very dynamic because they may change
+		// 	// whenever the content changes. As such we always ask the
+		// 	// text file service for the name of the untitled editor
+		// 	const untitledName = this.textFileService.untitled.get(resource)?.getName();
+		// 	if (untitledName) {
+		// 		label = untitledName;
+		// 	}
+		// }
 
 		this.setLabel(label, this.label.description, iconLabelOptions);
 

--- a/src/vs/workbench/common/editor/untitledTextEditorModel.ts
+++ b/src/vs/workbench/common/editor/untitledTextEditorModel.ts
@@ -242,9 +242,8 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 	}
 
 	private updateNameFromFirstLine(): void {
-		return; // {{SQL CARBON EDIT}} - For Query Editor, must not change name even without file path.
-		// if (this.hasAssociatedFilePath) {
-		// 	return;
+		// if (this.hasAssociatedFilePath) { {{SQL CARBON EDIT}} - For Query Editor, must not change name even without file path.
+		return;
 		// }
 
 		// Determine the first words of the model following these rules:

--- a/src/vs/workbench/common/editor/untitledTextEditorModel.ts
+++ b/src/vs/workbench/common/editor/untitledTextEditorModel.ts
@@ -242,7 +242,8 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 	}
 
 	private updateNameFromFirstLine(): void {
-		if (this.hasAssociatedFilePath) {
+		// {{SQL CARBON EDIT}} - For Query Editor, must not change name even without file path.
+		if (!this.hasAssociatedFilePath && this.hasAssociatedFilePath) {
 			return; // not in case of an associated file path
 		}
 

--- a/src/vs/workbench/common/editor/untitledTextEditorModel.ts
+++ b/src/vs/workbench/common/editor/untitledTextEditorModel.ts
@@ -243,7 +243,7 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 
 	private updateNameFromFirstLine(): void {
 		// {{SQL CARBON EDIT}} - For Query Editor, must not change name even without file path.
-		if (!this.hasAssociatedFilePath && this.hasAssociatedFilePath) {
+		if (!this.hasAssociatedFilePath || this.hasAssociatedFilePath) {
 			return; // not in case of an associated file path
 		}
 

--- a/src/vs/workbench/common/editor/untitledTextEditorModel.ts
+++ b/src/vs/workbench/common/editor/untitledTextEditorModel.ts
@@ -242,10 +242,7 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 	}
 
 	private updateNameFromFirstLine(): void {
-		// {{SQL CARBON EDIT}} - For Query Editor, must not change name even without file path.
-		if (!this.hasAssociatedFilePath || this.hasAssociatedFilePath) {
-			return; // not in case of an associated file path
-		}
+		return; // {{SQL CARBON EDIT}} - For Query Editor, must not change name even without file path.
 
 		// Determine the first words of the model following these rules:
 		// - cannot be only whitespace (so we trim())

--- a/src/vs/workbench/common/editor/untitledTextEditorModel.ts
+++ b/src/vs/workbench/common/editor/untitledTextEditorModel.ts
@@ -246,6 +246,7 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 		// if (this.hasAssociatedFilePath) {
 		// 	return;
 		// }
+
 		// Determine the first words of the model following these rules:
 		// - cannot be only whitespace (so we trim())
 		// - cannot be only non-alphanumeric characters (so we run word definition regex over it)

--- a/src/vs/workbench/common/editor/untitledTextEditorModel.ts
+++ b/src/vs/workbench/common/editor/untitledTextEditorModel.ts
@@ -243,7 +243,9 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 
 	private updateNameFromFirstLine(): void {
 		return; // {{SQL CARBON EDIT}} - For Query Editor, must not change name even without file path.
-
+		// if (this.hasAssociatedFilePath) {
+		// 	return;
+		// }
 		// Determine the first words of the model following these rules:
 		// - cannot be only whitespace (so we trim())
 		// - cannot be only non-alphanumeric characters (so we run word definition regex over it)

--- a/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
+++ b/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
@@ -16,8 +16,8 @@ import { snapshotToString } from 'vs/workbench/services/textfile/common/textfile
 import { ModesRegistry, PLAINTEXT_MODE_ID } from 'vs/editor/common/modes/modesRegistry';
 import { IWorkingCopyService, IWorkingCopy } from 'vs/workbench/services/workingCopy/common/workingCopyService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { IIdentifiedSingleEditOperation } from 'vs/editor/common/model';
-import { Range } from 'vs/editor/common/core/range';
+// import { IIdentifiedSingleEditOperation } from 'vs/editor/common/model'; // {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
+// import { Range } from 'vs/editor/common/core/range'; // {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
 
 class ServiceAccessor {
 	constructor(
@@ -303,24 +303,24 @@ suite('Workbench untitled text editors', () => {
 		model.dispose();
 	});
 
-	test('service#onDidChangeLabel', async () => {
-		const service = accessor.untitledTextEditorService;
-		const input = service.create();
+	// test('service#onDidChangeLabel', async () => {
+	// 	const service = accessor.untitledTextEditorService;
+	// 	const input = service.create();
 
-		let counter = 0;
+	// 	let counter = 0;
 
-		service.onDidChangeLabel(r => {
-			counter++;
-			assert.equal(r.toString(), input.getResource().toString());
-		});
+	// 	service.onDidChangeLabel(r => {
+	// 		counter++;
+	// 		assert.equal(r.toString(), input.getResource().toString());
+	// 	});
 
-		// label
-		const model = await input.resolve();
-		model.textEditorModel.setValue('Foo Bar');
-		assert.equal(counter, 1);
-		input.dispose();
-		model.dispose();
-	});
+	// 	// label
+	// 	const model = await input.resolve();
+	// 	model.textEditorModel.setValue('Foo Bar');
+	// 	assert.equal(counter, 1);
+	// 	input.dispose();
+	// 	model.dispose();
+	// });
 
 	test('service#onDidDisposeModel', async () => {
 		const service = accessor.untitledTextEditorService;
@@ -383,70 +383,70 @@ suite('Workbench untitled text editors', () => {
 		assert.ok(counter > 1);
 	});
 
-	test('model#onDidChangeName and input name', async function () {
-		const service = accessor.untitledTextEditorService;
-		const input = service.create();
+	// test('model#onDidChangeName and input name', async function () {
+	// 	const service = accessor.untitledTextEditorService;
+	// 	const input = service.create();
 
-		let counter = 0;
+	// 	let counter = 0;
 
-		let model = await input.resolve();
-		model.onDidChangeName(() => counter++);
+	// 	let model = await input.resolve();
+	// 	model.onDidChangeName(() => counter++);
 
-		model.textEditorModel.setValue('foo');
-		assert.equal(input.getName(), 'foo');
+	// 	model.textEditorModel.setValue('foo');
+	// 	assert.equal(input.getName(), 'foo');
 
-		assert.equal(counter, 1);
-		model.textEditorModel.setValue('bar');
-		assert.equal(input.getName(), 'bar');
+	// 	assert.equal(counter, 1);
+	// 	model.textEditorModel.setValue('bar');
+	// 	assert.equal(input.getName(), 'bar');
 
-		assert.equal(counter, 2);
-		model.textEditorModel.setValue('');
-		assert.equal(input.getName(), 'Untitled-1');
+	// 	assert.equal(counter, 2);
+	// 	model.textEditorModel.setValue('');
+	// 	assert.equal(input.getName(), 'Untitled-1');
 
-		model.textEditorModel.setValue('        ');
-		assert.equal(input.getName(), 'Untitled-1');
+	// 	model.textEditorModel.setValue('        ');
+	// 	assert.equal(input.getName(), 'Untitled-1');
 
-		model.textEditorModel.setValue('([]}'); // require actual words
-		assert.equal(input.getName(), 'Untitled-1');
+	// 	model.textEditorModel.setValue('([]}'); // require actual words
+	// 	assert.equal(input.getName(), 'Untitled-1');
 
-		model.textEditorModel.setValue('([]}hello   '); // require actual words
-		assert.equal(input.getName(), '([]}hello');
+	// 	model.textEditorModel.setValue('([]}hello   '); // require actual words
+	// 	assert.equal(input.getName(), '([]}hello');
 
-		assert.equal(counter, 4);
+	// 	assert.equal(counter, 4);
 
-		model.textEditorModel.setValue('Hello\nWorld');
-		assert.equal(counter, 5);
+	// 	model.textEditorModel.setValue('Hello\nWorld');
+	// 	assert.equal(counter, 5);
 
-		function createSingleEditOp(text: string, positionLineNumber: number, positionColumn: number, selectionLineNumber: number = positionLineNumber, selectionColumn: number = positionColumn): IIdentifiedSingleEditOperation {
-			let range = new Range(
-				selectionLineNumber,
-				selectionColumn,
-				positionLineNumber,
-				positionColumn
-			);
+	// 	function createSingleEditOp(text: string, positionLineNumber: number, positionColumn: number, selectionLineNumber: number = positionLineNumber, selectionColumn: number = positionColumn): IIdentifiedSingleEditOperation {
+	// 		let range = new Range(
+	// 			selectionLineNumber,
+	// 			selectionColumn,
+	// 			positionLineNumber,
+	// 			positionColumn
+	// 		);
 
-			return {
-				identifier: null,
-				range,
-				text,
-				forceMoveMarkers: false
-			};
-		}
+	// 		return {
+	// 			identifier: null,
+	// 			range,
+	// 			text,
+	// 			forceMoveMarkers: false
+	// 		};
+	// 	}
 
-		model.textEditorModel.applyEdits([createSingleEditOp('hello', 2, 2)]);
-		assert.equal(counter, 5); // change was not on first line
+	// 	model.textEditorModel.applyEdits([createSingleEditOp('hello', 2, 2)]);
+	// 	assert.equal(counter, 5); // change was not on first line
 
-		input.dispose();
-		model.dispose();
+	// 	input.dispose();
+	// 	model.dispose();
 
-		const inputWithContents = service.create({ initialValue: 'Foo' });
-		model = await inputWithContents.resolve();
+	// 	const inputWithContents = service.create({ initialValue: 'Foo' });
+	// 	model = await inputWithContents.resolve();
 
-		assert.equal(inputWithContents.getName(), 'Foo');
+	// 	assert.equal(inputWithContents.getName(), 'Foo');
 
-		inputWithContents.dispose();
-		model.dispose();
-	});
+	// 	inputWithContents.dispose();
+	// 	model.dispose();
+	// });
 
 	test('model#onDidChangeDirty', async function () {
 		const service = accessor.untitledTextEditorService;

--- a/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
+++ b/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
@@ -383,7 +383,7 @@ suite('Workbench untitled text editors', () => {
 		assert.ok(counter > 1);
 	});
 
-	// test('model#onDidChangeName and input name', async function () {		// {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
+	// test('model#onDidChangeName and input name', async function () {	// {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
 	// 	const service = accessor.untitledTextEditorService;
 	// 	const input = service.create();
 

--- a/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
+++ b/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
@@ -16,8 +16,8 @@ import { snapshotToString } from 'vs/workbench/services/textfile/common/textfile
 import { ModesRegistry, PLAINTEXT_MODE_ID } from 'vs/editor/common/modes/modesRegistry';
 import { IWorkingCopyService, IWorkingCopy } from 'vs/workbench/services/workingCopy/common/workingCopyService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-// import { IIdentifiedSingleEditOperation } from 'vs/editor/common/model'; // {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
-// import { Range } from 'vs/editor/common/core/range'; // {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
+import { IIdentifiedSingleEditOperation } from 'vs/editor/common/model';
+import { Range } from 'vs/editor/common/core/range';
 
 class ServiceAccessor {
 	constructor(
@@ -303,24 +303,24 @@ suite('Workbench untitled text editors', () => {
 		model.dispose();
 	});
 
-	// test('service#onDidChangeLabel', async () => { // {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
-	// 	const service = accessor.untitledTextEditorService;
-	// 	const input = service.create();
+	test.skip('service#onDidChangeLabel', async () => { // {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
+		const service = accessor.untitledTextEditorService;
+		const input = service.create();
 
-	// 	let counter = 0;
+		let counter = 0;
 
-	// 	service.onDidChangeLabel(r => {
-	// 		counter++;
-	// 		assert.equal(r.toString(), input.getResource().toString());
-	// 	});
+		service.onDidChangeLabel(r => {
+			counter++;
+			assert.equal(r.toString(), input.getResource().toString());
+		});
 
-	// 	// label
-	// 	const model = await input.resolve();
-	// 	model.textEditorModel.setValue('Foo Bar');
-	// 	assert.equal(counter, 1);
-	// 	input.dispose();
-	// 	model.dispose();
-	// });
+		// label
+		const model = await input.resolve();
+		model.textEditorModel.setValue('Foo Bar');
+		assert.equal(counter, 1);
+		input.dispose();
+		model.dispose();
+	});
 
 	test('service#onDidDisposeModel', async () => {
 		const service = accessor.untitledTextEditorService;
@@ -383,70 +383,70 @@ suite('Workbench untitled text editors', () => {
 		assert.ok(counter > 1);
 	});
 
-	// test('model#onDidChangeName and input name', async function () { // {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
-	// 	const service = accessor.untitledTextEditorService;
-	// 	const input = service.create();
+	test.skip('model#onDidChangeName and input name', async function () { // {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
+		const service = accessor.untitledTextEditorService;
+		const input = service.create();
 
-	// 	let counter = 0;
+		let counter = 0;
 
-	// 	let model = await input.resolve();
-	// 	model.onDidChangeName(() => counter++);
+		let model = await input.resolve();
+		model.onDidChangeName(() => counter++);
 
-	// 	model.textEditorModel.setValue('foo');
-	// 	assert.equal(input.getName(), 'foo');
+		model.textEditorModel.setValue('foo');
+		assert.equal(input.getName(), 'foo');
 
-	// 	assert.equal(counter, 1);
-	// 	model.textEditorModel.setValue('bar');
-	// 	assert.equal(input.getName(), 'bar');
+		assert.equal(counter, 1);
+		model.textEditorModel.setValue('bar');
+		assert.equal(input.getName(), 'bar');
 
-	// 	assert.equal(counter, 2);
-	// 	model.textEditorModel.setValue('');
-	// 	assert.equal(input.getName(), 'Untitled-1');
+		assert.equal(counter, 2);
+		model.textEditorModel.setValue('');
+		assert.equal(input.getName(), 'Untitled-1');
 
-	// 	model.textEditorModel.setValue('        ');
-	// 	assert.equal(input.getName(), 'Untitled-1');
+		model.textEditorModel.setValue('        ');
+		assert.equal(input.getName(), 'Untitled-1');
 
-	// 	model.textEditorModel.setValue('([]}'); // require actual words
-	// 	assert.equal(input.getName(), 'Untitled-1');
+		model.textEditorModel.setValue('([]}'); // require actual words
+		assert.equal(input.getName(), 'Untitled-1');
 
-	// 	model.textEditorModel.setValue('([]}hello   '); // require actual words
-	// 	assert.equal(input.getName(), '([]}hello');
+		model.textEditorModel.setValue('([]}hello   '); // require actual words
+		assert.equal(input.getName(), '([]}hello');
 
-	// 	assert.equal(counter, 4);
+		assert.equal(counter, 4);
 
-	// 	model.textEditorModel.setValue('Hello\nWorld');
-	// 	assert.equal(counter, 5);
+		model.textEditorModel.setValue('Hello\nWorld');
+		assert.equal(counter, 5);
 
-	// 	function createSingleEditOp(text: string, positionLineNumber: number, positionColumn: number, selectionLineNumber: number = positionLineNumber, selectionColumn: number = positionColumn): IIdentifiedSingleEditOperation {
-	// 		let range = new Range(
-	// 			selectionLineNumber,
-	// 			selectionColumn,
-	// 			positionLineNumber,
-	// 			positionColumn
-	// 		);
+		function createSingleEditOp(text: string, positionLineNumber: number, positionColumn: number, selectionLineNumber: number = positionLineNumber, selectionColumn: number = positionColumn): IIdentifiedSingleEditOperation {
+			let range = new Range(
+				selectionLineNumber,
+				selectionColumn,
+				positionLineNumber,
+				positionColumn
+			);
 
-	// 		return {
-	// 			identifier: null,
-	// 			range,
-	// 			text,
-	// 			forceMoveMarkers: false
-	// 		};
-	// 	}
+			return {
+				identifier: null,
+				range,
+				text,
+				forceMoveMarkers: false
+			};
+		}
 
-	// 	model.textEditorModel.applyEdits([createSingleEditOp('hello', 2, 2)]);
-	// 	assert.equal(counter, 5); // change was not on first line
+		model.textEditorModel.applyEdits([createSingleEditOp('hello', 2, 2)]);
+		assert.equal(counter, 5); // change was not on first line
 
-	// 	input.dispose();
-	// 	model.dispose();
+		input.dispose();
+		model.dispose();
 
-	// 	const inputWithContents = service.create({ initialValue: 'Foo' });
-	// 	model = await inputWithContents.resolve();
+		const inputWithContents = service.create({ initialValue: 'Foo' });
+		model = await inputWithContents.resolve();
 
-	// 	assert.equal(inputWithContents.getName(), 'Foo');
+		assert.equal(inputWithContents.getName(), 'Foo');
 
-	// 	inputWithContents.dispose();
-	// 	model.dispose();
-	// });
+		inputWithContents.dispose();
+		model.dispose();
+	});
 
 	test('model#onDidChangeDirty', async function () {
 		const service = accessor.untitledTextEditorService;

--- a/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
+++ b/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
@@ -303,7 +303,7 @@ suite('Workbench untitled text editors', () => {
 		model.dispose();
 	});
 
-	// test('service#onDidChangeLabel', async () => {	// {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
+	// test('service#onDidChangeLabel', async () => { // {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
 	// 	const service = accessor.untitledTextEditorService;
 	// 	const input = service.create();
 
@@ -383,7 +383,7 @@ suite('Workbench untitled text editors', () => {
 		assert.ok(counter > 1);
 	});
 
-	// test('model#onDidChangeName and input name', async function () {	// {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
+	// test('model#onDidChangeName and input name', async function () { // {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
 	// 	const service = accessor.untitledTextEditorService;
 	// 	const input = service.create();
 

--- a/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
+++ b/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
@@ -303,7 +303,7 @@ suite('Workbench untitled text editors', () => {
 		model.dispose();
 	});
 
-	// test('service#onDidChangeLabel', async () => {
+	// test('service#onDidChangeLabel', async () => {	// {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
 	// 	const service = accessor.untitledTextEditorService;
 	// 	const input = service.create();
 
@@ -383,7 +383,7 @@ suite('Workbench untitled text editors', () => {
 		assert.ok(counter > 1);
 	});
 
-	// test('model#onDidChangeName and input name', async function () {
+	// test('model#onDidChangeName and input name', async function () {		// {{SQL CARBON EDIT}} - Disable as untitledTextEditorModel test is disabled.
 	// 	const service = accessor.untitledTextEditorService;
 	// 	const input = service.create();
 


### PR DESCRIPTION
untitledTextEditorModel is created without a file path before the Query Editor is instantiated, and it detects whenever the editor text changes. As a result, it will replace the header name with the first line of text in the editor. There is currently no way to alter this behavior outside of vscode.

This PR handles #9058 until updates to vscode have been made.
