### PR TITLE
Turn-off connection dialog on 1st-launch

### DIFF
--- a/src/sql/workbench/browser/actions.contribution.ts
+++ b/src/sql/workbench/browser/actions.contribution.ts
@@ -33,7 +33,7 @@ Registry.as<IConfigurationRegistry>(ConfigExtensions.Configuration).registerConf
 	'properties': {
 		'workbench.showConnectDialogOnStartup': {
 			'type': 'boolean',
-			'default': true,
+			'default': false,
 			'description': nls.localize('showConnectDialogOnStartup', "Show connect dialog on startup")
 		}
 	}


### PR DESCRIPTION
No longer show the connection dialog on 1st launch since we have a new Welcome page that has a better experience, including a prominent "Create Connection" button.

*Current 1st Launch*
<img width="1193" alt="Screen Shot 2020-04-03 at 6 46 19 PM" src="https://user-images.githubusercontent.com/599935/78416173-dcbec980-75db-11ea-8d7c-0c807cd75b6a.png">

*Proposed 1st Launch*
<img width="1192" alt="Screen Shot 2020-04-03 at 6 47 08 PM" src="https://user-images.githubusercontent.com/599935/78416175-e0525080-75db-11ea-9700-28bdb9e568e5.png">
 