### PR TITLE
Increase test coverage of admin-tool-ext-win

### DIFF
--- a/extensions/admin-tool-ext-win/src/main.ts
+++ b/extensions/admin-tool-ext-win/src/main.ts
@@ -232,8 +232,8 @@ async function launchSsmsDialog(action: string, connectionContext: azdata.Object
  * @param params The params used to build up the command parameter string
  */
 export function buildSsmsMinCommandArgs(params: LaunchSsmsDialogParams): string {
-	return `${params.action ? '-a "' + backEscapeDoubleQuotes(params.action) + '"' : ''}\
-${params.server ? ' -S "' + backEscapeDoubleQuotes(params.server) + '"' : ''}\
+	return `-a "${backEscapeDoubleQuotes(params.action)}" \
+-S "${backEscapeDoubleQuotes(params.server)}"\
 ${params.database ? ' -D "' + backEscapeDoubleQuotes(params.database) + '"' : ''}\
 ${params.user ? ' -U "' + backEscapeDoubleQuotes(params.user) + '"' : ''}\
 ${params.useAad === true ? ' -G' : ''}\

--- a/extensions/admin-tool-ext-win/src/test/utils.test.ts
+++ b/extensions/admin-tool-ext-win/src/test/utils.test.ts
@@ -7,7 +7,7 @@ import * as should from 'should';
 import 'mocha';
 
 import { buildSsmsMinCommandArgs, buildUrn, LaunchSsmsDialogParams } from '../main';
-import { doubleEscapeSingleQuotes, backEscapeDoubleQuotes } from '../utils';
+import { doubleEscapeSingleQuotes, backEscapeDoubleQuotes, getTelemetryErrorType } from '../utils';
 import { ExtHostObjectExplorerNodeStub } from './stubs';
 
 describe('buildSsmsMinCommandArgs Method Tests', () => {
@@ -73,13 +73,14 @@ const tableSchema = 'tbl\'sch';
 const escapedTableSchema = doubleEscapeSingleQuotes(tableSchema);
 
 describe('buildUrn Method Tests', () => {
-	it('Urn should be correct with just server', async function (): Promise<void> {
+	it('Urn should be correct with no node', async function (): Promise<void> {
 		should(await buildUrn(undefined)).equal('Server');
 	});
 
 	it('Urn should be correct with Server and only Databases folder', async function (): Promise<void> {
 		const leafNode: ExtHostObjectExplorerNodeStub =
-			new ExtHostObjectExplorerNodeStub('Databases', undefined, 'Folder', undefined);
+			new ExtHostObjectExplorerNodeStub('MyServer', undefined, 'Server', undefined)
+				.createChild('Databases', undefined, 'Folder');
 		should(await buildUrn(leafNode)).equal('Server');
 	});
 
@@ -99,6 +100,16 @@ describe('buildUrn Method Tests', () => {
 				.createChild(tableName, tableSchema, 'Table');
 		should(await buildUrn(rootNode)).equal(
 			`Server/Database[@Name='${escapedDbName}' and @Schema='${escapedDbSchema}']/Table[@Name='${escapedTableName}' and @Schema='${escapedTableSchema}']`);
+	});
+
+	it('Urn should be correct with Multiple levels of Nodes without schemas', async function (): Promise<void> {
+		const rootNode: ExtHostObjectExplorerNodeStub =
+			new ExtHostObjectExplorerNodeStub('Databases', undefined, 'Folder', undefined)
+				.createChild(dbName, undefined, 'Database')
+				.createChild('Tables', undefined, 'Folder')
+				.createChild(tableName, undefined, 'Table');
+		should(await buildUrn(rootNode)).equal(
+			`Server/Database[@Name='${escapedDbName}']/Table[@Name='${escapedTableName}']`);
 	});
 });
 
@@ -127,5 +138,32 @@ describe('backEscapeDoubleQuotes Method Tests', () => {
 		const testString: string = 'MyTestString\"\"WithQuotes';
 		const ret = backEscapeDoubleQuotes(testString);
 		should(ret).equal('MyTestString\\"\\"WithQuotes');
+	});
+});
+
+describe('getTelemetryErrorType Method Tests', () => {
+	it('ExeNotFound', function (): void {
+		const msg = getTelemetryErrorType('SsmsMin.exe is not recognized as an internal or external command');
+		should(msg).equal('ExeNotFound');
+	});
+
+	it('UnknownAction', function (): void {
+		const msg = getTelemetryErrorType('Unknown Action "foo"');
+		should(msg).equal('UnknownAction');
+	});
+
+	it('NoActionProvided', function (): void {
+		const msg = getTelemetryErrorType('No Action Provided');
+		should(msg).equal('NoActionProvided');
+	});
+
+	it('RunException', function (): void {
+		const msg = getTelemetryErrorType('Run exception "Error occurred"');
+		should(msg).equal('RunException');
+	});
+
+	it('Other', function (): void {
+		const msg = getTelemetryErrorType('Some other error message');
+		should(msg).equal('Other');
 	});
 });

--- a/extensions/admin-tool-ext-win/src/utils.ts
+++ b/extensions/admin-tool-ext-win/src/utils.ts
@@ -9,15 +9,12 @@ export interface IPackageInfo {
 	aiKey: string;
 }
 
-export function getPackageInfo(packageJson: any): IPackageInfo | undefined {
-	if (packageJson) {
-		return {
-			name: packageJson.name,
-			version: packageJson.version,
-			aiKey: packageJson.aiKey
-		};
-	}
-	return undefined;
+export function getPackageInfo(packageJson: any): IPackageInfo {
+	return {
+		name: packageJson.name,
+		version: packageJson.version,
+		aiKey: packageJson.aiKey
+	};
 }
 
 /**


### PR DESCRIPTION
Testing coveralls integration by adding some tests! Still only ~50%, but the majority of the code here isn't really something that is easily covered with a unit test and should probably be done in a full integration test. 

To increase the coverage I did remove a few places where we were doing what should be unnecessary checks. For example the undefined check in getPackageInfo - it's safe to assume that exists since if it doesn't that means things are really broken anyways and there isn't any recovering from that state. 