### PR TITLE
Clean up modal/options dialog disposable use

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -7,7 +7,7 @@ import { attachButtonStyler } from 'vs/platform/theme/common/styler';
 import { Color } from 'vs/base/common/color';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { mixin } from 'vs/base/common/objects';
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable, DisposableStore } from 'vs/base/common/lifecycle';
 import * as DOM from 'vs/base/browser/dom';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { generateUuid } from 'vs/base/common/uuid';
@@ -83,6 +83,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	protected _useDefaultMessageBoxLocation: boolean = true;
 	protected _messageElement: HTMLElement;
 	protected _modalOptions: IModalOptions;
+	protected readonly disposableStore = this._register(new DisposableStore());
 	private _detailsButtonContainer: HTMLElement;
 	private _messageIcon: HTMLElement;
 	private _messageSeverity: HTMLElement;
@@ -117,10 +118,6 @@ export abstract class Modal extends Disposable implements IThemable {
 	private _leftFooter: HTMLElement;
 	private _rightFooter: HTMLElement;
 	private _footerButtons: Button[];
-
-	private _keydownListener: IDisposable;
-	private _resizeListener: IDisposable;
-
 	private _backButton: Button;
 
 	private _modalShowingContext: IContextKey<Array<string>>;
@@ -359,7 +356,7 @@ export abstract class Modal extends Disposable implements IThemable {
 		DOM.append(this.layoutService.container, this._bodyContainer);
 		this.setInitialFocusedElement();
 
-		this._keydownListener = DOM.addDisposableListener(document, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+		this.disposableStore.add(DOM.addDisposableListener(document, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
 			let context = this._modalShowingContext.get()!;
 			if (context[context.length - 1] === this._staticKey) {
 				let event = new StandardKeyboardEvent(e);
@@ -373,10 +370,10 @@ export abstract class Modal extends Disposable implements IThemable {
 					this.handleForwardTab(e);
 				}
 			}
-		});
-		this._resizeListener = DOM.addDisposableListener(window, DOM.EventType.RESIZE, (e: Event) => {
+		}));
+		this.disposableStore.add(DOM.addDisposableListener(window, DOM.EventType.RESIZE, (e: Event) => {
 			this.layout(DOM.getTotalHeight(this._modalBodySection));
-		});
+		}));
 
 		this.layout(DOM.getTotalHeight(this._modalBodySection));
 		this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.ModalDialogOpened)
@@ -395,8 +392,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	protected hide() {
 		this._modalShowingContext.get()!.pop();
 		this._bodyContainer.remove();
-		this._keydownListener.dispose();
-		this._resizeListener.dispose();
+		this.disposableStore.clear();
 		this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.ModalDialogClosed)
 			.withAdditionalProperties({ name: this._name })
 			.send();
@@ -416,7 +412,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	 */
 	protected addFooterButton(label: string, onSelect: () => void, orientation: 'left' | 'right' = 'right'): Button {
 		let footerButton = DOM.$('.footer-button');
-		let button = new Button(footerButton);
+		let button = this._register(new Button(footerButton));
 		button.label = label;
 		button.onDidClick(() => onSelect()); // @todo this should be registered to dispose but that brakes some dialogs
 		if (orientation === 'left') {
@@ -618,7 +614,6 @@ export abstract class Modal extends Disposable implements IThemable {
 
 	public dispose() {
 		super.dispose();
-		this._keydownListener.dispose();
 		this._footerButtons = [];
 	}
 }

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -7,7 +7,7 @@ import { attachButtonStyler } from 'vs/platform/theme/common/styler';
 import { Color } from 'vs/base/common/color';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { mixin } from 'vs/base/common/objects';
-import { Disposable, IDisposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import * as DOM from 'vs/base/browser/dom';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { generateUuid } from 'vs/base/common/uuid';

--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -25,7 +25,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { append, $ } from 'vs/base/browser/dom';
+import { append, $, clearNode } from 'vs/base/browser/dom';
 import { IThemeService, IColorTheme } from 'vs/platform/theme/common/themeService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
@@ -163,7 +163,8 @@ export class OptionsDialog extends Modal {
 		for (let i = 0; i < options.length; i++) {
 			let option: azdata.ServiceOption = options[i];
 			let rowContainer = DialogHelper.appendRow(container, option.displayName, 'optionsDialog-label', 'optionsDialog-input');
-			OptionsDialogHelper.createOptionElement(option, rowContainer, this._optionValues, this._optionElements, this._contextViewService, (name) => this.onOptionLinkClicked(name));
+			const optionElement = OptionsDialogHelper.createOptionElement(option, rowContainer, this._optionValues, this._optionElements, this._contextViewService, (name) => this.onOptionLinkClicked(name));
+			this.disposableStore.add(optionElement.optionWidget);
 		}
 	}
 
@@ -175,12 +176,12 @@ export class OptionsDialog extends Modal {
 			switch (option.valueType) {
 				case ServiceOptionType.category:
 				case ServiceOptionType.boolean:
-					this._register(styler.attachSelectBoxStyler(<SelectBox>widget, this._themeService));
+					this.disposableStore.add(styler.attachSelectBoxStyler(<SelectBox>widget, this._themeService));
 					break;
 				case ServiceOptionType.string:
 				case ServiceOptionType.password:
 				case ServiceOptionType.number:
-					this._register(styler.attachInputBoxStyler(<InputBox>widget, this._themeService));
+					this.disposableStore.add(styler.attachInputBoxStyler(<InputBox>widget, this._themeService));
 			}
 		}
 	}
@@ -224,8 +225,8 @@ export class OptionsDialog extends Modal {
 	}
 
 	public close() {
-		this.dispose();
 		this.hide();
+		this._optionElements = {};
 		this._onCloseEvent.fire();
 	}
 
@@ -233,6 +234,7 @@ export class OptionsDialog extends Modal {
 		this._optionValues = optionValues;
 		let firstOption: string;
 		let categoryMap = OptionsDialogHelper.groupOptionsByCategory(options);
+		clearNode(this._optionGroupsContainer);
 		for (let category in categoryMap) {
 			const title = append(this._optionGroupsContainer, $('h2.option-category-title'));
 			title.innerText = category;
@@ -259,10 +261,6 @@ export class OptionsDialog extends Modal {
 
 	public dispose(): void {
 		super.dispose();
-		for (let optionName in this._optionElements) {
-			let widget: Widget = this._optionElements[optionName].optionWidget;
-			widget.dispose();
-			delete this._optionElements[optionName];
-		}
+		this._optionElements = {};
 	}
 }

--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -25,7 +25,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { append, $, clearNode } from 'vs/base/browser/dom';
+import { append, $ } from 'vs/base/browser/dom';
 import { IThemeService, IColorTheme } from 'vs/platform/theme/common/themeService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
@@ -234,7 +234,6 @@ export class OptionsDialog extends Modal {
 		this._optionValues = optionValues;
 		let firstOption: string;
 		let categoryMap = OptionsDialogHelper.groupOptionsByCategory(options);
-		clearNode(this._optionGroupsContainer);
 		for (let category in categoryMap) {
 			const title = append(this._optionGroupsContainer, $('h2.option-category-title'));
 			title.innerText = category;

--- a/src/sql/workbench/browser/modal/optionsDialogHelper.ts
+++ b/src/sql/workbench/browser/modal/optionsDialogHelper.ts
@@ -21,7 +21,7 @@ export interface IOptionElement {
 }
 
 export function createOptionElement(option: azdata.ServiceOption, rowContainer: HTMLElement, options: { [name: string]: any },
-	optionsMap: { [optionName: string]: IOptionElement }, contextViewService: IContextViewService, onFocus: (name) => void): void {
+	optionsMap: { [optionName: string]: IOptionElement }, contextViewService: IContextViewService, onFocus: (name) => void): IOptionElement {
 	let possibleInputs: string[] = [];
 	let optionValue = getOptionValueAndCategoryValues(option, options, possibleInputs);
 	let optionWidget: any;
@@ -63,8 +63,10 @@ export function createOptionElement(option: azdata.ServiceOption, rowContainer: 
 		}
 		inputElement = findElement(rowContainer, 'input');
 	}
-	optionsMap[option.name] = { optionWidget: optionWidget, option: option, optionValue: optionValue };
+	const optionElement = { optionWidget: optionWidget, option: option, optionValue: optionValue };
+	optionsMap[option.name] = optionElement;
 	inputElement.onfocus = () => onFocus(option.name);
+	return optionElement;
 }
 
 export function getOptionValueAndCategoryValues(option: azdata.ServiceOption, options: { [optionName: string]: any }, possibleInputs: string[]): any {


### PR DESCRIPTION
Cleaned up the disposable use in the Options and Modal dialog classes. There were a couple issues here : 

1. We were calling dispose on the hide function of the Options dialog, but then re-using the same object and just calling open again later which caused errors to be thrown about trying to add things to a disposed object (through _register). Instead made it follow the Modal dialog way and just changed it to only dispose the things that needed to be disposed of (such as temporary UI elements) when closed

2. Updated Modal to use DisposableStore instead of keeping track of temporary elements separately