### PR TITLE
Fix search icon only working when section expanded

### DIFF
--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -45,7 +45,7 @@ export class BookTreeItem extends vscode.TreeItem {
 				this.contextValue = 'savedBook';
 			}
 		} else {
-			if (book.type === BookTreeItemType.Markdown && book.page.expand_sections) {
+			if (book.page && book.page.sections && book.page.sections.length > 0) {
 				this.contextValue = 'section';
 			}
 			this.setPageVariables();


### PR DESCRIPTION
This is for #9595.

Was setting context key incorrectly beforehand; we really need to check for the existence of sections, since that's how the viewlet is populated.