### PR TITLE
fix the focus outline color

### DIFF
--- a/src/sql/workbench/browser/modal/media/modal.css
+++ b/src/sql/workbench/browser/modal/media/modal.css
@@ -214,7 +214,16 @@
 
 .modal.flyout-dialog .dialog-message-button {
 	min-width: 60px;
-	margin-right: 10px;
+	margin: 3px 10px 3px 3px;
+}
+
+.modal.flyout-dialog .dialog-message.info .dialog-message-button > a:focus,
+.modal.flyout-dialog .dialog-message.error .dialog-message-button > a:focus{
+	outline-color: #FFFFFF;
+}
+
+.modal.flyout-dialog .dialog-message.warning .dialog-message-button > a:focus{
+	outline-color: #000000;
 }
 
 .modal.flyout-dialog .dialog-message-button > a {


### PR DESCRIPTION
This PR fixes #9321 

the default outline color on focus doesn't have enough contrast ratio for the message header, i am setting its color per message level now, also increase the bottom/top margin to make the outline visible
![Screen Shot 2020-03-15 at 9 17 44 PM](https://user-images.githubusercontent.com/13777222/76722943-e18e0d00-6702-11ea-8c29-1cdd9d57a91f.png)

