### PR TITLE
Update dashboard style to be closer to mockups

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.html
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.html
@@ -9,7 +9,7 @@
 	<div #header>
 		<div style="display: flex; flex: 0 0; padding: 3px 0 3px 0; flex-direction: row-reverse; justify-content: space-between">
 			<span #actionbar style="flex: 0 0 auto; align-self: end"></span>
-			<span *ngIf="_config.name" style="margin-left: 5px">{{_config.name}}</span>
+			<span *ngIf="_config.name" style="margin-left: 5px; font-weight: bold">{{_config.name}}</span>
 			<span *ngIf="_config.icon" [ngClass]="['icon', _config.icon]" style="display: inline-block; padding: 10px; margin-left: 5px"></span>
 		</div>
 	</div>

--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
@@ -37,7 +37,6 @@ import { generateUuid } from 'vs/base/common/uuid';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILogService } from 'vs/platform/log/common/log';
 import { values } from 'vs/base/common/collections';
-import { LIGHT } from 'vs/platform/theme/common/themeService';
 
 const componentMap: { [x: string]: Type<IDashboardWidget> } = {
 	'properties-widget': PropertiesWidgetComponent,
@@ -221,7 +220,7 @@ export class DashboardWidgetWrapper extends AngularDisposable implements OnInit 
 	private updateTheme(theme: IColorTheme): void {
 		const el = <HTMLElement>this._ref.nativeElement;
 		const headerEl: HTMLElement = this.header.nativeElement;
-		let borderColor = theme.type === LIGHT ? '#DDDDDD' : '#8A8886';
+		let borderColor = theme.getColor(themeColors.DASHBOARD_BORDER);
 		let backgroundColor = theme.getColor(colors.editorBackground, true);
 		const foregroundColor = theme.getColor(themeColors.SIDE_BAR_FOREGROUND, true);
 		const border = theme.getColor(colors.contrastBorder, true);

--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
@@ -161,7 +161,7 @@ export class DashboardWidgetWrapper extends AngularDisposable implements OnInit 
 		// If _config.name is not set, set it to _config.widget.name
 		if (!this._config.name) {
 			const widget = values(this._config.widget)[0];
-			if (widget.name) {
+			if (widget && widget.name) {
 				this._config.name = widget.name;
 			}
 		}
@@ -249,15 +249,9 @@ export class DashboardWidgetWrapper extends AngularDisposable implements OnInit 
 			el.style.borderStyle = 'solid';
 		} else if (borderColor) {
 			borderString = borderColor.toString();
-			el.style.border = '3px solid ' + borderColor.toString();
+			el.style.border = '1px solid ' + borderColor.toString();
 		} else {
 			el.style.border = 'none';
-		}
-
-		if (borderString) {
-			headerEl.style.backgroundColor = borderString;
-		} else {
-			headerEl.style.backgroundColor = '';
 		}
 
 		if (this._config.fontSize) {

--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
@@ -37,6 +37,7 @@ import { generateUuid } from 'vs/base/common/uuid';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILogService } from 'vs/platform/log/common/log';
 import { values } from 'vs/base/common/collections';
+import { LIGHT } from 'vs/platform/theme/common/themeService';
 
 const componentMap: { [x: string]: Type<IDashboardWidget> } = {
 	'properties-widget': PropertiesWidgetComponent,
@@ -220,7 +221,7 @@ export class DashboardWidgetWrapper extends AngularDisposable implements OnInit 
 	private updateTheme(theme: IColorTheme): void {
 		const el = <HTMLElement>this._ref.nativeElement;
 		const headerEl: HTMLElement = this.header.nativeElement;
-		let borderColor = theme.getColor(themeColors.SIDE_BAR_BACKGROUND, true);
+		let borderColor = theme.type === LIGHT ? '#DDDDDD' : '#8A8886';
 		let backgroundColor = theme.getColor(colors.editorBackground, true);
 		const foregroundColor = theme.getColor(themeColors.SIDE_BAR_FOREGROUND, true);
 		const border = theme.getColor(colors.contrastBorder, true);
@@ -248,8 +249,8 @@ export class DashboardWidgetWrapper extends AngularDisposable implements OnInit 
 			el.style.borderWidth = '1px';
 			el.style.borderStyle = 'solid';
 		} else if (borderColor) {
-			borderString = borderColor.toString();
-			el.style.border = '1px solid ' + borderColor.toString();
+			borderString = borderColor;
+			el.style.border = '1px solid ' + borderColor;
 		} else {
 			el.style.border = 'none';
 		}

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -50,7 +50,8 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { NAV_SECTION } from 'sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution';
 import { IWorkbenchThemeService, IColorTheme } from 'vs/workbench/services/themes/common/workbenchThemeService';
-import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
+import { contrastBorder } from 'vs/platform/theme/common/colorRegistry';
+import { LIGHT } from 'vs/platform/theme/common/themeService';
 
 
 const dashboardRegistry = Registry.as<IDashboardRegistry>(DashboardExtensions.DashboardContributions);
@@ -546,7 +547,13 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 	}
 
 	private updateTheme(theme: IColorTheme): void {
-		const border = theme.getColor(SIDE_BAR_BACKGROUND);
+		let border;
+		const highContrastBorder = theme.getColor(contrastBorder, true);
+		if (highContrastBorder) {
+			border = highContrastBorder.toString();
+		} else {
+			border = theme.type === LIGHT ? '#DDDDDD' : '#8A8886';
+		}
 		this.toolbarContainer.nativeElement.style.borderBottomColor = border.toString();
 	}
 }

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -50,8 +50,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { NAV_SECTION } from 'sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution';
 import { IWorkbenchThemeService, IColorTheme } from 'vs/workbench/services/themes/common/workbenchThemeService';
-import { contrastBorder } from 'vs/platform/theme/common/colorRegistry';
-import { LIGHT } from 'vs/platform/theme/common/themeService';
+import { DASHBOARD_BORDER } from 'vs/workbench/common/theme';
 
 
 const dashboardRegistry = Registry.as<IDashboardRegistry>(DashboardExtensions.DashboardContributions);
@@ -547,13 +546,7 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 	}
 
 	private updateTheme(theme: IColorTheme): void {
-		let border;
-		const highContrastBorder = theme.getColor(contrastBorder, true);
-		if (highContrastBorder) {
-			border = highContrastBorder.toString();
-		} else {
-			border = theme.type === LIGHT ? '#DDDDDD' : '#8A8886';
-		}
+		const border = theme.getColor(DASHBOARD_BORDER);
 		this.toolbarContainer.nativeElement.style.borderBottomColor = border.toString();
 	}
 }

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -49,6 +49,8 @@ import { fillInActions, LabeledMenuItemActionItem } from 'vs/platform/actions/br
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { NAV_SECTION } from 'sql/workbench/contrib/dashboard/browser/containers/dashboardNavSection.contribution';
+import { IWorkbenchThemeService, IColorTheme } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 
 
 const dashboardRegistry = Registry.as<IDashboardRegistry>(DashboardExtensions.DashboardContributions);
@@ -122,10 +124,15 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		@Inject(IContextKeyService) contextKeyService: IContextKeyService,
 		@Inject(IMenuService) private menuService: IMenuService,
 		@Inject(IKeybindingService) private keybindingService: IKeybindingService,
-		@Inject(IContextMenuService) private contextMenuService: IContextMenuService
+		@Inject(IContextMenuService) private contextMenuService: IContextMenuService,
+		@Inject(IWorkbenchThemeService) private themeService: IWorkbenchThemeService
 	) {
 		super();
 		this._tabName = DashboardPage.tabName.bindTo(contextKeyService);
+	}
+
+	ngAfterViewInit(): void {
+		this.updateTheme(this.themeService.getColorTheme());
 	}
 
 	protected init() {
@@ -165,6 +172,10 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		const homeToolbarConfig = this.dashboardService.getSettings<Array<WidgetConfig>>([this.context, 'widgets'].join('.'))[0].widget['tasks-widget'];
 		this.tabToolbarActionsConfig.set(this.homeTabId, homeToolbarConfig);
 		this.createToolbar(this.toolbarContainer.nativeElement, this.homeTabId);
+
+		this._register(this.themeService.onDidColorThemeChange((event: IColorTheme) => {
+			this.updateTheme(event);
+		}));
 	}
 
 	private getExtensionContributedHomeToolbarContent(content: ITaskbarContent[]): void {
@@ -532,5 +543,10 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		const index = firstIndex(this.tabs, i => i.id === tab.identifier);
 		this.tabs.splice(index, 1);
 		this.angularEventingService.sendAngularEvent(this.dashboardService.getUnderlyingUri(), AngularEventType.CLOSE_TAB, { id: tab.identifier });
+	}
+
+	private updateTheme(theme: IColorTheme): void {
+		const border = theme.getColor(SIDE_BAR_BACKGROUND);
+		this.toolbarContainer.nativeElement.style.borderBottomColor = border.toString();
 	}
 }

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
@@ -58,7 +58,6 @@ dashboard-page .editor-toolbar {
 	flex-flow: row;
 	width: 100%;
 	align-items: center;
-	border-bottom-color:rgb(234, 234, 234);
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
 	height:26px;

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanel.css
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanel.css
@@ -22,3 +22,7 @@ panel.dashboard-panel > .tabbedPanel > .title > .monaco-scrollable-element > .ta
 	box-sizing: border-box;
 	border: 1px solid transparent;
 }
+
+panel.dashboard-panel > .tabbedPanel.vertical > .title > .tabContainer {
+	border-right: 1px solid rgb(234, 234, 234)
+}

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanel.css
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanel.css
@@ -22,7 +22,3 @@ panel.dashboard-panel > .tabbedPanel > .title > .monaco-scrollable-element > .ta
 	box-sizing: border-box;
 	border: 1px solid transparent;
 }
-
-panel.dashboard-panel > .tabbedPanel.vertical > .title > .tabContainer {
-	border-right: 1px solid rgb(234, 234, 234)
-}

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
@@ -5,27 +5,19 @@
 
 import 'vs/css!./dashboardPanel';
 
-import { registerThemingParticipant, ITheme, ICssStyleCollector, LIGHT, HIGH_CONTRAST } from 'vs/platform/theme/common/themeService';
+import { registerThemingParticipant, ITheme, ICssStyleCollector, HIGH_CONTRAST } from 'vs/platform/theme/common/themeService';
 import {
 	TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_ACTIVE_BORDER, TAB_INACTIVE_BACKGROUND,
-	TAB_INACTIVE_FOREGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND, TAB_BORDER, EDITOR_GROUP_BORDER
+	TAB_INACTIVE_FOREGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND, TAB_BORDER, EDITOR_GROUP_BORDER, DASHBOARD_TAB_ACTIVE_BACKGROUND, DASHBOARD_BORDER
 } from 'vs/workbench/common/theme';
-import { activeContrastBorder, contrastBorder } from 'vs/platform/theme/common/colorRegistry';
+import { activeContrastBorder } from 'vs/platform/theme/common/colorRegistry';
 registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 
 	// Title Active
 	const tabActiveBackground = theme.getColor(TAB_ACTIVE_BACKGROUND);
 	const tabActiveForeground = theme.getColor(TAB_ACTIVE_FOREGROUND);
-	let tabActiveBackgroundVertical;
-	if (theme.type === HIGH_CONTRAST) {
-		tabActiveBackgroundVertical = tabActiveBackground.toString();
-	} else {
-		tabActiveBackgroundVertical = theme.type === LIGHT ? '#e1f0fe' : '#444444';
-	}
+	let tabActiveBackgroundVertical = theme.getColor(DASHBOARD_TAB_ACTIVE_BACKGROUND);
 
-	if (theme.getColor(contrastBorder)) {
-		tabActiveBackgroundVertical = tabActiveBackground.toString();
-	}
 	if (tabActiveBackground || tabActiveForeground) {
 		collector.addRule(`
 			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab:hover .tabLabel,
@@ -126,13 +118,7 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 		`);
 	}
 
-	let sideBorder;
-	const border = theme.getColor(contrastBorder, true);
-	if (border) {
-		sideBorder = border.toString();
-	} else {
-		sideBorder = theme.type === LIGHT ? '#DDDDDD' : '#8A8886';
-	}
+	const sideBorder = theme.getColor(DASHBOARD_BORDER);
 	if (divider) {
 		collector.addRule(`panel.dashboard-panel > .tabbedPanel.vertical > .title > .tabContainer {
 			border-right-width: 1px;

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
@@ -7,7 +7,8 @@ import 'vs/css!./dashboardPanel';
 
 import { registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
 import {
-	TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_ACTIVE_BORDER, EDITOR_GROUP_BORDER
+	TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_ACTIVE_BORDER, TAB_INACTIVE_BACKGROUND,
+	TAB_INACTIVE_FOREGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND, TAB_BORDER, EDITOR_GROUP_BORDER, DASHBOARD_TAB_ACTIVE_BACKGROUND
 } from 'vs/workbench/common/theme';
 import { activeContrastBorder } from 'vs/platform/theme/common/colorRegistry';
 
@@ -16,6 +17,7 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	// Title Active
 	const tabActiveBackground = theme.getColor(TAB_ACTIVE_BACKGROUND);
 	const tabActiveForeground = theme.getColor(TAB_ACTIVE_FOREGROUND);
+	const tabActiveBackgroundVertical = theme.getColor(DASHBOARD_TAB_ACTIVE_BACKGROUND);
 	if (tabActiveBackground || tabActiveForeground) {
 		collector.addRule(`
 			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab:hover .tabLabel,
@@ -24,8 +26,13 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 				border-bottom: 0px solid;
 			}
 
-			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab-header.active {
-				background-color: #e1f0fe;
+			panel.dashboard-panel > .tabbedPanel.vertical > .title .tabList .tab-header.active {
+				background-color: ${tabActiveBackgroundVertical};
+				outline-color: ${tabActiveBackgroundVertical};
+			}
+
+			panel.dashboard-panel > .tabbedPanel.horizontal > .title .tabList .tab-header.active {
+				background-color: ${tabActiveBackground};
 				outline-color: ${tabActiveBackground};
 			}
 
@@ -48,12 +55,35 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 		`);
 	}
 
+	// Title Inactive
+	const tabInactiveBackground = theme.getColor(TAB_INACTIVE_BACKGROUND);
+	const tabInactiveForeground = theme.getColor(TAB_INACTIVE_FOREGROUND);
+	if (tabInactiveBackground || tabInactiveForeground) {
+		collector.addRule(`
+			panel.dashboard-panel > .tabbedPanel.horizontal > .title .tabList .tab .tabLabel {
+				color: ${tabInactiveForeground};
+			}
+			panel.dashboard-panel > .tabbedPanel.horizontal > .title .tabList .tab-header {
+				background-color: ${tabInactiveBackground};
+			}
+		`);
+	}
 
 	// Panel title background
-	const tabBorder = '#FFFFFF';//theme.getColor(TAB_BORDER);
+	const panelTitleBackground = theme.getColor(EDITOR_GROUP_HEADER_TABS_BACKGROUND);
+	if (panelTitleBackground) {
+		collector.addRule(`
+			panel.dashboard-panel > .tabbedPanel.horizontal > .title {
+				background-color: ${panelTitleBackground};
+			}
+		`);
+	}
+
+	// Panel title background
+	const tabBorder = theme.getColor(TAB_BORDER);
 	if (tabBorder) {
 		collector.addRule(`
-			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab-header {
+			panel.dashboard-panel > .tabbedPanel.horizontal > .title .tabList .tab-header {
 				border-right-color: ${tabBorder};
 				border-bottom-color: ${tabBorder};
 			}
@@ -64,7 +94,7 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	const outline = theme.getColor(activeContrastBorder);
 	if (outline) {
 		collector.addRule(`
-			panel.dashboard-panel > .tabbedPanel > .title {
+			panel.dashboard-panel > .tabbedPanel.horizontal > .title {
 				border-bottom-color: ${tabBorder};
 				border-bottom-width: 1px;
 				border-bottom-style: solid;
@@ -81,7 +111,7 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	const divider = theme.getColor(EDITOR_GROUP_BORDER);
 	if (divider) {
 		collector.addRule(`
-			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab-header {
+			panel.dashboard-panel > .tabbedPanel.horizontal > .title .tabList .tab-header {
 				border-right-width: 1px;
 				border-right-style: solid;
 			}

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
@@ -5,19 +5,27 @@
 
 import 'vs/css!./dashboardPanel';
 
-import { registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
+import { registerThemingParticipant, ITheme, ICssStyleCollector, LIGHT, HIGH_CONTRAST } from 'vs/platform/theme/common/themeService';
 import {
 	TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_ACTIVE_BORDER, TAB_INACTIVE_BACKGROUND,
-	TAB_INACTIVE_FOREGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND, TAB_BORDER, EDITOR_GROUP_BORDER, DASHBOARD_TAB_ACTIVE_BACKGROUND, SIDE_BAR_BACKGROUND
+	TAB_INACTIVE_FOREGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND, TAB_BORDER, EDITOR_GROUP_BORDER
 } from 'vs/workbench/common/theme';
-import { activeContrastBorder } from 'vs/platform/theme/common/colorRegistry';
-
+import { activeContrastBorder, contrastBorder } from 'vs/platform/theme/common/colorRegistry';
 registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 
 	// Title Active
 	const tabActiveBackground = theme.getColor(TAB_ACTIVE_BACKGROUND);
 	const tabActiveForeground = theme.getColor(TAB_ACTIVE_FOREGROUND);
-	const tabActiveBackgroundVertical = theme.getColor(DASHBOARD_TAB_ACTIVE_BACKGROUND);
+	let tabActiveBackgroundVertical;
+	if (theme.type === HIGH_CONTRAST) {
+		tabActiveBackgroundVertical = tabActiveBackground.toString();
+	} else {
+		tabActiveBackgroundVertical = theme.type === LIGHT ? '#e1f0fe' : '#444444';
+	}
+
+	if (theme.getColor(contrastBorder)) {
+		tabActiveBackgroundVertical = tabActiveBackground.toString();
+	}
 	if (tabActiveBackground || tabActiveForeground) {
 		collector.addRule(`
 			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab:hover .tabLabel,
@@ -46,7 +54,7 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 		`);
 	}
 
-	const activeTabBorderColor = theme.getColor(TAB_ACTIVE_BORDER);
+	const activeTabBorderColor = theme.type === HIGH_CONTRAST ? theme.getColor(activeContrastBorder) : theme.getColor(TAB_ACTIVE_BORDER);
 	if (activeTabBorderColor) {
 		collector.addRule(`
 			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab-header.active {
@@ -118,7 +126,13 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 		`);
 	}
 
-	const sideBorder = theme.getColor(SIDE_BAR_BACKGROUND);
+	let sideBorder;
+	const border = theme.getColor(contrastBorder, true);
+	if (border) {
+		sideBorder = border.toString();
+	} else {
+		sideBorder = theme.type === LIGHT ? '#DDDDDD' : '#8A8886';
+	}
 	if (divider) {
 		collector.addRule(`panel.dashboard-panel > .tabbedPanel.vertical > .title > .tabContainer {
 			border-right-width: 1px;

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
@@ -7,8 +7,7 @@ import 'vs/css!./dashboardPanel';
 
 import { registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
 import {
-	TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_ACTIVE_BORDER, TAB_INACTIVE_BACKGROUND,
-	TAB_INACTIVE_FOREGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND, TAB_BORDER, EDITOR_GROUP_BORDER
+	TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_ACTIVE_BORDER, EDITOR_GROUP_BORDER
 } from 'vs/workbench/common/theme';
 import { activeContrastBorder } from 'vs/platform/theme/common/colorRegistry';
 
@@ -26,7 +25,7 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 			}
 
 			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab-header.active {
-				background-color: ${tabActiveBackground};
+				background-color: #e1f0fe;
 				outline-color: ${tabActiveBackground};
 			}
 
@@ -49,33 +48,9 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 		`);
 	}
 
-	// Title Inactive
-	const tabInactiveBackground = theme.getColor(TAB_INACTIVE_BACKGROUND);
-	const tabInactiveForeground = theme.getColor(TAB_INACTIVE_FOREGROUND);
-	if (tabInactiveBackground || tabInactiveForeground) {
-		collector.addRule(`
-			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab .tabLabel {
-				color: ${tabInactiveForeground};
-			}
-
-			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab-header {
-				background-color: ${tabInactiveBackground};
-			}
-		`);
-	}
 
 	// Panel title background
-	const panelTitleBackground = theme.getColor(EDITOR_GROUP_HEADER_TABS_BACKGROUND);
-	if (panelTitleBackground) {
-		collector.addRule(`
-			panel.dashboard-panel > .tabbedPanel > .title {
-				background-color: ${panelTitleBackground};
-			}
-		`);
-	}
-
-	// Panel title background
-	const tabBorder = theme.getColor(TAB_BORDER);
+	const tabBorder = '#FFFFFF';//theme.getColor(TAB_BORDER);
 	if (tabBorder) {
 		collector.addRule(`
 			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab-header {

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
@@ -8,7 +8,7 @@ import 'vs/css!./dashboardPanel';
 import { registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
 import {
 	TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_ACTIVE_BORDER, TAB_INACTIVE_BACKGROUND,
-	TAB_INACTIVE_FOREGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND, TAB_BORDER, EDITOR_GROUP_BORDER, DASHBOARD_TAB_ACTIVE_BACKGROUND
+	TAB_INACTIVE_FOREGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND, TAB_BORDER, EDITOR_GROUP_BORDER, DASHBOARD_TAB_ACTIVE_BACKGROUND, SIDE_BAR_BACKGROUND
 } from 'vs/workbench/common/theme';
 import { activeContrastBorder } from 'vs/platform/theme/common/colorRegistry';
 
@@ -116,5 +116,14 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 				border-right-style: solid;
 			}
 		`);
+	}
+
+	const sideBorder = theme.getColor(SIDE_BAR_BACKGROUND);
+	if (divider) {
+		collector.addRule(`panel.dashboard-panel > .tabbedPanel.vertical > .title > .tabContainer {
+			border-right-width: 1px;
+			border-right-style: solid;
+			border-right-color: ${sideBorder};
+		}`);
 	}
 });

--- a/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component.ts
@@ -14,7 +14,6 @@ import { CommonServiceInterface } from 'sql/workbench/services/bootstrap/browser
 import { IAngularEventingService } from 'sql/platform/angularEventing/browser/angularEventingService';
 
 import * as colors from 'vs/platform/theme/common/colorRegistry';
-import * as nls from 'vs/nls';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -26,7 +25,6 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 
 export class DatabaseDashboardPage extends DashboardPage implements OnInit {
 	protected propertiesWidget: WidgetConfig = {
-		name: nls.localize('databasePageName', "DATABASE DASHBOARD"),
 		widget: {
 			'properties-widget': undefined
 		},

--- a/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component.ts
@@ -22,6 +22,7 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IMenuService } from 'vs/platform/actions/common/actions';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 
 export class DatabaseDashboardPage extends DashboardPage implements OnInit {
 	protected propertiesWidget: WidgetConfig = {
@@ -52,9 +53,10 @@ export class DatabaseDashboardPage extends DashboardPage implements OnInit {
 		@Inject(IContextKeyService) contextKeyService: IContextKeyService,
 		@Inject(IMenuService) menuService: IMenuService,
 		@Inject(IKeybindingService) keybindingService: IKeybindingService,
-		@Inject(IContextMenuService) contextMenuService: IContextMenuService
+		@Inject(IContextMenuService) contextMenuService: IContextMenuService,
+		@Inject(IWorkbenchThemeService) themeService: IWorkbenchThemeService
 	) {
-		super(dashboardService, el, _cd, notificationService, angularEventingService, configurationService, logService, commandService, contextKeyService, menuService, keybindingService, contextMenuService);
+		super(dashboardService, el, _cd, notificationService, angularEventingService, configurationService, logService, commandService, contextKeyService, menuService, keybindingService, contextMenuService, themeService);
 		this._register(dashboardService.onUpdatePage(() => {
 			this.refresh(true);
 			this._cd.detectChanges();

--- a/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
@@ -24,6 +24,7 @@ import { IMenuService } from 'vs/platform/actions/common/actions';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { onUnexpectedError } from 'vs/base/common/errors';
+import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 
 export class ServerDashboardPage extends DashboardPage implements OnInit {
 	protected propertiesWidget: WidgetConfig = {
@@ -55,9 +56,10 @@ export class ServerDashboardPage extends DashboardPage implements OnInit {
 		@Inject(IContextKeyService) contextKeyService: IContextKeyService,
 		@Inject(IMenuService) menuService: IMenuService,
 		@Inject(IKeybindingService) keybindingService: IKeybindingService,
-		@Inject(IContextMenuService) contextMenuService: IContextMenuService
+		@Inject(IContextMenuService) contextMenuService: IContextMenuService,
+		@Inject(IWorkbenchThemeService) themeService: IWorkbenchThemeService
 	) {
-		super(dashboardService, el, _cd, notificationService, angularEventingService, configurationService, logService, commandService, contextKeyService, menuService, keybindingService, contextMenuService);
+		super(dashboardService, el, _cd, notificationService, angularEventingService, configurationService, logService, commandService, contextKeyService, menuService, keybindingService, contextMenuService, themeService);
 
 		// special-case handling for MSSQL data provider
 		const connInfo = this.dashboardService.connectionManagementService.connectionInfo;

--- a/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
@@ -14,7 +14,6 @@ import { CommonServiceInterface } from 'sql/workbench/services/bootstrap/browser
 import { IAngularEventingService } from 'sql/platform/angularEventing/browser/angularEventingService';
 
 import * as colors from 'vs/platform/theme/common/colorRegistry';
-import * as nls from 'vs/nls';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -28,7 +27,6 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 
 export class ServerDashboardPage extends DashboardPage implements OnInit {
 	protected propertiesWidget: WidgetConfig = {
-		name: nls.localize('serverPageName', "SERVER DASHBOARD"),
 		widget: {
 			'properties-widget': undefined
 		},

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.html
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.html
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 -->
 <div #parent style="position: absolute; height: 100%; width: 100%;">
-	<div [style.margin-right.px]="_clipped ? 30 : 0" [style.width]="_clipped ? 94 + '%' : '100%'" style="overflow: hidden">
+	<div [style.margin-right.px]="_clipped ? 30 : 0" [style.width]="_clipped ? 94 + '%' : '100%'" style="overflow: hidden; border-bottom: 1px solid rgb(234, 234, 234); padding-bottom: 15px">
 		<span #child style="white-space : nowrap; width: fit-content">
 			<ng-template ngFor let-item [ngForOf]="properties">
 				<span style="margin-left: 10px; display: inline-block;">

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.html
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.html
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 -->
 <div #parent style="position: absolute; height: 100%; width: 100%;">
-	<div [style.margin-right.px]="_clipped ? 30 : 0" [style.width]="_clipped ? 94 + '%' : '100%'" style="overflow: hidden; border-bottom: 1px solid rgb(234, 234, 234); padding-bottom: 15px">
+	<div #container [style.margin-right.px]="_clipped ? 30 : 0" [style.width]="_clipped ? 94 + '%' : '100%'" style="overflow: hidden; padding-bottom: 15px">
 		<span #child style="white-space : nowrap; width: fit-content">
 			<ng-template ngFor let-item [ngForOf]="properties">
 				<span style="margin-left: 10px; display: inline-block;">

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
@@ -18,8 +18,9 @@ import * as nls from 'vs/nls';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ILogService } from 'vs/platform/log/common/log';
 import { subscriptionToDisposable } from 'sql/base/browser/lifecycle';
-import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { IWorkbenchThemeService, IColorTheme } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { contrastBorder } from 'vs/platform/theme/common/colorRegistry';
+import { LIGHT } from 'vs/platform/theme/common/themeService';
 
 export interface PropertiesConfig {
 	properties: Array<Property>;
@@ -279,7 +280,13 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 	}
 
 	private updateTheme(theme: IColorTheme): void {
-		const border = theme.getColor(SIDE_BAR_BACKGROUND);
+		let border;
+		const highContrastBorder = theme.getColor(contrastBorder, true);
+		if (highContrastBorder) {
+			border = highContrastBorder.toString();
+		} else {
+			border = theme.type === LIGHT ? '#DDDDDD' : '#8A8886';
+		}
 		this._container.nativeElement.style.borderBottom = '1px solid ' + border.toString();
 	}
 }

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
@@ -19,8 +19,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { ILogService } from 'vs/platform/log/common/log';
 import { subscriptionToDisposable } from 'sql/base/browser/lifecycle';
 import { IWorkbenchThemeService, IColorTheme } from 'vs/workbench/services/themes/common/workbenchThemeService';
-import { contrastBorder } from 'vs/platform/theme/common/colorRegistry';
-import { LIGHT } from 'vs/platform/theme/common/themeService';
+import { DASHBOARD_BORDER } from 'vs/workbench/common/theme';
 
 export interface PropertiesConfig {
 	properties: Array<Property>;
@@ -280,13 +279,7 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 	}
 
 	private updateTheme(theme: IColorTheme): void {
-		let border;
-		const highContrastBorder = theme.getColor(contrastBorder, true);
-		if (highContrastBorder) {
-			border = highContrastBorder.toString();
-		} else {
-			border = theme.type === LIGHT ? '#DDDDDD' : '#8A8886';
-		}
+		const border = theme.getColor(DASHBOARD_BORDER);
 		this._container.nativeElement.style.borderBottom = '1px solid ' + border.toString();
 	}
 }

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
@@ -18,6 +18,8 @@ import * as nls from 'vs/nls';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ILogService } from 'vs/platform/log/common/log';
 import { subscriptionToDisposable } from 'sql/base/browser/lifecycle';
+import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
+import { IWorkbenchThemeService, IColorTheme } from 'vs/workbench/services/themes/common/workbenchThemeService';
 
 export interface PropertiesConfig {
 	properties: Array<Property>;
@@ -69,13 +71,15 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 
 	@ViewChild('child', { read: ElementRef }) private _child: ElementRef;
 	@ViewChild('parent', { read: ElementRef }) private _parent: ElementRef;
+	@ViewChild('container', { read: ElementRef }) private _container: ElementRef;
 
 	constructor(
 		@Inject(forwardRef(() => CommonServiceInterface)) private _bootstrap: CommonServiceInterface,
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
 		@Inject(forwardRef(() => ElementRef)) private _el: ElementRef,
 		@Inject(WIDGET_CONFIG) protected _config: WidgetConfig,
-		@Inject(ILogService) private logService: ILogService
+		@Inject(ILogService) private logService: ILogService,
+		@Inject(IWorkbenchThemeService) private themeService: IWorkbenchThemeService
 	) {
 		super();
 		this.init();
@@ -85,6 +89,14 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 		this._hasInit = true;
 		this._register(addDisposableListener(window, EventType.RESIZE, () => this.handleClipping()));
 		this._changeRef.detectChanges();
+
+		this._register(this.themeService.onDidColorThemeChange((event: IColorTheme) => {
+			this.updateTheme(event);
+		}));
+	}
+
+	ngAfterViewInit(): void {
+		this.updateTheme(this.themeService.getColorTheme());
 	}
 
 	public refresh(): void {
@@ -264,5 +276,10 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 			val = defaultVal;
 		}
 		return val;
+	}
+
+	private updateTheme(theme: IColorTheme): void {
+		const border = theme.getColor(SIDE_BAR_BACKGROUND);
+		this._container.nativeElement.style.borderBottom = '1px solid ' + border.toString();
 	}
 }

--- a/src/sql/workbench/contrib/dashboard/test/electron-browser/propertiesWidget.component.test.ts
+++ b/src/sql/workbench/contrib/dashboard/test/electron-browser/propertiesWidget.component.test.ts
@@ -98,7 +98,7 @@ suite('Dashboard Properties Widget Tests', () => {
 			}
 		};
 
-		let testComponent = new PropertiesWidgetComponent(dashboardService.object, new TestChangeDetectorRef(), undefined, widgetConfig, testLogService);
+		let testComponent = new PropertiesWidgetComponent(dashboardService.object, new TestChangeDetectorRef(), undefined, widgetConfig, testLogService, undefined);
 
 		return new Promise(resolve => {
 			// because config parsing is done async we need to put our asserts on the thread stack

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -607,6 +607,21 @@ export const WINDOW_INACTIVE_BORDER = registerColor('window.inactiveBorder', {
 	hc: contrastBorder
 }, nls.localize('windowInactiveBorder', "The color used for the border of the window when it is inactive. Only supported in the desktop client when using the custom title bar."));
 
+// {{SQL CARBON EDIT}}
+// < --- Dashboard --- >
+
+export const DASHBOARD_TAB_ACTIVE_BACKGROUND = registerColor('dashboard.tabActiveBackground', {
+	dark: '#444444',
+	light: '#e1f0fe',
+	hc: TAB_ACTIVE_BACKGROUND
+}, nls.localize('dashboardTabActiveBackground', "Active tab background color for dashboard navigation"));
+
+export const DASHBOARD_BORDER = registerColor('dashboard.border', {
+	dark: '#8A8886',
+	light: '#DDDDDD',
+	hc: contrastBorder
+}, nls.localize('dashboardBorder', "Color for borders in dashboard"));
+
 /**
  * Base class for all themable workbench components.
  */

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -144,6 +144,12 @@ export const TAB_UNFOCUSED_INACTIVE_FOREGROUND = registerColor('tab.unfocusedIna
 	hc: Color.white
 }, nls.localize('tabUnfocusedInactiveForeground', "Inactive tab foreground color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 
+export const DASHBOARD_TAB_ACTIVE_BACKGROUND = registerColor('tab.dashboardActiveBackground', {
+	dark: '#e1f0fe',
+	light: '#e1f0fe',
+	hc: '#e1f0fe'
+}, nls.localize('tabDashboardActiveBackground', "Active tab background color for dashboard navigation"));
+
 // < --- Editors --- >
 
 export const EDITOR_PANE_BACKGROUND = registerColor('editorPane.background', {

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from 'vs/nls';
-import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, listInactiveSelectionBackground } from 'vs/platform/theme/common/colorRegistry';
+import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground } from 'vs/platform/theme/common/colorRegistry';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IThemeService, ITheme } from 'vs/platform/theme/common/themeService';
 import { Color } from 'vs/base/common/color';
@@ -143,12 +143,6 @@ export const TAB_UNFOCUSED_INACTIVE_FOREGROUND = registerColor('tab.unfocusedIna
 	light: transparent(TAB_INACTIVE_FOREGROUND, 0.5),
 	hc: Color.white
 }, nls.localize('tabUnfocusedInactiveForeground', "Inactive tab foreground color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
-
-export const DASHBOARD_TAB_ACTIVE_BACKGROUND = registerColor('tab.dashboardActiveBackground', {
-	dark: listInactiveSelectionBackground,
-	light: '#e1f0fe',
-	hc: listInactiveSelectionBackground
-}, nls.localize('tabDashboardActiveBackground', "Active tab background color for dashboard navigation"));
 
 // < --- Editors --- >
 

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from 'vs/nls';
-import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground } from 'vs/platform/theme/common/colorRegistry';
+import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, listInactiveSelectionBackground } from 'vs/platform/theme/common/colorRegistry';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IThemeService, ITheme } from 'vs/platform/theme/common/themeService';
 import { Color } from 'vs/base/common/color';
@@ -145,9 +145,9 @@ export const TAB_UNFOCUSED_INACTIVE_FOREGROUND = registerColor('tab.unfocusedIna
 }, nls.localize('tabUnfocusedInactiveForeground', "Inactive tab foreground color in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 
 export const DASHBOARD_TAB_ACTIVE_BACKGROUND = registerColor('tab.dashboardActiveBackground', {
-	dark: '#e1f0fe',
+	dark: listInactiveSelectionBackground,
 	light: '#e1f0fe',
-	hc: '#e1f0fe'
+	hc: listInactiveSelectionBackground
 }, nls.localize('tabDashboardActiveBackground', "Active tab background color for dashboard navigation"));
 
 // < --- Editors --- >


### PR DESCRIPTION
- Update look of left nav
- Dashboard widget wrapper: get rid of grey header, bold title
- Update border lines of toolbar and properties widget to change color with the theme

Mockup: https://www.figma.com/proto/QRkuP8YG7sZr87LRoS210ldo/Azure-Data-Studio?node-id=7109%3A173389&viewport=-833%2C-19569%2C0.5569696426391602&scaling=min-zoom

Changes in this PR:
![image](https://user-images.githubusercontent.com/31145923/76908728-a3a9f980-6866-11ea-98b2-6fbeb888f459.png)

![image](https://user-images.githubusercontent.com/31145923/76908655-807f4a00-6866-11ea-9545-6a8dea1f6b9d.png)

horizontal tabs are still the old style:
![image](https://user-images.githubusercontent.com/31145923/76549689-1b82b900-644e-11ea-85d3-e1eb62d8c06a.png)

