### PR TITLE
only show the tabs for server context

### DIFF
--- a/extensions/agent/package.json
+++ b/extensions/agent/package.json
@@ -32,7 +32,7 @@
         "description": "Manage and troubleshoot SQL Agent jobs",
         "provider": "MSSQL",
         "title": "SQL Agent",
-        "when": "connectionProvider == 'MSSQL' && !mssql:iscloud && mssql:engineedition != 11",
+        "when": "connectionProvider == 'MSSQL' && !mssql:iscloud && mssql:engineedition != 11 && dashboardContext == 'server'",
         "container": {
           "controlhost-container": {
             "type": "agent"

--- a/extensions/machine-learning-services/package.json
+++ b/extensions/machine-learning-services/package.json
@@ -80,7 +80,7 @@
         "description": "%description%",
         "provider": "MSSQL",
         "title": "%displayName%",
-        "when": "connectionProvider == 'MSSQL' && !mssql:iscloud",
+        "when": "connectionProvider == 'MSSQL' && !mssql:iscloud && dashboardContext == 'server'",
         "container": {
           "grid-container": [
             {

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -443,7 +443,7 @@
         "description": "%tab.bigDataClusterDescription%",
         "provider": "MSSQL",
         "title": "%title.bigDataCluster%",
-        "when": "connectionProvider == 'MSSQL' && mssql:iscluster",
+        "when": "connectionProvider == 'MSSQL' && mssql:iscluster && dashboardContext == 'server'",
         "container": {
           "grid-container": [
             {


### PR DESCRIPTION
This PR fixes #8938
@kburtram the agent tab is already filtered for standalone server now, i am making furthur changes to make it only visible for server context. also updated other extensions that are contributing dashboard tabs.

agent tab is not showing for database dashboard now:
![Screen Shot 2020-02-25 at 11 31 13 PM](https://user-images.githubusercontent.com/13777222/75322288-49011d00-5827-11ea-9ded-ea543baf2d47.png)

agent tab is not showing for Azure SQL DB:
![Screen Shot 2020-02-25 at 11 30 47 PM](https://user-images.githubusercontent.com/13777222/75322289-4a324a00-5827-11ea-810a-84f3a61a0f11.png)

