### PR TITLE
do nothing if the focus is already in dialog

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -498,9 +498,11 @@ export abstract class Modal extends Disposable implements IThemable {
 				DOM.prepend(this._modalContent, (this._messageElement));
 			}
 		} else {
-			// Set the focus manually otherwise it'll escape the dialog to something behind it
-			this.setInitialFocusedElement();
 			DOM.removeNode(this._messageElement);
+			// Set the focus to first focus element if the focus is not within the dialog
+			if (!DOM.isAncestor(this._bodyContainer.ownerDocument.activeElement, this._bodyContainer)) {
+				this.setInitialFocusedElement();
+			}
 		}
 	}
 

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -500,7 +500,7 @@ export abstract class Modal extends Disposable implements IThemable {
 		} else {
 			DOM.removeNode(this._messageElement);
 			// Set the focus to first focus element if the focus is not within the dialog
-			if (!DOM.isAncestor(this._bodyContainer.ownerDocument.activeElement, this._bodyContainer)) {
+			if (!DOM.isAncestor(document.activeElement, this._bodyContainer)) {
 				this.setInitialFocusedElement();
 			}
 		}


### PR DESCRIPTION
This PR fixes #9293

finally figured out why the focus is moving away, setting the dialog.message will change the focus 😆 
the fix is to keep the focus if the it is already inside the dialog.
