### PR TITLE
Allow extensions to add actions to home toolbar

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
@@ -32,6 +32,7 @@ dashboard-page .actions-container .action-item .action-label{
 
 dashboard-page .actions-container .taskbarSeparator {
 	height: 14px;
+	margin-right: 16px;
 }
 
 dashboard-page .editor-toolbar {

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardToolbarHomeAction.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardToolbarHomeAction.contribution.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IExtensionPointUser, ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
+import { IJSONSchema } from 'vs/base/common/jsonSchema';
+import { localize } from 'vs/nls';
+import { registerToolbarHomeAction } from 'sql/workbench/contrib/dashboard/browser/dashboardRegistry';
+
+export interface IDashboardToolbarHomeActionContrib {
+	name: string
+	when?: string;
+}
+
+const toolbarHomeActionSchema: IJSONSchema = {
+	type: 'object',
+	properties: {
+		name: {
+			description: localize('azdata.extension.contributes.toolbarHomeAction.name', "Name of task that executes when this item is clicked"),
+			type: 'string'
+		},
+		when: {
+			description: localize('azdata.extension.contributes.toolbarHomeAction.when', "Condition which must be true to show this item"),
+			type: 'string'
+		}
+	}
+};
+
+const toolbarHomeActionContributionSchema: IJSONSchema = {
+	description: localize('azdata.extension.contributes.toolbarHomeAction', "Contributes a single or multiple actions for users to add to their dashboard home toolbar."),
+	oneOf: [
+		toolbarHomeActionSchema,
+		{
+			type: 'array',
+			items: toolbarHomeActionSchema
+		}
+	]
+};
+
+ExtensionsRegistry.registerExtensionPoint<IDashboardToolbarHomeActionContrib | IDashboardToolbarHomeActionContrib[]>({ extensionPoint: 'dashboard.toolbarHomeActions', jsonSchema: toolbarHomeActionContributionSchema }).setHandler(extensions => {
+
+	function handleToolbarHomeAction(toolbarAction: IDashboardToolbarHomeActionContrib, extension: IExtensionPointUser<any>) {
+		let { name, when } = toolbarAction;
+
+		if (!name) {
+			extension.collector.error(localize('dashboardToolbarHomeAction.contribution.noNameError', "No name specified for extension toolbar action."));
+			return;
+		}
+
+		registerToolbarHomeAction({ name, when });
+	}
+
+	for (const extension of extensions) {
+		const { value } = extension;
+		if (Array.isArray<IDashboardToolbarHomeActionContrib>(value)) {
+			for (const command of value) {
+				handleToolbarHomeAction(command, extension);
+			}
+		} else {
+			handleToolbarHomeAction(value, extension);
+		}
+	}
+});

--- a/src/sql/workbench/contrib/dashboard/browser/dashboardRegistry.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/dashboardRegistry.ts
@@ -37,19 +37,27 @@ export interface IDashboardTabGroup {
 	title: string;
 }
 
+export interface IDashboardToolbarHomeAction {
+	name: string
+	when?: string;
+}
+
 export interface IDashboardRegistry {
 	registerDashboardProvider(id: string, properties: ProviderProperties): void;
 	getProperties(id: string): ProviderProperties;
 	registerTab(tab: IDashboardTab): void;
 	registerTabGroup(tabGroup: IDashboardTabGroup): void;
+	registerToolbarHomeAction(action: IDashboardToolbarHomeAction): void;
 	tabs: Array<IDashboardTab>;
 	tabGroups: Array<IDashboardTabGroup>;
+	toolbarHomeActions: Array<IDashboardToolbarHomeAction>;
 }
 
 class DashboardRegistry implements IDashboardRegistry {
 	private _properties = new Map<string, ProviderProperties>();
 	private _tabs = new Array<IDashboardTab>();
 	private _tabGroups = new Array<IDashboardTabGroup>();
+	private _toolbarHomeActions = new Array<IDashboardToolbarHomeAction>();
 	private _configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtension.Configuration);
 
 	/**
@@ -87,12 +95,20 @@ class DashboardRegistry implements IDashboardRegistry {
 		}
 	}
 
+	registerToolbarHomeAction(action: IDashboardToolbarHomeAction): void {
+		this._toolbarHomeActions.push(action);
+	}
+
 	public get tabs(): Array<IDashboardTab> {
 		return this._tabs;
 	}
 
 	public get tabGroups(): Array<IDashboardTabGroup> {
 		return this._tabGroups;
+	}
+
+	public get toolbarHomeActions(): Array<IDashboardToolbarHomeAction> {
+		return this._toolbarHomeActions;
 	}
 }
 
@@ -130,6 +146,10 @@ const dashboardPropertiesPropertyContrib: IJSONSchema = {
 		}
 	}
 };
+
+export function registerToolbarHomeAction(action: IDashboardToolbarHomeAction) {
+	dashboardRegistry.registerToolbarHomeAction(action);
+}
 
 const dashboardPropertyFlavorContrib: IJSONSchema = {
 	description: nls.localize('dashboard.properties.flavor', "A flavor for defining dashboard properties"),

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -446,7 +446,6 @@ import 'sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewCon
 import 'sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution';
 import 'sql/workbench/contrib/dashboard/browser/core/dashboardToolbarHomeAction.contribution';
 
-
 // Model-based Views
 import 'sql/workbench/contrib/modelView/browser/components.contribution';
 import 'sql/workbench/browser/modelComponents/modelViewEditor.contribution';

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -444,6 +444,8 @@ import 'sql/workbench/contrib/dashboard/browser/containers/dashboardContainer.co
 import 'sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution';
 import 'sql/workbench/contrib/dashboard/browser/containers/dashboardModelViewContainer.contribution';
 import 'sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution';
+import 'sql/workbench/contrib/dashboard/browser/core/dashboardToolbarHomeAction.contribution';
+
 
 // Model-based Views
 import 'sql/workbench/contrib/modelView/browser/components.contribution';


### PR DESCRIPTION
This adds support for extensions to add an action to the home page toolbar by specifying it in the contributes section in the package.json. For now, all actions added by extensions will be in a section between the server/database actions section and the refresh and edit section.

Example adding action to toolbar to start flat file import wizard:
![image](https://user-images.githubusercontent.com/31145923/74998460-a3f0d980-540d-11ea-9875-4a21f47b75f2.png)

![image](https://user-images.githubusercontent.com/31145923/74998435-950a2700-540d-11ea-828b-893c84953446.png)
