### PR TITLE
Fix notebook command palette clauses

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -251,23 +251,23 @@
         },
         {
           "command": "notebook.command.runactivecell",
-          "when": "notebookEditorVisible"
+          "when": "activeEditor == workbench.editor.notebookEditor"
         },
         {
           "command": "notebook.command.clearactivecellresult",
-          "when": "notebookEditorVisible"
+          "when": "activeEditor == workbench.editor.notebookEditor"
         },
         {
           "command": "notebook.command.runallcells",
-          "when": "notebookEditorVisible"
+          "when": "activeEditor == workbench.editor.notebookEditor"
         },
         {
           "command": "notebook.command.addcode",
-          "when": "notebookEditorVisible"
+          "when": "activeEditor == workbench.editor.notebookEditor"
         },
         {
           "command": "notebook.command.addtext",
-          "when": "notebookEditorVisible"
+          "when": "activeEditor == workbench.editor.notebookEditor"
         },
         {
           "command": "notebook.command.addcell",


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/9318

The context key these are using were removed in https://github.com/microsoft/azuredatastudio/pull/9139/files#diff-d6b0380fdfb46feed80fd9c6628eb43dL181 and replaced with this new clause but these were missed.