### PR TITLE
Update step when page is navigated to

### DIFF
--- a/src/sql/workbench/services/dialog/browser/dialogContainer.component.ts
+++ b/src/sql/workbench/services/dialog/browser/dialogContainer.component.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/dialogModal';
-import { Component, ViewChild, Inject, forwardRef, ElementRef, AfterViewInit } from '@angular/core';
+import { Component, ViewChild, Inject, forwardRef, ElementRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 import { ModelViewContent } from 'sql/workbench/browser/modelComponents/modelViewContent.component';
 import { DialogPane } from 'sql/workbench/services/dialog/browser/dialogPane';
 import { Event, Emitter } from 'vs/base/common/event';
@@ -50,6 +50,7 @@ export class DialogContainer implements AfterViewInit {
 	@ViewChild(ModelViewContent) private _modelViewContent: ModelViewContent;
 	constructor(
 		@Inject(forwardRef(() => ElementRef)) private _el: ElementRef,
+		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
 		@Inject(IBootstrapParams) private _params: DialogComponentParams) {
 		this.modelViewId = this._params.modelViewId;
 		this._params.onLayoutRequested(layoutParams => {
@@ -73,5 +74,6 @@ export class DialogContainer implements AfterViewInit {
 
 	public layout(): void {
 		this._modelViewContent.layout();
+		this._changeRef.detectChanges();
 	}
 }

--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -190,6 +190,7 @@ export class WizardModal extends Modal {
 		this._dialogPanes.forEach((dialogPane, page) => {
 			if (page === pageToShow) {
 				dialogPaneToShow = dialogPane;
+				dialogPane.layout(true);
 				dialogPane.show(focus);
 			} else {
 				dialogPane.hide();


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/7412

We weren't updating the container component when navigating to another page, this fixes that so modifying the page number will update the display accordingly. 