### PR TITLE
Fail product build if tests fail during the Windows_Test task.

### DIFF
--- a/build/azure-pipelines/win32/sql-product-test-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-test-win32.yml
@@ -98,5 +98,4 @@ steps:
     searchFolder: '$(Build.ArtifactStagingDirectory)\test-results'
     mergeTestResults: true
     failTaskOnFailedTests: true
-  continueOnError: true
   condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/9427

Looks like we were already failing the Publish task on test failure, but were still continuing despite that failure.