### PR TITLE
Add required value validations for checkbox and dropdown

### DIFF
--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -105,9 +105,10 @@ export function createNumberInput(view: azdata.ModelView, info: { defaultValue?:
 	}).component();
 }
 
-export function createCheckbox(view: azdata.ModelView, info: { initialValue: boolean, label: string }): azdata.CheckBoxComponent {
+export function createCheckbox(view: azdata.ModelView, info: { initialValue: boolean, label: string, required?: boolean }): azdata.CheckBoxComponent {
 	return view.modelBuilder.checkBox().withProperties<azdata.CheckBoxProperties>({
 		checked: info.initialValue,
+		required: info.required,
 		label: info.label
 	}).component();
 }
@@ -119,6 +120,7 @@ export function createDropdown(view: azdata.ModelView, info: { defaultValue?: st
 		width: info.width,
 		editable: info.editable,
 		fireOnTextChange: true,
+		required: info.required,
 		ariaLabel: info.label
 	}).component();
 }
@@ -420,7 +422,7 @@ function processReadonlyTextField(context: FieldContext): void {
 }
 
 function processCheckboxField(context: FieldContext): void {
-	const checkbox = createCheckbox(context.view, { initialValue: context.fieldInfo.defaultValue! === 'true', label: context.fieldInfo.label });
+	const checkbox = createCheckbox(context.view, { initialValue: context.fieldInfo.defaultValue! === 'true', label: context.fieldInfo.label, required: context.fieldInfo.required });
 	context.components.push(checkbox);
 	context.onNewInputComponentCreated(context.fieldInfo.variableName!, checkbox);
 }

--- a/src/sql/workbench/browser/modelComponents/checkbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/checkbox.component.ts
@@ -32,7 +32,7 @@ export default class CheckBoxComponent extends ComponentBase implements ICompone
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef,
 		@Inject(IWorkbenchThemeService) private themeService: IWorkbenchThemeService,
-		@Inject(forwardRef(() => ElementRef)) el: ElementRef,) {
+		@Inject(forwardRef(() => ElementRef)) el: ElementRef) {
 		super(changeRef, el);
 	}
 
@@ -50,14 +50,16 @@ export default class CheckBoxComponent extends ComponentBase implements ICompone
 			this._input = new Checkbox(this._inputContainer.nativeElement, inputOptions);
 
 			this._register(this._input);
-			this._register(this._input.onChange(e => {
+			this._register(this._input.onChange(async e => {
 				this.checked = this._input.checked;
+				await this.validate();
 				this.fireEvent({
 					eventType: ComponentEventType.onDidChange,
 					args: e
 				});
 			}));
 			this._register(attachCheckboxStyler(this._input, this.themeService));
+			this._validations.push(() => !this.required || this.checked);
 		}
 	}
 
@@ -93,6 +95,7 @@ export default class CheckBoxComponent extends ComponentBase implements ICompone
 		if (this.required) {
 			this._input.required = this.required;
 		}
+		this.validate();
 	}
 
 	// CSS-bound properties

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -74,30 +74,34 @@ export default class DropDownComponent extends ComponentBase implements ICompone
 
 			this._register(this._editableDropdown);
 			this._register(attachEditableDropdownStyler(this._editableDropdown, this.themeService));
-			this._register(this._editableDropdown.onValueChange(e => {
+			this._register(this._editableDropdown.onValueChange(async e => {
 				if (this.editable) {
 					this.setSelectedValue(this._editableDropdown.value);
+					await this.validate();
 					this.fireEvent({
 						eventType: ComponentEventType.onDidChange,
 						args: e
 					});
 				}
 			}));
+			this._validations.push(() => !this.required || !this.editable || !!this._editableDropdown.value);
 		}
 		if (this._dropDownContainer) {
 			this._selectBox = new SelectBox(this.getValues(), this.getSelectedValue(), this.contextViewService, this._dropDownContainer.nativeElement);
 			this._selectBox.render(this._dropDownContainer.nativeElement);
 			this._register(this._selectBox);
 			this._register(attachSelectBoxStyler(this._selectBox, this.themeService));
-			this._register(this._selectBox.onDidSelect(e => {
+			this._register(this._selectBox.onDidSelect(async e => {
 				if (!this.editable) {
 					this.setSelectedValue(this._selectBox.value);
+					await this.validate();
 					this.fireEvent({
 						eventType: ComponentEventType.onDidChange,
 						args: e
 					});
 				}
 			}));
+			this._validations.push(() => !this.required || this.editable || !!this._selectBox.value);
 		}
 	}
 
@@ -139,6 +143,7 @@ export default class DropDownComponent extends ComponentBase implements ICompone
 
 		this._selectBox.selectElem.required = this.required;
 		this._editableDropdown.inputElement.required = this.required;
+		this.validate();
 	}
 
 	private getValues(): string[] {


### PR DESCRIPTION
This is primarily for resource deployment.

Most ModelView components aren't currently correctly hooked up for proper validation. This made it so dialogs which had the components marked as required weren't actually checking that and so the Ok/Next button would still be enabled.

Fixing this for dropdowns and checkboxes so that if they're required then they must have a value/be checked. Other components can be fixed up to do the checks as needed. 

Verified on both MIAA and PostgreSQL Deployment dialogs

Checkbox : 

![Capture](https://user-images.githubusercontent.com/28519865/77806548-42daa800-7042-11ea-8110-03fb8730f9fc.gif)

Dropdown disabled (note other fields are filled in correctly)

![image](https://user-images.githubusercontent.com/28519865/77806616-70bfec80-7042-11ea-9991-408f8a1d4c51.png)

Dropdown enabled 

![image](https://user-images.githubusercontent.com/28519865/77806682-977e2300-7042-11ea-9346-956213c15b48.png)
