### PR TITLE
Suppress another file for CredScan

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -4,6 +4,10 @@
         {
             "file": "src\\vs\\base\\test\\common\\uri.test.ts",
             "_justification": "External code"
+        },
+        {
+            "file": "build\\actions\\AutoLabel\\dist\\index.js",
+            "_justification": "False positive from webpacked code"
         }
     ]
 }


### PR DESCRIPTION
It's seeing the authorization header and flagging it because of that - even though this particular usage is just doing a deprecation check for the headers and so there's no actual secrets involved. Suppressing the file since this is build from index.ts anyways so scanning that should catch any issues we care about regardless. 

`[["gitdata", "git"], ["authorization", "oauthAuthorizations"], ["pullRequests", "pulls"]].forEach(([deprecatedScope, scope]) => {`