### PR TITLE
Initial post-release extension vBump

### DIFF
--- a/extensions/admin-pack/package.json
+++ b/extensions/admin-pack/package.json
@@ -2,7 +2,7 @@
 	"name": "admin-pack",
 	"displayName": "Admin Pack for SQL Server",
 	"description": "",
-	"version": "0.0.2",
+	"version": "0.1.0",
 	"publisher": "Microsoft",
 	"engines": {
 		"vscode": "*",

--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -2,7 +2,7 @@
   "name": "admin-tool-ext-win",
   "displayName": "%adminToolExtWin.displayName%",
   "description": "%adminToolExtWin.description%",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/admin-tool-ext-win/license/Azure%20Data%20Studio%20Extension%20-%20Standalone%20(free)%20Use%20Terms.txt",

--- a/extensions/agent/package.json
+++ b/extensions/agent/package.json
@@ -2,7 +2,7 @@
   "name": "agent",
   "displayName": "SQL Server Agent",
   "description": "Manage and troubleshoot SQL Server Agent jobs",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",

--- a/extensions/cms/package.json
+++ b/extensions/cms/package.json
@@ -2,7 +2,7 @@
   "name": "cms",
   "displayName": "%cms.displayName%",
   "description": "%cms.description%",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",

--- a/extensions/dacpac/package.json
+++ b/extensions/dacpac/package.json
@@ -2,7 +2,7 @@
   "name": "dacpac",
   "displayName": "SQL Server Dacpac",
   "description": "SQL Server Dacpac for Azure Data Studio.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "Microsoft",
   "preview": false,
   "engines": {

--- a/extensions/import/package.json
+++ b/extensions/import/package.json
@@ -2,7 +2,7 @@
 	"name": "import",
 	"displayName": "SQL Server Import",
 	"description": "SQL Server Import for Azure Data Studio supports importing CSV or JSON files into SQL Server.",
-	"version": "0.13.1",
+	"version": "0.14.0",
 	"publisher": "Microsoft",
 	"preview": true,
 	"engines": {

--- a/extensions/profiler/package.json
+++ b/extensions/profiler/package.json
@@ -2,7 +2,7 @@
 	"name": "profiler",
 	"displayName": "SQL Server Profiler",
 	"description": "SQL Server Profiler for Azure Data Studio",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"publisher": "Microsoft",
 	"preview": true,
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",

--- a/extensions/query-history/package.json
+++ b/extensions/query-history/package.json
@@ -2,7 +2,7 @@
 	"name": "query-history",
 	"displayName": "%queryHistory.displayName%",
 	"description": "%queryHistory.description%",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"publisher": "Microsoft",
 	"preview": true,
 	"license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt",

--- a/extensions/schema-compare/package.json
+++ b/extensions/schema-compare/package.json
@@ -2,7 +2,7 @@
   "name": "schema-compare",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "Microsoft",
   "preview": false,
   "engines": {

--- a/samples/serverReports/package.json
+++ b/samples/serverReports/package.json
@@ -2,7 +2,7 @@
 	"name": "server-report",
 	"displayName": "Server Reports",
 	"description": "Server Reports",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"publisher": "Microsoft",
 	"preview": true,
 	"engines": {

--- a/samples/sp_whoIsActive/package.json
+++ b/samples/sp_whoIsActive/package.json
@@ -2,7 +2,7 @@
     "name": "whoisactive",
     "displayName": "whoisactive",
     "description": "sp_whoisactive for Azure Data Studio",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "publisher": "Microsoft",
     "preview": true,
     "engines": {


### PR DESCRIPTION
Proposed change - going forward we'll handle extension version bumps similar to how we handle it for ADS - every time we release the extension to the stable gallery we'll immediately bump the version.

This does mean that if we want to follow semantic versioning and end up doing a bug fix release for an extension we'll have to temporarily revert the version number - but in general I also think it's fine to just always bump up the minor version for every release (and then do major version bumps for major changes). Going along with this I aligned all the version numbers to the next minor version.

So this is the initial version bump for all currently released extensions. 