### PR TITLE
Fix tabbable selector for modals

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -339,7 +339,7 @@ export abstract class Modal extends Disposable implements IThemable {
 		// Try to find focusable element in dialog pane rather than overall container. _modalBodySection contains items in the pane for a wizard.
 		// This ensures that we are setting the focus on a useful element in the form when possible.
 		const focusableElements = this._modalBodySection ?
-			this._modalBodySection.querySelectorAll('input') :
+			this._modalBodySection.querySelectorAll(tabbableElementsQuerySelector) :
 			this._bodyContainer.querySelectorAll(tabbableElementsQuerySelector);
 
 		this._focusedElementBeforeOpen = <HTMLElement>document.activeElement;

--- a/src/sql/workbench/contrib/charts/browser/configureChartDialog.ts
+++ b/src/sql/workbench/contrib/charts/browser/configureChartDialog.ts
@@ -34,24 +34,13 @@ export class ConfigureChartDialog extends Modal {
 
 	public open() {
 		this.show();
-		this.focusFirstElement();
-	}
-
-	private focusFirstElement(): void {
-		let generalControlsItems = this._chart.optionsControl.getElementsByClassName('general-controls');
-		if (generalControlsItems?.length > 0) {
-			let inputControlItems = generalControlsItems[0].getElementsByClassName('monaco-select-box');
-			if (inputControlItems?.length > 0) {
-				(inputControlItems[0] as HTMLElement).focus();
-			}
-		}
 	}
 
 	public render() {
 		super.render();
 		attachModalDialogStyler(this, this._themeService);
 
-		let closeButton = this.addFooterButton(localize('optionsDialog.close', "Close"), () => this.close());
+		let closeButton = this.addFooterButton(localize('configureChartDialog.close', "Close"), () => this.close());
 		attachButtonStyler(closeButton, this._themeService);
 	}
 


### PR DESCRIPTION
I don't know why this was only getting input elements before for the modal body case, but that doesn't seem correct. @alanrenmsft do you have any context on why this might have been done? I tested some other modal dialogs after this change and things seem fine - although we'll want to pay attention to the focusing for the next release to make sure things didn't regress.

With this change though the modal dialog will handle selecting the correct element so we don't need to have the custom logic to focus it in the chart view. 

Also fixed loc key name while I was here. 