### PR TITLE
Fix duplicate options in Advanced Options dialog

### DIFF
--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -25,7 +25,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { append, $ } from 'vs/base/browser/dom';
+import { append, $, clearNode } from 'vs/base/browser/dom';
 import { IThemeService, IColorTheme } from 'vs/platform/theme/common/themeService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
@@ -233,6 +233,7 @@ export class OptionsDialog extends Modal {
 		this._optionValues = optionValues;
 		let firstOption: string;
 		let categoryMap = OptionsDialogHelper.groupOptionsByCategory(options);
+		clearNode(this._optionGroupsContainer);
 		for (let category in categoryMap) {
 			const title = append(this._optionGroupsContainer, $('h2.option-category-title'));
 			title.innerText = category;


### PR DESCRIPTION
Fixes #9738

The fix here for that was to clear the body of existing child nodes before adding new ones. This logic was in there before, I just missed adding it back in during my refactor. 

![Capture](https://user-images.githubusercontent.com/28519865/77593444-71754900-6eb1-11ea-8d9e-3cb1c1297bd8.gif)


