### PR TITLE
fix sub leak

### DIFF
--- a/src/sql/base/browser/lifecycle.ts
+++ b/src/sql/base/browser/lifecycle.ts
@@ -10,7 +10,9 @@ import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
 
 export function subscriptionToDisposable(sub: Subscription): IDisposable {
 	return {
-		dispose: sub.unsubscribe
+		dispose: () => {
+			sub.unsubscribe();
+		}
 	};
 }
 


### PR DESCRIPTION
This PR fixes #9708 

It is because the unsubscribe didn't really do the job. if we pass in the method directly, the `this` reference will not be the subscription object as it expects. I've fixed similar issues before.

@Charles-Gagnon I am not going to convert the Observable to Event now, If we have to stop using Angular if we really want to get rid of all Rx Observables, by that time, we can refactor the code to use Promise directly.
