### PR TITLE
remove unnecessary tabindex attribute 

### DIFF
--- a/src/sql/base/browser/ui/panel/tab.component.ts
+++ b/src/sql/base/browser/ui/panel/tab.component.ts
@@ -15,7 +15,7 @@ export abstract class TabChild extends AngularDisposable {
 @Component({
 	selector: 'tab',
 	template: `
-		<div role="tabpanel" [attr.aria-labelledby]="identifier" tabindex="0" class="visibility" [class.hidden]="shouldBeHidden()" *ngIf="shouldBeIfed()" class="fullsize">
+		<div role="tabpanel" [attr.aria-labelledby]="identifier" class="visibility" [class.hidden]="shouldBeHidden()" *ngIf="shouldBeIfed()" class="fullsize">
 			<ng-container *ngTemplateOutlet="templateRef"></ng-container>
 		</div>
 	`


### PR DESCRIPTION
noticed this for quite a while, finally fixing it. in the screenshot below see the focus indicator (blue line), it is focusing on the whole tab panel, which is unnecessary.
<img width="665" alt="Screen Shot 2020-03-13 at 1 44 53 PM" src="https://user-images.githubusercontent.com/13777222/76658420-56115200-6531-11ea-84af-3864f6caac5e.png">

