### PR TITLE
Work around coveralls parallel upload issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,9 @@ jobs:
     - run: DISPLAY=:10 ./scripts/test-extensions-unit.sh
       name: Run Extension Unit Tests (Electron)
     # {{SQL CARBON EDIT}} Add coveralls. We merge first to get around issue where parallel builds weren't being combined correctly
-    # Also fix up extension test paths to be rooted correctly
     - run: |
         mkdir .build/coverage-combined
         cat .build/coverage-single/lcov.info ./extensions/admin-tool-ext-win/coverage/lcov.info ./extensions/agent/coverage/lcov.info ./extensions/azurecore/coverage/lcov.info ./extensions/cms/coverage/lcov.info ./extensions/dacpac/coverage/lcov.info ./extensions/schema-compare/coverage/lcov.info ./extensions/notebook/coverage/lcov.info ./extensions/resource-deployment/coverage/lcov.info ./extensions/machine-learning-services/coverage/lcov.info > .build/coverage-combined/lcov.info
-        sed -i 's/\.\.\\\.\.\\extensions/extensions/g' .build/coverage-combined/lcov.info
       name: Merge coverage reports
     - name: Upload Code Coverage
       uses: coverallsapp/github-action@v1.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,72 +51,14 @@ jobs:
       name: Run Unit Tests (Electron)
     - run: DISPLAY=:10 ./scripts/test-extensions-unit.sh
       name: Run Extension Unit Tests (Electron)
-    # {{SQL CARBON EDIT}} Add coveralls
-    - name: Upload Core Coverage
-      uses: coverallsapp/github-action@v1.0.1
-      with:
-        parallel: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: '.build/coverage-single/lcov.info'
-    - name: Upload admin-tool-ext-win Extension Coverage
-      uses: coverallsapp/github-action@v1.0.1
-      with:
-        parallel: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: './extensions/admin-tool-ext-win/coverage/lcov.info'
-    - name: Upload agent Extension Coverage
-      uses: coverallsapp/github-action@v1.0.1
-      with:
-        parallel: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: './extensions/agent/coverage/lcov.info'
-    - name: Upload azurecore Extension Coverage
-      uses: coverallsapp/github-action@v1.0.1
-      with:
-        parallel: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: './extensions/azurecore/coverage/lcov.info'
-    - name: Upload cms Extension Coverage
-      uses: coverallsapp/github-action@v1.0.1
-      with:
-        parallel: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: './extensions/cms/coverage/lcov.info'
-    - name: Upload dacpac Extension Coverage
-      uses: coverallsapp/github-action@v1.0.1
-      with:
-        parallel: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: './extensions/dacpac/coverage/lcov.info'
-    - name: Upload schema-compare Extension Coverage
-      uses: coverallsapp/github-action@v1.0.1
-      with:
-        parallel: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: './extensions/schema-compare/coverage/lcov.info'
-    - name: Upload notebook Extension Coverage
-      uses: coverallsapp/github-action@v1.0.1
-      with:
-        parallel: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: './extensions/notebook/coverage/lcov.info'
-    - name: Upload resource-deployment Extension Coverage
-      uses: coverallsapp/github-action@v1.0.1
-      with:
-        parallel: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: './extensions/resource-deployment/coverage/lcov.info'
-    - name: Upload machine-learning-services Extension Coverage
-      uses: coverallsapp/github-action@v1.0.1
-      with:
-        parallel: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: './extensions/machine-learning-services/coverage/lcov.info'
-    - name: Finish Parallel Coveralls Uploads
+    # {{SQL CARBON EDIT}} Add coveralls. We merge first to get around issue where parallel builds weren't being combined correctly
+    - run: cat .build/coverage-single/lcov.info ./extensions/admin-tool-ext-win/coverage/lcov.info ./extensions/agent/coverage/lcov.info ./extensions/azurecore/coverage/lcov.info ./extensions/cms/coverage/lcov.info ./extensions/dacpac/coverage/lcov.info ./extensions/schema-compare/coverage/lcov.info ./extensions/notebook/coverage/lcov.info ./extensions/resource-deployment/coverage/lcov.info ./extensions/machine-learning-services/coverage/lcov.info > .build/coverage-combined/lcov.info
+      name: Merge coverage reports
+    - name: Upload Code Coverage
       uses: coverallsapp/github-action@v1.0.1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        parallel-finished: true
+        path-to-lcov: '.build/coverage-combined/lcov.info'
 
     # Fails with cryptic error (e.g. https://github.com/microsoft/vscode/pull/90292/checks?check_run_id=433681926#step:13:9)
     # - run: DISPLAY=:10 yarn test-browser --browser chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,11 @@ jobs:
     - run: DISPLAY=:10 ./scripts/test-extensions-unit.sh
       name: Run Extension Unit Tests (Electron)
     # {{SQL CARBON EDIT}} Add coveralls. We merge first to get around issue where parallel builds weren't being combined correctly
+    # Also fix up extension test paths to be rooted correctly
     - run: |
         mkdir .build/coverage-combined
         cat .build/coverage-single/lcov.info ./extensions/admin-tool-ext-win/coverage/lcov.info ./extensions/agent/coverage/lcov.info ./extensions/azurecore/coverage/lcov.info ./extensions/cms/coverage/lcov.info ./extensions/dacpac/coverage/lcov.info ./extensions/schema-compare/coverage/lcov.info ./extensions/notebook/coverage/lcov.info ./extensions/resource-deployment/coverage/lcov.info ./extensions/machine-learning-services/coverage/lcov.info > .build/coverage-combined/lcov.info
+        sed -i 's/\.\.\\\.\.\\extensions/extensions/g' .build/coverage-combined/lcov.info
       name: Merge coverage reports
     - name: Upload Code Coverage
       uses: coverallsapp/github-action@v1.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
     - run: DISPLAY=:10 ./scripts/test-extensions-unit.sh
       name: Run Extension Unit Tests (Electron)
     # {{SQL CARBON EDIT}} Add coveralls. We merge first to get around issue where parallel builds weren't being combined correctly
-    - run: cat .build/coverage-single/lcov.info ./extensions/admin-tool-ext-win/coverage/lcov.info ./extensions/agent/coverage/lcov.info ./extensions/azurecore/coverage/lcov.info ./extensions/cms/coverage/lcov.info ./extensions/dacpac/coverage/lcov.info ./extensions/schema-compare/coverage/lcov.info ./extensions/notebook/coverage/lcov.info ./extensions/resource-deployment/coverage/lcov.info ./extensions/machine-learning-services/coverage/lcov.info > .build/coverage-combined/lcov.info
+    - run: |
+        mkdir .build/coverage-combined
+        cat .build/coverage-single/lcov.info ./extensions/admin-tool-ext-win/coverage/lcov.info ./extensions/agent/coverage/lcov.info ./extensions/azurecore/coverage/lcov.info ./extensions/cms/coverage/lcov.info ./extensions/dacpac/coverage/lcov.info ./extensions/schema-compare/coverage/lcov.info ./extensions/notebook/coverage/lcov.info ./extensions/resource-deployment/coverage/lcov.info ./extensions/machine-learning-services/coverage/lcov.info > .build/coverage-combined/lcov.info
       name: Merge coverage reports
     - name: Upload Code Coverage
       uses: coverallsapp/github-action@v1.0.1


### PR DESCRIPTION
This is an attempt to work around an issue with coveralls where push CI builds don't seem to handle parallel uploads correctly. 

https://github.com/lemurheavy/coveralls-public/issues/1403 seems to be the same/a similar type of issue

So instead of using parallel upload I'm just having it merge all the files together before doing the upload. 