### PR TITLE
fix collapse widget action icon

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/actions.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/actions.ts
@@ -196,8 +196,8 @@ export class CollapseWidgetAction extends Action {
 	private static readonly ID = 'collapseWidget';
 	private static readonly COLLPASE_LABEL = nls.localize('collapseWidget', "Collapse");
 	private static readonly EXPAND_LABEL = nls.localize('expandWidget', "Expand");
-	private static readonly COLLAPSE_ICON = 'maximize-panel-action';
-	private static readonly EXPAND_ICON = 'minimize-panel-action';
+	private static readonly COLLAPSE_ICON = 'codicon-chevron-up';
+	private static readonly EXPAND_ICON = 'codicon-chevron-down';
 
 	constructor(
 		private _uri: string,


### PR DESCRIPTION
this PR fixes #9536 

this is a vscode icon and they have changed the class name, i searched in the code, this is the only placing referencing the icon in sql tree and vscode is also using it as a string directly no constant defined for it. so I just replaced the strings.

before 
![Screen Shot 2020-03-10 at 3 02 31 PM](https://user-images.githubusercontent.com/13777222/76363504-667ebe00-62e0-11ea-8826-9823ba743fdf.png)

after
![Screen Shot 2020-03-10 at 3 02 56 PM](https://user-images.githubusercontent.com/13777222/76363507-67afeb00-62e0-11ea-820b-5ffabdd9eaf0.png)
