### PR TITLE
wipe status message only when not installing

### DIFF
--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -199,9 +199,11 @@ export class ResourceTypePickerDialog extends DialogBase {
 		const currentRefreshTimestamp = this.toolRefreshTimestamp;
 		const headerRowHeight = 28;
 		this._toolsTable.height = 25 * Math.max(this.toolRequirements.length, 1) + headerRowHeight;
-		this._dialogObject.message = {
-			text: ''
-		};
+		if (!this._installationInProgress) { // Wipe the informational message clean unless installation is already in progress.
+			this._dialogObject.message = {
+				text: ''
+			};
+		}
 		this._installToolButton.hidden = true;
 		if (this.toolRequirements.length === 0) {
 			this._dialogObject.okButton.enabled = true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

The buggy code was wiping out the informational messages that we display at the top of the deployment screen that a tool was being installed. The fix makes sure that the informational messages are not cleared out if we are in an 'installing' state.

This PR fixes #8596 
