### PR TITLE
Fix server group dialog open

### DIFF
--- a/src/sql/workbench/services/serverGroup/browser/serverGroupDialog.ts
+++ b/src/sql/workbench/services/serverGroup/browser/serverGroupDialog.ts
@@ -83,8 +83,8 @@ export class ServerGroupDialog extends Modal {
 		const cancelLabel = localize('serverGroup.cancel', "Cancel");
 		this._addServerButton = this.addFooterButton(okLabel, () => this.addGroup());
 		this._closeButton = this.addFooterButton(cancelLabel, () => this.cancel());
-		this.registerListeners();
 		this.isRendered = true;
+		this.registerListeners();
 	}
 
 	protected layout(height?: number): void {


### PR DESCRIPTION
Fixes #9309

Registering the listeners requires that the dialog be rendered (because it's hooking to the components) so setting isRendered after that call meant we would always throw when trying to do the render.