### PR TITLE
Move objects widget back to database home tab

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -517,28 +517,6 @@
             }
           ]
         }
-      },
-      {
-        "id": "database-objects-tab",
-        "description": "%database-objects-tab-description%",
-        "provider": "MSSQL",
-        "title": "%database-objects-tab-title%",
-        "when": "dashboardContext == 'database'",
-        "group": "contents",
-        "container": {
-          "widgets-container": [
-            {
-              "name": "%explorer-widget-title%",
-              "gridItemConfig": {
-                "sizex": 3,
-                "sizey": 3
-              },
-              "widget": {
-                "explorer-widget": {}
-              }
-            }
-          ]
-        }
       }
     ],
     "connectionProvider": {

--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -137,6 +137,4 @@
 	"databases-tab-description": "Databases tab of server dashboard",
 	"databases-tab-title": "Databases",
 	"explorer-widget-title": "Search",
-	"database-objects-tab-description": "Objects tab of database dashboard",
-	"database-objects-tab-title": "Objects",
 }

--- a/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution.ts
@@ -96,10 +96,10 @@ export const databaseDashboardSettingSchema: IJSONSchema = {
 			},
 			widget: {
 				'tasks-widget': [
-					{ name: 'backup', when: '!mssql:iscloud && mssql:engineedition != 11' },
-					{ name: 'restore', when: '!mssql:iscloud && mssql:engineedition != 11' },
 					'newQuery',
-					'mssqlCluster.task.newNotebook'
+					'mssqlCluster.task.newNotebook',
+					{ name: 'backup', when: '!mssql:iscloud && mssql:engineedition != 11' },
+					{ name: 'restore', when: '!mssql:iscloud && mssql:engineedition != 11' }
 				]
 			}
 		},

--- a/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution.ts
@@ -96,11 +96,21 @@ export const databaseDashboardSettingSchema: IJSONSchema = {
 			},
 			widget: {
 				'tasks-widget': [
-					'newQuery',
-					'mssqlCluster.task.newNotebook',
 					{ name: 'backup', when: '!mssql:iscloud && mssql:engineedition != 11' },
-					{ name: 'restore', when: '!mssql:iscloud && mssql:engineedition != 11' }
+					{ name: 'restore', when: '!mssql:iscloud && mssql:engineedition != 11' },
+					'newQuery',
+					'mssqlCluster.task.newNotebook'
 				]
+			}
+		},
+		{
+			name: 'Search',
+			gridItemConfig: {
+				sizex: 1,
+				sizey: 2
+			},
+			widget: {
+				'explorer-widget': {}
 			}
 		}
 	]


### PR DESCRIPTION
- Move objects widget back to database home tab(previously was in a separate tab) so that home tab has content
- Reorder toolbar actions as specified by Hannah
![image](https://user-images.githubusercontent.com/31145923/75827755-332bb480-5d5f-11ea-9956-de33877b8283.png)

