### PR TITLE
bump sqltoolsservice to 2.0.0-release.56

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "2.0.0-release.53",
+	"version": "2.0.0-release.56",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",


### PR DESCRIPTION
includes these 3 changes:
[Fix default test server names file path construction (#941)](https://github.com/microsoft/sqltoolsservice/commit/1cb0b98148201da54a82a0a27313d14d941cdd4a)
[Fix to not add parens for global variable built in functions (#940)](https://github.com/microsoft/sqltoolsservice/commit/7d37de218a04c33ae0bda758305f2f90766f7063)
[bump DacFx nuget package (#942)](https://github.com/microsoft/sqltoolsservice/commit/bf6c573e7bb42b695c74a11bca3e32901c9f51eb)