### PR TITLE
Fix input box error to always announce when error shown

### DIFF
--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -159,23 +159,7 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 
 	public validate(): Thenable<boolean> {
 		return super.validate().then(valid => {
-			const otherErrorMsg = valid || this.inputElement.value === '' ? undefined : this.validationErrorMessage;
-			valid = valid && this.inputElement.validate();
-
-			// set aria label based on validity of input
-			if (valid) {
-				this.inputElement.setAriaLabel(this.ariaLabel);
-			} else {
-				if (otherErrorMsg) {
-					this.inputElement.showMessage({ type: MessageType.ERROR, content: otherErrorMsg }, true);
-				}
-				if (this.ariaLabel) {
-					this.inputElement.setAriaLabel(nls.localize('period', "{0}. {1}", this.ariaLabel, this.inputElement.inputElement.validationMessage));
-				} else {
-					this.inputElement.setAriaLabel(this.inputElement.inputElement.validationMessage);
-				}
-			}
-
+			this.inputElement.validate();
 			return valid;
 		});
 	}

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -402,6 +402,20 @@ export class InputBox extends Widget {
 		const styles = this.stylesForType(this.message.type);
 		this.element.style.border = styles.border ? `1px solid ${styles.border}` : '';
 
+		// ARIA Support
+		/* {{SQL CARBON EDIT}} Logic moved down below
+		let alertText: string;
+		if (message.type === MessageType.ERROR) {
+			alertText = nls.localize('alertErrorMessage', "Error: {0}", message.content);
+		} else if (message.type === MessageType.WARNING) {
+			alertText = nls.localize('alertWarningMessage', "Warning: {0}", message.content);
+		} else {
+			alertText = nls.localize('alertInfoMessage', "Info: {0}", message.content);
+		}
+
+		aria.alert(alertText);
+		*/
+
 		if (this.hasFocus() || force) {
 			this._showMessage();
 		}

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -402,18 +402,6 @@ export class InputBox extends Widget {
 		const styles = this.stylesForType(this.message.type);
 		this.element.style.border = styles.border ? `1px solid ${styles.border}` : '';
 
-		// ARIA Support
-		let alertText: string;
-		if (message.type === MessageType.ERROR) {
-			alertText = nls.localize('alertErrorMessage', "Error: {0}", message.content);
-		} else if (message.type === MessageType.WARNING) {
-			alertText = nls.localize('alertWarningMessage', "Warning: {0}", message.content);
-		} else {
-			alertText = nls.localize('alertInfoMessage', "Info: {0}", message.content);
-		}
-
-		aria.alert(alertText);
-
 		if (this.hasFocus() || force) {
 			this._showMessage();
 		}
@@ -525,6 +513,18 @@ export class InputBox extends Widget {
 		});
 
 		this.state = 'open';
+
+		// ARIA Support
+		let alertText: string;
+		if (this.message.type === MessageType.ERROR) {
+			alertText = nls.localize('alertErrorMessage', "Error: {0}", this.message.content);
+		} else if (this.message.type === MessageType.WARNING) {
+			alertText = nls.localize('alertWarningMessage', "Warning: {0}", this.message.content);
+		} else {
+			alertText = nls.localize('alertInfoMessage', "Info: {0}", this.message.content);
+		}
+
+		aria.alert(alertText);
 	}
 
 	private _hideMessage(): void {

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -514,7 +514,7 @@ export class InputBox extends Widget {
 
 		this.state = 'open';
 
-		// ARIA Support
+		// ARIA Support {{SQL CARBON EDIT}} Always announce message when shown
 		let alertText: string;
 		if (this.message.type === MessageType.ERROR) {
 			alertText = nls.localize('alertErrorMessage', "Error: {0}", this.message.content);


### PR DESCRIPTION
Fixes #9175

The extra text was added in https://github.com/microsoft/azuredatastudio/pull/7133 to fix an issue where the error text wasn't being announced when tabbing away then back. 

I've reverted that change and instead the fix is to make the aria alert be announced every time the error message is shown instead. That seems like it should be the expected behavior anyways. If we end up going with this fix I plan on submitting it to VS Code as well. 

Verified that https://github.com/microsoft/azuredatastudio/issues/6846 still seems to be fixed as well.