### PR TITLE
Change to PAT

### DIFF
--- a/.github/workflows/merger.yml
+++ b/.github/workflows/merger.yml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v2
       - uses: ./build/actions/AutoMerge
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GithubMerger }}"


### PR DESCRIPTION
The merger can't push to protected branches - for now I'll use a PAT but for next month i'll move this to a bot.