### PR TITLE
Remove most CMS commands from palette

### DIFF
--- a/extensions/cms/package.json
+++ b/extensions/cms/package.json
@@ -618,6 +618,31 @@
           "when": "viewItem == cms.resource.itemType.databaseServerContainer",
           "group": "navigation@10"
         }
+      ],"commandPalette": [
+        {
+          "command": "cms.resource.addRegisteredServer",
+          "when": "false"
+        },
+        {
+          "command": "cms.resource.deleteRegisteredServer",
+          "when": "viewItem == cms.resource.itemType.databaseServer"
+        },
+        {
+          "command": "cms.resource.deleteServerGroup",
+          "when": "false"
+        },
+        {
+          "command": "cms.resource.addServerGroup",
+          "when": "false"
+        },
+        {
+          "command": "cms.resource.refresh",
+          "when": "false"
+        },
+        {
+          "command": "cms.resource.deleteCmsServer",
+          "when": "false"
+        }
       ]
     }
   },

--- a/extensions/cms/package.json
+++ b/extensions/cms/package.json
@@ -625,7 +625,7 @@
         },
         {
           "command": "cms.resource.deleteRegisteredServer",
-          "when": "viewItem == cms.resource.itemType.databaseServer"
+          "when": "false"
         },
         {
           "command": "cms.resource.deleteServerGroup",


### PR DESCRIPTION
The CMS commands were showing up in the palette, but as written most of them currently don't do anything when ran and so were just cluttering it up with generic names like "Delete".

The only one I left was "Add Central Management Server" since that will still function correctly.