### PR TITLE
minimist version bump

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -10,7 +10,7 @@
     "@types/eslint": "4.16.1",
     "@types/fancy-log": "^1.3.0",
     "@types/glob": "^7.1.1",
-    "@types/gulp": "^4.0.5",
+    "@types/gulp": "^4.0.6",
     "@types/gulp-concat": "^0.0.32",
     "@types/gulp-filter": "^3.0.32",
     "@types/gulp-json-editor": "^2.2.31",

--- a/build/package.json
+++ b/build/package.json
@@ -43,7 +43,7 @@
     "iconv-lite": "0.4.23",
     "mime": "^1.3.4",
     "minimatch": "3.0.4",
-    "minimist": "^1.2.2",
+    "minimist": "^1.2.5",
     "request": "^2.85.0",
     "rollup": "^1.20.3",
     "rollup-plugin-commonjs": "^10.1.0",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -192,7 +192,7 @@
     "@types/node" "*"
     "@types/uglify-js" "^2"
 
-"@types/gulp@^4.0.5":
+"@types/gulp@^4.0.6":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@types/gulp/-/gulp-4.0.6.tgz#68fe0e1f0ff3657cfca46fb564806b744a1bf899"
   integrity sha512-0E8/iV/7FKWyQWSmi7jnUvgXXgaw+pfAzEB06Xu+l0iXVJppLbpOye5z7E2klw5akXd+8kPtYuk65YBcZPM4ow==

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -2499,10 +2499,15 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.2:
+minimist@^1.1.0, minimist@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.2.tgz#b00a00230a1108c48c169e69a291aafda3aacd63"
   integrity sha512-rIqbOrKb8GJmx/5bc2M0QchhUouMXSpd1RTclXsB41JdL+VtnojfaJR+h7F9k18/4kHUsBFgk80Uk+q569vjPA==
+
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minimist@~0.0.1:
   version "0.0.10"


### PR DESCRIPTION
Fixes Canary build failures seen [here](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=58186&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=389a8c90-6558-5ae7-af8a-372e07c569f4&l=25400). Our build dependency on minimist needed to be upgraded.

Using PR validation to ensure it works then will reach out for review.