### PR TITLE
remove the message on page enter

### DIFF
--- a/extensions/resource-deployment/src/ui/deployClusterWizard/pages/summaryPage.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/pages/summaryPage.ts
@@ -30,12 +30,6 @@ export class SummaryPage extends WizardPageBase<DeployClusterWizard> {
 	}
 
 	public onEnter() {
-		if (this.wizard.model.deploymentTarget === BdcDeploymentType.NewAKS) {
-			this.wizard.wizardObject.message = {
-				level: azdata.window.MessageLevel.Information,
-				text: localize('resourceDeployment.NewAKSBrowserWindowPrompt', "A browser window for signing into Azure will be opened during the SQL Server Big Data Cluster deployment.")
-			};
-		}
 		this.wizard.showCustomButtons();
 		this.formItems.forEach(item => {
 			this.form!.removeFormItem(item);


### PR DESCRIPTION
if two messages come in a short period of time, the screen reader will read the later one, there is really no good fix to the issue, since we already have the same message in the notebook, I am removing it from the wizard to avoid the issue.

This PR fixes #9348 
