### PR TITLE
Change active tab to have full outline for high contrast

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
@@ -43,11 +43,13 @@ registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) =
 		`);
 	}
 
-	const activeTabBorderColor = theme.type === HIGH_CONTRAST ? theme.getColor(activeContrastBorder) : theme.getColor(TAB_ACTIVE_BORDER);
-	if (activeTabBorderColor) {
+	const highContrastActiveTabBorderColor = theme.getColor(activeContrastBorder);
+	if (highContrastActiveTabBorderColor) {
 		collector.addRule(`
 			panel.dashboard-panel > .tabbedPanel > .title .tabList .tab-header.active {
-				box-shadow: ${activeTabBorderColor} 0 -1px inset;
+				outline: 1px solid;
+				outline-offset: -3px;
+				outline-color: ${highContrastActiveTabBorderColor};
 			}
 		`);
 	}

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPanelStyles.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./dashboardPanel';
-import { registerThemingParticipant, IColorTheme, ICssStyleCollector, HIGH_CONTRAST } from 'vs/platform/theme/common/themeService';
+import { registerThemingParticipant, IColorTheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
 import {
-	TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_ACTIVE_BORDER, TAB_INACTIVE_BACKGROUND,
+	TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_BACKGROUND,
 	TAB_INACTIVE_FOREGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND, TAB_BORDER, EDITOR_GROUP_BORDER, DASHBOARD_TAB_ACTIVE_BACKGROUND, DASHBOARD_BORDER
 } from 'vs/workbench/common/theme';
 import { activeContrastBorder } from 'vs/platform/theme/common/colorRegistry';


### PR DESCRIPTION
This fixes: 
![image](https://user-images.githubusercontent.com/31145923/78719630-16901880-78d9-11ea-8df1-8a906216dc41.png)

When navigating using arrow keys, there isn't a second border around the tab. 

Full outline for active tabs (picture looks better when you click on it):
![image](https://user-images.githubusercontent.com/31145923/78719917-928a6080-78d9-11ea-800d-d7a0c97a4f6a.png)


