### PR TITLE
remove the extensionDependencies

### DIFF
--- a/extensions/integration-tests/package.json
+++ b/extensions/integration-tests/package.json
@@ -12,7 +12,13 @@
     "*"
   ],
   "main": "./out/main",
-  "extensionDependencies": [],
+  "extensionDependencies": [
+    "Microsoft.agent",
+    "Microsoft.import",
+    "Microsoft.profiler",
+    "Microsoft.mssql",
+    "Microsoft.notebook"
+  ],
   "contributes": {
     "configuration": {
       "type": "object",

--- a/extensions/integration-tests/package.json
+++ b/extensions/integration-tests/package.json
@@ -12,13 +12,7 @@
     "*"
   ],
   "main": "./out/main",
-  "extensionDependencies": [
-    "Microsoft.agent",
-    "Microsoft.import",
-    "Microsoft.profiler",
-    "Microsoft.mssql",
-    "Microsoft.notebook"
-  ],
+  "extensionDependencies": [],
   "contributes": {
     "configuration": {
       "type": "object",

--- a/extensions/integration-tests/src/setup.test.ts
+++ b/extensions/integration-tests/src/setup.test.ts
@@ -2,12 +2,13 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+import { EnvironmentVariable_AZURE_PASSWORD, EnvironmentVariable_AZURE_SERVER, EnvironmentVariable_AZURE_USERNAME, EnvironmentVariable_BDC_PASSWORD, EnvironmentVariable_BDC_SERVER, EnvironmentVariable_BDC_USERNAME, EnvironmentVariable_PYTHON_PATH, EnvironmentVariable_STANDALONE_PASSWORD, EnvironmentVariable_STANDALONE_SERVER, EnvironmentVariable_STANDALONE_USERNAME, getConfigValue } from './testConfig';
+import { isTestSetupCompleted } from './testContext';
 
 import 'mocha';
-import * as vscode from 'vscode';
-import { isTestSetupCompleted } from './testContext';
-import * as assert from 'assert';
-import { getConfigValue, EnvironmentVariable_BDC_SERVER, EnvironmentVariable_BDC_USERNAME, EnvironmentVariable_BDC_PASSWORD, EnvironmentVariable_AZURE_PASSWORD, EnvironmentVariable_AZURE_SERVER, EnvironmentVariable_AZURE_USERNAME, EnvironmentVariable_STANDALONE_PASSWORD, EnvironmentVariable_STANDALONE_SERVER, EnvironmentVariable_STANDALONE_USERNAME, EnvironmentVariable_PYTHON_PATH } from './testConfig';
 
 assert(getConfigValue(EnvironmentVariable_BDC_SERVER) !== undefined &&
 	getConfigValue(EnvironmentVariable_BDC_USERNAME) !== undefined &&
@@ -24,6 +25,10 @@ if (!isTestSetupCompleted()) {
 	suite('integration test setup', () => {
 		test('test setup', async function () {
 			this.timeout(5 * 60 * 1000);
+			console.info('Extension loading status (extension id, loaded):');
+			vscode.extensions.all.forEach(extension => {
+				console.info(`${extension.id},${extension.isActive}`);
+			});
 			// Prepare the environment and make it ready for testing
 			await vscode.commands.executeCommand('test.setupIntegrationTest');
 			// Wait for the extensions to load


### PR DESCRIPTION
recently the build failed a couple times due to the loading of extension taking too long, this is because it needs to wait for all extensions to load. we can remove the extension dependencies from the integration test extension's package.json since we already have the wait logic in the test code (command: test.waitForExtensionsToLoad) which is more tolerant.