### PR TITLE
Print jupyter URL without encoded characters in notebook start message.

### DIFF
--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -278,7 +278,7 @@ export class PerFolderServerInstance implements IServerInstance {
 						this._uri = url;
 						this._port = port;
 					}
-					this.notifyStarted(install, url.toString());
+					this.notifyStarted(install, url.toString(true));
 					this._isStarted = true;
 
 					this.updateListeners(handleStdout, handleStdErr, onErrorBeforeStartup, onExitBeforeStart);


### PR DESCRIPTION
I noticed when trying to click on the jupyter URL in the notebook output that there are encoded characters which prevent the URL from routing to the right instance. For example, '=' gets replaced by 
'%3D'. This change removes the encoding just for the user-facing message.