### PR TITLE
pre-defined dashboard tab groups

### DIFF
--- a/extensions/agent/package.json
+++ b/extensions/agent/package.json
@@ -32,6 +32,7 @@
         "description": "Manage and troubleshoot SQL Agent jobs",
         "provider": "MSSQL",
         "title": "SQL Agent",
+        "group": "administration",
         "when": "connectionProvider == 'MSSQL' && !mssql:iscloud && mssql:engineedition != 11 && dashboardContext == 'server'",
         "container": {
           "controlhost-container": {
@@ -91,7 +92,7 @@
     "vscodetestcover": "github:corivera/vscodetestcover#1.0.5"
   },
   "resolutions": {
-      "esprima": "^4.0.0"
+    "esprima": "^4.0.0"
   },
   "__metadata": {
     "id": "10",

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -444,6 +444,7 @@
         "description": "%tab.bigDataClusterDescription%",
         "provider": "MSSQL",
         "title": "%title.bigDataCluster%",
+        "group": "monitoring",
         "when": "connectionProvider == 'MSSQL' && mssql:iscluster && dashboardContext == 'server'",
         "container": {
           "grid-container": [

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution.ts
@@ -17,6 +17,7 @@ import { GRID_CONTAINER, validateGridContainerContribution } from 'sql/workbench
 import { values } from 'vs/base/common/collections';
 import { IUserFriendlyIcon } from 'sql/workbench/contrib/dashboard/browser/core/dashboardWidget';
 import { isValidIcon, createCSSRuleForIcon } from 'sql/workbench/contrib/dashboard/browser/dashboardIconUtil';
+import { IDashboardTabGroup } from 'sql/workbench/services/dashboard/browser/common/interfaces';
 
 export interface IDashboardTabContrib {
 	id: string;
@@ -29,11 +30,6 @@ export interface IDashboardTabContrib {
 	isHomeTab?: boolean;
 	group?: string;
 	icon?: IUserFriendlyIcon;
-}
-
-export interface IDashboardTabGroupContrib {
-	id: string;
-	title: string;
 }
 
 const tabSchema: IJSONSchema = {
@@ -184,56 +180,26 @@ ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabCo
 	}
 });
 
-const tabGroupSchema: IJSONSchema = {
-	type: 'object',
-	properties: {
-		id: {
-			type: 'string',
-			description: localize('azdata.extension.contributes.dashboard.tabGroup.id', "Unique identifier for this tab group.")
-		},
-		title: {
-			type: 'string',
-			description: localize('azdata.extension.contributes.dashboard.tabGroup.title', "Title of the tab group.")
-		}
+const TabGroups: IDashboardTabGroup[] = [
+	{
+		id: 'administration',
+		title: localize('administrationTabGroup', "Administration")
+	}, {
+		id: 'monitoring',
+		title: localize('monitoringTabGroup', "Monitoring")
+	}, {
+		id: 'performance',
+		title: localize('performanceTabGroup', "Performance")
+	}, {
+		id: 'security',
+		title: localize('securityTabGroup', "Security")
+	}, {
+		id: 'troubleshooting',
+		title: localize('troubleshootingTabGroup', "Troubleshooting")
+	}, {
+		id: 'settings',
+		title: localize('settingsTabGroup', "Settings")
 	}
-};
+];
 
-const tabGroupContributionSchema: IJSONSchema = {
-	description: localize('azdata.extension.contributes.tabGroups', "Contributes a single or multiple tab groups for users to add to their dashboard."),
-	oneOf: [
-		tabGroupSchema,
-		{
-			type: 'array',
-			items: tabGroupSchema
-		}
-	]
-};
-
-ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabContrib[]>({ extensionPoint: 'dashboard.tabGroups', jsonSchema: tabGroupContributionSchema }).setHandler(extensions => {
-
-	function handleTabGroup(tabgroup: IDashboardTabGroupContrib, extension: IExtensionPointUser<any>) {
-		let { id, title } = tabgroup;
-
-		if (!id) {
-			extension.collector.error(localize('dashboardTabGroup.contribution.noIdError', "No id specified for tab group."));
-			return;
-		}
-
-		if (!title) {
-			extension.collector.error(localize('dashboardTabGroup.contribution.noTitleError', "No title specified for tab group."));
-			return;
-		}
-		registerTabGroup({ id, title });
-	}
-
-	for (const extension of extensions) {
-		const { value } = extension;
-		if (Array.isArray<IDashboardTabGroupContrib>(value)) {
-			for (const command of value) {
-				handleTabGroup(command, extension);
-			}
-		} else {
-			handleTabGroup(value, extension);
-		}
-	}
-});
+TabGroups.forEach(tabGroup => registerTabGroup(tabGroup));

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution.ts
@@ -239,8 +239,10 @@ ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabCo
 	}
 });
 
-// Pre-defined tab groups
-const TabGroups: IDashboardTabGroup[] = [
+/**
+ * Predefined tab groups
+ */
+const PredefinedTabGroups: IDashboardTabGroup[] = [
 	{
 		id: 'administration',
 		title: localize('administrationTabGroup', "Administration")
@@ -262,4 +264,4 @@ const TabGroups: IDashboardTabGroup[] = [
 	}
 ];
 
-TabGroups.forEach(tabGroup => registerTabGroup(tabGroup));
+PredefinedTabGroups.forEach(tabGroup => registerTabGroup(tabGroup));


### PR DESCRIPTION
in our review meeting, we decided not to allow contribution of the custom tab group, instead, we will predefine the groups/categories. I got this list from @hannahqin , and updated the group of Agent extension. Update to the whoisactive and server reports will be in separate PRs.

<img width="1151" alt="Screen Shot 2020-04-08 at 9 54 52 PM" src="https://user-images.githubusercontent.com/13777222/78859230-97d3d200-79e3-11ea-920a-a90019c6987f.png">
