### PR TITLE
Add quality build tag to build

### DIFF
--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -10,6 +10,10 @@ jobs:
     vmImage: 'Ubuntu-16.04'
   container: linux-x64
   steps:
+  - script: |
+      set -e
+      echo "##vso[build.addbuildtag]$(VSCODE_QUALITY)"
+    displayName: Add Quality Build Tag
   - template: sql-product-compile.yml
 
 - job: macOS


### PR DESCRIPTION
This will help discovering builds of a particular type from our product build pipeline. I was originally thinking we'd just create separate pipelines for different types (such as the saw one I created) but that just gets messy and means we might miss updating all the pipelines with configuration changes.

Example build : https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=58427&view=results

![image](https://user-images.githubusercontent.com/28519865/77091655-18e01080-69c6-11ea-94eb-edba6da5032c.png)

![image](https://user-images.githubusercontent.com/28519865/77091739-30b79480-69c6-11ea-885d-b024f8e71b34.png)
