### PR TITLE
Update aria label for modal dialog when title is updated

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -528,8 +528,12 @@ export abstract class Modal extends Disposable implements IThemable {
 	 * Set the title of the modal
 	 */
 	protected set title(title: string) {
-		if (this._title !== undefined) {
+		this._title = title;
+		if (this._modalTitle) {
 			this._modalTitle.innerText = title;
+		}
+		if (this._bodyContainer) {
+			this._bodyContainer.setAttribute('aria-label', title);
 		}
 	}
 


### PR DESCRIPTION
Fixes #9228

The title wasn't being fully updated after changing the title.

Also fixed it so it actually sets the local _title var when set title is called, which seemed like another bug here too. 

Not sure why we were checking for undefined - it would be kind of odd but I don't see why clearing a title after opening a dialog shouldn't be allowed. Although currently if one was to try that it wouldn't look correct since the header area would still be there - just empty. If we really thought this was a supported scenario I suppose we should remove the header. But I figure we'll address that if it ever comes up as a valid scenario. 