### PR TITLE
Fix properties widget bottom border not showing

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.html
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.html
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 -->
 <div #parent style="position: absolute; height: 100%; width: 100%;">
-	<div #container [style.margin-right.px]="_clipped ? 30 : 0" [style.width]="_clipped ? 94 + '%' : '100%'" style="overflow: hidden; padding-bottom: 15px">
+	<div #container [style.margin-right.px]="_clipped ? 30 : 0" [style.width]="_clipped ? 94 + '%' : '100%'" style="overflow: hidden; padding-bottom: 10px">
 		<span #child style="white-space : nowrap; width: fit-content">
 			<ng-template ngFor let-item [ngForOf]="properties">
 				<span style="margin-left: 10px; display: inline-block;">


### PR DESCRIPTION
Bottom border of properties widget wasn't showing after collapse action was fixed in #9537
because it moved the other content of the widget down.

before:
![image](https://user-images.githubusercontent.com/31145923/77378337-f1c17000-6d32-11ea-9333-a7148dd3aa20.png)
fixed:
![image](https://user-images.githubusercontent.com/31145923/77378385-0998f400-6d33-11ea-80a0-2087232a3f40.png)

