### PR TITLE
Fix feature request links

### DIFF
--- a/product.json
+++ b/product.json
@@ -29,7 +29,7 @@
 	},
 	"sendASmile": {
 		"reportIssueUrl": "https://github.com/Microsoft/azuredatastudio/issues/new?labels=customer%20reported%20issue",
-		"requestFeatureUrl": "https://github.com/Microsoft/azuredatastudio/issues/new?template=feature_request.md"
+		"requestFeatureUrl": "https://go.microsoft.com/fwlink/?linkid=2118115"
 	},
 	"gettingStartedUrl": "https://go.microsoft.com/fwlink/?linkid=862039",
 	"releaseNotesUrl": "https://go.microsoft.com/fwlink/?linkid=875578",

--- a/product.json
+++ b/product.json
@@ -19,7 +19,7 @@
 	"linuxIconName": "com.azuredatastudio.oss",
 	"licenseFileName": "LICENSE.txt",
 	"reportIssueUrl": "https://github.com/Microsoft/azuredatastudio/issues/new?labels=customer%20reported%20issue",
-	"requestFeatureUrl": "https://github.com/Microsoft/azuredatastudio/issues/new?labels=feature-request",
+	"requestFeatureUrl": "https://go.microsoft.com/fwlink/?linkid=2118021",
 	"privacyStatementUrl": "https://privacy.microsoft.com/en-us/privacystatement",
 	"telemetryOptOutUrl": "https://github.com/Microsoft/azuredatastudio/wiki/How-to-Disable-Telemetry-Reporting",
 	"urlProtocol": "azuredatastudio",
@@ -29,7 +29,7 @@
 	},
 	"sendASmile": {
 		"reportIssueUrl": "https://github.com/Microsoft/azuredatastudio/issues/new?labels=customer%20reported%20issue",
-		"requestFeatureUrl": "https://github.com/Microsoft/azuredatastudio/issues/new?labels=feature-request"
+		"requestFeatureUrl": "https://github.com/Microsoft/azuredatastudio/issues/new?template=feature_request.md"
 	},
 	"gettingStartedUrl": "https://go.microsoft.com/fwlink/?linkid=862039",
 	"releaseNotesUrl": "https://go.microsoft.com/fwlink/?linkid=875578",


### PR DESCRIPTION
Fixes #9085

Two separate links - one for **Search Feature Requests** and one for **Request a missing feature** in the send-a-smile dialog.

Currently they both are set to go to https://github.com/Microsoft/azuredatastudio/issues?q=is%3Aopen+is%3Aissue+label%3AEnhancement+sort%3Areactions-%2B1-desc. This is what VS Code does and seems to make sense for the Request a missing feature link since that doesn't have them fill out a form ahead of time so having users see the currently open list of issues is likely to reduce duplicate issues.

I set up two separate fwlinks though in case we want to change this behavior in the future without requiring a product update. 

Note that currently you can select **Feature Request** from the dropdown in the dialog 

![image](https://user-images.githubusercontent.com/28519865/74059340-adedf380-499c-11ea-916f-e3f08e2c59d4.png)

in which case it'll open up a generic issue with the filled-in information and bypass the issue template. This is currently the same behavior VS Code has and is likely just an oversight - but is a bit of a bigger change so not going to try and fix that now.