### PR TITLE
Update toolbar actions

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -131,7 +131,9 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 			let tempWidgets = this.dashboardService.getSettings<Array<WidgetConfig>>([this.context, 'widgets'].join('.'));
 			// remove tasks widget because those will be shown in the toolbar
 			const index = tempWidgets.findIndex(c => c.widget['tasks-widget']);
-			tempWidgets.splice(index, 1);
+			if (index !== -1) {
+				tempWidgets.splice(index, 1);
+			}
 
 			this._originalConfig = objects.deepClone(tempWidgets);
 			let properties = this.getProperties();

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -74,7 +74,6 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 	// tslint:disable:no-unused-variable
 	private readonly homeTabTitle: string = nls.localize('home', "Home");
 	private readonly homeTabId: string = 'homeTab';
-	private tabToolbarActions = new Map<string, ITaskbarContent[]>();
 	private tabToolbarActionsConfig = new Map<string, WidgetConfig>();
 	private tabContents = new Map<string, string>();
 
@@ -153,18 +152,9 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		}
 
 		this.showToolbar = true;
-		const homeToolbarContent = this.getHomeToolbarContent();
-		this.tabToolbarActions.set(this.homeTabId, homeToolbarContent);
-		this.createToolbar(this.toolbarContainer.nativeElement, this.homeTabId);
-	}
-
-	private getHomeToolbarContent(): ITaskbarContent[] {
 		const homeToolbarConfig = this.dashboardService.getSettings<Array<WidgetConfig>>([this.context, 'widgets'].join('.'))[0].widget['tasks-widget'];
-
-		let content = this.getToolbarContent(homeToolbarConfig);
-		this.addRefreshAction(content);
-
-		return content;
+		this.tabToolbarActionsConfig.set(this.homeTabId, homeToolbarConfig);
+		this.createToolbar(this.toolbarContainer.nativeElement, this.homeTabId);
 	}
 
 	private createToolbar(parentElement: HTMLElement, tabName: string): void {
@@ -173,13 +163,10 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		let taskbarContainer = DOM.append(parentElement, DOM.$('div'));
 		this.toolbar = this._register(new Taskbar(taskbarContainer));
 
-		let content = this.tabToolbarActions.get(tabName);
+		let content = [];
 		// get toolbar content if it wasn't loaded previously
-		if (!content || content.length === 0) {
-			content = this.getToolbarContent(this.tabToolbarActionsConfig.get(tabName));
-			this.addRefreshAction(content);
-			this.tabToolbarActions.set(tabName, content);
-		}
+		content = this.getToolbarContent(this.tabToolbarActionsConfig.get(tabName));
+		this.addRefreshAction(content);
 
 		this.toolbar.setContent(content);
 	}
@@ -403,11 +390,6 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 			const index = configs.findIndex(c => c.widget['tasks-widget']);
 			if (index !== -1) {
 				this.tabToolbarActionsConfig.set(value.id, configs[index].widget['tasks-widget']);
-				const content = this.getToolbarContent(configs[index].widget['tasks-widget']);
-				if (content.length > 0) {
-					this.addRefreshAction(content);
-				}
-				this.tabToolbarActions.set(value.id, content);
 				configs.splice(index, 1);
 			}
 

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -164,9 +164,14 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		this.toolbar = this._register(new Taskbar(taskbarContainer));
 
 		let content = [];
-		// get toolbar content if it wasn't loaded previously
 		content = this.getToolbarContent(this.tabToolbarActionsConfig.get(tabName));
 		this.addRefreshAction(content);
+
+		if (tabName === this.homeTabId) {
+			const configureDashboardCommand = MenuRegistry.getCommand('configureDashboard');
+			const configureDashboardAction = new ToolbarAction(configureDashboardCommand.id, configureDashboardCommand.title.toString(), TaskRegistry.getOrCreateTaskIconClassName(configureDashboardCommand), this.runAction, this, this.logService);
+			content.push({ action: configureDashboardAction });
+		}
 
 		this.toolbar.setContent(content);
 	}


### PR DESCRIPTION
- Remove edit from home toolbar
- Add Refresh to the toolbar of other pages too if it has widgets container, grid container, or nav section because these have refresh implemented. Refresh for other tab content types are no ops so refresh won't be shown there because the extensions should define the refresh action themselves.

![image](https://user-images.githubusercontent.com/31145923/75394904-0a5e7780-58a6-11ea-802a-8af40e18c271.png)

![image](https://user-images.githubusercontent.com/31145923/75205931-fd1c7e00-5729-11ea-899a-d35a56b96ba1.png)

![image](https://user-images.githubusercontent.com/31145923/75291283-c486ae00-57d6-11ea-8599-787d2f34d45b.png)
