### PR TITLE
add azdata.extension.open command

### DIFF
--- a/src/sql/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/sql/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+
+CommandsRegistry.registerCommand('azdata.extension.open', (accessor: ServicesAccessor, extension: { id: string }) => {
+	if (extension && extension.id) {
+		const commandService = accessor.get(ICommandService);
+		return commandService.executeCommand('extension.open', extension.id);
+	} else {
+		throw new Error('Extension id is not provided');
+	}
+});

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -470,4 +470,7 @@ import 'sql/workbench/contrib/scripting/browser/scripting.contribution';
 // Resource Deployment
 import 'sql/workbench/contrib/resourceDeployment/browser/resourceDeployment.contribution';
 
+// Extension
+import 'sql/workbench/contrib/extensions/browser/extensions.contribution';
+
 //#endregion


### PR DESCRIPTION
@v-bbrady is working on the welcome page and he needs the ability to open Extension details using command link, the vscode command: "extension.open" only accept string parameter which doesn't work with command link, command link expects all parameters to be inside an JSON object. adding a shim command for it instead of updating the vscode command to avoid merge conflicts.

usage example to open agent extension page:

href="command:azdata.extension.open?%7B%22id%22%3A%22microsoft.agent%22%7D"