### PR TITLE
always show the header

### DIFF
--- a/extensions/resource-deployment/src/ui/deployClusterWizard/pages/serviceSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/pages/serviceSettingsPage.ts
@@ -421,6 +421,8 @@ export class ServiceSettingsPage extends WizardPageBase<DeployClusterWizard> {
 		this.endpointSection.collapsed = !adAuth;
 		if (adAuth) {
 			this.endpointHeaderRow.addItems([this.endpointNameColumnHeader, this.dnsColumnHeader, this.portColumnHeader]);
+		} else {
+			this.endpointHeaderRow.addItems([this.endpointNameColumnHeader, this.portColumnHeader]);
 		}
 
 		getInputBoxComponent(VariableNames.ControllerDNSName_VariableName, this.inputComponents).required = adAuth;


### PR DESCRIPTION

previously the port label is not shown and caused confusion on the aria-label for the text boxes. always show it to make it clear.

This PR fixes #9292 
![Screen Shot 2020-03-10 at 12 07 04 AM](https://user-images.githubusercontent.com/13777222/76288192-61c7f480-6263-11ea-8aa4-dd96824f0483.png)
![Screen Shot 2020-03-10 at 12 07 20 AM](https://user-images.githubusercontent.com/13777222/76288195-62608b00-6263-11ea-830a-f1a9099ce5e6.png)
