### PR TITLE
Add Arc Resources to Azure view

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -41,6 +41,17 @@
             "description": "%config.enablePublicCloudDescription%"
           }
         }
+      },
+      {
+        "type": "object",
+        "title": "Azure",
+        "properties": {
+          "azure.enableArcFeatures": {
+            "type": "boolean",
+            "default": false,
+            "description": "%config.enableArcFeatures%"
+          }
+        }
       }
     ],
     "account-type": [

--- a/extensions/azurecore/package.nls.json
+++ b/extensions/azurecore/package.nls.json
@@ -21,5 +21,5 @@
 	"config.enableUsGovCloudDescription": "Should US Government Azure cloud (Fairfax) integration be enabled",
 	"config.enableChinaCloudDescription": "Should Azure China integration be enabled",
 	"config.enableGermanyCloudDescription": "Should Azure Germany integration be enabled",
-	"config.enableArcFeatures": "Should features related to Azure Arc be enabled"
+	"config.enableArcFeatures": "Should features related to Azure Arc be enabled (preview)"
 }

--- a/extensions/azurecore/package.nls.json
+++ b/extensions/azurecore/package.nls.json
@@ -20,5 +20,6 @@
 	"config.enablePublicCloudDescription": "Should Azure public cloud integration be enabled",
 	"config.enableUsGovCloudDescription": "Should US Government Azure cloud (Fairfax) integration be enabled",
 	"config.enableChinaCloudDescription": "Should Azure China integration be enabled",
-	"config.enableGermanyCloudDescription": "Should Azure Germany integration be enabled"
+	"config.enableGermanyCloudDescription": "Should Azure Germany integration be enabled",
+	"config.enableArcFeatures": "Should features related to Azure Arc be enabled"
 }

--- a/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as constants from '../constants';
 import * as azdata from 'azdata';
 import * as events from 'events';
 import * as nls from 'vscode-nls';
@@ -13,6 +12,7 @@ import CredentialServiceTokenCache from './tokenCache';
 import providerSettings from './providerSettings';
 import { AzureAccountProvider as AzureAccountProvider } from './azureAccountProvider2';
 import { AzureAccountProviderMetadata, ProviderSettings } from './interfaces';
+import * as loc from '../localizedConstants';
 
 let localize = nls.loadMessageBundle();
 
@@ -78,11 +78,11 @@ export class AzureAccountProviderService implements vscode.Disposable {
 			.then(
 				() => {
 					let message = localize('clearTokenCacheSuccess', "Token cache successfully cleared");
-					vscode.window.showInformationMessage(`${constants.extensionName}: ${message}`);
+					vscode.window.showInformationMessage(`${loc.extensionName}: ${message}`);
 				},
 				err => {
 					let message = localize('clearTokenCacheFailure', "Failed to clear token cache");
-					vscode.window.showErrorMessage(`${constants.extensionName}: ${message}: ${err}`);
+					vscode.window.showErrorMessage(`${loc.extensionName}: ${message}: ${err}`);
 				});
 	}
 

--- a/extensions/azurecore/src/apiWrapper.ts
+++ b/extensions/azurecore/src/apiWrapper.ts
@@ -138,6 +138,10 @@ export class ApiWrapper {
 		return this.getConfiguration(constants.extensionConfigSectionName);
 	}
 
+	public get onDidChangeConfiguration(): vscode.Event<vscode.ConfigurationChangeEvent> {
+		return vscode.workspace.onDidChangeConfiguration;
+	}
+
 	/**
 	 * Parse uri
 	 */

--- a/extensions/azurecore/src/azureResource/providers/database/databaseTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/database/databaseTreeDataProvider.ts
@@ -18,7 +18,7 @@ import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
 export class AzureResourceDatabaseTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabase> {
 
 	private static readonly containerId = 'azure.resource.providers.database.treeDataProvider.databaseContainer';
-	private static readonly containerLabel = localize('azure.resource.providers.database.treeDataProvider.databaseContainerLabel', "SQL Databases");
+	private static readonly containerLabel = localize('azure.resource.providers.database.treeDataProvider.databaseContainerLabel', "SQL database");
 
 	public constructor(
 		databaseService: IAzureResourceService<azureResource.AzureResourceDatabase>,

--- a/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerTreeDataProvider.ts
@@ -17,7 +17,7 @@ import { azureResource } from '../../azure-resource';
 
 export class AzureResourceDatabaseServerTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
 	private static readonly containerId = 'azure.resource.providers.databaseServer.treeDataProvider.databaseServerContainer';
-	private static readonly containerLabel = localize('azure.resource.providers.databaseServer.treeDataProvider.databaseServerContainerLabel', "SQL Servers");
+	private static readonly containerLabel = localize('azure.resource.providers.databaseServer.treeDataProvider.databaseServerContainerLabel', "SQL server");
 
 	public constructor(
 		databaseServerService: IAzureResourceService<azureResource.AzureResourceDatabaseServer>,

--- a/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerProvider.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ExtensionContext } from 'vscode';
+import { ApiWrapper } from '../../../apiWrapper';
+
+import { azureResource } from '../../azure-resource';
+import { IAzureResourceService } from '../../interfaces';
+import { PostgresServerArcTreeDataProvider as PostgresServerArcTreeDataProvider } from './postgresServerTreeDataProvider';
+
+export class PostgresServerArcProvider implements azureResource.IAzureResourceProvider {
+	public constructor(
+		private _databaseServerService: IAzureResourceService<azureResource.AzureResourceDatabaseServer>,
+		private _apiWrapper: ApiWrapper,
+		private _extensionContext: ExtensionContext
+	) {
+	}
+
+	public getTreeDataProvider(): azureResource.IAzureResourceTreeDataProvider {
+		return new PostgresServerArcTreeDataProvider(this._databaseServerService, this._apiWrapper, this._extensionContext);
+	}
+
+	public get providerId(): string {
+		return 'azure.resource.providers.postgresArcServer';
+	}
+}

--- a/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerService.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerService.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceServiceBase, GraphData } from '../resourceTreeDataProviderBase';
+import { azureResource } from '../../azure-resource';
+
+export interface PostgresArcServerGraphData extends GraphData {
+	properties: {
+		admin: string;
+	};
+}
+
+export const serversQuery = 'where type == "microsoft.azuredata/postgresinstances"';
+
+export class PostgresServerArcService extends ResourceServiceBase<PostgresArcServerGraphData, azureResource.AzureResourceDatabaseServer> {
+
+	protected get query(): string {
+		return serversQuery;
+	}
+
+	protected convertResource(resource: PostgresArcServerGraphData): azureResource.AzureResourceDatabaseServer {
+		return {
+			id: resource.id,
+			name: resource.name,
+			fullName: resource.name,
+			loginName: resource.properties.admin,
+			defaultDatabaseName: 'postgres'
+		};
+	}
+}

--- a/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerTreeDataProvider.ts
@@ -32,7 +32,6 @@ export class PostgresServerArcTreeDataProvider extends ResourceTreeDataProviderB
 		return {
 			id: `databaseServer_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
 			label: databaseServer.name,
-			// TODO: should get PGSQL-specific icons (also needed in that extension)
 			iconPath: {
 				dark: this._extensionContext.asAbsolutePath('resources/dark/sql_server_inverse.svg'),
 				light: this._extensionContext.asAbsolutePath('resources/light/sql_server.svg')

--- a/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerTreeDataProvider.ts
@@ -15,9 +15,9 @@ import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
 import { azureResource } from '../../azure-resource';
 
-export class SqlInstanceTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
-	private static readonly containerId = 'azure.resource.providers.sqlInstanceContainer';
-	private static readonly containerLabel = localize('azure.resource.providers.sqlInstanceContainerLabel', "Azure SQL DB managed instance");
+export class PostgresServerArcTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
+	private static readonly containerId = 'azure.resource.providers.postgresArcServer.treeDataProvider.postgresServerContainer';
+	private static readonly containerLabel = localize('azure.resource.providers.postgresArcServer.treeDataProvider.postgresServerContainerLabel', "PostgreSQL Hyperscale - Azure Arc");
 
 	public constructor(
 		databaseServerService: IAzureResourceService<azureResource.AzureResourceDatabaseServer>,
@@ -30,11 +30,12 @@ export class SqlInstanceTreeDataProvider extends ResourceTreeDataProviderBase<az
 
 	protected getTreeItemForResource(databaseServer: azureResource.AzureResourceDatabaseServer): TreeItem {
 		return {
-			id: `sqlInstance_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
+			id: `databaseServer_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
 			label: databaseServer.name,
+			// TODO: should get PGSQL-specific icons (also needed in that extension)
 			iconPath: {
-				dark: this._extensionContext.asAbsolutePath('resources/dark/sql_instance_inverse.svg'),
-				light: this._extensionContext.asAbsolutePath('resources/light/sql_instance.svg')
+				dark: this._extensionContext.asAbsolutePath('resources/dark/sql_server_inverse.svg'),
+				light: this._extensionContext.asAbsolutePath('resources/light/sql_server.svg')
 			},
 			collapsibleState: TreeItemCollapsibleState.Collapsed,
 			contextValue: AzureResourceItemType.databaseServer,
@@ -43,17 +44,20 @@ export class SqlInstanceTreeDataProvider extends ResourceTreeDataProviderBase<az
 				connectionName: undefined,
 				serverName: databaseServer.fullName,
 				databaseName: databaseServer.defaultDatabaseName,
-				userName: databaseServer.loginName,
+				userName: `${databaseServer.loginName}@${databaseServer.fullName}`,
 				password: '',
 				authenticationType: 'SqlLogin',
 				savePassword: true,
 				groupFullName: '',
 				groupId: '',
-				providerName: 'MSSQL',
+				providerName: 'PGSQL',
 				saveProfile: false,
-				options: {}
+				options: {
+					// Set default for SSL or will get error complaining about it not being set correctly
+					'sslmode': 'require'
+				}
 			},
-			childProvider: 'MSSQL',
+			childProvider: 'PGSQL',
 			type: ExtensionNodeType.Server
 		};
 	}
@@ -64,8 +68,8 @@ export class SqlInstanceTreeDataProvider extends ResourceTreeDataProviderBase<az
 			subscription: undefined,
 			tenantId: undefined,
 			treeItem: {
-				id: SqlInstanceTreeDataProvider.containerId,
-				label: SqlInstanceTreeDataProvider.containerLabel,
+				id: PostgresServerArcTreeDataProvider.containerId,
+				label: PostgresServerArcTreeDataProvider.containerLabel,
 				iconPath: {
 					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
 					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')

--- a/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerTreeDataProvider.ts
@@ -32,7 +32,6 @@ export class PostgresServerTreeDataProvider extends ResourceTreeDataProviderBase
 		return {
 			id: `databaseServer_${databaseServer.id ? databaseServer.id : databaseServer.name}`,
 			label: databaseServer.name,
-			// TODO: should get PGSQL-specific icons (also needed in that extension)
 			iconPath: {
 				dark: this._extensionContext.asAbsolutePath('resources/dark/sql_server_inverse.svg'),
 				light: this._extensionContext.asAbsolutePath('resources/light/sql_server.svg')

--- a/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerTreeDataProvider.ts
@@ -17,7 +17,7 @@ import { azureResource } from '../../azure-resource';
 
 export class PostgresServerTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
 	private static readonly containerId = 'azure.resource.providers.databaseServer.treeDataProvider.postgresServerContainer';
-	private static readonly containerLabel = localize('azure.resource.providers.databaseServer.treeDataProvider.postgresServerContainerLabel', "Azure Database for PostgreSQL Servers");
+	private static readonly containerLabel = localize('azure.resource.providers.databaseServer.treeDataProvider.postgresServerContainerLabel', "Azure Database for PostgreSQL server");
 
 	public constructor(
 		databaseServerService: IAzureResourceService<azureResource.AzureResourceDatabaseServer>,

--- a/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcProvider.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ExtensionContext } from 'vscode';
+import { ApiWrapper } from '../../../apiWrapper';
+
+import { azureResource } from '../../azure-resource';
+import { IAzureResourceService } from '../../interfaces';
+import { SqlInstanceArcTreeDataProvider as SqlInstanceArcTreeDataProvider } from './sqlInstanceArcTreeDataProvider';
+
+export class SqlInstanceArcProvider implements azureResource.IAzureResourceProvider {
+	public constructor(
+		private _service: IAzureResourceService<azureResource.AzureResourceDatabaseServer>,
+		private _apiWrapper: ApiWrapper,
+		private _extensionContext: ExtensionContext
+	) {
+	}
+
+	public getTreeDataProvider(): azureResource.IAzureResourceTreeDataProvider {
+		return new SqlInstanceArcTreeDataProvider(this._service, this._apiWrapper, this._extensionContext);
+	}
+
+	public get providerId(): string {
+		return 'azure.resource.providers.sqlInstanceArc';
+	}
+}

--- a/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcService.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcService.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceServiceBase, GraphData } from '../resourceTreeDataProviderBase';
+import { azureResource } from '../../azure-resource';
+
+export interface SqlInstanceArcGraphData extends GraphData {
+	properties: {
+		admin: string;
+		hybridDataManager: string;
+	};
+}
+
+const instanceQuery = 'where type == "microsoft.azuredata/sqlinstances"';
+export class SqlInstanceArcResourceService extends ResourceServiceBase<SqlInstanceArcGraphData, azureResource.AzureResourceDatabaseServer> {
+
+	protected get query(): string {
+		return instanceQuery;
+	}
+
+	protected convertResource(resource: SqlInstanceArcGraphData): azureResource.AzureResourceDatabaseServer {
+		return {
+			id: resource.id,
+			name: resource.name,
+			fullName: resource.name,
+			loginName: resource.properties.admin,
+			defaultDatabaseName: 'master'
+		};
+	}
+}

--- a/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcTreeDataProvider.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcTreeDataProvider.ts
@@ -15,9 +15,9 @@ import { IAzureResourceService } from '../../interfaces';
 import { ResourceTreeDataProviderBase } from '../resourceTreeDataProviderBase';
 import { azureResource } from '../../azure-resource';
 
-export class SqlInstanceTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
-	private static readonly containerId = 'azure.resource.providers.sqlInstanceContainer';
-	private static readonly containerLabel = localize('azure.resource.providers.sqlInstanceContainerLabel', "Azure SQL DB managed instance");
+export class SqlInstanceArcTreeDataProvider extends ResourceTreeDataProviderBase<azureResource.AzureResourceDatabaseServer> {
+	private static readonly containerId = 'azure.resource.providers.sqlInstanceArcContainer';
+	private static readonly containerLabel = localize('azure.resource.providers.sqlInstanceArcContainerLabel', "Azure SQL DB managed instance – Azure Arc");
 
 	public constructor(
 		databaseServerService: IAzureResourceService<azureResource.AzureResourceDatabaseServer>,
@@ -64,8 +64,8 @@ export class SqlInstanceTreeDataProvider extends ResourceTreeDataProviderBase<az
 			subscription: undefined,
 			tenantId: undefined,
 			treeItem: {
-				id: SqlInstanceTreeDataProvider.containerId,
-				label: SqlInstanceTreeDataProvider.containerLabel,
+				id: SqlInstanceArcTreeDataProvider.containerId,
+				label: SqlInstanceArcTreeDataProvider.containerLabel,
 				iconPath: {
 					dark: this._extensionContext.asAbsolutePath('resources/dark/folder_inverse.svg'),
 					light: this._extensionContext.asAbsolutePath('resources/light/folder.svg')

--- a/extensions/azurecore/src/azureResource/resourceService.ts
+++ b/extensions/azurecore/src/azureResource/resourceService.ts
@@ -105,7 +105,9 @@ export class AzureResourceService {
 
 				if (extension.exports && extension.exports.provideResources) {
 					for (const resourceProvider of <azureResource.IAzureResourceProvider[]>extension.exports.provideResources()) {
-						this.doRegisterResourceProvider(resourceProvider);
+						if (resourceProvider) {
+							this.doRegisterResourceProvider(resourceProvider);
+						}
 					}
 				}
 			}

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -31,6 +31,11 @@ import { SqlInstanceResourceService } from './azureResource/providers/sqlinstanc
 import { SqlInstanceProvider } from './azureResource/providers/sqlinstance/sqlInstanceProvider';
 import { PostgresServerProvider } from './azureResource/providers/postgresServer/postgresServerProvider';
 import { PostgresServerService } from './azureResource/providers/postgresServer/postgresServerService';
+import { SqlInstanceArcProvider } from './azureResource/providers/sqlinstanceArc/sqlInstanceArcProvider';
+import { SqlInstanceArcResourceService } from './azureResource/providers/sqlinstanceArc/sqlInstanceArcService';
+import { PostgresServerArcProvider } from './azureResource/providers/postgresArcServer/postgresServerProvider';
+import { PostgresServerArcService } from './azureResource/providers/postgresArcServer/postgresServerService';
+import { azureResource } from './azureResource/azure-resource';
 
 let extensionContext: vscode.ExtensionContext;
 
@@ -76,12 +81,20 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	return {
 		provideResources() {
-			return [
+			const arcFeaturedEnabled = apiWrapper.getExtensionConfiguration().get('enableArcFeatures');
+			const providers: azureResource.IAzureResourceProvider[] = [
 				new AzureResourceDatabaseServerProvider(new AzureResourceDatabaseServerService(), apiWrapper, extensionContext),
 				new AzureResourceDatabaseProvider(new AzureResourceDatabaseService(), apiWrapper, extensionContext),
 				new SqlInstanceProvider(new SqlInstanceResourceService(), apiWrapper, extensionContext),
-				new PostgresServerProvider(new PostgresServerService(), apiWrapper, extensionContext)
+				new PostgresServerProvider(new PostgresServerService(), apiWrapper, extensionContext),
 			];
+			if (arcFeaturedEnabled) {
+				providers.push(
+					new SqlInstanceArcProvider(new SqlInstanceArcResourceService(), apiWrapper, extensionContext),
+					new PostgresServerArcProvider(new PostgresServerArcService(), apiWrapper, extensionContext)
+				);
+			}
+			return providers;
 		}
 	};
 }

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -3,9 +3,10 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export const extensionConfigSectionName = 'azure';
-export const ViewType = 'view';
+import * as nls from 'vscode-nls';
+const localize = nls.loadMessageBundle();
 
-export enum BuiltInCommands {
-	SetContext = 'setContext'
-}
+export const extensionName = localize('extensionName', "Azure Accounts");
+
+export const requiresReload = localize('requiresReload', "Modifying this setting requires reloading the window for all changes to take effect.");
+export const reload = localize('reload', "Reload");

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -6,7 +6,7 @@
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
-export const extensionName = localize('extensionName', "Azure Accounts");
+export const extensionName = localize('azurecore.extensionName', "Azure Accounts");
 
-export const requiresReload = localize('requiresReload', "Modifying this setting requires reloading the window for all changes to take effect.");
-export const reload = localize('reload', "Reload");
+export const requiresReload = localize('azurecore.requiresReload', "Modifying this setting requires reloading the window for all changes to take effect.");
+export const reload = localize('azurecore.reload', "Reload");

--- a/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
@@ -121,7 +121,7 @@ describe('AzureResourceDatabaseTreeDataProvider.getChildren', function (): void 
 		should(child.subscription).undefined();
 		should(child.tenantId).undefined();
 		should(child.treeItem.id).equal('azure.resource.providers.database.treeDataProvider.databaseContainer');
-		should(child.treeItem.label).equal('SQL Databases');
+		should(child.treeItem.label).equal('SQL database');
 		should(child.treeItem.collapsibleState).equal(vscode.TreeItemCollapsibleState.Collapsed);
 		should(child.treeItem.contextValue).equal('azure.resource.itemType.databaseContainer');
 	});

--- a/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
@@ -121,7 +121,7 @@ describe('AzureResourceDatabaseServerTreeDataProvider.getChildren', function ():
 		should(child.subscription).undefined();
 		should(child.tenantId).undefined();
 		should(child.treeItem.id).equal('azure.resource.providers.databaseServer.treeDataProvider.databaseServerContainer');
-		should(child.treeItem.label).equal('SQL Servers');
+		should(child.treeItem.label).equal('SQL server');
 		should(child.treeItem.collapsibleState).equal(vscode.TreeItemCollapsibleState.Collapsed);
 		should(child.treeItem.contextValue).equal('azure.resource.itemType.databaseServerContainer');
 	});


### PR DESCRIPTION
Added a general setting for enabling Arc features - `azure.enableArcFeatures` which these new resource nodes are hidden behind.

This is mostly just a straight port from the work that Kevin did earlier. This also includes the resource renames that was suggested by the platform side. 

![image](https://user-images.githubusercontent.com/28519865/75064131-2c698b80-549b-11ea-9e7c-0c7e43a87744.png)
