### PR TITLE
Remove required from dacpac wizard dropdowns

### DIFF
--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -44,7 +44,6 @@ export abstract class DacFxConfigPage extends BasePage {
 	protected async createServerDropdown(isTargetServer: boolean): Promise<azdata.FormComponent> {
 		const serverDropDownTitle = isTargetServer ? loc.targetServer : loc.sourceServer;
 		this.serverDropdown = this.view.modelBuilder.dropDown().withProperties({
-			required: true,
 			ariaLabel: serverDropDownTitle
 		}).component();
 
@@ -112,9 +111,7 @@ export abstract class DacFxConfigPage extends BasePage {
 			this.model.filePath = this.fileTextBox.value;
 		});
 
-		this.databaseLoader = this.view.modelBuilder.loadingComponent().withItem(this.databaseDropdown).withProperties({
-			required: true
-		}).component();
+		this.databaseLoader = this.view.modelBuilder.loadingComponent().withItem(this.databaseDropdown).component();
 
 
 		return {

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -44,6 +44,7 @@ export abstract class DacFxConfigPage extends BasePage {
 	protected async createServerDropdown(isTargetServer: boolean): Promise<azdata.FormComponent> {
 		const serverDropDownTitle = isTargetServer ? loc.targetServer : loc.sourceServer;
 		this.serverDropdown = this.view.modelBuilder.dropDown().withProperties({
+			required: true,
 			ariaLabel: serverDropDownTitle
 		}).component();
 
@@ -101,6 +102,7 @@ export abstract class DacFxConfigPage extends BasePage {
 	protected async createDatabaseDropdown(): Promise<azdata.FormComponent> {
 		const databaseDropdownTitle = loc.sourceDatabase;
 		this.databaseDropdown = this.view.modelBuilder.dropDown().withProperties({
+			required: true,
 			ariaLabel: databaseDropdownTitle
 		}).component();
 

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -113,8 +113,9 @@ export abstract class DacFxConfigPage extends BasePage {
 			this.model.filePath = this.fileTextBox.value;
 		});
 
-		this.databaseLoader = this.view.modelBuilder.loadingComponent().withItem(this.databaseDropdown).component();
-
+		this.databaseLoader = this.view.modelBuilder.loadingComponent().withItem(this.databaseDropdown).withProperties({
+			required: true
+		}).component();
 
 		return {
 			component: this.databaseLoader,

--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -318,6 +318,10 @@ export class SelectBox extends vsSelectBox {
 			super.render(container);
 		}
 	}
+
+	public get selectElem(): HTMLSelectElement {
+		return this.selectElement;
+	}
 }
 
 export interface ISelectBoxOptionsWithLabel extends ISelectBoxOptions {

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -310,6 +310,10 @@ export class Dropdown extends Disposable {
 		this._input.value = val;
 	}
 
+	public get inputElement(): HTMLInputElement {
+		return this._input.inputElement;
+	}
+
 	public focus() {
 		this._input.focus();
 	}

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -138,6 +138,7 @@ export default class DropDownComponent extends ComponentBase implements ICompone
 		}
 
 		this._selectBox.selectElem.required = this.required;
+		this._editableDropdown.inputElement.required = this.required;
 	}
 
 	private getValues(): string[] {

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -136,6 +136,8 @@ export default class DropDownComponent extends ComponentBase implements ICompone
 				this._selectBox.disable();
 			}
 		}
+
+		this._selectBox.selectElem.required = this.required;
 	}
 
 	private getValues(): string[] {
@@ -215,6 +217,14 @@ export default class DropDownComponent extends ComponentBase implements ICompone
 
 	private setValuesProperties(properties: azdata.DropDownProperties, values: string[] | azdata.CategoryValue[]): void {
 		properties.values = values;
+	}
+
+	public get required(): boolean {
+		return this.getPropertyOrDefault<azdata.DropDownProperties, boolean>((props) => props.required, false);
+	}
+
+	public set required(newValue: boolean) {
+		this.setPropertyFromUI<azdata.DropDownProperties, boolean>((props, value) => props.required = value, newValue);
 	}
 
 	public focus(): void {


### PR DESCRIPTION
This PR fixes #9183. Required wasn't being announced for dropdowns because it wasn't getting set. 
![image](https://user-images.githubusercontent.com/31145923/74885579-c8c05080-532a-11ea-895a-e8a7f031a172.png)
