### PR TITLE
Fix account label being cut off

### DIFF
--- a/src/sql/workbench/services/accountManagement/browser/media/accountListRenderer.css
+++ b/src/sql/workbench/services/accountManagement/browser/media/accountListRenderer.css
@@ -16,12 +16,10 @@
 
 .list-row.account-picker-list .label .contextual-display-name {
 	font-size: 15px;
-	line-height: 15px;
 }
 
 .list-row.account-picker-list .label .display-name {
 	font-size: 13px;
-	line-height: 13px;
 }
 
 .list-row.account-picker-list .label .content {


### PR DESCRIPTION
The addition of the overflow: hidden attribute caused the text to be cut off when the refresh message wasn't being displayed.

![image](https://user-images.githubusercontent.com/28519865/76434720-46e4a580-6373-11ea-8ce8-69a6cc00c672.png)

With fix

![image](https://user-images.githubusercontent.com/28519865/76434903-8c08d780-6373-11ea-9ca2-f8dc1e8db8e3.png)

![image](https://user-images.githubusercontent.com/28519865/76434967-a5aa1f00-6373-11ea-9785-af35287f1afe.png)

