### PR TITLE
Ignore jpgs for whitespace check

### DIFF
--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -97,7 +97,7 @@ const indentationFilter = [
 	'!extensions/markdown-language-features/media/*.js',
 	// {{SQL CARBON EDIT}}
 	'!build/actions/**/dist/*',
-	'!**/*.{xlf,docx,sql,vsix,bacpac,ipynb}',
+	'!**/*.{xlf,docx,sql,vsix,bacpac,ipynb,jpg}',
 	'!extensions/mssql/sqltoolsservice/**',
 	'!extensions/import/flatfileimportservice/**',
 	'!extensions/admin-tool-ext-win/ssmsmin/**',


### PR DESCRIPTION
Specifically for https://github.com/microsoft/azuredatastudio/blob/master/docs/overview_screen.jpg, but we should be ignoring all JPGs anyways. 