### PR TITLE
tab panel fixes

### DIFF
--- a/extensions/mssql/package.nls.json
+++ b/extensions/mssql/package.nls.json
@@ -142,5 +142,5 @@
 	"contents-tab-group-title" : "Contents",
 	"databases-tab-description": "Databases tab of server dashboard",
 	"databases-tab-title": "Databases",
-	"explorer-widget-title": "Search",
+	"explorer-widget-title": "Search"
 }

--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -145,7 +145,7 @@ panel {
 
 .tabbedPanel .tab-group-header {
 	font-weight: bold;
-	margin: 15px 5px 0px 5px;
+	margin: 15px 5px 3px 5px;
 	line-height: 35px;
 	height: 35px;
 	border-style: solid;

--- a/src/sql/base/browser/ui/panel/panel.component.ts
+++ b/src/sql/base/browser/ui/panel/panel.component.ts
@@ -298,7 +298,7 @@ export class PanelComponent extends Disposable {
 		const currentIndex = this.focusedTabHeaderIndex;
 		if (currentIndex !== -1) {
 			// Move to the previous tab, if we are at the first tab then move to the last tab.
-			this.focusOnTabHeader(currentIndex === 0 ? this._tabHeaders.length - 1 : this.focusedTabHeaderIndex - 1);
+			this.focusOnTabHeader(currentIndex === 0 ? this._tabHeaders.length - 1 : currentIndex - 1);
 		}
 	}
 
@@ -317,13 +317,8 @@ export class PanelComponent extends Disposable {
 	}
 
 	private get focusedTabHeaderIndex(): number {
-		const headers = this._tabHeaders.toArray();
-		let idx = -1;
-		for (let i = 0; i < headers.length; i++) {
-			if (headers[i].nativeElement === document.activeElement) {
-				idx = i;
-			}
-		}
-		return idx;
+		return this._tabHeaders.toArray().findIndex((header) => {
+			return header.nativeElement === document.activeElement;
+		});
 	}
 }

--- a/src/sql/base/browser/ui/panel/panel.component.ts
+++ b/src/sql/base/browser/ui/panel/panel.component.ts
@@ -5,7 +5,7 @@
 
 import {
 	Component, ContentChildren, QueryList, Inject, forwardRef, NgZone,
-	Input, EventEmitter, Output, ViewChild, ElementRef, ChangeDetectorRef
+	Input, EventEmitter, Output, ViewChild, ElementRef, ChangeDetectorRef, ViewChildren
 } from '@angular/core';
 
 import { TabComponent } from 'sql/base/browser/ui/panel/tab.component';
@@ -20,6 +20,9 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { firstIndex } from 'vs/base/common/arrays';
 import * as nls from 'vs/nls';
+import { TabHeaderComponent } from 'sql/base/browser/ui/panel/tabHeader.component';
+import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { KeyCode } from 'vs/base/common/keyCodes';
 
 export interface IPanelOptions {
 	/**
@@ -52,7 +55,7 @@ let idPool = 0;
 					<div *ngIf="options.layout === NavigationBarLayout.vertical" class="action-container">
 						<button [attr.aria-expanded]="_tabExpanded" [title]="toggleTabPanelButtonAriaLabel" [attr.aria-label]="toggleTabPanelButtonAriaLabel" [ngClass]="toggleTabPanelButtonCssClass" tabindex="0" (click)="toggleTabPanel()"></button>
 					</div>
-					<div *ngIf="_tabExpanded" class="tabList" role="tablist" scrollable [horizontalScroll]="AutoScrollbarVisibility" [verticalScroll]="HiddenScrollbarVisibility" [scrollYToX]="true">
+					<div *ngIf="_tabExpanded" class="tabList" role="tablist" scrollable [horizontalScroll]="AutoScrollbarVisibility" [verticalScroll]="HiddenScrollbarVisibility" [scrollYToX]="true" (keydown)="onKey($event)">
 						<div role="presentation" *ngFor="let tab of _tabs">
 							<ng-container *ngIf="tab.type!=='group-header'">
 								<tab-header role="presentation" [active]="_activeTab === tab" [tab]="tab" [showIcon]="options.showIcon" (onSelectTab)='selectTab($event)' (onCloseTab)='closeTab($event)'></tab-header>
@@ -82,6 +85,7 @@ export class PanelComponent extends Disposable {
 	@Input() public options?: IPanelOptions;
 	@Input() public actions?: Array<Action>;
 	@ContentChildren(TabComponent) private readonly _tabs!: QueryList<TabComponent>;
+	@ViewChildren(TabHeaderComponent) private readonly _tabHeaders!: QueryList<TabHeaderComponent>;
 	@ViewChild(ScrollableDirective) private scrollable?: ScrollableDirective;
 
 	@Output() public onTabChange = new EventEmitter<TabComponent>();
@@ -271,5 +275,55 @@ export class PanelComponent extends Disposable {
 
 	public layout() {
 		this._activeTab?.layout();
+	}
+
+	onKey(e: KeyboardEvent): void {
+		const event = new StandardKeyboardEvent(e);
+		let eventHandled: boolean = false;
+		if (event.equals(KeyCode.DownArrow) || event.equals(KeyCode.RightArrow)) {
+			this.focusNextTab();
+			eventHandled = true;
+		} else if (event.equals(KeyCode.UpArrow) || event.equals(KeyCode.LeftArrow)) {
+			this.focusPreviousTab();
+			eventHandled = true;
+		}
+
+		if (eventHandled) {
+			event.preventDefault();
+			event.stopPropagation();
+		}
+	}
+
+	private focusPreviousTab(): void {
+		const currentIndex = this.focusedTabHeaderIndex;
+		if (currentIndex !== -1) {
+			// Move to the previous tab, if we are at the first tab then move to the last tab.
+			this.focusOnTabHeader(currentIndex === 0 ? this._tabHeaders.length - 1 : this.focusedTabHeaderIndex - 1);
+		}
+	}
+
+	private focusNextTab(): void {
+		const currentIndex = this.focusedTabHeaderIndex;
+		if (currentIndex !== -1) {
+			// Move to the next tab, if we are at the last tab then move to the first tab.
+			this.focusOnTabHeader(currentIndex === this._tabHeaders.length - 1 ? 0 : currentIndex + 1);
+		}
+	}
+
+	private focusOnTabHeader(index: number): void {
+		if (index >= 0 && index <= this._tabHeaders.length - 1) {
+			this._tabHeaders.toArray()[index].focusOnTabHeader();
+		}
+	}
+
+	private get focusedTabHeaderIndex(): number {
+		const headers = this._tabHeaders.toArray();
+		let idx = -1;
+		for (let i = 0; i < headers.length; i++) {
+			if (headers[i].nativeElement === document.activeElement) {
+				idx = i;
+			}
+		}
+		return idx;
 	}
 }

--- a/src/sql/base/browser/ui/panel/tabHeader.component.ts
+++ b/src/sql/base/browser/ui/panel/tabHeader.component.ts
@@ -19,8 +19,8 @@ import { CloseTabAction } from 'sql/base/browser/ui/panel/tabActions';
 @Component({
 	selector: 'tab-header',
 	template: `
-		<div #actionHeader role="presentation" class="tab-header" style="flex: 0 0; flex-direction: row; height: 100%" [class.active]="tab.active" tabindex="0" (click)="selectTab(tab)" (keyup)="onKey($event)">
-			<span class="tab" role="tab" [attr.aria-selected]="tab.active" [attr.aria-controls]="tab.title">
+		<div #actionHeader role="tab" [attr.aria-selected]="tab.active" [attr.aria-label]="tab.title" class="tab-header" style="flex: 0 0; flex-direction: row; height: 100%" [class.active]="tab.active" tabindex="0" (click)="selectTab(tab)" (keyup)="onKey($event)">
+			<span class="tab" role="presentation">
 				<div role="presentation">
 					<a #tabIcon></a>
 					<a class="tabLabel" [class.active]="tab.active" #tabLabel>
@@ -37,6 +37,7 @@ export class TabHeaderComponent extends Disposable implements AfterContentInit, 
 	@Input() public active?: boolean;
 	@Output() public onSelectTab: EventEmitter<TabComponent> = new EventEmitter<TabComponent>();
 	@Output() public onCloseTab: EventEmitter<TabComponent> = new EventEmitter<TabComponent>();
+	@Output() public onFocusTab: EventEmitter<TabComponent> = new EventEmitter<TabComponent>();
 
 	private _actionbar!: ActionBar;
 
@@ -47,6 +48,10 @@ export class TabHeaderComponent extends Disposable implements AfterContentInit, 
 
 	constructor() {
 		super();
+	}
+
+	public get nativeElement(): HTMLElement {
+		return this._actionHeaderRef.nativeElement;
 	}
 
 	ngAfterContentInit(): void {
@@ -66,11 +71,9 @@ export class TabHeaderComponent extends Disposable implements AfterContentInit, 
 			const tabIconContainer = this._tabIconRef.nativeElement as HTMLElement;
 			tabIconContainer.className = 'tabIcon codicon';
 			tabIconContainer.classList.add(this.tab.iconClass);
-			tabIconContainer.title = this.tab.title;
 		}
 
 		tabLabelContainer.textContent = this.tab.title;
-		tabLabelContainer.title = this.tab.title;
 	}
 
 	ngOnDestroy() {

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
@@ -27,12 +27,10 @@ registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) =
 
 			panel.dashboard-panel > .tabbedPanel.vertical > .title .tabList .tab-header.active {
 				background-color: ${tabActiveBackgroundVertical};
-				outline-color: ${tabActiveBackgroundVertical};
 			}
 
 			panel.dashboard-panel > .tabbedPanel.horizontal > .title .tabList .tab-header.active {
 				background-color: ${tabActiveBackground};
-				outline-color: ${tabActiveBackground};
 			}
 
 			panel.dashboard-panel > .tabbedPanel.horizontal > .title .tabList .tab-header.active {


### PR DESCRIPTION
fixes the following issues
1. VoiceOver reads the tab header as presentation
1. VoiceOver reads the tab name twice
1. Focus indicator not visible for focused tab header
1. Should be able to navigate between tabs using arrow keys