### PR TITLE
Add automated comment for needs logs.

### DIFF
--- a/.github/commands.yml
+++ b/.github/commands.yml
@@ -6,7 +6,7 @@
       name: 'Needs Logs',
       allowTriggerByBot: false,
       action: 'comment',
-      comment: 'Looks like we need for info to debug your particular issue. If you could attach your logs (ensure no private data is in them) to the issue it would help us fix the issue much faster.\n\nTo find your logs run the command `Developer: Open Logs Folder`, this will open the log file locally. We generally care most about renderer.log'
+      comment: "We need more info to debug your particular issue. If you could attach your logs to the issue (ensure no private data is in them), it would help us fix the issue much faster.\n\nTo find your logs:\n\n- Open command palette (Click **View** -> **Command Palette**)\n- Run the command: **`Developer: Open Logs Folder`**\n\nThis will open the log file locally. Please include renderer.log"
     }
   ]
 }

--- a/.github/commands.yml
+++ b/.github/commands.yml
@@ -3,7 +3,7 @@
   commands: [
     {
       type: 'label',
-      name: 'Needs More Info',
+      name: 'Needs Logs',
       allowTriggerByBot: false,
       action: 'comment',
       comment: 'Looks like we need for info to debug your particular issue. If you could attach your logs (ensure no private data is in them) to the issue it would help us fix the issue much faster.\n\nTo find your logs run the command `Developer: Open Logs Folder`, this will open the log file locally. We generally care most about renderer.log'

--- a/.github/commands.yml
+++ b/.github/commands.yml
@@ -1,12 +1,12 @@
 {
-  perform: false,
+  perform: true,
   commands: [
     {
       type: 'label',
-      name: 'duplicate',
-      allowTriggerByBot: true,
-      action: 'close',
-      comment: "Thanks for creating this issue! We figured it's covering the same as another one we already have. Thus, we closed this one as a duplicate. You can search for existing issues [here](https://aka.ms/vscodeissuesearch). See also our [issue reporting](https://aka.ms/vscodeissuereporting) guidelines.\n\nHappy Coding!"
+      name: 'Needs More Info',
+      allowTriggerByBot: false,
+      action: 'comment',
+      comment: 'Looks like we need for info to debug your particular issue. If you could attach your logs (ensure no private data is in them) to the issue it would help us fix the issue much faster.\n\nTo find your logs run the command `Developer: Open Logs Folder`, this will open the log file locally. We generally care most about renderer.log'
     }
   ]
 }


### PR DESCRIPTION
Some help from @yualan would be useful for the best wording for the comment.

Also not sure if we want to use the existing `Needs More Info` label or we want to create a label specifically for 'needs logs'.

EDIT:
Moved to `Needs Logs` label