### PR TITLE
No console linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -505,17 +505,17 @@
             "rules": {
                 "jsdoc/no-types": "off"
             }
-		},
-		{
-			"files": [
-				"**/sql/**"
-			],
-			"rules": {
-				"no-sync": "warn",
-				"strict": ["warn", "never"],
-				"no-console": "warn"
-			}
-		},
+        },
+        {
+            "files": [
+                "**/sql/**"
+            ],
+            "rules": {
+                "no-sync": "warn",
+                "strict": ["warn", "never"],
+                "no-console": "warn"
+            }
+        },
         {
             "files": [
                 "**/vscode.d.ts",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -505,7 +505,17 @@
             "rules": {
                 "jsdoc/no-types": "off"
             }
-        },
+		},
+		{
+			"files": [
+				"**/sql/**"
+			],
+			"rules": {
+				"no-sync": "warn",
+				"strict": ["warn", "never"],
+				"no-console": "warn"
+			}
+		},
         {
             "files": [
                 "**/vscode.d.ts",

--- a/.eslintrc.sql.json
+++ b/.eslintrc.sql.json
@@ -1,7 +1,0 @@
-{
-	"extends": ".eslintrc.json",
-	"rules": {
-		"no-sync": "warn",
-		"strict": ["warn", "never"]
-	}
-}

--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -202,13 +202,6 @@ const tsHygieneFilter = [
 	'!src/vs/workbench/contrib/extensions/browser/extensionTipsService.ts' // {{SQL CARBON EDIT}} skip this because known issue
 ];
 
-const sqlHygieneFilter = [ // for rules we want to only apply to our code
-	'src/sql/**/*.ts',
-	'!**/node_modules/**',
-	'extensions/**/*.ts',
-	'!extensions/{git,search-result,vscode-test-resolver,extension-editing,json-language-features,vscode-colorize-tests}/**/*.ts',
-];
-
 const copyrightHeaderLines = [
 	'/*---------------------------------------------------------------------------------------------',
 	' *  Copyright (c) Microsoft Corporation. All rights reserved.',
@@ -376,20 +369,8 @@ function hygiene(some) {
 			errorCount += results.errorCount;
 		}));
 
-	const sqlJavascript = result
-		.pipe(filter(sqlHygieneFilter))
-		.pipe(gulpeslint({
-			configFile: '.eslintrc.sql.json',
-			rulePaths: ['./build/lib/eslint']
-		}))
-		.pipe(gulpeslint.formatEach('compact'))
-		.pipe(gulpeslint.results(results => {
-			errorCount += results.warningCount;
-			errorCount += results.errorCount;
-		}));
-
 	let count = 0;
-	return es.merge(typescript, javascript, sqlJavascript)
+	return es.merge(typescript, javascript)
 		.pipe(es.through(function (data) {
 			count++;
 			if (process.env['TRAVIS'] && count % 10 === 0) {

--- a/src/sql/base/browser/ui/scrollableSplitview/heightMap.ts
+++ b/src/sql/base/browser/ui/scrollableSplitview/heightMap.ts
@@ -45,6 +45,7 @@ export class HeightMap {
 			viewItem = this.heightMap[i - 1];
 
 			if (!viewItem) {
+				// eslint-disable-next-line no-console
 				console.error('view item doesnt exist');
 				return undefined;
 			}
@@ -100,6 +101,7 @@ export class HeightMap {
 			viewItem = this.heightMap[i];
 
 			if (!viewItem) {
+				// eslint-disable-next-line no-console
 				console.error('view item doesnt exist');
 				return;
 			}

--- a/src/sql/workbench/api/browser/mainThreadExtensionManagement.ts
+++ b/src/sql/workbench/api/browser/mainThreadExtensionManagement.ts
@@ -12,6 +12,7 @@ import { URI } from 'vs/base/common/uri';
 import { IConfigurationService, ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { localize } from 'vs/nls';
+import { ILogService } from 'vs/platform/log/common/log';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadExtensionManagement)
 export class MainThreadExtensionManagement extends Disposable implements MainThreadExtensionManagementShape {
@@ -22,7 +23,8 @@ export class MainThreadExtensionManagement extends Disposable implements MainThr
 		extHostContext: IExtHostContext,
 		@IExtensionManagementService private _extensionService: IExtensionManagementService,
 		@IConfigurationService private _configurationService: IConfigurationService,
-		@INotificationService private _notificationService: INotificationService
+		@INotificationService private _notificationService: INotificationService,
+		@ILogService private readonly logService: ILogService
 	) {
 		super();
 	}
@@ -32,7 +34,7 @@ export class MainThreadExtensionManagement extends Disposable implements MainThr
 	}
 
 	public $showObsoleteExtensionApiUsageNotification(message: string): void {
-		console.warn(message);
+		this.logService.warn(message);
 
 		if (this._obsoleteExtensionApiUsageNotificationShown) {
 			return;

--- a/src/sql/workbench/api/browser/mainThreadQueryEditor.ts
+++ b/src/sql/workbench/api/browser/mainThreadQueryEditor.ts
@@ -91,7 +91,7 @@ export class MainThreadQueryEditor extends Disposable implements MainThreadQuery
 			let profile: IConnectionProfile = MainThreadQueryEditor.connectionProfileToIConnectionProfile(connection);
 			let connectionResult = await this._connectionManagementService.connect(profile, fileUri, options);
 			if (connectionResult && connectionResult.connected) {
-				console.log(`editor ${fileUri} connected`);
+				this._logService.info(`editor ${fileUri} connected`);
 			}
 		});
 	}

--- a/src/sql/workbench/api/common/extHostModelViewTree.ts
+++ b/src/sql/workbench/api/common/extHostModelViewTree.ts
@@ -14,6 +14,7 @@ import * as  vsTreeExt from 'vs/workbench/api/common/extHostTreeViews';
 import { Emitter } from 'vs/base/common/event';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { assign } from 'vs/base/common/objects';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export class ExtHostModelViewTreeViews implements ExtHostModelViewTreeViewsShape {
 	private _proxy: MainThreadModelViewShape;
@@ -21,7 +22,8 @@ export class ExtHostModelViewTreeViews implements ExtHostModelViewTreeViewsShape
 	private treeViews: Map<string, ExtHostTreeView<any>> = new Map<string, ExtHostTreeView<any>>();
 
 	constructor(
-		private _mainContext: IMainContext
+		private _mainContext: IMainContext,
+		private readonly logService: ILogService
 	) {
 		this._proxy = this._mainContext.getProxy(SqlMainContext.MainThreadModelView);
 	}
@@ -31,7 +33,7 @@ export class ExtHostModelViewTreeViews implements ExtHostModelViewTreeViewsShape
 			throw new Error('Options with treeDataProvider is mandatory');
 		}
 
-		const treeView = this.createExtHostTreeViewer(handle, componentId, options.treeDataProvider, extension);
+		const treeView = this.createExtHostTreeViewer(handle, componentId, options.treeDataProvider, extension, this.logService);
 		return {
 			dispose: () => {
 				this.treeViews.delete(componentId);
@@ -74,8 +76,8 @@ export class ExtHostModelViewTreeViews implements ExtHostModelViewTreeViewsShape
 	$setVisible(treeViewId: string, visible: boolean): void {
 	}
 
-	private createExtHostTreeViewer<T>(handle: number, id: string, dataProvider: azdata.TreeComponentDataProvider<T>, extension: IExtensionDescription): ExtHostTreeView<T> {
-		const treeView = new ExtHostTreeView<T>(handle, id, dataProvider, this._proxy, undefined, extension);
+	private createExtHostTreeViewer<T>(handle: number, id: string, dataProvider: azdata.TreeComponentDataProvider<T>, extension: IExtensionDescription, logService: ILogService): ExtHostTreeView<T> {
+		const treeView = new ExtHostTreeView<T>(handle, id, dataProvider, this._proxy, undefined, extension, logService);
 		this.treeViews.set(`${handle}-${id}`, treeView);
 		return treeView;
 	}
@@ -89,14 +91,15 @@ export class ExtHostTreeView<T> extends vsTreeExt.ExtHostTreeView<T> {
 	public readonly ChangeSelection: vscode.Event<vscode.TreeViewSelectionChangeEvent<T>> = this._onChangeSelection.event;
 	constructor(
 		private handle: number, private componentId: string, private componentDataProvider: azdata.TreeComponentDataProvider<T>,
-		private modelViewProxy: MainThreadModelViewShape, commands: CommandsConverter, extension: IExtensionDescription) {
-		super(componentId, { treeDataProvider: componentDataProvider }, undefined, commands, undefined, extension);
+		private modelViewProxy: MainThreadModelViewShape, commands: CommandsConverter, extension: IExtensionDescription,
+		private readonly _logService: ILogService) {
+		super(componentId, { treeDataProvider: componentDataProvider }, undefined, commands, _logService, extension);
 	}
 
 	onNodeCheckedChanged(parentHandle?: vsTreeExt.TreeItemHandle, checked?: boolean): void {
 		const parentElement = parentHandle ? this.getExtensionElement(parentHandle) : void 0;
 		if (parentHandle && !parentElement) {
-			console.error(`No tree item with id \'${parentHandle}\' found.`);
+			this._logService.error(`No tree item with id \'${parentHandle}\' found.`);
 		}
 
 		this._onNodeCheckedChanged.fire({ element: parentElement, checked: checked });

--- a/src/sql/workbench/api/common/extHostRequireInterceptor.ts
+++ b/src/sql/workbench/api/common/extHostRequireInterceptor.ts
@@ -10,6 +10,7 @@ import { ExtensionIdentifier, IExtensionDescription } from 'vs/platform/extensio
 import * as azdata from 'azdata';
 import { IAzdataExtensionApiFactory } from 'sql/workbench/api/common/sqlExtHost.api.impl';
 import { INodeModuleFactory } from 'vs/workbench/api/common/extHostRequireInterceptor';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export class AzdataNodeModuleFactory implements INodeModuleFactory {
 	public readonly nodeModuleName = 'azdata';
@@ -19,7 +20,8 @@ export class AzdataNodeModuleFactory implements INodeModuleFactory {
 
 	constructor(
 		private readonly _apiFactory: IAzdataExtensionApiFactory,
-		private readonly _extensionPaths: TernarySearchTree<IExtensionDescription>
+		private readonly _extensionPaths: TernarySearchTree<IExtensionDescription>,
+		private readonly _logService: ILogService
 	) {
 	}
 
@@ -40,7 +42,7 @@ export class AzdataNodeModuleFactory implements INodeModuleFactory {
 		if (!this._defaultApiImpl) {
 			let extensionPathsPretty = '';
 			this._extensionPaths.forEach((value, index) => extensionPathsPretty += `\t${index} -> ${value.identifier.value}\n`);
-			console.warn(`Could not identify extension for 'azdata' require call from ${parent.fsPath}. These are the extension path mappings: \n${extensionPathsPretty}`);
+			this._logService.warn(`Could not identify extension for 'azdata' require call from ${parent.fsPath}. These are the extension path mappings: \n${extensionPathsPretty}`);
 			this._defaultApiImpl = this._apiFactory(nullExtensionDescription);
 		}
 		return this._defaultApiImpl;

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -70,6 +70,7 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 	const uriTransformer = accessor.get(IURITransformerService);
 	const rpcProtocol = accessor.get(IExtHostRpcService);
 	const extHostLogService = accessor.get(ILogService);
+	const logService = accessor.get(ILogService);
 
 	// Addressable instances
 	const extHostAccountManagement = rpcProtocol.set(SqlExtHostContext.ExtHostAccountManagement, new ExtHostAccountManagement(rpcProtocol));
@@ -82,15 +83,14 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 	const extHostTasks = rpcProtocol.set(SqlExtHostContext.ExtHostTasks, new ExtHostTasks(rpcProtocol, extHostLogService));
 	const extHostBackgroundTaskManagement = rpcProtocol.set(SqlExtHostContext.ExtHostBackgroundTaskManagement, new ExtHostBackgroundTaskManagement(rpcProtocol));
 	const extHostWebviewWidgets = rpcProtocol.set(SqlExtHostContext.ExtHostDashboardWebviews, new ExtHostDashboardWebviews(rpcProtocol));
-	const extHostModelViewTree = rpcProtocol.set(SqlExtHostContext.ExtHostModelViewTreeViews, new ExtHostModelViewTreeViews(rpcProtocol));
-	const extHostModelView = rpcProtocol.set(SqlExtHostContext.ExtHostModelView, new ExtHostModelView(rpcProtocol, extHostModelViewTree));
+	const extHostModelViewTree = rpcProtocol.set(SqlExtHostContext.ExtHostModelViewTreeViews, new ExtHostModelViewTreeViews(rpcProtocol, logService));
+	const extHostModelView = rpcProtocol.set(SqlExtHostContext.ExtHostModelView, new ExtHostModelView(rpcProtocol, extHostModelViewTree, logService));
 	const extHostDashboard = rpcProtocol.set(SqlExtHostContext.ExtHostDashboard, new ExtHostDashboard(rpcProtocol));
 	const extHostModelViewDialog = rpcProtocol.set(SqlExtHostContext.ExtHostModelViewDialog, new ExtHostModelViewDialog(rpcProtocol, extHostModelView, extHostBackgroundTaskManagement));
 	const extHostQueryEditor = rpcProtocol.set(SqlExtHostContext.ExtHostQueryEditor, new ExtHostQueryEditor(rpcProtocol));
 	const extHostNotebook = rpcProtocol.set(SqlExtHostContext.ExtHostNotebook, new ExtHostNotebook(rpcProtocol));
 	const extHostNotebookDocumentsAndEditors = rpcProtocol.set(SqlExtHostContext.ExtHostNotebookDocumentsAndEditors, new ExtHostNotebookDocumentsAndEditors(rpcProtocol));
 	const extHostExtensionManagement = rpcProtocol.set(SqlExtHostContext.ExtHostExtensionManagement, new ExtHostExtensionManagement(rpcProtocol));
-
 
 	return {
 		azdata: function (extension: IExtensionDescription): typeof azdata {
@@ -113,7 +113,7 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				},
 				// "sqlops" back-compat APIs
 				getActiveConnections(): Thenable<azdata.connection.Connection[]> {
-					console.warn('the method azdata.connection.getActiveConnections has been deprecated, replace it with azdata.connection.getConnections');
+					logService.warn('the method azdata.connection.getActiveConnections has been deprecated, replace it with azdata.connection.getConnections');
 					return extHostConnectionManagement.$getActiveConnections();
 				},
 				getCredentials(connectionId: string): Thenable<{ [name: string]: string }> {

--- a/src/sql/workbench/browser/modelComponents/splitviewContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/splitviewContainer.component.ts
@@ -12,6 +12,7 @@ import { ContainerBase, ComponentBase } from 'sql/workbench/browser/modelCompone
 import { Event } from 'vs/base/common/event';
 import { SplitView, Orientation, Sizing, IView } from 'vs/base/browser/ui/splitview/splitview';
 import { IComponent, IComponentDescriptor, IModelStore } from 'sql/platform/dashboard/browser/interfaces';
+import { ILogService } from 'vs/platform/log/common/log';
 
 class SplitPane implements IView {
 	orientation: Orientation;
@@ -63,7 +64,8 @@ export default class SplitViewContainer extends ContainerBase<FlexItemLayout> im
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef,
-		@Inject(forwardRef(() => ElementRef)) el: ElementRef
+		@Inject(forwardRef(() => ElementRef)) el: ElementRef,
+		@Inject(ILogService) private readonly logService: ILogService
 	) {
 		super(changeRef, el);
 		this._flexFlow = '';	// default
@@ -117,7 +119,7 @@ export default class SplitViewContainer extends ContainerBase<FlexItemLayout> im
 						this._splitView.addView(view, Sizing.Distribute);
 					}
 					else {
-						console.log('Could not add views inside split view container');
+						this.logService.warn('Could not add views inside split view container');
 					}
 				});
 			});

--- a/src/sql/workbench/contrib/backup/browser/backupDialog.ts
+++ b/src/sql/workbench/contrib/backup/browser/backupDialog.ts
@@ -55,7 +55,7 @@ export class BackupDialog extends Modal {
 	 * Get the bootstrap params and perform the bootstrap
 	 */
 	private bootstrapAngular(bodyContainer: HTMLElement) {
-		bootstrapAngular(this._instantiationService,
+		this._instantiationService.invokeFunction(bootstrapAngular,
 			BackupModule,
 			bodyContainer,
 			BACKUP_SELECTOR,

--- a/src/sql/workbench/contrib/dashboard/browser/dashboardEditor.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/dashboardEditor.ts
@@ -126,7 +126,7 @@ export class DashboardEditor extends BaseEditor {
 
 		input.hasBootstrapped = true;
 
-		const uniqueSelector = bootstrapAngular(this.instantiationService,
+		const uniqueSelector = this.instantiationService.invokeFunction(bootstrapAngular,
 			DashboardModule,
 			this._dashboardContainer,
 			DASHBOARD_SELECTOR,

--- a/src/sql/workbench/contrib/dataExplorer/browser/connectionViewletPanel.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/connectionViewletPanel.ts
@@ -23,6 +23,7 @@ import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/vie
 import { IViewDescriptorService } from 'vs/workbench/common/views';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export class ConnectionViewletPanel extends ViewPane {
 
@@ -44,7 +45,8 @@ export class ConnectionViewletPanel extends ViewPane {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
 		@IOpenerService protected openerService: IOpenerService,
-		@IThemeService protected themeService: IThemeService
+		@IThemeService protected themeService: IThemeService,
+		@ILogService private readonly logService: ILogService
 	) {
 		super({ ...(options as IViewPaneOptions), ariaHeaderLabel: options.title }, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, opener, themeService);
 		this._addServerAction = this.instantiationService.createInstance(AddServerAction,
@@ -73,7 +75,7 @@ export class ConnectionViewletPanel extends ViewPane {
 		const viewletContainer = DOM.append(container, DOM.$('div.server-explorer-viewlet'));
 		const viewContainer = DOM.append(viewletContainer, DOM.$('div.object-explorer-view'));
 		this._serverTreeView.renderBody(viewContainer).then(undefined, error => {
-			console.warn('render registered servers: ' + error);
+			this.logService.warn('render registered servers: ' + error);
 		});
 		this._root = container;
 	}

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -445,7 +445,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 					() => this.nextPage(), this.navigationResult.next ? true : false);
 				this.detectChanges();
 			}, err => {
-				console.log(err);
+				this.logService.info(err);
 			});
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -227,7 +227,7 @@ export class NotebookEditor extends BaseEditor implements IFindNotebookControlle
 			providerInfo: input.getProviderInfo(),
 			profile: input.connectionProfile
 		};
-		bootstrapAngular(this._instantiationService,
+		this._instantiationService.invokeFunction(bootstrapAngular,
 			NotebookModule,
 			this._notebookContainer,
 			NOTEBOOK_SELECTOR,

--- a/src/sql/workbench/contrib/query/browser/modelViewTab/queryModelViewTab.ts
+++ b/src/sql/workbench/contrib/query/browser/modelViewTab/queryModelViewTab.ts
@@ -78,7 +78,7 @@ export class QueryModelViewTabView implements IPanelView {
 	 * Load the angular components and record for this input that we have done so
 	 */
 	private bootstrapAngular(container: HTMLElement): string {
-		let uniqueSelector = bootstrapAngular(this._instantiationService,
+		let uniqueSelector = this._instantiationService.invokeFunction(bootstrapAngular,
 			QueryModelViewTabModule,
 			container,
 			'querytab-modelview-container',

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -42,6 +42,7 @@ import { TreeViewItemHandleArg } from 'sql/workbench/common/views';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { IQueryManagementService } from 'sql/workbench/services/query/common/queryManagement';
+import { ILogService } from 'vs/platform/log/common/log';
 
 /**
  * Action class that query-based Actions will extend. This base class automatically handles activating and
@@ -268,7 +269,8 @@ export class CancelQueryAction extends QueryTaskbarAction {
 	constructor(
 		editor: QueryEditor,
 		@IQueryModelService private readonly queryModelService: IQueryModelService,
-		@IConnectionManagementService connectionManagementService: IConnectionManagementService
+		@IConnectionManagementService connectionManagementService: IConnectionManagementService,
+		@ILogService private readonly logService: ILogService
 	) {
 		super(connectionManagementService, editor, CancelQueryAction.ID, CancelQueryAction.EnabledClass);
 		this.enabled = false;
@@ -278,7 +280,7 @@ export class CancelQueryAction extends QueryTaskbarAction {
 	public async run(): Promise<void> {
 		if (this.isConnected(this.editor)) {
 			if (!this.editor.input) {
-				console.error('editor input was null');
+				this.logService.error('editor input was null');
 				return;
 			}
 			this.queryModelService.cancelQuery(this.editor.input.uri);
@@ -526,7 +528,8 @@ export class ToggleSqlCmdModeAction extends QueryTaskbarAction {
 		private _isSqlCmdMode: boolean,
 		@IQueryManagementService protected readonly queryManagementService: IQueryManagementService,
 		@IConfigurationService protected readonly configurationService: IConfigurationService,
-		@IConnectionManagementService connectionManagementService: IConnectionManagementService
+		@IConnectionManagementService connectionManagementService: IConnectionManagementService,
+		@ILogService private readonly logService: ILogService
 	) {
 		super(connectionManagementService, editor, ToggleSqlCmdModeAction.ID, undefined);
 	}
@@ -554,7 +557,7 @@ export class ToggleSqlCmdModeAction extends QueryTaskbarAction {
 		let queryoptions: QueryExecutionOptions = { options: {} };
 		queryoptions.options['isSqlCmdMode'] = toSqlCmdState;
 		if (!this.editor.input) {
-			console.error('editor input was null');
+			this.logService.error('editor input was null');
 			return;
 		}
 		this.queryManagementService.setQueryExecutionOptions(this.editor.input.uri, queryoptions);
@@ -586,7 +589,8 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 		@IContextViewService contextViewProvider: IContextViewService,
 		@IConnectionManagementService private readonly connectionManagementService: IConnectionManagementService,
 		@INotificationService private readonly notificationService: INotificationService,
-		@IConfigurationService private readonly configurationService: IConfigurationService
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ILogService private readonly logService: ILogService
 	) {
 		super();
 		this._databaseListDropdown = $('.databaseListDropdown');
@@ -680,7 +684,7 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 	// PRIVATE HELPERS /////////////////////////////////////////////////////
 	private databaseSelected(dbName: string): void {
 		if (!this._editor.input) {
-			console.error('editor input was null');
+			this.logService.error('editor input was null');
 			return;
 		}
 
@@ -716,7 +720,7 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 
 	private getCurrentDatabaseName(): string | undefined {
 		if (!this._editor.input) {
-			console.error('editor input was null');
+			this.logService.error('editor input was null');
 			return undefined;
 		}
 
@@ -744,7 +748,7 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 		}
 
 		if (!this._editor.input) {
-			console.error('editor input was null');
+			this.logService.error('editor input was null');
 			return;
 		}
 
@@ -758,7 +762,7 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 
 	private onDropdownFocus(): void {
 		if (!this._editor.input) {
-			console.error('editor input was null');
+			this.logService.error('editor input was null');
 			return;
 		}
 
@@ -782,7 +786,7 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 		if (this._isInAccessibilityMode) {
 			this._databaseSelectBox.enable();
 			if (!this._editor.input) {
-				console.error('editor input was null');
+				this.logService.error('editor input was null');
 				return;
 			}
 			let uri = this._editor.input.uri;

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -333,7 +333,7 @@ suite('SQL QueryAction Tests', () => {
 		});
 
 		// If I call run on CancelQueryAction when I am not connected
-		let queryAction: CancelQueryAction = new CancelQueryAction(editor.object, queryModelService.object, connectionManagementService.object);
+		let queryAction: CancelQueryAction = new CancelQueryAction(editor.object, queryModelService.object, connectionManagementService.object, undefined);
 		isConnected = false;
 		await queryAction.run();
 
@@ -467,7 +467,7 @@ suite('SQL QueryAction Tests', () => {
 		});
 
 		// If I query without having initialized anything, state should be clear
-		listItem = new ListDatabasesActionItem(editor.object, undefined, connectionManagementService.object, undefined, configurationService.object);
+		listItem = new ListDatabasesActionItem(editor.object, undefined, connectionManagementService.object, undefined, configurationService.object, undefined);
 
 		assert.equal(listItem.isEnabled(), false, 'do not expect dropdown enabled unless connected');
 		assert.equal(listItem.currentDatabaseName, undefined, 'do not expect dropdown to have entries unless connected');
@@ -498,7 +498,7 @@ suite('SQL QueryAction Tests', () => {
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{ databaseName: databaseName });
 
 		// ... Create a database dropdown that has been connected
-		let listItem = new ListDatabasesActionItem(editor.object, undefined, connectionManagementService.object, undefined, configurationService.object);
+		let listItem = new ListDatabasesActionItem(editor.object, undefined, connectionManagementService.object, undefined, configurationService.object, undefined);
 		listItem.onConnected();
 
 		// If: I raise a connection changed event
@@ -520,7 +520,7 @@ suite('SQL QueryAction Tests', () => {
 		connectionManagementService.setup(x => x.getConnectionProfile(TypeMoq.It.isAny())).returns(() => <IConnectionProfile>{ databaseName: databaseName });
 
 		// ... Create a database dropdown that has been connected
-		let listItem = new ListDatabasesActionItem(editor.object, undefined, connectionManagementService.object, undefined, configurationService.object);
+		let listItem = new ListDatabasesActionItem(editor.object, undefined, connectionManagementService.object, undefined, configurationService.object, undefined);
 		listItem.onConnected();
 
 		// If: I raise a connection changed event for the 'wrong' URI
@@ -545,7 +545,7 @@ suite('SQL QueryAction Tests', () => {
 		connectionManagementService.setup(x => x.onConnectionChanged).returns(() => dbChangedEmitter.event);
 
 		// ... Create a database dropdown
-		let listItem = new ListDatabasesActionItem(editor.object, undefined, connectionManagementService.object, undefined, configurationService.object);
+		let listItem = new ListDatabasesActionItem(editor.object, undefined, connectionManagementService.object, undefined, configurationService.object, undefined);
 
 		// If: I raise a connection changed event
 		let eventParams = <IConnectionParams>{

--- a/src/sql/workbench/contrib/query/test/browser/queryEditor.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryEditor.test.ts
@@ -63,7 +63,7 @@ suite('SQL QueryEditor Tests', () => {
 		instantiationService.setup(x => x.createInstance(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((classDef, editor, action) => {
 			if (classDef.ID) {
 				if (classDef.ID === 'listDatabaseQueryActionItem') {
-					return new ListDatabasesActionItem(editor, undefined, connectionManagementService.object, undefined, configurationService.object);
+					return new ListDatabasesActionItem(editor, undefined, connectionManagementService.object, undefined, configurationService.object, undefined);
 				}
 			}
 			// Default
@@ -295,7 +295,7 @@ suite('SQL QueryEditor Tests', () => {
 			queryActionInstantiationService.setup(x => x.createInstance(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
 				.returns((definition, editor, action, selectBox) => {
 					if (definition.ID === 'listDatabaseQueryActionItem') {
-						let item = new ListDatabasesActionItem(editor, undefined, connectionManagementService.object, undefined, configurationService.object);
+						let item = new ListDatabasesActionItem(editor, undefined, connectionManagementService.object, undefined, configurationService.object, undefined);
 						return item;
 					}
 					// Default

--- a/src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor.ts
+++ b/src/sql/workbench/contrib/queryPlan/browser/queryPlanEditor.ts
@@ -102,7 +102,7 @@ export class QueryPlanEditor extends BaseEditor {
 			planXml: input.planXml
 		};
 
-		let uniqueSelector = bootstrapAngular(this.instantiationService,
+		let uniqueSelector = this.instantiationService.invokeFunction(bootstrapAngular,
 			QueryPlanModule,
 			this.getContainer(),
 			QUERYPLAN_SELECTOR,

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -23,6 +23,7 @@ import { URI } from 'vs/base/common/uri';
 import { firstIndex } from 'vs/base/common/arrays';
 import { values } from 'vs/base/common/collections';
 import { onUnexpectedError } from 'vs/base/common/errors';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export class AccountManagementService implements IAccountManagementService {
 	// CONSTANTS ///////////////////////////////////////////////////////////
@@ -52,7 +53,8 @@ export class AccountManagementService implements IAccountManagementService {
 		@IInstantiationService private _instantiationService: IInstantiationService,
 		@IStorageService private _storageService: IStorageService,
 		@IClipboardService private _clipboardService: IClipboardService,
-		@IOpenerService private _openerService: IOpenerService
+		@IOpenerService private _openerService: IOpenerService,
+		@ILogService private readonly logService: ILogService
 	) {
 		// Create the account store
 		if (!this._mementoObj) {
@@ -301,7 +303,7 @@ export class AccountManagementService implements IAccountManagementService {
 		this.doWithProvider(providerId, provider => provider.provider.autoOAuthCancelled())
 			.then(	// Swallow errors
 				null,
-				err => { console.warn(`Error when cancelling auto OAuth: ${err}`); }
+				err => { this.logService.warn(`Error when cancelling auto OAuth: ${err}`); }
 			)
 			.then(() => this.autoOAuthDialogController.closeAutoOAuthDialog());
 	}

--- a/src/sql/workbench/services/accountManagement/test/browser/accountManagementService.test.ts
+++ b/src/sql/workbench/services/accountManagement/test/browser/accountManagementService.test.ts
@@ -506,7 +506,7 @@ function getTestState(): AccountManagementState {
 	let mockMemento = {};
 
 	// Create the account management service
-	let ams = new AccountManagementService(mockMemento, mockInstantiationService.object, new TestStorageService(), null, null);
+	let ams = new AccountManagementService(mockMemento, mockInstantiationService.object, new TestStorageService(), null, null, undefined);
 
 	// Wire up event handlers
 	let evUpdate = new EventVerifierSingle<UpdateAccountListEventParams>();

--- a/src/sql/workbench/services/bootstrap/browser/bootstrapService.ts
+++ b/src/sql/workbench/services/bootstrap/browser/bootstrapService.ts
@@ -5,7 +5,7 @@
 
 import { NgModuleRef, PlatformRef, Provider, enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { IInstantiationService, _util } from 'vs/platform/instantiation/common/instantiation';
+import { IInstantiationService, _util, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IEditorInput } from 'vs/workbench/common/editor';
 import { Trace } from 'vs/platform/instantiation/common/instantiationService';
 import { values } from 'vs/base/common/map';
@@ -40,14 +40,15 @@ function createUniqueSelector(selector: string): string {
 
 let platform: PlatformRef;
 
-export function bootstrapAngular<T>(service: IInstantiationService, moduleType: IModuleFactory<T>, container: HTMLElement, selectorString: string, params: IBootstrapParams, input?: IEditorInput, callbackSetModule?: (value: NgModuleRef<T>) => void): string {
+export function bootstrapAngular<T>(accessor: ServicesAccessor, moduleType: IModuleFactory<T>, container: HTMLElement, selectorString: string, params: IBootstrapParams, input?: IEditorInput, callbackSetModule?: (value: NgModuleRef<T>) => void): string {
 	// Create the uniqueSelectorString
 	let uniqueSelectorString = createUniqueSelector(selectorString);
 	let selector = document.createElement(uniqueSelectorString);
 	container.appendChild(selector);
+	const instantiationService = accessor.get(IInstantiationService);
 
 	if (!platform) {
-		service.invokeFunction((accessor) => {
+		instantiationService.invokeFunction((accessor) => {
 			const environmentService = accessor.get(IEnvironmentService);
 			if (environmentService.isBuilt) {
 				enableProdMode();
@@ -56,7 +57,7 @@ export function bootstrapAngular<T>(service: IInstantiationService, moduleType: 
 		platform = platformBrowserDynamic();
 	}
 
-	platform.bootstrapModule(moduleType(params, uniqueSelectorString, service)).then(moduleRef => {
+	platform.bootstrapModule(moduleType(params, uniqueSelectorString, instantiationService)).then(moduleRef => {
 		if (input) {
 			input.onDispose(() => {
 				moduleRef.destroy();
@@ -66,14 +67,8 @@ export function bootstrapAngular<T>(service: IInstantiationService, moduleType: 
 			callbackSetModule(moduleRef);
 		}
 	}).catch((e) => {
-		service.invokeFunction((accessor) => {
-			const logService = accessor.get(ILogService);
-			if (!logService) {
-				console.error(e);
-				return;
-			}
-			logService.error(e);
-		});
+		const logService = accessor.get(ILogService);
+		logService.error(e);
 	});
 
 	return uniqueSelectorString;

--- a/src/sql/workbench/services/dialog/browser/dialogPane.ts
+++ b/src/sql/workbench/services/dialog/browser/dialogPane.ts
@@ -109,7 +109,7 @@ export class DialogPane extends Disposable implements IThemable {
 	 * Bootstrap angular for the dialog's model view controller with the given model view ID
 	 */
 	private initializeModelViewContainer(bodyContainer: HTMLElement, modelViewId: string, tab?: DialogTab) {
-		bootstrapAngular(this._instantiationService,
+		this._instantiationService.invokeFunction(bootstrapAngular,
 			DialogModule,
 			bodyContainer,
 			'dialog-modelview-container',

--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -232,7 +232,7 @@ export class WizardModal extends Modal {
 	 * Bootstrap angular for the wizard's left nav bar
 	 */
 	private initializeNavigation(bodyContainer: HTMLElement) {
-		bootstrapAngular(this._instantiationService,
+		this._instantiationService.invokeFunction(bootstrapAngular,
 			DialogModule,
 			bodyContainer,
 			'wizard-navigation',

--- a/src/sql/workbench/services/dialog/test/electron-browser/dialogPane.test.ts
+++ b/src/sql/workbench/services/dialog/test/electron-browser/dialogPane.test.ts
@@ -9,6 +9,7 @@ import { DialogPane } from 'sql/workbench/services/dialog/browser/dialogPane';
 import { DialogComponentParams } from 'sql/workbench/services/dialog/browser/dialogContainer.component';
 import { bootstrapAngular } from 'sql/workbench/services/bootstrap/browser/bootstrapService';
 import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
+import { workbenchInstantiationService } from 'vs/workbench/test/electron-browser/workbenchTestServices';
 
 
 interface BootstrapAngular {
@@ -41,7 +42,7 @@ suite('Dialog Pane Tests', () => {
 		});
 		dialog.content = modelViewId;
 		const themeService = new TestThemeService();
-		let dialogPane = new DialogPane(dialog.title, dialog.content, () => undefined, undefined, themeService, false);
+		let dialogPane = new DialogPane(dialog.title, dialog.content, () => undefined, workbenchInstantiationService(), themeService, undefined);
 		dialogPane.createBody(container);
 		assert.equal(bootstrapCalls, 1);
 	});
@@ -56,7 +57,7 @@ suite('Dialog Pane Tests', () => {
 		});
 		dialog.content = [new DialogTab('', modelViewId)];
 		const themeService = new TestThemeService();
-		let dialogPane = new DialogPane(dialog.title, dialog.content, () => undefined, undefined, themeService, false);
+		let dialogPane = new DialogPane(dialog.title, dialog.content, () => undefined, workbenchInstantiationService(), themeService, false);
 		dialogPane.createBody(container);
 		assert.equal(bootstrapCalls, 1);
 	});
@@ -73,7 +74,7 @@ suite('Dialog Pane Tests', () => {
 		let modelViewId2 = 'test_content_2';
 		dialog.content = [new DialogTab('tab1', modelViewId1), new DialogTab('tab2', modelViewId2)];
 		const themeService = new TestThemeService();
-		let dialogPane = new DialogPane(dialog.title, dialog.content, valid => dialog.notifyValidityChanged(valid), undefined, themeService, false);
+		let dialogPane = new DialogPane(dialog.title, dialog.content, valid => dialog.notifyValidityChanged(valid), workbenchInstantiationService(), themeService, false);
 		dialogPane.createBody(container);
 
 		let validityChanges: boolean[] = [];

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -40,7 +40,6 @@ import { Schemas } from 'vs/base/common/network';
 import { ILogService } from 'vs/platform/log/common/log';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
 import { NotebookChangeType } from 'sql/workbench/services/notebook/common/contracts';
-import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { find, firstIndex } from 'vs/base/common/arrays';
 import { onUnexpectedError } from 'vs/base/common/errors';
 
@@ -129,7 +128,7 @@ export class NotebookService extends Disposable implements INotebookService {
 		@IFileService private readonly _fileService: IFileService,
 		@ILogService private readonly _logService: ILogService,
 		@IQueryManagementService private readonly _queryManagementService: IQueryManagementService,
-		@IEnvironmentService environmentService: IEnvironmentService
+		@ILogService private readonly logService: ILogService
 	) {
 		super();
 		this._providersMemento = new Memento('notebookProviders', this._storageService);
@@ -455,7 +454,7 @@ export class NotebookService extends Disposable implements INotebookService {
 				try {
 					await this._extensionService.whenInstalledExtensionsRegistered();
 				} catch (error) {
-					console.error(error);
+					this.logService.error(error);
 				}
 				instance = await this.waitOnProviderAvailability(providerDescriptor);
 			} else {

--- a/src/sql/workbench/test/electron-browser/api/extHostModelView.test.ts
+++ b/src/sql/workbench/test/electron-browser/api/extHostModelView.test.ts
@@ -52,7 +52,7 @@ suite('ExtHostModelView Validation Tests', () => {
 		mockProxy.setup(x => x.$registerEvent(It.isAny(), It.isAny())).returns(() => Promise.resolve());
 		mockProxy.setup(x => x.$setProperties(It.isAny(), It.isAny(), It.isAny())).returns(() => Promise.resolve());
 
-		extHostModelView = new ExtHostModelView(mainContext, undefined);
+		extHostModelView = new ExtHostModelView(mainContext, undefined, undefined);
 	});
 
 	// Set of general tests using a couple of common components
@@ -371,7 +371,7 @@ suite('ExtHostModelView Validation Tests', () => {
 			mockProxy.setup(x => x.$addToContainer(It.isAny(), It.isAny(), It.isAny(), It.isAny())).returns(() => Promise.resolve());
 			mockProxy.setup(x => x.$removeFromContainer(It.isAny(), It.isAny(), It.isAny())).returns(() => Promise.resolve());
 
-			extHostModelView = new ExtHostModelView(mainContext, undefined);
+			extHostModelView = new ExtHostModelView(mainContext, undefined, undefined);
 			extHostModelView.$registerProvider(widgetId, async view => {
 				modelView = view;
 				done();

--- a/src/vs/workbench/api/common/extHostRequireInterceptor.ts
+++ b/src/vs/workbench/api/common/extHostRequireInterceptor.ts
@@ -60,7 +60,7 @@ export abstract class RequireInterceptor {
 		const extensionPaths = await this._extHostExtensionService.getExtensionPathIndex();
 
 		this.register(new VSCodeNodeModuleFactory(this._apiFactory.vscode, extensionPaths, this._extensionRegistry, configProvider, this._logService)); // {{SQL CARBON EDIT}} // add node module
-		this.register(new AzdataNodeModuleFactory(this._apiFactory.azdata, extensionPaths)); // {{SQL CARBON EDIT}} // add node module
+		this.register(new AzdataNodeModuleFactory(this._apiFactory.azdata, extensionPaths, this._logService)); // {{SQL CARBON EDIT}} // add node module
 		this.register(this._instaService.createInstance(KeytarNodeModuleFactory));
 		if (this._initData.remote.isRemote) {
 			this.register(this._instaService.createInstance(OpenNodeModuleFactory, extensionPaths, this._initData.environment.appUriScheme));

--- a/test/smoke/src/sql/queryEditor/queryEditor.test.ts
+++ b/test/smoke/src/sql/queryEditor/queryEditor.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Application } from '../../../../automation';
-import * as fs from 'fs';
+import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -13,7 +13,7 @@ export function setup() {
 
 		it('Can open and edit existing file', async function () {
 			const testFilePath = path.join(os.tmpdir(), 'QueryEditorSmokeTest.sql');
-			fs.writeFileSync(testFilePath, '');
+			await fs.writeFile(testFilePath, '');
 			try {
 				const app = this.app as Application;
 				await app.workbench.queryEditors.openFile(testFilePath);
@@ -21,7 +21,7 @@ export function setup() {
 				await app.workbench.editor.waitForTypeInEditor(fileBaseName, 'SELECT * FROM sys.tables');
 			}
 			finally {
-				fs.unlinkSync(testFilePath);
+				await fs.unlink(testFilePath);
 			}
 		});
 	});


### PR DESCRIPTION
Adds the no console linting option. In most cases if we want to log information for debugging user logs, we should be using the logservice, since that also logs to a file.

You can always bypass this rule if a scenario warrants just printing to the console and not to the file.

Also uses eslint overrides instead of a separate file for sql specific linting (this should significantly reduce linting times since we won't be linting the sql files twice now)