### PR TITLE
Fix for revert on pressing escape.

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -398,7 +398,6 @@ export class EditDataGridPanel extends GridParentComponent {
 
 		// Setup the state of the selected cell
 		this.resetCurrentCell();
-		this.currentEditCellValue = undefined;
 		this.removingNewRow = false;
 		this.newRowVisible = false;
 		this.dirtyCells = [];
@@ -511,7 +510,6 @@ export class EditDataGridPanel extends GridParentComponent {
 					return this.removeRow(currentNewRowIndex);
 				}).then(() => {
 					this.newRowVisible = false;
-					this.currentEditCellValue = undefined;
 					this.resetCurrentCell();
 				});
 		} else {
@@ -525,7 +523,6 @@ export class EditDataGridPanel extends GridParentComponent {
 				// so clear any existing client-side edit and refresh on-screen data
 				// do not refresh the whole dataset as it will move the focus away to the first row.
 				//
-				this.currentEditCellValue = undefined;
 				this.dirtyCells = [];
 				let row = this.currentCell.row;
 				this.resetCurrentCell();
@@ -764,6 +761,7 @@ export class EditDataGridPanel extends GridParentComponent {
 			isEditable: false,
 			isDirty: false
 		};
+		this.currentEditCellValue = undefined;
 	}
 
 	private setCurrentCell(row: number, column: number) {

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -511,6 +511,7 @@ export class EditDataGridPanel extends GridParentComponent {
 					return this.removeRow(currentNewRowIndex);
 				}).then(() => {
 					this.newRowVisible = false;
+					this.currentEditCellValue = undefined;
 					this.resetCurrentCell();
 				});
 		} else {

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -33,6 +33,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { deepClone, assign } from 'vs/base/common/objects';
 import { Emitter, Event } from 'vs/base/common/event';
 import { equals } from 'vs/base/common/arrays';
+import * as DOM from 'vs/base/browser/dom';
 
 export class EditDataGridPanel extends GridParentComponent {
 	// The time(in milliseconds) we wait before refreshing the grid.
@@ -110,6 +111,7 @@ export class EditDataGridPanel extends GridParentComponent {
 	onInit(): void {
 		const self = this;
 		this.baseInit();
+		this._register(DOM.addDisposableListener(this.nativeElement, DOM.EventType.KEY_DOWN, e => this.tryHandleKeyEvent(new StandardKeyboardEvent(e))));
 
 		// Add the subscription to the list of things to be disposed on destroy, or else on a new component init
 		// may get the "destroyed" object still getting called back.


### PR DESCRIPTION
Added a listener for escape key, row will be reverted upon hitting escape. Also the currentEditCellValue is set to undefined in the function so that the value will not persist upon clicking another cell.

This PR fixes #9083 
