### PR TITLE
Fix UI not selecting false options initially

### DIFF
--- a/src/sql/workbench/browser/modal/optionsDialogHelper.ts
+++ b/src/sql/workbench/browser/modal/optionsDialogHelper.ts
@@ -69,7 +69,7 @@ export function createOptionElement(option: azdata.ServiceOption, rowContainer: 
 
 export function getOptionValueAndCategoryValues(option: azdata.ServiceOption, options: { [optionName: string]: any }, possibleInputs: string[]): any {
 	let optionValue = option.defaultValue;
-	if (options[option.name]) {
+	if (options[option.name] !== undefined) {
 		// if the value type is boolean, the option value can be either boolean or string
 		if (option.valueType === ServiceOptionType.boolean) {
 			if (options[option.name] === true || options[option.name] === trueInputValue) {


### PR DESCRIPTION
Note that this didn't seem to have any functional impact - the setting was applied correctly. This is just making the UI display the selected value if it's specifically selected as False. 

Fixes #9166