### PR TITLE
Maintain notebook trust status after saving.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/cell.ts
@@ -19,7 +19,7 @@ import { INotificationService, Severity } from 'vs/platform/notification/common/
 import { Schemas } from 'vs/base/common/network';
 import { INotebookService } from 'sql/workbench/services/notebook/browser/notebookService';
 import { optional } from 'vs/platform/instantiation/common/instantiation';
-import { getErrorMessage } from 'vs/base/common/errors';
+import { getErrorMessage, onUnexpectedError } from 'vs/base/common/errors';
 import { generateUuid } from 'vs/base/common/uuid';
 import { IModelContentChangedEvent } from 'vs/editor/common/model/textModelEvents';
 import { firstIndex, find } from 'vs/base/common/arrays';
@@ -286,7 +286,7 @@ export class CellModel implements ICellModel {
 	private notifyExecutionComplete(): void {
 		if (this._notebookService) {
 			this._notebookService.serializeNotebookStateChange(this.notebookModel.notebookUri, NotebookChangeType.CellExecuted, this)
-				.catch(() => { });
+				.catch(e => onUnexpectedError(e));
 		}
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/cell.ts
@@ -285,7 +285,8 @@ export class CellModel implements ICellModel {
 
 	private notifyExecutionComplete(): void {
 		if (this._notebookService) {
-			this._notebookService.serializeNotebookStateChange(this.notebookModel.notebookUri, NotebookChangeType.CellExecuted, this);
+			this._notebookService.serializeNotebookStateChange(this.notebookModel.notebookUri, NotebookChangeType.CellExecuted, this)
+				.catch(() => { });
 		}
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -32,6 +32,7 @@ import { ResourceEditorInput } from 'vs/workbench/common/editor/resourceEditorIn
 import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
 import { BinaryEditorModel } from 'vs/workbench/common/editor/binaryEditorModel';
 import { NotebookFindModel } from 'sql/workbench/contrib/notebook/find/notebookFindModel';
+import { onUnexpectedError } from 'vs/base/common/errors';
 
 export type ModeViewSaveHandler = (handle: number) => Thenable<boolean>;
 
@@ -161,7 +162,7 @@ export class NotebookEditorModel extends EditorModel {
 		let notebookModel = this.getNotebookModel();
 		if (notebookModel) {
 			this.notebookService.serializeNotebookStateChange(this.notebookUri, NotebookChangeType.Saved)
-				.catch(() => { });
+				.catch(e => onUnexpectedError(e));
 		}
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -284,10 +284,12 @@ export abstract class NotebookInput extends EditorInput {
 	}
 
 	save(groupId: number, options?: ITextFileSaveOptions): Promise<IEditorInput | undefined> {
+		this._model.getNotebookModel().trustedMode = true;
 		return this.textInput.save(groupId, options);
 	}
 
 	saveAs(group: number, options?: ITextFileSaveOptions): Promise<IEditorInput | undefined> {
+		this._model.getNotebookModel().trustedMode = true;
 		return this.textInput.saveAs(group, options);
 	}
 

--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -249,7 +249,7 @@ export class NotebookServiceStub implements INotebookService {
 	isNotebookTrustCached(notebookUri: URI, isDirty: boolean): Promise<boolean> {
 		throw new Error('Method not implemented.');
 	}
-	serializeNotebookStateChange(notebookUri: URI, changeType: NotebookChangeType, cell?: ICellModel): void {
+	serializeNotebookStateChange(notebookUri: URI, changeType: NotebookChangeType, cell?: ICellModel, isTrusted?: boolean): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
 	navigateTo(notebookUri: URI, sectionId: string): void {

--- a/src/sql/workbench/services/notebook/browser/notebookService.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookService.ts
@@ -101,7 +101,7 @@ export interface INotebookService {
 	 * sent to listeners that can act on the point-in-time notebook state
 	 * @param notebookUri the URI identifying a notebook
 	 */
-	serializeNotebookStateChange(notebookUri: URI, changeType: NotebookChangeType, cell?: ICellModel): void;
+	serializeNotebookStateChange(notebookUri: URI, changeType: NotebookChangeType, cell?: ICellModel, isTrusted?: boolean): Promise<void>;
 
 	/**
 	 *

--- a/src/sql/workbench/services/notebook/browser/notebookService.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookService.ts
@@ -99,7 +99,10 @@ export interface INotebookService {
 	 * Serializes an impactful Notebook state change. This will result
 	 * in trusted state being serialized if needed, and notifications being
 	 * sent to listeners that can act on the point-in-time notebook state
-	 * @param notebookUri the URI identifying a notebook
+	 * @param notebookUri The URI identifying a notebook.
+	 * @param changeType The type of notebook state change to serialize.
+	 * @param cell The notebook cell associated with the state change.
+	 * @param isTrusted A manual override for the notebook's trusted state.
 	 */
 	serializeNotebookStateChange(notebookUri: URI, changeType: NotebookChangeType, cell?: ICellModel, isTrusted?: boolean): Promise<void>;
 

--- a/src/sql/workbench/services/notebook/browser/notebookService.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookService.ts
@@ -101,8 +101,8 @@ export interface INotebookService {
 	 * sent to listeners that can act on the point-in-time notebook state
 	 * @param notebookUri The URI identifying a notebook.
 	 * @param changeType The type of notebook state change to serialize.
-	 * @param cell The notebook cell associated with the state change.
-	 * @param isTrusted A manual override for the notebook's trusted state.
+	 * @param cell (Optional) The notebook cell associated with the state change.
+	 * @param isTrusted (Optional) A manual override for the notebook's trusted state.
 	 */
 	serializeNotebookStateChange(notebookUri: URI, changeType: NotebookChangeType, cell?: ICellModel, isTrusted?: boolean): Promise<void>;
 


### PR DESCRIPTION
Currently, a notebook that's marked as trusted will be reopened as untrusted after saveAs. This is because the current editor gets closed as part of saveAs, and the trust state is tracked by the editor input's URI. This change adds the new notebook file input's URI to the trusted cache as part of the save call, so that the trusted state is maintained as the new editor opens.