### PR TITLE
Implement query editor move

### DIFF
--- a/src/sql/workbench/common/editor/query/queryEditorInput.ts
+++ b/src/sql/workbench/common/editor/query/queryEditorInput.ts
@@ -193,10 +193,6 @@ export abstract class QueryEditorInput extends EditorInput implements IConnectab
 	public isDirty(): boolean { return this._text.isDirty(); }
 	public get resource(): URI { return this._text.resource; }
 
-	public matchInputInstanceType(inputType: any): boolean {
-		return (this._text instanceof inputType);
-	}
-
 	public getName(longForm?: boolean): string {
 		if (this.configurationService.getValue('sql.showConnectionInfoInTitle')) {
 			let profile = this.connectionManagementService.getConnectionProfile(this.uri);
@@ -289,7 +285,9 @@ export abstract class QueryEditorInput extends EditorInput implements IConnectab
 
 	public onDisconnect(): void {
 		this.state.connected = false;
-		this._onDidChangeLabel.fire();
+		if (!this.isDisposed()) {
+			this._onDidChangeLabel.fire();
+		}
 	}
 
 	public onRunQuery(): void {
@@ -309,10 +307,9 @@ export abstract class QueryEditorInput extends EditorInput implements IConnectab
 	}
 
 	public dispose() {
+		super.dispose(); // we want to dispose first so that for future logic we know we are disposed
 		this.queryModelService.disposeQuery(this.uri);
 		this.connectionManagementService.disconnectEditor(this, true);
-
-		super.dispose();
 	}
 
 	public get isSharedSession(): boolean {

--- a/src/sql/workbench/contrib/query/common/fileQueryEditorInput.ts
+++ b/src/sql/workbench/contrib/query/common/fileQueryEditorInput.ts
@@ -10,9 +10,10 @@ import { IQueryModelService } from 'sql/workbench/services/query/common/queryMod
 
 import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { EncodingMode } from 'vs/workbench/common/editor';
+import { EncodingMode, IMoveResult, GroupIdentifier } from 'vs/workbench/common/editor';
 import { BinaryEditorModel } from 'vs/workbench/common/editor/binaryEditorModel';
 import { ITextFileEditorModel } from 'vs/workbench/services/textfile/common/textfiles';
+import { URI } from 'vs/base/common/uri';
 
 type PublicPart<T> = { [K in keyof T]: T[K] };
 
@@ -81,5 +82,9 @@ export class FileQueryEditorInput extends QueryEditorInput implements PublicPart
 
 	public isResolved(): boolean {
 		return this.text.isResolved();
+	}
+
+	public move(group: GroupIdentifier, target: URI): IMoveResult {
+		return this.text.move(group, target);
 	}
 }


### PR DESCRIPTION
Implements the editor.move api for file query editors. This will allow vscode to handle proper replacing of the editor when an underlying file is renamed. (at the moment if the file is rename we just close the editor and don't reopen the editor for the file.

In theory we could also use this to maintain connection state, but I think that would need a design review and api changes to work properly.

@chlafreniere may also want to implement this for notebooks, but since I'm not familiar and it seems like that might be more complex I'm sticking with just query editor atm.

Also fixes a bug when a disposed editor was trying to trigger an update label.