### PR TITLE
Remove keytar from azurecore

### DIFF
--- a/extensions/azurecore/extension.webpack.config.js
+++ b/extensions/azurecore/extension.webpack.config.js
@@ -13,5 +13,8 @@ module.exports = withDefaults({
 	context: __dirname,
 	entry: {
 		extension: './src/extension.ts'
+	},
+	externals: {
+		'keytar': 'commonjs keytar'
 	}
 });

--- a/extensions/azurecore/extension.webpack.config.js
+++ b/extensions/azurecore/extension.webpack.config.js
@@ -13,8 +13,5 @@ module.exports = withDefaults({
 	context: __dirname,
 	entry: {
 		extension: './src/extension.ts'
-	},
-	externals: {
-		'keytar': 'commonjs keytar'
 	}
 });

--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -230,7 +230,6 @@
     "@azure/arm-subscriptions": "1.0.0",
     "adal-node": "^0.2.1",
     "axios": "^0.19.2",
-    "keytar": "^5.4.0",
     "qs": "^6.9.1",
     "request": "2.88.0",
     "vscode-nls": "^4.0.0"

--- a/extensions/azurecore/yarn.lock
+++ b/extensions/azurecore/yarn.lock
@@ -962,7 +962,7 @@ jws@3.x.x:
     jwa "^1.2.0"
     safe-buffer "^5.0.1"
 
-keytar@*, keytar@^5.4.0:
+keytar@*:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/keytar/-/keytar-5.4.0.tgz#71d8209e7dd2fe99008c243791350a6bd6ceab67"
   integrity sha512-Ta0RtUmkq7un177SPgXKQ7FGfGDV4xvsV0cGNiWVEzash5U0wyOsXpwfrK2+Oq+hHvsvsbzIZUUuJPimm3avFw==


### PR DESCRIPTION
The core product injects their keytar into the extensions, so you don't need to have it as a dependency.