### PR TITLE
handle invoke by command link

### DIFF
--- a/src/sql/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/sql/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+
+CommandsRegistry.registerCommand('azdata.extension.open', (accessor: ServicesAccessor, extension: { id: string }) => {
+	if (extension && extension.id) {
+		const commandService = accessor.get(ICommandService);
+		return commandService.executeCommand('extension.open', extension.id);
+	} else {
+		throw new Error('Extension id is not provided');
+	}
+});

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -232,7 +232,13 @@ CommandsRegistry.registerCommand('_extensions.manage', (accessor: ServicesAccess
 	}
 });
 
-CommandsRegistry.registerCommand('extension.open', (accessor: ServicesAccessor, extensionId: string) => {
+CommandsRegistry.registerCommand('extension.open', (accessor: ServicesAccessor, extensionId: string | { id: string }) => { // {{SQL CARBON EDIT}} extend the extensionId parameter to accept object type.
+	// {{SQL CARBON EDIT}}
+	// handle the scenario when command is invoked in HTML, and only JSON object can be used.
+	if (typeof extensionId === 'object') {
+		extensionId = extensionId.id;
+	}
+
 	const extensionService = accessor.get(IExtensionsWorkbenchService);
 
 	return extensionService.queryGallery({ names: [extensionId], pageSize: 1 }, CancellationToken.None).then(pager => {

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -470,4 +470,7 @@ import 'sql/workbench/contrib/scripting/browser/scripting.contribution';
 // Resource Deployment
 import 'sql/workbench/contrib/resourceDeployment/browser/resourceDeployment.contribution';
 
+// Extension
+import 'sql/workbench/contrib/extensions/browser/extensions.contribution';
+
 //#endregion


### PR DESCRIPTION
@v-bbrady is working on the welcome page and he needs the ability to open Extension details using command link, currently the command only accept string parameter which doesn't work with command link, command link expects all parameters to be inside an JSON object.

usage example to open agent extension page.

href="command:extension.open?%7B%22id%22%3A%22microsoft.agent%22%7D"