### PR TITLE
update the order of css selectors

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
@@ -28,8 +28,8 @@ dashboard-page .home-tab-icon {
 	background-image: url("media/home.svg");
 }
 
-dashboard-page .vs-dark .home-tab-icon,
-.hc-black .home-tab-icon {
+.vs-dark dashboard-page .home-tab-icon,
+.hc-black dashboard-page .home-tab-icon {
 	background-image: url("media/home_inverse.svg");
 }
 
@@ -37,8 +37,8 @@ dashboard-page .default-tab-icon {
 	background-image: url("media/default.svg");
 }
 
-dashboard-page .vs-dark .default-tab-icon,
-dashboard-page .hc-black .default-tab-icon {
+.vs-dark dashboard-page .default-tab-icon,
+.hc-black dashboard-page .default-tab-icon {
 	background-image: url("media/default_inverse.svg");
 }
 


### PR DESCRIPTION
adjust the order of css selectors to fix the issue that wrong icon is shown for dark theme.
<img width="237" alt="Screen Shot 2020-03-13 at 11 47 51 AM" src="https://user-images.githubusercontent.com/13777222/76650766-80a6df00-6520-11ea-88bd-1cee9e88e193.png">
