### PR TITLE
upload the extension unit test coverage files to pipeline

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -235,14 +235,6 @@ steps:
     continueOnError: true
     condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
-  - task: PublishTestResults@2
-    displayName: 'Publish Integration and Smoke Test Results'
-    inputs:
-      testResultsFiles: 'dawin-integration-tests-results.xml'
-      searchFolder: '$(Build.ArtifactStagingDirectory)\test-results'
-    continueOnError: true
-    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
-
   - task: PublishCodeCoverageResults@1
     displayName: 'Publish code coverage from $(Build.SourcesDirectory)/.build/coverage/cobertura-coverage.xml'
     inputs:

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -154,16 +154,16 @@ steps:
       Contents: '*/coverage/**'
       TargetFolder: '$(Build.ArtifactStagingDirectory)/test-results/coverage'
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: drop'
-
   - task: PublishTestResults@2
     displayName: 'Publish Test Results test-results.xml'
     inputs:
-      testResultsFiles: '*-test-results.xml'
+      testResultsFiles: '*.xml'
       searchFolder: '$(Build.ArtifactStagingDirectory)/test-results'
     continueOnError: true
     condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -147,6 +147,13 @@ steps:
       ./build/azure-pipelines/linux/createDrop.sh
     displayName: Create Drop
 
+  - task: CopyFiles@2
+    displayName: 'Copy Extension Unit Test Coverage Files to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)/extensions'
+      Contents: '**/coverage/**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/test-results/'
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
 

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -151,8 +151,8 @@ steps:
     displayName: 'Copy Extension Unit Test Coverage Files to: $(Build.ArtifactStagingDirectory)'
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)/extensions'
-      Contents: '**/coverage/**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)/test-results/'
+      Contents: '*/coverage/**'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/test-results/coverage'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
@@ -160,18 +160,10 @@ steps:
   - task: PublishTestResults@2
     displayName: 'Publish Test Results test-results.xml'
     inputs:
-      testResultsFiles: 'test-results.xml'
-      searchFolder: '$(Build.SourcesDirectory)'
+      testResultsFiles: '*-test-results.xml'
+      searchFolder: '$(Build.ArtifactStagingDirectory)/test-results'
     continueOnError: true
     condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
-
-  - task: PublishCodeCoverageResults@1
-    displayName: 'Publish code coverage from $(Build.SourcesDirectory)/.build/coverage/cobertura-coverage.xml'
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: '$(Build.SourcesDirectory)/.build/coverage/cobertura-coverage.xml'
-      reportDirectory: '$(Build.SourcesDirectory)/.build/coverage'
-    continueOnError: true
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'


### PR DESCRIPTION
this is for the 2nd work item tracked in #9391 - upload the extension unit test coverage files to pipeline artifacts, i am not using the publish test coverage step in the pipeline due to following 2 reasons:
1. ADO limitation, one pipeline can only have one test coverage upload step (mentioned in the issue)
1. having the report for each extension will make it easier for extension authors to only look at their own area

folder structure in the drop artifacts:
<img width="1585" alt="Screen Shot 2020-02-28 at 9 31 38 PM" src="https://user-images.githubusercontent.com/13777222/75601829-11d37b80-5a74-11ea-8e66-fa7ef2186d7e.png">

download the icov-report folder of an extension and open the index.html, you can have very detailed coverage report.

<img width="1916" alt="Screen Shot 2020-02-28 at 9 51 41 PM" src="https://user-images.githubusercontent.com/13777222/75601905-ca99ba80-5a74-11ea-8b0b-be2ae35a8343.png">
<img width="1912" alt="Screen Shot 2020-02-28 at 9 51 56 PM" src="https://user-images.githubusercontent.com/13777222/75601907-ccfc1480-5a74-11ea-83f3-523a5d761f0a.png">
<img width="1059" alt="Screen Shot 2020-02-28 at 9 52 14 PM" src="https://user-images.githubusercontent.com/13777222/75601908-cd94ab00-5a74-11ea-905e-0da2eddcea32.png">


also fixed the following issues:
1. fix the macos build warning - we are not running integration test in it, removing the step to fix the warning
1. upload the correct test results for linux job

without the fix:
<img width="1579" alt="Screen Shot 2020-02-28 at 9 36 16 PM" src="https://user-images.githubusercontent.com/13777222/75601925-003ea380-5a75-11ea-99b2-94cdcecc399e.png">

with the fix:
<img width="1191" alt="Screen Shot 2020-02-28 at 9 36 36 PM" src="https://user-images.githubusercontent.com/13777222/75601935-18aebe00-5a75-11ea-8845-f0a1e8529d65.png">

the remaining error will be fixed later separately.
