### PR TITLE
Notebooks: Remove Unnecessary Rewrite Code, Add Tests

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -536,12 +536,10 @@ export class CellModel implements ICellModel {
 							let host = hostAndIp.host ? hostAndIp.host : model.context.serverName;
 							let port = hostAndIp.port ? ':' + hostAndIp.port : defaultPort;
 							let html = result.data['text/html'];
-							// CTP 3.1 and earlier Spark link
-							html = this.rewriteUrlUsingRegex(/(https?:\/\/master.*\/proxy)(.*)/g, html, host, port, yarnUi);
-							// CTP 3.2 and later spark link
-							html = this.rewriteUrlUsingRegex(/(https?:\/\/sparkhead.*\/proxy)(.*)/g, html, host, port, yarnUi);
+							// BDC Spark UI Link
+							html = notebookUtils.rewriteUrlUsingRegex(/(https?:\/\/sparkhead.*\/proxy)(.*)/g, html, host, port, yarnUi);
 							// Driver link
-							html = this.rewriteUrlUsingRegex(/(https?:\/\/storage.*\/containerlogs)(.*)/g, html, host, port, driverLog);
+							html = notebookUtils.rewriteUrlUsingRegex(/(https?:\/\/storage.*\/containerlogs)(.*)/g, html, host, port, driverLog);
 							(<nb.IDisplayResult>output).data['text/html'] = html;
 						}
 					}
@@ -550,19 +548,6 @@ export class CellModel implements ICellModel {
 			catch (e) { }
 		}
 		return output;
-	}
-
-	private rewriteUrlUsingRegex(regex: RegExp, html: string, host: string, port: string, target: string): string {
-		return html.replace(regex, function (a, b, c) {
-			let ret = '';
-			if (b !== '') {
-				ret = 'https://' + host + port + target;
-			}
-			if (c !== '') {
-				ret = ret + c;
-			}
-			return ret;
-		});
 	}
 
 	public setStdInHandler(handler: nb.MessageHandler<nb.IStdinMessage>): void {

--- a/src/sql/workbench/services/notebook/browser/models/notebookUtils.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookUtils.ts
@@ -110,6 +110,19 @@ export function getHostAndPortFromEndpoint(endpoint: string): HostAndIp {
 	};
 }
 
+export function rewriteUrlUsingRegex(regex: RegExp, html: string, host: string, port: string, target: string): string {
+	return html.replace(regex, function (a, b, c) {
+		let ret = '';
+		if (b !== '') {
+			ret = 'https://' + host + port + target;
+		}
+		if (c !== '') {
+			ret = ret + c;
+		}
+		return ret;
+	});
+}
+
 export interface RawEndpoint {
 	serviceName: string;
 	description?: string;


### PR DESCRIPTION
Noticed that we had some code that we don't need anymore (references to an old CTP for rewriting Spark URLs in notebooks). Tested with the latest CU bits, and the URLs are being rewritten as expected to the external endpoints.

Took the opportunity to refactor a method into the notebookUtils class and just did a couple of quick test cases based on some real-world inputs. I realize it's not exhaustive, but it's a good start.