### PR TITLE
bump sqltoolsservice to 2.0.0-release.50

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "2.0.0-release.48",
+	"version": "2.0.0-release.50",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",


### PR DESCRIPTION
Getting updated DacFx bits and also includes [Correctly skip intellisense for non-MSSQL language flavors ](https://github.com/microsoft/sqltoolsservice/pull/910 )