### PR TITLE
add padding for toolbar container

### DIFF
--- a/src/sql/workbench/browser/modelComponents/media/toolbarLayout.css
+++ b/src/sql/workbench/browser/modelComponents/media/toolbarLayout.css
@@ -9,6 +9,7 @@
 	line-height: 1.4em;
 	white-space: nowrap;
 	flex-wrap: wrap;
+	padding: 3px 0px;
 }
 
 .modelview-toolbar-container.toolbar-horizontal {


### PR DESCRIPTION
the outline-offset for button is set to be 2px in vs code tree (all the buttons in VSCode and ADS behaves). adding 3px of top and bottom padding to the container to accommodate it.

This PR fixes #9792 

![Screen Shot 2020-03-30 at 4 40 00 PM](https://user-images.githubusercontent.com/13777222/77972133-64879980-72a5-11ea-85ba-fc0ae3c3ba26.png)
