### PR TITLE
Fix min/max ignoring 0 value

### DIFF
--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -24,6 +24,7 @@ import { KeyCode } from 'vs/base/common/keyCodes';
 import * as DOM from 'vs/base/browser/dom';
 import { assign } from 'vs/base/common/objects';
 import { IComponent, IComponentDescriptor, IModelStore, ComponentEventType } from 'sql/platform/dashboard/browser/interfaces';
+import { isNumber } from 'vs/base/common/types';
 
 @Component({
 	selector: 'modelview-inputBox',
@@ -191,10 +192,10 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 	}
 
 	private layoutInputBox(): void {
-		if (this.width) {
+		if (isNumber(this.width)) {
 			this.inputElement.width = this.convertSizeToNumber(this.width);
 		}
-		if (this.height) {
+		if (isNumber(this.height)) {
 			this.inputElement.setHeight(this.convertSize(this.height));
 		}
 	}
@@ -215,10 +216,10 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 			input.inputElement.type = this.inputType;
 			if (this.inputType === 'number') {
 				input.inputElement.step = 'any';
-				if (this.min) {
+				if (isNumber(this.min)) {
 					input.inputElement.min = this.min.toString();
 				}
-				if (this.max) {
+				if (isNumber(this.max === undefined)) {
 					input.inputElement.max = this.max.toString();
 				}
 			}
@@ -229,10 +230,10 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 		input.setEnabled(this.enabled);
 		this.layoutInputBox();
 		if (this.multiline) {
-			if (this.rows) {
+			if (isNumber(this.rows)) {
 				this.inputElement.rows = this.rows;
 			}
-			if (this.columns) {
+			if (isNumber(this.columns)) {
 				this.inputElement.columns = this.columns;
 			}
 		}


### PR DESCRIPTION
Fixes #9136

I'm going to go through and check other places for these kind of checks, it's likely we're doing this wrong in other places as well.

I looked around for an eslint rule to check this but couldn't immediately find one. @anthonydresser @aaomidi Either of you have any idea whether such a rule exists? (basically don't allow numbers in a logical statement)
