### PR TITLE
Check for valid uri/resource

### DIFF
--- a/src/sql/workbench/browser/taskUtilities.ts
+++ b/src/sql/workbench/browser/taskUtilities.ts
@@ -57,7 +57,7 @@ export function replaceConnection(oldUri: string, newUri: string, connectionServ
  *
  * @param topLevelOnly If true, only return top-level (i.e. connected) Object Explorer connections instead of database connections when appropriate
 */
-export function getCurrentGlobalConnection(objectExplorerService: IObjectExplorerService, connectionManagementService: IConnectionManagementService, workbenchEditorService: IEditorService, topLevelOnly: boolean = false): IConnectionProfile {
+export function getCurrentGlobalConnection(objectExplorerService: IObjectExplorerService, connectionManagementService: IConnectionManagementService, workbenchEditorService: IEditorService, topLevelOnly: boolean = false): IConnectionProfile | undefined {
 	let connection: IConnectionProfile;
 	// object Explorer Connection
 	let objectExplorerSelection = objectExplorerService.getSelectedProfileAndDatabase();
@@ -78,9 +78,9 @@ export function getCurrentGlobalConnection(objectExplorerService: IObjectExplore
 	let activeInput = workbenchEditorService.activeEditor;
 	if (activeInput) {
 		// dashboard Connection
-		if (activeInput instanceof DashboardInput) {
+		if (activeInput instanceof DashboardInput && activeInput.uri) {
 			connection = connectionManagementService.getConnectionProfile(activeInput.uri.toString());
-		} else {
+		} else if (activeInput.resource) {
 			// editor Connection
 			connection = connectionManagementService.getConnectionProfile(activeInput.resource.toString());
 		}

--- a/src/sql/workbench/contrib/query/browser/flavorStatus.ts
+++ b/src/sql/workbench/contrib/query/browser/flavorStatus.ts
@@ -96,12 +96,12 @@ export class SqlFlavorStatusbarItem extends Disposable implements IWorkbenchCont
 	}
 
 	private _onEditorClosed(event: IEditorCloseEvent): void {
-		let uri = event.editor.resource.toString();
+		let uri = event.editor.resource?.toString();
 		if (uri && uri in this._sqlStatusEditors) {
 			// If active editor is being closed, hide the query status.
 			let activeEditor = this.editorService.activeEditorPane;
 			if (activeEditor) {
-				let currentUri = activeEditor.input.resource.toString();
+				let currentUri = activeEditor.input.resource?.toString();
 				if (uri === currentUri) {
 					this.hide();
 				}
@@ -114,7 +114,7 @@ export class SqlFlavorStatusbarItem extends Disposable implements IWorkbenchCont
 	private _onEditorsChanged(): void {
 		let activeEditor = this.editorService.activeEditorPane;
 		if (activeEditor) {
-			let uri = activeEditor.input.resource.toString();
+			let uri = activeEditor.input.resource?.toString();
 
 			// Show active editor's language flavor	status
 			if (uri) {
@@ -145,7 +145,7 @@ export class SqlFlavorStatusbarItem extends Disposable implements IWorkbenchCont
 	private _showStatus(uri: string): void {
 		let activeEditor = this.editorService.activeEditorPane;
 		if (activeEditor) {
-			let currentUri = activeEditor.input.resource.toString();
+			let currentUri = activeEditor.input.resource?.toString();
 			if (uri === currentUri) {
 				let flavor: SqlProviderEntry = this._sqlStatusEditors[uri];
 				if (flavor) {
@@ -186,7 +186,7 @@ export class ChangeFlavorAction extends Action {
 
 	public run(): Promise<any> {
 		let activeEditor = this._editorService.activeEditorPane;
-		let currentUri = activeEditor?.input.resource.toString();
+		let currentUri = activeEditor?.input.resource?.toString();
 		if (this._connectionManagementService.isConnected(currentUri)) {
 			let currentProvider = this._connectionManagementService.getProviderIdFromUri(currentUri);
 			return this._showMessage(Severity.Info, nls.localize('alreadyConnected',


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/9592

Not all inputs have a resource so make sure we check for that. All existing callers of this function were already assuming it could return undefined - just making that more explicit now. 

Original error was from taskUtilities but noticed and fixed some others in flavorStatus while I was looking at this.