### PR TITLE
small dashboard toolbar fixes 

### DIFF
--- a/src/sql/media/icons/common-icons.css
+++ b/src/sql/media/icons/common-icons.css
@@ -13,7 +13,7 @@
 }
 
 .vs .codicon.backup {
-	background: url("backup.svg") center center no-repeat;
+	background: url("backup.svg") no-repeat;
 }
 
 .vs-dark .codicon.backup,

--- a/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component.ts
@@ -66,5 +66,6 @@ export class DatabaseDashboardPage extends DashboardPage implements OnInit {
 	ngOnInit() {
 		this.init();
 		this._breadcrumbService.setBreadcrumbs(BreadcrumbClass.DatabasePage);
+		super.ngAfterViewInit();
 	}
 }


### PR DESCRIPTION
1. Backup icon was centered again(probably from merge from master)
2. Database page toolbar border wasn't getting set to the right color when opened from the databases tab in the server dashboard

before:
![image](https://user-images.githubusercontent.com/31145923/77352817-0a169800-6cfd-11ea-882e-477e13e44f63.png)

after:
![image](https://user-images.githubusercontent.com/31145923/77352829-100c7900-6cfd-11ea-8052-5618fb5ac1a4.png)
