### PR TITLE
call refreshDatasets upon loading new dataset

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -394,8 +394,10 @@ export class EditDataGridPanel extends GridParentComponent {
 		undefinedDataSet.dataRows = undefined;
 		undefinedDataSet.resized = new Emitter();
 		self.placeHolderDataSets.push(undefinedDataSet);
+		if (self.placeHolderDataSets[0]) {
+			this.refreshDatasets();
+		}
 		self.refreshGrid();
-
 		// Setup the state of the selected cell
 		this.resetCurrentCell();
 		this.removingNewRow = false;

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -398,6 +398,7 @@ export class EditDataGridPanel extends GridParentComponent {
 			this.refreshDatasets();
 		}
 		self.refreshGrid();
+
 		// Setup the state of the selected cell
 		this.resetCurrentCell();
 		this.removingNewRow = false;


### PR DESCRIPTION
The load dataset function now updates the rendered datasets upon loading a new dataSet (such as after a query).

This PR fixes #9145
