### PR TITLE
revert the changes impacting query editor and profiler editor

### DIFF
--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -18,7 +18,7 @@ panel {
 	width: 100%;
 }
 
-.tabbedPanel.horizontal>.title {
+.tabbedPanel .composite.title {
 	display: flex;
 	flex: 0 0 auto;
 	position: relative;
@@ -52,15 +52,33 @@ panel {
 	margin: auto;
 }
 
+.tabbedPanel.horizontal .tabList .tab .tabLabel {
+	font-size: 12px;
+	font-weight: normal;
+}
+
+.tabbedPanel.vertical .tabList .tab .tabLabel {
+	font-size: 12px;
+	padding-bottom: 0px;
+	font-weight: normal;
+}
+
+.tabbedPanel .tabList .tab .tabLabel {
+	font-size: 13px;
+	padding-bottom: 4px;
+	font-weight: 600;
+}
+
 .tabbedPanel .tabList .tab-header {
 	padding-left: 5px;
 	padding-right: 10px;
 	line-height: 35px;
 }
 
-.tabbedPanel.horizontal > .title .tabList .tab-header {
+.tabbedPanel .tabList .tab-header {
 	display: flex;
-	min-width: 80px;
+	padding-left: 5px;
+	padding-right: 5px;
 }
 
 .tabbedPanel.vertical > .title .tabList .tab-header {

--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 .tabbedPanel {
+	border-top-color: rgba(128, 128, 128, 0.35);
+	border-top-width: 1px;
+	border-top-style: solid;
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;

--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -70,20 +70,16 @@ panel {
 }
 
 .tabbedPanel .tabList .tab-header {
-	padding-left: 5px;
-	padding-right: 10px;
-	line-height: 35px;
-}
-
-.tabbedPanel .tabList .tab-header {
 	display: flex;
 	padding-left: 5px;
 	padding-right: 5px;
+	min-width: 65px;
 }
 
 .tabbedPanel.vertical > .title .tabList .tab-header {
 	display: block;
 	min-width: 150px;
+	line-height: 35px;
 }
 
 .tabbedPanel .tabList .tab .tabIcon.codicon {

--- a/src/sql/workbench/browser/modelComponents/media/tabbedPanel.css
+++ b/src/sql/workbench/browser/modelComponents/media/tabbedPanel.css
@@ -8,6 +8,10 @@
 	height: 100%;
 }
 
+.tabbedpanel-component .tabbedPanel {
+	border-top-width: 0px;
+}
+
 .tabbedpanel-component .tabbedPanel .tabContainer {
 	border-style: solid;
 	border-color: rgb(237, 235, 233);


### PR DESCRIPTION
this pr fixes #9841 

in my previous PR's i have updated the panel css, and didn't realize it impacts the query editor and profiler editor. these changes will revert the query editor's old behavior meanwhile make the dashboard look the same. I will review these styles and try to consolidate them later.
 
with the change:
<img width="963" alt="Screen Shot 2020-04-02 at 8 37 10 PM" src="https://user-images.githubusercontent.com/13777222/78321774-bf2d2980-7521-11ea-8fd2-1d69c4253a83.png">


offending PRs: https://github.com/microsoft/azuredatastudio/commit/41d21d799cc2adfdd38a85356eb3617b81d4b231#diff-9362485f5d7a7bebeb607a247cda813b

https://github.com/microsoft/azuredatastudio/commit/be83b31e378774ed14879fb1889c47422e68bea5#diff-9362485f5d7a7bebeb607a247cda813b
