### PR TITLE
Fix screenreader not reading tabular structure in dacpac deploy page

### DIFF
--- a/extensions/dacpac/src/wizard/pages/deployPlanPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployPlanPage.ts
@@ -98,8 +98,7 @@ export class DeployPlanPage extends DacFxConfigPage {
 			data: this.getColumnData(result),
 			columns: this.getTableColumns(result.dataLossAlerts.size > 0),
 			width: 875,
-			height: 300,
-			ariaRole: 'alert'
+			height: 300
 		});
 
 		if (result.dataLossAlerts.size > 0) {


### PR DESCRIPTION
This PR fixes #9260. The table wasn't being recognized as a table by screenreaders because the role was alert. This was previously added to solve #6826, but that only asked for the loading status to be announced and it still is after this change.