### PR TITLE
fix bottom of dashboard widgets being cutoff

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
@@ -129,6 +129,7 @@ export class DashboardWidgetWrapper extends AngularDisposable implements OnInit 
 				this._collapseAction = this.instantiationService.createInstance(CollapseWidgetAction, this._bootstrap.getUnderlyingUri(), this.guid, this.collapsed);
 				if (this.bottomCollapse) {
 					this._bottomActionbar.push(this._collapseAction, { icon: true, label: false });
+					this._bottomActionbarRef.nativeElement.style.display = 'block';
 				} else {
 					this._actionbar.push(this._collapseAction, { icon: true, label: false });
 				}

--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.css
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.css
@@ -48,4 +48,5 @@ dashboard-widget-wrapper .bottomActionbar {
 	flex: 0 0 auto;
 	align-self: center;
 	margin-top: -28px;
+	display: none;
 }


### PR DESCRIPTION
The bottom of dashboard widgets got cutoff after the collapse was moved to the bottom for properties widget. This fixes it by hiding the bottom toolbar for collapse when there isn't a bottom collapse.

cutoff bottom on database size widget:
![image](https://user-images.githubusercontent.com/31145923/79016830-c4dbce00-7b24-11ea-920f-2312b991dd22.png)

fixed:
![image](https://user-images.githubusercontent.com/31145923/79016845-cefdcc80-7b24-11ea-91a8-f2329755b28f.png)


