### PR TITLE
Add livy_session_startup_timeout_seconds config back in

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -26,6 +26,7 @@ const configBase = {
 	'kernel_r_credentials': {
 		'url': ''
 	},
+	'livy_session_startup_timeout_seconds': 100,
 	'logging_config': {
 		'version': 1,
 		'formatters': {


### PR DESCRIPTION
Should fix #9155 - @chlafreniere @corivera is there an easy way to check that this is actually fixed?