### PR TITLE
fix the contrast ratio

### DIFF
--- a/src/sql/workbench/browser/modal/media/modal.css
+++ b/src/sql/workbench/browser/modal/media/modal.css
@@ -180,7 +180,7 @@
 
 .vs .modal.flyout-dialog .dialog-message.info,
 .vs-dark .modal.flyout-dialog .dialog-message.info {
-	background-color:#0078D7 !important;
+	background-color:#096CC9 !important;
 	color:#FFFFFF !important;
 }
 


### PR DESCRIPTION
This PR fixes #9297 

using the same blue color as the wizard page number for the informational message background.
![Screen Shot 2020-03-15 at 11 29 22 AM](https://user-images.githubusercontent.com/13777222/76708086-749e5700-66b1-11ea-995e-fc5d6013686d.png)

the contrast ratio is now:
<img width="678" alt="Screen Shot 2020-03-15 at 11 39 06 AM" src="https://user-images.githubusercontent.com/13777222/76708107-9d265100-66b1-11ea-81bd-8316f02df571.png">

also checked the contrast ratio for Error and Warning, they are both greater than 4.5:1, and for high contrast theme, we use default color, and it looks good too.
![Screen Shot 2020-03-15 at 11 35 44 AM](https://user-images.githubusercontent.com/13777222/76708127-bcbd7980-66b1-11ea-8197-cf88fe14273a.png)

