### PR TITLE
Fix for manage access dialog focus

### DIFF
--- a/extensions/mssql/src/hdfs/ui/hdfsManageAccessDialog.ts
+++ b/extensions/mssql/src/hdfs/ui/hdfsManageAccessDialog.ts
@@ -13,6 +13,7 @@ import { HdfsError } from '../webhdfs';
 import { ApiWrapper } from '../../apiWrapper';
 import { IconPathHelper } from '../../iconHelper';
 import { HdfsFileType } from '../fileStatus';
+import { EventEmitter } from 'vscode';
 
 const permissionsTypeIconColumnWidth = 35;
 const permissionsDeleteColumnWidth = 50;
@@ -34,7 +35,7 @@ type PermissionCheckboxesMapping = {
 export class ManageAccessDialog {
 
 	private hdfsModel: HdfsModel;
-	private viewInitializedOrInProgress: boolean = false;
+	private viewInitialized: boolean = false;
 	private modelInitialized: boolean = false;
 	private modelBuilder: azdata.ModelBuilder;
 	private rootContainer: azdata.FlexContainer;
@@ -49,6 +50,7 @@ export class ManageAccessDialog {
 	private posixPermissionCheckboxesMapping: PermissionCheckboxesMapping[] = [];
 	private namedSectionInheritCheckboxes: azdata.CheckBoxComponent[] = [];
 	private addUserOrGroupSelectedType: AclType;
+	private onViewInitializedEvent: EventEmitter<void> = new EventEmitter();
 
 	constructor(private hdfsPath: string, private fileSource: IFileSource, private readonly apiWrapper: ApiWrapper) {
 		this.hdfsModel = new HdfsModel(this.fileSource, this.hdfsPath);
@@ -101,8 +103,6 @@ export class ManageAccessDialog {
 	}
 
 	private initializeView(permissionStatus: PermissionStatus): void {
-		this.viewInitializedOrInProgress = true;
-
 		// We nest the content inside another container for the margins - getting them on the root container isn't supported
 		const contentContainer = this.modelBuilder.flexContainer()
 			.withLayout({ flexFlow: 'column', width: '100%', height: '100%' })
@@ -238,6 +238,8 @@ export class ManageAccessDialog {
 			.withLayout({ flexFlow: 'column' })
 			.component();
 		contentContainer.addItem(this.namedUsersAndGroupsPermissionsContainer, { flex: '1', CSSStyles: { 'overflow': 'scroll', 'min-height': '200px' } });
+		this.viewInitialized = true;
+		this.onViewInitializedEvent.fire();
 	}
 
 	private handlePermissionStatusUpdated(permissionStatus: PermissionStatus): void {
@@ -246,86 +248,88 @@ export class ManageAccessDialog {
 		}
 
 		// If this is the first time go through and create the UI components now that we have a model to use
-		if (!this.viewInitializedOrInProgress) {
+		if (!this.viewInitialized) {
 			this.initializeView(permissionStatus);
 		}
 
-		this.stickyCheckbox.checked = permissionStatus.stickyBit;
-		if (this.hdfsModel.fileStatus.type === HdfsFileType.Directory) {
-			this.inheritDefaultsCheckbox.checked =
-				!permissionStatus.owner.getPermission(AclEntryScope.default) &&
-				!permissionStatus.group.getPermission(AclEntryScope.default) &&
-				!permissionStatus.other.getPermission(AclEntryScope.default);
-		}
+		this.eventuallyRunOnInitialized(() => {
+			this.stickyCheckbox.checked = permissionStatus.stickyBit;
+			if (this.hdfsModel.fileStatus.type === HdfsFileType.Directory) {
+				this.inheritDefaultsCheckbox.checked =
+					!permissionStatus.owner.getPermission(AclEntryScope.default) &&
+					!permissionStatus.group.getPermission(AclEntryScope.default) &&
+					!permissionStatus.other.getPermission(AclEntryScope.default);
+			}
 
-		this.applyRecursivelyButton.hidden = this.hdfsModel.fileStatus.type !== HdfsFileType.Directory;
+			this.applyRecursivelyButton.hidden = this.hdfsModel.fileStatus.type !== HdfsFileType.Directory;
 
-		this.posixPermissionsContainer.clearItems();
+			this.posixPermissionsContainer.clearItems();
 
-		const posixPermissionData = [permissionStatus.owner, permissionStatus.group, permissionStatus.other].map(aclEntry => {
-			return this.createPermissionsTableRow(aclEntry, false/*includeDelete*/, false/*includeInherit*/);
+			const posixPermissionData = [permissionStatus.owner, permissionStatus.group, permissionStatus.other].map(aclEntry => {
+				return this.createPermissionsTableRow(aclEntry, false/*includeDelete*/, false/*includeInherit*/);
+			});
+
+			const posixPermissionsNamesColumnWidth = 800 + (this.hdfsModel.fileStatus.type === HdfsFileType.Directory ? 0 : permissionsCheckboxColumnWidth * 3);
+			const namedUsersAndGroupsPermissionsNamesColumnWidth = 700 + (this.hdfsModel.fileStatus.type === HdfsFileType.Directory ? 0 : permissionsCheckboxColumnWidth * 3);
+
+			// Default set of columns that are always shown
+			let posixPermissionsColumns = [
+				this.createTableColumn('', loc.userOrGroupIcon, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
+				this.createTableColumn('', loc.defaultUserAndGroups, posixPermissionsNamesColumnWidth, azdata.DeclarativeDataType.string),
+				this.createTableColumn(loc.readHeader, `${loc.accessHeader} ${loc.readHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
+				this.createTableColumn(loc.writeHeader, `${loc.accessHeader} ${loc.writeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
+				this.createTableColumn(loc.executeHeader, `${loc.accessHeader} ${loc.executeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component)];
+			let namedUsersAndGroupsColumns = [
+				this.createTableColumn('', loc.userOrGroupIcon, 50, azdata.DeclarativeDataType.component),
+				this.createTableColumn(loc.namedUsersAndGroupsHeader, loc.namedUsersAndGroupsHeader, namedUsersAndGroupsPermissionsNamesColumnWidth, azdata.DeclarativeDataType.string),
+				this.createTableColumn(loc.readHeader, `${loc.accessHeader} ${loc.readHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
+				this.createTableColumn(loc.writeHeader, `${loc.accessHeader} ${loc.writeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
+				this.createTableColumn(loc.executeHeader, `${loc.accessHeader} ${loc.executeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component)];
+
+			// Additional columns that are only shown for directories
+			if (this.hdfsModel.fileStatus.type === HdfsFileType.Directory) {
+				posixPermissionsColumns = posixPermissionsColumns.concat([
+					this.createTableColumn(loc.readHeader, `${loc.defaultHeader} ${loc.readHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
+					this.createTableColumn(loc.writeHeader, `${loc.defaultHeader} ${loc.writeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
+					this.createTableColumn(loc.executeHeader, `${loc.defaultHeader} ${loc.executeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component)
+				]);
+				namedUsersAndGroupsColumns = namedUsersAndGroupsColumns.concat([
+					this.createTableColumn(loc.inheritDefaultsLabel, loc.inheritDefaultsLabel, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
+					this.createTableColumn(loc.readHeader, `${loc.defaultHeader} ${loc.readHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
+					this.createTableColumn(loc.writeHeader, `${loc.defaultHeader} ${loc.writeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
+					this.createTableColumn(loc.executeHeader, `${loc.defaultHeader} ${loc.executeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
+				]);
+			}
+			namedUsersAndGroupsColumns.push(this.createTableColumn('', loc.deleteTitle, permissionsDeleteColumnWidth, azdata.DeclarativeDataType.component));
+
+			const posixPermissionsTable = this.modelBuilder.declarativeTable()
+				.withProperties<azdata.DeclarativeTableProperties>(
+					{
+						columns: posixPermissionsColumns,
+						data: posixPermissionData
+					}).component();
+
+			this.posixPermissionsContainer.addItem(posixPermissionsTable, { CSSStyles: { 'margin-right': '12px' } });
+
+			this.namedUsersAndGroupsPermissionsContainer.clearItems();
+
+			const namedUsersAndGroupsData = permissionStatus.aclEntries.map(aclEntry => {
+				return this.createPermissionsTableRow(aclEntry, true/*includeDelete*/, this.hdfsModel.fileStatus.type === HdfsFileType.Directory/*includeInherit*/);
+			});
+
+			const namedUsersAndGroupsTable = this.modelBuilder.declarativeTable()
+				.withProperties<azdata.DeclarativeTableProperties>(
+					{
+						columns: namedUsersAndGroupsColumns,
+						data: namedUsersAndGroupsData
+					}).component();
+
+			this.namedUsersAndGroupsPermissionsContainer.addItem(namedUsersAndGroupsTable);
+
+			this.rootLoadingComponent.loading = false;
+
+			this.addUserOrGroupInput.focus();
 		});
-
-		const posixPermissionsNamesColumnWidth = 800 + (this.hdfsModel.fileStatus.type === HdfsFileType.Directory ? 0 : permissionsCheckboxColumnWidth * 3);
-		const namedUsersAndGroupsPermissionsNamesColumnWidth = 700 + (this.hdfsModel.fileStatus.type === HdfsFileType.Directory ? 0 : permissionsCheckboxColumnWidth * 3);
-
-		// Default set of columns that are always shown
-		let posixPermissionsColumns = [
-			this.createTableColumn('', loc.userOrGroupIcon, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
-			this.createTableColumn('', loc.defaultUserAndGroups, posixPermissionsNamesColumnWidth, azdata.DeclarativeDataType.string),
-			this.createTableColumn(loc.readHeader, `${loc.accessHeader} ${loc.readHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
-			this.createTableColumn(loc.writeHeader, `${loc.accessHeader} ${loc.writeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
-			this.createTableColumn(loc.executeHeader, `${loc.accessHeader} ${loc.executeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component)];
-		let namedUsersAndGroupsColumns = [
-			this.createTableColumn('', loc.userOrGroupIcon, 50, azdata.DeclarativeDataType.component),
-			this.createTableColumn(loc.namedUsersAndGroupsHeader, loc.namedUsersAndGroupsHeader, namedUsersAndGroupsPermissionsNamesColumnWidth, azdata.DeclarativeDataType.string),
-			this.createTableColumn(loc.readHeader, `${loc.accessHeader} ${loc.readHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
-			this.createTableColumn(loc.writeHeader, `${loc.accessHeader} ${loc.writeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
-			this.createTableColumn(loc.executeHeader, `${loc.accessHeader} ${loc.executeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component)];
-
-		// Additional columns that are only shown for directories
-		if (this.hdfsModel.fileStatus.type === HdfsFileType.Directory) {
-			posixPermissionsColumns = posixPermissionsColumns.concat([
-				this.createTableColumn(loc.readHeader, `${loc.defaultHeader} ${loc.readHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
-				this.createTableColumn(loc.writeHeader, `${loc.defaultHeader} ${loc.writeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
-				this.createTableColumn(loc.executeHeader, `${loc.defaultHeader} ${loc.executeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component)
-			]);
-			namedUsersAndGroupsColumns = namedUsersAndGroupsColumns.concat([
-				this.createTableColumn(loc.inheritDefaultsLabel, loc.inheritDefaultsLabel, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
-				this.createTableColumn(loc.readHeader, `${loc.defaultHeader} ${loc.readHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
-				this.createTableColumn(loc.writeHeader, `${loc.defaultHeader} ${loc.writeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
-				this.createTableColumn(loc.executeHeader, `${loc.defaultHeader} ${loc.executeHeader}`, permissionsCheckboxColumnWidth, azdata.DeclarativeDataType.component),
-			]);
-		}
-		namedUsersAndGroupsColumns.push(this.createTableColumn('', loc.deleteTitle, permissionsDeleteColumnWidth, azdata.DeclarativeDataType.component));
-
-		const posixPermissionsTable = this.modelBuilder.declarativeTable()
-			.withProperties<azdata.DeclarativeTableProperties>(
-				{
-					columns: posixPermissionsColumns,
-					data: posixPermissionData
-				}).component();
-
-		this.posixPermissionsContainer.addItem(posixPermissionsTable, { CSSStyles: { 'margin-right': '12px' } });
-
-		this.namedUsersAndGroupsPermissionsContainer.clearItems();
-
-		const namedUsersAndGroupsData = permissionStatus.aclEntries.map(aclEntry => {
-			return this.createPermissionsTableRow(aclEntry, true/*includeDelete*/, this.hdfsModel.fileStatus.type === HdfsFileType.Directory/*includeInherit*/);
-		});
-
-		const namedUsersAndGroupsTable = this.modelBuilder.declarativeTable()
-			.withProperties<azdata.DeclarativeTableProperties>(
-				{
-					columns: namedUsersAndGroupsColumns,
-					data: namedUsersAndGroupsData
-				}).component();
-
-		this.namedUsersAndGroupsPermissionsContainer.addItem(namedUsersAndGroupsTable);
-
-		this.rootLoadingComponent.loading = false;
-
-		this.addUserOrGroupInput.focus();
 	}
 
 	private createRadioButton(modelBuilder: azdata.ModelBuilder, label: string, name: string, aclEntryType: AclType): azdata.RadioButtonComponent {
@@ -584,6 +588,25 @@ export class ManageAccessDialog {
 		sectionHeaderContainer.addItem(rightSpacer, { flex: '0 0 auto' });
 
 		return sectionHeaderContainer;
+	}
+
+	/**
+	 * Runs the specified action when the component is initialized. If already initialized just runs
+	 * the action immediately.
+	 * @param action The action to be ran when the page is initialized
+	 */
+	protected eventuallyRunOnInitialized(action: () => void): void {
+		if (!this.viewInitialized) {
+			this.onViewInitializedEvent.event(() => {
+				try {
+					action();
+				} catch (error) {
+					console.error(`Unexpected error running onInitialized action for Manage Access dialog : ${error}`);
+				}
+			});
+		} else {
+			action();
+		}
 	}
 }
 

--- a/extensions/mssql/src/hdfs/ui/hdfsManageAccessDialog.ts
+++ b/extensions/mssql/src/hdfs/ui/hdfsManageAccessDialog.ts
@@ -34,7 +34,7 @@ type PermissionCheckboxesMapping = {
 export class ManageAccessDialog {
 
 	private hdfsModel: HdfsModel;
-	private viewInitialized: boolean = false;
+	private viewInitializedOrInProgress: boolean = false;
 	private modelInitialized: boolean = false;
 	private modelBuilder: azdata.ModelBuilder;
 	private rootContainer: azdata.FlexContainer;
@@ -92,7 +92,6 @@ export class ManageAccessDialog {
 				await modelView.initializeModel(this.rootLoadingComponent);
 				this.modelInitialized = true;
 				this.handlePermissionStatusUpdated(this.hdfsModel.permissionStatus);
-				this.addUserOrGroupInput.focus();
 			});
 			this.dialog.content = [tab];
 		}
@@ -102,6 +101,8 @@ export class ManageAccessDialog {
 	}
 
 	private initializeView(permissionStatus: PermissionStatus): void {
+		this.viewInitializedOrInProgress = true;
+
 		// We nest the content inside another container for the margins - getting them on the root container isn't supported
 		const contentContainer = this.modelBuilder.flexContainer()
 			.withLayout({ flexFlow: 'column', width: '100%', height: '100%' })
@@ -237,7 +238,6 @@ export class ManageAccessDialog {
 			.withLayout({ flexFlow: 'column' })
 			.component();
 		contentContainer.addItem(this.namedUsersAndGroupsPermissionsContainer, { flex: '1', CSSStyles: { 'overflow': 'scroll', 'min-height': '200px' } });
-		this.viewInitialized = true;
 	}
 
 	private handlePermissionStatusUpdated(permissionStatus: PermissionStatus): void {
@@ -246,7 +246,7 @@ export class ManageAccessDialog {
 		}
 
 		// If this is the first time go through and create the UI components now that we have a model to use
-		if (!this.viewInitialized) {
+		if (!this.viewInitializedOrInProgress) {
 			this.initializeView(permissionStatus);
 		}
 
@@ -324,6 +324,8 @@ export class ManageAccessDialog {
 		this.namedUsersAndGroupsPermissionsContainer.addItem(namedUsersAndGroupsTable);
 
 		this.rootLoadingComponent.loading = false;
+
+		this.addUserOrGroupInput.focus();
 	}
 
 	private createRadioButton(modelBuilder: azdata.ModelBuilder, label: string, name: string, aclEntryType: AclType): azdata.RadioButtonComponent {


### PR DESCRIPTION
This addresses #7794.

On first launch of the dialog, it was possible to get an undefined error because we were trying to call focus() on an element that hadn't been initalized yet. Moved the logic just after we turn off the loading animation.

Also took a look at a potential issue where initializeView() could be called twice, so trying to prevent against that.
