### PR TITLE
Check if notebook model is undefined in setTrustForNewEditor.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -299,8 +299,8 @@ export abstract class NotebookInput extends EditorInput {
 	}
 
 	private async setTrustForNewEditor(newInput: IEditorInput | undefined): Promise<void> {
-		let isTrusted = this._model.getNotebookModel().trustedMode;
-		if (isTrusted && newInput && newInput.resource !== this.resource) {
+		let model = this._model.getNotebookModel();
+		if (model?.trustedMode && newInput?.resource !== this.resource) {
 			await this.notebookService.serializeNotebookStateChange(newInput.resource, NotebookChangeType.Saved, undefined, true);
 		}
 	}


### PR DESCRIPTION
If you try to save the notebook right after opening it, the underlying notebook model may not be ready yet. This was causing an undefined error in setTrustForNewEditor.