### PR TITLE
fix the input width height issue

### DIFF
--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -192,10 +192,10 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 	}
 
 	private layoutInputBox(): void {
-		if (this.width) {
+		if (isNumber(this.width) || this.width) {
 			this.inputElement.width = this.convertSizeToNumber(this.width);
 		}
-		if (this.height) {
+		if (isNumber(this.height) || this.height) {
 			this.inputElement.setHeight(this.convertSize(this.height));
 		}
 	}
@@ -219,7 +219,7 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 				if (isNumber(this.min)) {
 					input.inputElement.min = this.min.toString();
 				}
-				if (isNumber(this.max === undefined)) {
+				if (isNumber(this.max)) {
 					input.inputElement.max = this.max.toString();
 				}
 			}

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -192,10 +192,10 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 	}
 
 	private layoutInputBox(): void {
-		if (isNumber(this.width)) {
+		if (this.width) {
 			this.inputElement.width = this.convertSizeToNumber(this.width);
 		}
-		if (isNumber(this.height)) {
+		if (this.height) {
 			this.inputElement.setHeight(this.convertSize(this.height));
 		}
 	}


### PR DESCRIPTION
This PR fixes #9272
the issue was introduced in https://github.com/microsoft/azuredatastudio/pull/9137

width and height can be strings for example 100px ,100%. I am reverting it to what it was before, for the scenario that width or height is 0, it is not a common case also we usually use 0px instead of 0.

with the fix:
![Screen Shot 2020-02-21 at 11 21 34 AM](https://user-images.githubusercontent.com/13777222/75064736-5b343180-549c-11ea-9df5-a2f926bf87bf.png)
