### PR TITLE
Fix for dacfx wizard if user doesn't have access to master db

### DIFF
--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -138,6 +138,7 @@ export abstract class DacFxConfigPage extends BasePage {
 		} catch (e) {
 			// if the user doesn't have access to master, just set the database to the one the current connection is to
 			values = [this.model.server.databaseName];
+			console.warn(e);
 		}
 
 		// only update values and regenerate filepath if this is the first time and database isn't set yet

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -132,7 +132,13 @@ export abstract class DacFxConfigPage extends BasePage {
 			return false;
 		}
 
-		let values = await this.getDatabaseValues();
+		let values: string[];
+		try {
+			values = await this.getDatabaseValues();
+		} catch (e) {
+			// if the user doesn't have access to master, just set the database to the one the current connection is to
+			values = [this.model.server.databaseName];
+		}
 
 		// only update values and regenerate filepath if this is the first time and database isn't set yet
 		if (this.model.database !== values[0]) {


### PR DESCRIPTION
This PR fixes #9187. The database dropdowns weren't populating in the dacfx wizard if the user didn't have access to the master db. This is because there was an error during the listDatabases call. For now, this will just add the database from the connection to the databases dropdown if there is an error duing the listDatabases call. Opened #9361 for the error from azdata.connection.listDatabases 
