### PR TITLE
fix dashboard tab style

### DIFF
--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -80,7 +80,8 @@ panel {
 	display: block;
 	min-width: 150px;
 	line-height: 35px;
-	padding-left: 22px;
+	padding-left: 24px;
+	padding-right: 24px;
 }
 
 .tabbedPanel .tabList .tab .tabIcon.codicon {


### PR DESCRIPTION
to match the mock up.

**before**
<img width="1231" alt="Screen Shot 2020-04-08 at 10 07 55 PM" src="https://user-images.githubusercontent.com/13777222/78859900-9c00ef00-79e5-11ea-9870-fa820f417378.png">

**after**
<img width="1155" alt="Screen Shot 2020-04-08 at 10 06 25 PM" src="https://user-images.githubusercontent.com/13777222/78859892-999e9500-79e5-11ea-875c-5abe36e7e0da.png">
