### PR TITLE
Fix declarative table missing right border

### DIFF
--- a/src/sql/workbench/browser/modelComponents/media/declarativeTable.css
+++ b/src/sql/workbench/browser/modelComponents/media/declarativeTable.css
@@ -17,5 +17,5 @@
 
 .declarative-table-cell {
 	padding: 5px;
-	border-left: 1px solid;
+	border: 1px solid;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/9666

This was changed in https://github.com/microsoft/azuredatastudio/commit/19dec78349052ca831a589ac9a558baa218cac0f#diff-69a589c622a2a6a973d6f0879cd537d3R20. Likely a typo here that caused it to be left as border-left. 