### PR TITLE
restore focus

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -404,10 +404,9 @@ export abstract class Modal extends Disposable implements IThemable {
 	}
 
 	private restoreKeyboardFocus() {
-		if (this._focusedElementBeforeOpen && this._focusedElementBeforeOpen.offsetParent) { // when the element is visible, we can try to set focus to it directly.
+		if (this._focusedElementBeforeOpen) {
 			this._focusedElementBeforeOpen.focus();
 		}
-
 	}
 
 	/**

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -404,23 +404,8 @@ export abstract class Modal extends Disposable implements IThemable {
 	}
 
 	private restoreKeyboardFocus() {
-		if (!this._focusedElementBeforeOpen) {
-			return;
-		} else if (this._focusedElementBeforeOpen.offsetParent) { // when the element is visible, we can try to set focus to it directly.
+		if (this._focusedElementBeforeOpen && this._focusedElementBeforeOpen.offsetParent) { // when the element is visible, we can try to set focus to it directly.
 			this._focusedElementBeforeOpen.focus();
-		} else if (this._focusedElementBeforeOpen.tagName === 'A' && this._focusedElementBeforeOpen.classList.contains('action-label')) {
-			// workaround for the scenario where the original focus was on the action buttons in the viewlet header
-			// the buttons are hidden if the focus is not on the view, we need to first set the focus on the header to make the action buttons appear
-			// and then set the focus to the button.
-			let element = this._focusedElementBeforeOpen;
-			do {
-				element = element.parentElement;
-			} while (element && !element.classList.contains('pane-header'));
-
-			if (element) {
-				element.focus();
-				this._focusedElementBeforeOpen.focus();
-			}
 		}
 
 	}

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -218,7 +218,7 @@ import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuratio
 			},
 			'workbench.view.alwaysShowHeaderActions': {
 				'type': 'boolean',
-				'default': false,
+				'default': true, // {{SQL CARBON EDIT}} - change the default value from false to true.
 				'description': nls.localize('viewVisibility', "Controls the visibility of view header actions. View header actions may either be always visible, or only visible when that view is focused or hovered over.")
 			},
 			'workbench.view.experimental.allowMovingToNewContainer': {


### PR DESCRIPTION
when we close the dialog opened by the action buttons in the view header (e.g. new connection dialog, new server group dialog, connect to BDC controller dialog and so on...), we are not able to easily set the focus back to the original button because it is no longer visible. 

It seems a proper fix for this would not be trivial and might take sometime for vscode team. This PR is a simple/low cost workaround for it.
![Screen Shot 2020-03-18 at 8 59 48 PM](https://user-images.githubusercontent.com/13777222/77030691-aedf5100-695c-11ea-8bae-ade939e81731.png)

This PR fixes #9227
