### PR TITLE
Center properties widget title when collapsed

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.css
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.css
@@ -47,6 +47,6 @@ dashboard-widget-wrapper .actionbar {
 dashboard-widget-wrapper .bottomActionbar {
 	flex: 0 0 auto;
 	align-self: center;
-	margin-top: -28px;
+	margin-top: -27px;
 	display: none;
 }

--- a/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.component.ts
@@ -35,7 +35,7 @@ export class DatabaseDashboardPage extends DashboardPage implements OnInit {
 		background_color: colors.editorBackground,
 		border: 'none',
 		fontSize: '14px',
-		padding: '5px 0 0 0',
+		padding: '2px 0 0 0',
 		provider: undefined,
 		edition: undefined
 	};

--- a/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.component.ts
@@ -37,7 +37,7 @@ export class ServerDashboardPage extends DashboardPage implements OnInit {
 		background_color: colors.editorBackground,
 		border: 'none',
 		fontSize: '14px',
-		padding: '5px 0 0 0',
+		padding: '2px 0 0 0',
 		provider: undefined,
 		edition: undefined
 	};


### PR DESCRIPTION
Remove some padding to vertically center properties widget title when collapsed

before:
![image](https://user-images.githubusercontent.com/31145923/79023427-2c9a1500-7b35-11ea-9e76-61789515c80d.png)

after:
![image](https://user-images.githubusercontent.com/31145923/79023345-f6f52c00-7b34-11ea-9321-def93b068974.png)
