### PR TITLE
Alanren/refresh widgets new

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/containers/dashboardHomeContainer.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/containers/dashboardHomeContainer.component.ts
@@ -69,4 +69,9 @@ export class DashboardHomeContainer extends DashboardWidgetContainer {
 			this._scrollable.layout();
 		}
 	}
+
+	public refresh(): void {
+		super.refresh();
+		this._propertiesClass.refresh();
+	}
 }

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardWidget.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardWidget.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { InjectionToken, OnDestroy } from '@angular/core';
+import { InjectionToken, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { NgGridItemConfig } from 'angular2-grid';
 import { Action } from 'vs/base/common/actions';
 import { Disposable } from 'vs/base/common/lifecycle';
@@ -63,6 +63,12 @@ export interface TabSettingConfig {
 
 export abstract class DashboardWidget extends Disposable implements OnDestroy {
 	protected _config: WidgetConfig;
+	protected _loading: boolean;
+	protected _inited: boolean = false;
+
+	constructor(protected _changeRef: ChangeDetectorRef) {
+		super();
+	}
 
 	get actions(): Array<Action> {
 		return [];
@@ -70,5 +76,12 @@ export abstract class DashboardWidget extends Disposable implements OnDestroy {
 
 	ngOnDestroy() {
 		this.dispose();
+	}
+
+	protected setLoadingStatus(loading: boolean): void {
+		this._loading = loading;
+		if (this._inited) {
+			this._changeRef.detectChanges();
+		}
 	}
 }

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardWidget.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardWidget.ts
@@ -65,6 +65,8 @@ export abstract class DashboardWidget extends Disposable implements OnDestroy {
 	protected _config: WidgetConfig;
 	protected _loading: boolean;
 	protected _inited: boolean = false;
+	protected _loadingMessage: string;
+	protected _loadingCompletedMessage: string;
 
 	constructor(protected _changeRef: ChangeDetectorRef) {
 		super();

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.html
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.html
@@ -4,11 +4,12 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 -->
-<div class="explorer-widget" style="display: flex; flex-flow: column; position: absolute; height:100%; width:100%; padding: 10px; box-sizing: border-box">
+<div class="explorer-widget"
+	style="display: flex; flex-flow: column; position: absolute; height:100%; width:100%; padding: 10px; box-sizing: border-box">
 	<div #input style="width: 100%"></div>
 	<div style="flex: 1 1 auto; position: relative">
-		<loading-spinner [loading]="loading" [loadingMessage]="loadingMessage"
-			[loadingCompletedMessage]="loadingCompletedMessage"></loading-spinner>
+		<loading-spinner [loading]="_loading" [loadingMessage]="_loadingMessage"
+			[loadingCompletedMessage]="_loadingCompletedMessage"></loading-spinner>
 		<div #table style="position: absolute; height: 100%; width: 100%"></div>
 	</div>
 </div>

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
@@ -47,8 +47,6 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 	private _treeDataSource = new ExplorerDataSource();
 	private _treeFilter = new ExplorerFilter();
 
-	private _inited = false;
-	public loading: boolean = false;
 	public loadingMessage: string;
 	public loadingCompletedMessage: string;
 
@@ -64,9 +62,9 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 		@Inject(IContextViewService) private readonly contextViewService: IContextViewService,
 		@Inject(IInstantiationService) private readonly instantiationService: IInstantiationService,
 		@Inject(ICapabilitiesService) private readonly capabilitiesService: ICapabilitiesService,
-		@Inject(forwardRef(() => ChangeDetectorRef)) private readonly _cd: ChangeDetectorRef
+		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef
 	) {
-		super();
+		super(changeRef);
 		this.loadingMessage = this._config.context === 'database' ? nls.localize('loadingObjects', "loading objects") : nls.localize('loadingDatabases', "loading databases");
 		this.loadingCompletedMessage = this._config.context === 'database' ? nls.localize('loadingObjectsCompleted', "loading objects completed.") : nls.localize('loadingDatabasesCompleted', "loading databases completed.");
 		this.init();
@@ -164,14 +162,6 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 	public layout(): void {
 		if (this._inited) {
 			this._tree.layout(getContentHeight(this._tableContainer.nativeElement));
-		}
-	}
-
-	private setLoadingStatus(loading: boolean): void {
-		this.loading = loading;
-
-		if (this._inited) {
-			this._cd.detectChanges();
 		}
 	}
 

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
@@ -47,9 +47,6 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 	private _treeDataSource = new ExplorerDataSource();
 	private _treeFilter = new ExplorerFilter();
 
-	public loadingMessage: string;
-	public loadingCompletedMessage: string;
-
 	@ViewChild('input') private _inputContainer: ElementRef;
 	@ViewChild('table') private _tableContainer: ElementRef;
 
@@ -65,8 +62,8 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef
 	) {
 		super(changeRef);
-		this.loadingMessage = this._config.context === 'database' ? nls.localize('loadingObjects', "loading objects") : nls.localize('loadingDatabases', "loading databases");
-		this.loadingCompletedMessage = this._config.context === 'database' ? nls.localize('loadingObjectsCompleted', "loading objects completed.") : nls.localize('loadingDatabasesCompleted', "loading databases completed.");
+		this._loadingMessage = this._config.context === 'database' ? nls.localize('loadingObjects', "loading objects") : nls.localize('loadingDatabases', "loading databases");
+		this._loadingCompletedMessage = this._config.context === 'database' ? nls.localize('loadingObjectsCompleted', "loading objects completed.") : nls.localize('loadingDatabasesCompleted', "loading databases completed.");
 		this.init();
 	}
 

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component.ts
@@ -217,12 +217,8 @@ export class InsightsWidget extends DashboardWidget implements IDashboardWidget,
 
 	public refresh(): void {
 		this._runQuery().then(
-			result => {
-				this._updateChild(result);
-			},
-			error => {
-				this.showError(error);
-			}
+			result => this._updateChild(result),
+			error => this.showError(error)
 		);
 	}
 

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.html
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.html
@@ -4,7 +4,9 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 -->
-<div #parent style="position: absolute; height: 100%; width: 100%;">
+<loading-spinner [loading]="_loading" [loadingMessage]="_loadingMessage"
+	[loadingCompletedMessage]="_loadingCompletedMessage"></loading-spinner>
+<div #parent style="position: absolute; height: 100%; width: 100%;" [style.display]="_loading ? 'none':'block'">
 	<div #container [style.margin-right.px]="_clipped ? 30 : 0" [style.width]="_clipped ? 94 + '%' : '100%'" style="overflow: hidden; padding-bottom: 10px">
 		<span #child style="white-space : nowrap; width: fit-content">
 			<ng-template ngFor let-item [ngForOf]="properties">

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
@@ -68,7 +68,6 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 	private _databaseInfo: DatabaseInfo;
 	public _clipped: boolean;
 	private properties: Array<DisplayProperty>;
-	private _hasInit = false;
 
 	@ViewChild('child', { read: ElementRef }) private _child: ElementRef;
 	@ViewChild('parent', { read: ElementRef }) private _parent: ElementRef;
@@ -76,18 +75,18 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 
 	constructor(
 		@Inject(forwardRef(() => CommonServiceInterface)) private _bootstrap: CommonServiceInterface,
-		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
+		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef,
 		@Inject(forwardRef(() => ElementRef)) private _el: ElementRef,
 		@Inject(WIDGET_CONFIG) protected _config: WidgetConfig,
 		@Inject(ILogService) private logService: ILogService,
 		@Inject(IWorkbenchThemeService) private themeService: IWorkbenchThemeService
 	) {
-		super();
+		super(changeRef);
 		this.init();
 	}
 
 	ngOnInit() {
-		this._hasInit = true;
+		this._inited = true;
 		this._register(addDisposableListener(window, EventType.RESIZE, () => this.handleClipping()));
 		this._changeRef.detectChanges();
 
@@ -110,7 +109,7 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 			this._databaseInfo = data;
 			this._changeRef.detectChanges();
 			this.parseProperties();
-			if (this._hasInit) {
+			if (this._inited) {
 				this.handleClipping();
 			}
 		}, error => {
@@ -238,7 +237,7 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 			this.properties.push(<DisplayProperty>assignProperty);
 		}
 
-		if (this._hasInit) {
+		if (this._inited) {
 			this._changeRef.detectChanges();
 		}
 	}

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
@@ -82,6 +82,8 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 		@Inject(IWorkbenchThemeService) private themeService: IWorkbenchThemeService
 	) {
 		super(changeRef);
+		this._loadingMessage = nls.localize('loadingProperties', "Loading properties");
+		this._loadingCompletedMessage = nls.localize('loadingPropertiesCompleted', "Loading properties completed");
 		this.init();
 	}
 
@@ -105,6 +107,7 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 
 	private init(): void {
 		this._connection = this._bootstrap.connectionManagementService.connectionInfo;
+		this.setLoadingStatus(true);
 		this._register(subscriptionToDisposable(this._bootstrap.adminService.databaseInfo.subscribe(data => {
 			this._databaseInfo = data;
 			this._changeRef.detectChanges();
@@ -112,7 +115,9 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 			if (this._inited) {
 				this.handleClipping();
 			}
+			this.setLoadingStatus(false);
 		}, error => {
+			this.setLoadingStatus(false);
 			(<HTMLElement>this._el.nativeElement).innerText = nls.localize('dashboard.properties.error', "Unable to load dashboard properties");
 		})));
 	}

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/webview/webviewWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/webview/webviewWidget.component.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Component, Inject, forwardRef, OnInit, ElementRef } from '@angular/core';
+import { Component, Inject, forwardRef, OnInit, ElementRef, ChangeDetectorRef } from '@angular/core';
 
 import { Event, Emitter } from 'vs/base/common/event';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -41,9 +41,10 @@ export class WebviewWidget extends DashboardWidget implements IDashboardWidget, 
 		@Inject(WIDGET_CONFIG) protected readonly _config: WidgetConfig,
 		@Inject(forwardRef(() => ElementRef)) private readonly _el: ElementRef,
 		@Inject(IDashboardViewService) private readonly dashboardViewService: IDashboardViewService,
-		@Inject(IWebviewService) private readonly webviewService: IWebviewService
+		@Inject(IWebviewService) private readonly webviewService: IWebviewService,
+		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef
 	) {
-		super();
+		super(changeRef);
 		this._id = (_config.widget[selector] as IWebviewWidgetConfig).id;
 	}
 


### PR DESCRIPTION
refresh indicator for all widget types, the loading status will be shown on initial load and subsequent refreshes.

<img width="1330" alt="Screen Shot 2020-04-04 at 11 33 11 PM" src="https://user-images.githubusercontent.com/13777222/78468410-b88ee580-76cc-11ea-80ad-662cf0c16596.png">
<img width="1175" alt="Screen Shot 2020-04-04 at 11 33 02 PM" src="https://user-images.githubusercontent.com/13777222/78468411-ba58a900-76cc-11ea-83ab-a1f9d9ee4ed1.png">

I am targeting my other branch because this PR is based on the removal of tasks widget