### PR TITLE
Use uuid for test

### DIFF
--- a/src/sql/platform/connection/test/common/connectionStore.test.ts
+++ b/src/sql/platform/connection/test/common/connectionStore.test.ts
@@ -18,6 +18,7 @@ import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { ConnectionProviderProperties } from 'sql/platform/capabilities/common/capabilitiesService';
 import { InMemoryStorageService } from 'vs/platform/storage/common/storage';
 import { find } from 'vs/base/common/arrays';
+import { generateUuid } from 'vs/base/common/uuid';
 
 suite('ConnectionStore', () => {
 	let defaultNamedProfile: IConnectionProfile = deepFreeze({
@@ -26,7 +27,7 @@ suite('ConnectionStore', () => {
 		databaseName: 'bcd',
 		authenticationType: 'SqlLogin',
 		userName: 'cde',
-		password: 'asdf!@#$',
+		password: generateUuid(),
 		savePassword: true,
 		groupId: '',
 		groupFullName: '',


### PR DESCRIPTION
Not really necessary since this is never actually used for a real connection, but doing this to get rid of the TSA scan flagging this. 