### PR TITLE
Add CredScanSuppressions file

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -1,0 +1,9 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+        {
+            "file": "src\vs\base\test\common\uri.test.ts",
+            "_justification": "External code"
+        }
+    ]
+}

--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -2,7 +2,7 @@
     "tool": "Credential Scanner",
     "suppressions": [
         {
-            "file": "src\vs\base\test\common\uri.test.ts",
+            "file": "src\\vs\\base\\test\\common\\uri.test.ts",
             "_justification": "External code"
         }
     ]


### PR DESCRIPTION
Unfortunately the tool doesn't support any sort of file globbing or wildcards so we'll have to add files one by one. This is currently the only one getting flagged though.