### PR TITLE
Fix refreshing nodes in Azure view

### DIFF
--- a/src/sql/workbench/browser/parts/views/customView.ts
+++ b/src/sql/workbench/browser/parts/views/customView.ts
@@ -698,26 +698,28 @@ class TreeDataSource implements IAsyncDataSource<ITreeItem, ITreeItem> {
 		return this.treeView.dataProvider && node.collapsibleState !== TreeItemCollapsibleState.None;
 	}
 
-	getChildren(node: ITreeItem): Promise<any[]> {
+	async getChildren(node: ITreeItem): Promise<any[]> {
 		if (node.childProvider) {
-			return this.withProgress(this.objectExplorerService.refreshNode(node, this.id)).catch(e => {
+			try {
+				return await this.withProgress(this.objectExplorerService.getChildren(node, this.id));
+			} catch (err) {
 				// if some error is caused we assume something tangently happened
 				// i.e the user could retry if they wanted.
 				// So in order to enable this we need to tell the tree to refresh this node so it will ask us for the data again
 				setTimeout(() => {
 					this.treeView.collapse(node);
-					if (e instanceof UserCancelledConnectionError) {
+					if (err instanceof UserCancelledConnectionError) {
 						return;
 					}
 					this.treeView.refresh([node]);
 				});
 				return [];
-			});
+			}
 		}
 		if (this.treeView.dataProvider) {
 			return this.withProgress(this.treeView.dataProvider.getChildren(node));
 		}
-		return Promise.resolve([]);
+		return [];
 	}
 }
 

--- a/src/sql/workbench/browser/parts/views/customView.ts
+++ b/src/sql/workbench/browser/parts/views/customView.ts
@@ -700,7 +700,7 @@ class TreeDataSource implements IAsyncDataSource<ITreeItem, ITreeItem> {
 
 	getChildren(node: ITreeItem): Promise<any[]> {
 		if (node.childProvider) {
-			return this.withProgress(this.objectExplorerService.getChildren(node, this.id)).catch(e => {
+			return this.withProgress(this.objectExplorerService.refreshNode(node, this.id)).catch(e => {
 				// if some error is caused we assume something tangently happened
 				// i.e the user could retry if they wanted.
 				// So in order to enable this we need to tell the tree to refresh this node so it will ask us for the data again

--- a/src/sql/workbench/browser/parts/views/customView.ts
+++ b/src/sql/workbench/browser/parts/views/customView.ts
@@ -717,7 +717,7 @@ class TreeDataSource implements IAsyncDataSource<ITreeItem, ITreeItem> {
 			}
 		}
 		if (this.treeView.dataProvider) {
-			return this.withProgress(this.treeView.dataProvider.getChildren(node));
+			return await this.withProgress(this.treeView.dataProvider.getChildren(node));
 		}
 		return [];
 	}

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
@@ -26,7 +26,6 @@ export const IOEShimService = createDecorator<IOEShimService>(SERVICE_ID);
 export interface IOEShimService {
 	_serviceBrand: undefined;
 	getChildren(node: ITreeItem, viewId: string): Promise<ITreeItem[]>;
-	refreshNode(node: ITreeItem, viewId: string): Promise<ITreeItem[]>;
 	disconnectNode(viewId: string, node: ITreeItem): Promise<boolean>;
 	providerExists(providerId: string): boolean;
 	isNodeConnected(viewId: string, node: ITreeItem): boolean;
@@ -130,28 +129,6 @@ export class OEShimService extends Disposable implements IOEShimService {
 	}
 
 	public async getChildren(node: ITreeItem, viewId: string): Promise<ITreeItem[]> {
-		if (node.payload) {
-			const sessionId = await this.getOrCreateSession(viewId, node);
-			const requestHandle = this.nodeHandleMap.get(generateNodeMapKey(viewId, node)) || node.handle;
-			const treeNode = new TreeNode(undefined, undefined, undefined, requestHandle, undefined, undefined, undefined, undefined, undefined, undefined);
-			treeNode.connection = new ConnectionProfile(this.capabilities, node.payload);
-			const childrenNodes = await this.oe.resolveTreeNodeChildren({
-				success: undefined,
-				sessionId,
-				rootNode: undefined,
-				errorMessage: undefined
-			}, treeNode);
-			return childrenNodes.map(n => this.treeNodeToITreeItem(viewId, n, node));
-		}
-		return [];
-	}
-
-	/**
-	 * Refreshes a node - returning the refreshed set of children for that node.
-	 * @param node The node to refresh
-	 * @param viewId The ID of the view requesting the refresh
-	 */
-	public async refreshNode(node: ITreeItem, viewId: string): Promise<ITreeItem[]> {
 		if (node.payload) {
 			const sessionId = await this.getOrCreateSession(viewId, node);
 			const requestHandle = this.nodeHandleMap.get(generateNodeMapKey(viewId, node)) || node.handle;

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
@@ -131,19 +131,19 @@ export class OEShimService extends Disposable implements IOEShimService {
 
 	public async getChildren(node: ITreeItem, viewId: string): Promise<ITreeItem[]> {
 		if (node.payload) {
-			let sessionId = await this.getOrCreateSession(viewId, node);
-			let requestHandle = this.nodeHandleMap.get(generateNodeMapKey(viewId, node)) || node.handle;
-			let treeNode = new TreeNode(undefined, undefined, undefined, requestHandle, undefined, undefined, undefined, undefined, undefined, undefined);
+			const sessionId = await this.getOrCreateSession(viewId, node);
+			const requestHandle = this.nodeHandleMap.get(generateNodeMapKey(viewId, node)) || node.handle;
+			const treeNode = new TreeNode(undefined, undefined, undefined, requestHandle, undefined, undefined, undefined, undefined, undefined, undefined);
 			treeNode.connection = new ConnectionProfile(this.capabilities, node.payload);
-			return this.oe.resolveTreeNodeChildren({
+			const childrenNodes = await this.oe.resolveTreeNodeChildren({
 				success: undefined,
 				sessionId,
 				rootNode: undefined,
 				errorMessage: undefined
-			}, treeNode).then(e => e.map(n => this.treeNodeToITreeItem(viewId, n, node)));
-		} else {
-			return Promise.resolve([]);
+			}, treeNode);
+			return childrenNodes.map(n => this.treeNodeToITreeItem(viewId, n, node));
 		}
+		return [];
 	}
 
 	/**
@@ -153,19 +153,19 @@ export class OEShimService extends Disposable implements IOEShimService {
 	 */
 	public async refreshNode(node: ITreeItem, viewId: string): Promise<ITreeItem[]> {
 		if (node.payload) {
-			let sessionId = await this.getOrCreateSession(viewId, node);
-			let requestHandle = this.nodeHandleMap.get(generateNodeMapKey(viewId, node)) || node.handle;
-			let treeNode = new TreeNode(undefined, undefined, undefined, requestHandle, undefined, undefined, undefined, undefined, undefined, undefined);
+			const sessionId = await this.getOrCreateSession(viewId, node);
+			const requestHandle = this.nodeHandleMap.get(generateNodeMapKey(viewId, node)) || node.handle;
+			const treeNode = new TreeNode(undefined, undefined, undefined, requestHandle, undefined, undefined, undefined, undefined, undefined, undefined);
 			treeNode.connection = new ConnectionProfile(this.capabilities, node.payload);
-			return this.oe.refreshTreeNode({
+			const childrenNodes = await this.oe.refreshTreeNode({
 				success: undefined,
 				sessionId,
 				rootNode: undefined,
 				errorMessage: undefined
-			}, treeNode).then(e => e.map(n => this.treeNodeToITreeItem(viewId, n, node)));
-		} else {
-			return Promise.resolve([]);
+			}, treeNode);
+			return childrenNodes.map(n => this.treeNodeToITreeItem(viewId, n, node));
 		}
+		return [];
 	}
 
 	private treeNodeToITreeItem(viewId: string, node: TreeNode, parentNode: ITreeItem): ITreeItem {


### PR DESCRIPTION
Fixes #9184

I'm not sure if this ever worked - I went back a couple releases and it was broken there.

In the end this is due to the refresh for asyncDataTree just calling getChildren on the provider when doing a refresh. Since the provider doesn't have any refresh functionality it expects that this will return the current set of children. But we weren't doing that - instead just returning the known set of children nodes and so any changes made after the initial load wouldn't be picked up.
