### PR TITLE
Increase constrast ratio of input boxes in default light theme

### DIFF
--- a/extensions/theme-carbon/themes/light_carbon.json
+++ b/extensions/theme-carbon/themes/light_carbon.json
@@ -75,7 +75,7 @@
 		"tab.unfocusedInactiveForeground": "#888888",
 		"tab.unfocusedActiveForeground": "#212121",
 		"panel.background": "#ffffff",
-		"panel.border": "#c8c8c8",
+		"panel.border": "#888888",
 		"panelTitle.activeForeground": "#212121",
 		"panelTitle.inactiveForeground": "#757575",
 		"panelTitle.activeBorder": "#026dc8"

--- a/extensions/theme-carbon/themes/light_carbon.json
+++ b/extensions/theme-carbon/themes/light_carbon.json
@@ -31,7 +31,7 @@
 		//Dropdown Control
 		"dropdown.background": "#ffffff",
 		"dropdown.foreground": "#4a4a4a",
-		"dropdown.border": "#c8c8c8",
+		"dropdown.border": "#888888",
 
 		//badge
 		"badge.background": "#777777",
@@ -39,7 +39,7 @@
 
 		//Input Control
 		"input.background": "#ffffff",
-		"input.border": "#c8c8c8",
+		"input.border": "#888888",
 		"input.disabled.background": "#dcdcdc",
 		"input.disabled.foreground": "#888888",
 		"inputOption.activeBorder": "#666666",


### PR DESCRIPTION
Per accessibility team we need to meet 3:1 contrast ratio in default themes

Fixes #9205

![image](https://user-images.githubusercontent.com/28519865/77585537-df197900-6ea1-11ea-8640-49508b2ac70e.png)

