### PR TITLE
Fix checks for checkbox height/width

### DIFF
--- a/src/sql/workbench/browser/modelComponents/checkbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/checkbox.component.ts
@@ -15,6 +15,7 @@ import { Checkbox, ICheckboxOptions } from 'sql/base/browser/ui/checkbox/checkbo
 import { attachCheckboxStyler } from 'sql/platform/theme/common/styler';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { IComponent, IComponentDescriptor, IModelStore, ComponentEventType } from 'sql/platform/dashboard/browser/interfaces';
+import { isNumber } from 'vs/base/common/types';
 
 @Component({
 	selector: 'modelview-checkbox',
@@ -80,10 +81,10 @@ export default class CheckBoxComponent extends ComponentBase implements ICompone
 		} else {
 			this._input.disable();
 		}
-		if (this.width) {
+		if (this.width || isNumber(this.width)) {
 			this._input.setWidth(this.convertSize(this.width));
 		}
-		if (this.height) {
+		if (this.height || isNumber(this.height)) {
 			this._input.setHeight(this.convertSize(this.height));
 		}
 		if (this.ariaLabel) {


### PR DESCRIPTION
A 0 width/height element doesn't really make much sense here but we should still do the right check