### PR TITLE
Notebooks: Listen for Enter on Add Package Tab

### DIFF
--- a/extensions/notebook/src/dialog/managePackages/addNewPackageTab.ts
+++ b/extensions/notebook/src/dialog/managePackages/addNewPackageTab.ts
@@ -33,6 +33,10 @@ export class AddNewPackageTab {
 
 		this.addNewPkgTab.registerContent(async view => {
 			this.newPackagesSearchBar = view.modelBuilder.inputBox().withProperties({ width: '400px' }).component();
+			// Search package by name when pressing enter
+			this.newPackagesSearchBar.onEnterKeyPressed(async () => {
+				await this.loadNewPackageInfo();
+			});
 
 			this.packagesSearchButton = view.modelBuilder.button()
 				.withProperties<azdata.ButtonProperties>({
@@ -90,11 +94,6 @@ export class AddNewPackageTab {
 			await view.initializeModel(formModel);
 
 			await this.resetPageFields();
-
-			// Search package by name when pressing enter
-			this.newPackagesSearchBar.onEnterKeyPressed(async () => {
-				await this.loadNewPackageInfo();
-			});
 		});
 	}
 

--- a/extensions/notebook/src/dialog/managePackages/addNewPackageTab.ts
+++ b/extensions/notebook/src/dialog/managePackages/addNewPackageTab.ts
@@ -90,6 +90,11 @@ export class AddNewPackageTab {
 			await view.initializeModel(formModel);
 
 			await this.resetPageFields();
+
+			// Search package by name when pressing enter
+			this.newPackagesSearchBar.onEnterKeyPressed(async () => {
+				await this.loadNewPackageInfo();
+			});
 		});
 	}
 


### PR DESCRIPTION
(Hopefully) final fix for #7264. I was using the dialog earlier and lamented the lack of this feature, so I did some investigation. Over the past few months, the ability to listen to the Enter key was added to modelView for the Manage Access dialog.

We can use this functionality in the Add Package tab for the Manage Packages dialog in notebooks. Next up, we'll focus on the select box by default when changing the tab. But one step at a time 😄 