### PR TITLE
Update dashboard breadcrumb style to match mockups

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
@@ -63,3 +63,23 @@ dashboard-page .editor-toolbar {
 	border-bottom-style: solid;
 	padding: 3px 0;
 }
+
+.dashboardEditor breadcrumb .chevron-right.codicon {
+	background-size: 8px;
+}
+
+.vs-dark .dashboardEditor breadcrumb,
+.hc-black .dashboardEditor breadcrumb {
+	font-size: 13px;
+	color: #FFFFFF;
+}
+
+.dashboardEditor breadcrumb {
+	font-size: 13px;
+	color: #323130;
+}
+
+.dashboardEditor breadcrumb .router-link {
+	color: #2170DE;;
+}
+

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
@@ -68,15 +68,14 @@ dashboard-page .editor-toolbar {
 	background-size: 8px;
 }
 
-.vs-dark .dashboardEditor breadcrumb,
-.hc-black .dashboardEditor breadcrumb {
-	font-size: 13px;
-	color: #FFFFFF;
-}
-
 .dashboardEditor breadcrumb {
 	font-size: 13px;
 	color: #323130;
+}
+
+.vs-dark .dashboardEditor breadcrumb,
+.hc-black .dashboardEditor breadcrumb {
+	color: #FFFFFF;
 }
 
 .dashboardEditor breadcrumb .router-link {


### PR DESCRIPTION
Fixes these three issues:
![image](https://user-images.githubusercontent.com/31145923/78402375-52f90700-75af-11ea-823a-4946cd23f9be.png)

old: 
![image](https://user-images.githubusercontent.com/31145923/78402224-10cfc580-75af-11ea-8b11-cc4a8240dd85.png)

new:
![image](https://user-images.githubusercontent.com/31145923/78402103-e120bd80-75ae-11ea-91a5-006cf6e0c938.png)

