### PR TITLE
Fix Notebook Tokenization Warnings

### DIFF
--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -594,8 +594,8 @@ export class SQLFuture extends Disposable implements FutureInternal {
 		let i = 2;
 		for (const row of d.resultSubset.rows) {
 			let rowData = '<tr>';
-			for (let i = 0; i < columns.length; i++) {
-				rowData += `<td>${escape(row[i].displayValue)}</td>`;
+			for (let columnIndex = 0; columnIndex < columns.length; columnIndex++) {
+				rowData += `<td>${escape(row[columnIndex].displayValue)}</td>`;
 			}
 			rowData += '</tr>';
 			htmlStringArr[i] = rowData;

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -584,20 +584,18 @@ export class SQLFuture extends Disposable implements FutureInternal {
 		let htmlStringArr: string[] = new Array(d.resultSubset.rowCount + 3);
 		htmlStringArr[0] = '<table>';
 		if (columns.length > 0) {
-			let columnHeaders = '';
-			columnHeaders += '<tr>';
+			let columnHeaders = '<tr>';
 			for (let column of columns) {
-				columnHeaders += '<th>' + escape(column.columnName) + '</th>';
+				columnHeaders += `<th>${escape(column.columnName)}</th>`;
 			}
 			columnHeaders += '</tr>';
 			htmlStringArr[1] = columnHeaders;
 		}
 		let i = 2;
 		for (const row of d.resultSubset.rows) {
-			let rowData = '';
-			rowData += '<tr>';
+			let rowData = '<tr>';
 			for (let i = 0; i < columns.length; i++) {
-				rowData += '<td>' + escape(row[i].displayValue) + '</td>';
+				rowData += `<td>${escape(row[i].displayValue)}</td>`;
 			}
 			rowData += '</tr>';
 			htmlStringArr[i] = rowData;

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -579,24 +579,32 @@ export class SQLFuture extends Disposable implements FutureInternal {
 		};
 	}
 
-	private convertToHtmlTable(columns: IDbColumn[], d: QueryExecuteSubsetResult): string {
-		let htmlString = '<table>';
+	private convertToHtmlTable(columns: IDbColumn[], d: QueryExecuteSubsetResult): string[] {
+		// Adding 3 for <table>, column title rows, </table>
+		let htmlStringArr: string[] = new Array(d.resultSubset.rowCount + 3);
+		htmlStringArr[0] = '<table>';
 		if (columns.length > 0) {
-			htmlString += '<tr>';
+			let columnHeaders = '';
+			columnHeaders += '<tr>';
 			for (let column of columns) {
-				htmlString += '<th>' + escape(column.columnName) + '</th>';
+				columnHeaders += '<th>' + escape(column.columnName) + '</th>';
 			}
-			htmlString += '</tr>';
+			columnHeaders += '</tr>';
+			htmlStringArr[1] = columnHeaders;
 		}
+		let i = 2;
 		for (const row of d.resultSubset.rows) {
-			htmlString += '<tr>';
+			let rowData = '';
+			rowData += '<tr>';
 			for (let i = 0; i < columns.length; i++) {
-				htmlString += '<td>' + escape(row[i].displayValue) + '</td>';
+				rowData += '<td>' + escape(row[i].displayValue) + '</td>';
 			}
-			htmlString += '</tr>';
+			rowData += '</tr>';
+			htmlStringArr[i] = rowData;
+			i++;
 		}
-		htmlString += '</table>';
-		return htmlString;
+		htmlStringArr[htmlStringArr.length - 1] = '</table>';
+		return htmlStringArr;
 	}
 
 	private convertToDisplayMessage(msg: IResultMessage | string): nb.IIOPubMessage {


### PR DESCRIPTION
Fixes almost all cases of #7558.

When saving data from the SQL kernel, our HTML tables were all serialized on one line (e.g. <table><tr><th>blah.....</table>). If there was enough data, in the table (more than 20k characters by default), then users would see a warning around tokenization.

Also tested on Jupyter, and HTML table data was loaded as expected. I also saved a notebook with ADS, edited the JSON, removed the vnd.dataresource output, and the HTML table also loaded in ADS.

I suppose if row data includes more than 20k characters, the message will pop-up for them, but let's start here and decide if we need to refine this further.