### PR TITLE
check for proper length of the cmdOutput

### DIFF
--- a/extensions/notebook/resources/notebooks/JupyterBooksCreate.ipynb
+++ b/extensions/notebook/resources/notebooks/JupyterBooksCreate.ipynb
@@ -41,7 +41,7 @@
                 "#install jupyter-book\r\n",
                 "cmd = f'{sys.executable} -m pip show jupyter-book'\r\n",
                 "cmdOutput = !{cmd}\r\n",
-                "if len(cmdOutput) > 0 and '0.6.4' in cmdOutput[1]:\r\n",
+                "if len(cmdOutput) > 1 and '0.6.4' in cmdOutput[1]:\r\n",
                 "    print('Jupyter-book required version is already installed!')\r\n",
                 "else:\r\n",
                 "    !pip install jupyter-book"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses issue 9577. 
With the latest pip, if a package is not installed instead of returning an empty array on pip show, it returning a warning message ex below. Updated the notebook code for checking length > 1 instead of 0. 
![image](https://user-images.githubusercontent.com/12754347/76556790-71a82a00-6457-11ea-8781-6dc180ab5751.png)

https://github.com/microsoft/azuredatastudio/issues/9577


