### PR TITLE
Connection widget dialog fix

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -698,7 +698,7 @@ export class ConnectionWidget extends lifecycle.Disposable {
 			if (this.authType === AuthenticationType.AzureMFA || this.authType === AuthenticationType.AzureMFAAndUser) {
 				this.fillInAzureAccountOptions().then(async () => {
 					let accountName = (this.authType === AuthenticationType.AzureMFA)
-						? connectionInfo.userName : connectionInfo.azureAccount;
+						? connectionInfo.azureAccount : connectionInfo.userName;
 					this._azureAccountDropdown.selectWithOptionName(this.getModelValue(accountName));
 					await this.onAzureAccountSelected();
 					let tenantId = connectionInfo.azureTenantId;


### PR DESCRIPTION
The connection widget wasn't selecting the correct linked account when the user had multiple accounts linked.