### PR TITLE
Fix trusting opened notebooks

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -76,6 +76,15 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		if (bookPathToTrust) {
 			let trustChanged = this._bookTrustManager.setBookAsTrusted(bookPathToTrust);
 
+			// update trust state of opened items
+			if (azdata.nb.notebookDocuments && azdata.nb.notebookDocuments.length) {
+				azdata.nb.notebookDocuments.forEach(document => {
+					if (this._bookTrustManager.isNotebookTrustedByDefault(document.uri.fsPath)) {
+						document.setTrusted(true);
+					}
+				});
+			}
+
 			if (trustChanged) {
 				this._apiWrapper.showInfoMessage(loc.msgBookTrusted);
 			} else {

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -74,18 +74,22 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		let bookPathToTrust = bookTreeItem ? bookTreeItem.root : this.currentBook?.bookPath;
 
 		if (bookPathToTrust) {
+
 			let trustChanged = this._bookTrustManager.setBookAsTrusted(bookPathToTrust);
 
-			// update trust state of opened items
-			if (azdata.nb.notebookDocuments && azdata.nb.notebookDocuments.length) {
-				azdata.nb.notebookDocuments.forEach(document => {
-					if (this._bookTrustManager.isNotebookTrustedByDefault(document.uri.fsPath)) {
-						document.setTrusted(true);
-					}
-				});
-			}
-
 			if (trustChanged) {
+
+				let notebookDocuments = this._apiWrapper.getNotebookDocuments();
+
+				if (notebookDocuments) {
+					// update trust state of opened items
+					notebookDocuments.forEach(document => {
+						let notebook = this.currentBook.getNotebook(document.uri.fsPath);
+						if (notebook && this._bookTrustManager.isNotebookTrustedByDefault(document.uri.fsPath)) {
+							document.setTrusted(true);
+						}
+					});
+				}
 				this._apiWrapper.showInfoMessage(loc.msgBookTrusted);
 			} else {
 				this._apiWrapper.showInfoMessage(loc.msgBookAlreadyTrusted);

--- a/extensions/notebook/src/common/apiWrapper.ts
+++ b/extensions/notebook/src/common/apiWrapper.ts
@@ -65,6 +65,10 @@ export class ApiWrapper {
 		return vscode.commands.executeCommand(BuiltInCommands.SetContext, key, value);
 	}
 
+	public getNotebookDocuments() {
+		return azdata.nb.notebookDocuments;
+	}
+
 	/**
 	 * Get the configuration for a extensionName
 	 * @param extensionName The string name of the extension to get the configuration for


### PR DESCRIPTION
Currently trusting a book does not update the Trust status of currently opened, inactive notebooks -- only those which are opened after the book was trusted. This fix updates the trust state of already opened books whenever trusting a book.