### PR TITLE
Notebooks: Fix Internal Links on Windows (#9513)

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
@@ -58,7 +58,7 @@ export class LinkHandlerDirective {
 			// ignore
 		}
 		if (uri && this.openerService && this.isSupportedLink(uri)) {
-			if (uri.fragment && uri.fragment.length > 0 && uri.path === this.workbenchFilePath.path) {
+			if (uri.fragment && uri.fragment.length > 0 && uri.fsPath === this.workbenchFilePath.fsPath) {
 				this.notebookService.navigateTo(this.notebookUri, uri.fragment);
 			} else {
 				this.openerService.open(uri).catch(onUnexpectedError);


### PR DESCRIPTION
Ports #9513.

Improves #8428 substantially to where most of the internal link formats are usable (as they are today on Mac). On Windows, the uri fragment's drive letter will be lowercase, where the work bench file path's drive letter will be uppercase, causing the condition to fail, and ADS to open workbench.html.

Tested on Mac and Windows, and using fsPath instead gets us around this issue.