### PR TITLE
We can't authenticate to every subscription

### DIFF
--- a/extensions/azurecore/src/azureResource/tree/accountTreeNode.ts
+++ b/extensions/azurecore/src/azureResource/tree/accountTreeNode.ts
@@ -79,6 +79,16 @@ export class AzureResourceAccountTreeNode extends AzureResourceContainerTreeNode
 			if (subscriptions.length === 0) {
 				return [AzureResourceMessageTreeNode.create(AzureResourceAccountTreeNode.noSubscriptionsLabel, this)];
 			} else {
+				// Filter out everything that we can't authenticate to.
+				subscriptions = subscriptions.filter(s => {
+					const token = tokens[s.id];
+					if (!token) {
+						console.info(`Account does not have permissions to view subscription ${JSON.stringify(s)}.`);
+						return false;
+					}
+					return true;
+				});
+
 				let subTreeNodes = await Promise.all(subscriptions.map(async (subscription) => {
 					const token = tokens[subscription.id];
 					const tenantId = await this._tenantService.getTenantId(subscription, this.account, new TokenCredentials(token.token, token.tokenType));


### PR DESCRIPTION
This PR fixes #9771 

Some subscriptions don't allow us to authenticate with them, causing issues in our code. I'm logging these subscriptions we're filtering out and I don't think this is the best solution, but at least if it happens to anyone we can dig deeper and understand whats going on with these subscriptions.

Special thanks to @chlafreniere for catching this bug and helping me debug it.