### PR TITLE
Fix offset when scrolling to section

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -669,7 +669,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		let section = find(this.getSectionElements(), s => s.relativeUri && s.relativeUri.toLowerCase() === id);
 		if (section) {
 			// Scroll this section to the top of the header instead of just bringing header into view.
-			let scrollTop = jQuery(section.headerEl).offset().top;
+			let scrollTop = section.headerEl.offsetTop;
 			(<HTMLElement>this.container.nativeElement).scrollTo({
 				top: scrollTop,
 				behavior: 'smooth'


### PR DESCRIPTION
This PR fixes offset when navigating to a section on a notebook.

The current method gets the offset relative to the document, which makes the header title no longer visible when navigating to the section. 
We should get the offset relative to the parent node, instead.

