### PR TITLE
Fix long account dialog text hiding actions (Port #9449)

### DIFF
--- a/src/sql/workbench/services/accountManagement/browser/media/accountDialog.css
+++ b/src/sql/workbench/services/accountManagement/browser/media/accountDialog.css
@@ -93,13 +93,3 @@
 .account-view .list-row .actions-container .action-item .action-label.codicon.remove {
 	background-size: 14px !important;
 }
-
-.account-view .list-row .actions-container {
-	display: none;
-}
-
-.account-view .monaco-list .monaco-list-row:hover .list-row .actions-container,
-.account-view .monaco-list .monaco-list-row.selected .list-row .actions-container,
-.account-view .monaco-list .monaco-list-row.focused .list-row .actions-container{
-	display: block;
-}

--- a/src/sql/workbench/services/accountManagement/browser/media/accountListRenderer.css
+++ b/src/sql/workbench/services/accountManagement/browser/media/accountListRenderer.css
@@ -11,6 +11,7 @@
 .list-row.account-picker-list .label {
 	flex: 1 1 auto;
 	margin-left: 15px;
+	overflow: hidden;
 }
 
 .list-row.account-picker-list .label .contextual-display-name {

--- a/src/sql/workbench/services/accountManagement/browser/media/accountListRenderer.css
+++ b/src/sql/workbench/services/accountManagement/browser/media/accountListRenderer.css
@@ -16,12 +16,10 @@
 
 .list-row.account-picker-list .label .contextual-display-name {
 	font-size: 15px;
-	line-height: 15px;
 }
 
 .list-row.account-picker-list .label .display-name {
 	font-size: 13px;
-	line-height: 13px;
 }
 
 .list-row.account-picker-list .label .content {


### PR DESCRIPTION
Long text (such as a long display name/account name) was causing the delete action to be pushed offscreen.

I played around with fixing it so that it worked correctly with the hover but couldn't get it to work properly - and after thinking about it a bit I think it's better to just remove the hover stuff anyways. It's not very accessibility-friendly and we've had numerous complaints about discoverability being difficult when actions are hidden.

New look with long text :

![image](https://user-images.githubusercontent.com/28519865/76006511-6f772600-5ec1-11ea-88aa-4895cb7215ea.png)

with shorter text :

![image](https://user-images.githubusercontent.com/28519865/76006635-a3524b80-5ec1-11ea-9f5c-bc0769659641.png)