### PR TITLE
more dashboard fixes

### DIFF
--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -41,7 +41,6 @@ panel {
 	margin: 0 auto;
 	padding: 0;
 	justify-content: flex-start;
-	line-height: 35px;
 	white-space: nowrap;
 	flex: 1;
 	height: 100%;
@@ -73,9 +72,10 @@ panel {
 
 .tabbedPanel.horizontal > .title .tabList .tab .tabLabel,
 .tabbedPanel.vertical > .title .tabList .tab .tabLabel {
-	max-width: 150px;
+	max-width: 250px;
 	text-overflow: ellipsis;
 	overflow: hidden;
+	border: 0px;
 }
 
 .tabbedPanel .tabList .tab-header {
@@ -146,10 +146,16 @@ panel {
 
 .tabbedPanel.vertical>.title > .tabContainer .tabList {
 	flex-flow: column;
+	height: calc(100% - 35px);
+	overflow: auto;
+	line-height: 35px;
 }
 
 .tabbedPanel.horizontal > .title > .tabContainer .tabList {
 	flex-flow: row;
+	width: 100%;
+	overflow: auto;
+	line-height: 35px;
 }
 
 .tabbedPanel > .title > .tabContainer > .monaco-scrollable-element {

--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -24,7 +24,7 @@ panel {
 	position: relative;
 }
 
-.tabbedPanel.vertical>.title {
+.tabbedPanel.vertical > .title {
 	flex: 0 0 auto;
 	flex-direction: column;
 	height: 100%;
@@ -53,15 +53,15 @@ panel {
 	flex-flow: row;
 }
 
-.tabbedPanel.horizontal .tabList .tab .tabLabel {
+.tabbedPanel.horizontal > .title .tabList .tab .tabLabel {
 	font-size: 12px;
-	font-weight: normal;
+	max-width: 100px;
 }
 
-.tabbedPanel.vertical .tabList .tab .tabLabel {
+.tabbedPanel.vertical >.title .tabList .tab .tabLabel {
 	font-size: 13px;
 	padding-bottom: 0px;
-	font-weight: normal;
+	max-width: 200px;
 }
 
 .tabbedPanel .tabList .tab .tabLabel {
@@ -72,10 +72,10 @@ panel {
 
 .tabbedPanel.horizontal > .title .tabList .tab .tabLabel,
 .tabbedPanel.vertical > .title .tabList .tab .tabLabel {
-	max-width: 250px;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	border: 0px;
+	font-weight: normal;
 }
 
 .tabbedPanel .tabList .tab-header {
@@ -133,18 +133,18 @@ panel {
 	flex-direction: row;
 }
 
-.tabbedPanel.vertical>.title {
+.tabbedPanel.vertical > .title {
 	flex: 0 0 auto;
 	flex-direction: column;
 	height: 100%;
 }
 
-.tabbedPanel>.tab-content {
+.tabbedPanel > .tab-content {
 	flex: 1 1 auto;
 	position: relative;
 }
 
-.tabbedPanel.vertical>.title > .tabContainer .tabList {
+.tabbedPanel.vertical > .title > .tabContainer .tabList {
 	flex-flow: column;
 	height: calc(100% - 35px);
 	overflow: auto;

--- a/src/sql/base/browser/ui/panel/media/panel.css
+++ b/src/sql/base/browser/ui/panel/media/panel.css
@@ -50,6 +50,8 @@ panel {
 .tabbedPanel .tabList .tab {
 	cursor: pointer;
 	margin: auto;
+	display: flex;
+	flex-flow: row;
 }
 
 .tabbedPanel.horizontal .tabList .tab .tabLabel {
@@ -67,6 +69,13 @@ panel {
 	font-size: 13px;
 	padding-bottom: 4px;
 	font-weight: 600;
+}
+
+.tabbedPanel.horizontal > .title .tabList .tab .tabLabel,
+.tabbedPanel.vertical > .title .tabList .tab .tabLabel {
+	max-width: 150px;
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 
 .tabbedPanel .tabList .tab-header {

--- a/src/sql/base/browser/ui/panel/panel.component.ts
+++ b/src/sql/base/browser/ui/panel/panel.component.ts
@@ -58,7 +58,7 @@ let idPool = 0;
 					<div *ngIf="options.layout === NavigationBarLayout.vertical" class="vertical-tab-action-container">
 						<button [attr.aria-expanded]="_tabExpanded" [title]="toggleTabPanelButtonAriaLabel" [attr.aria-label]="toggleTabPanelButtonAriaLabel" [ngClass]="toggleTabPanelButtonCssClass" tabindex="0" (click)="toggleTabPanel()"></button>
 					</div>
-					<div [style.display]="_tabExpanded ? 'flex': 'none'" [attr.aria-hidden]="_tabExpanded ? 'false': 'true'" class="tabList" role="tablist" scrollable [horizontalScroll]="AutoScrollbarVisibility" [verticalScroll]="HiddenScrollbarVisibility" [scrollYToX]="true" (keydown)="onKey($event)">
+					<div [style.display]="_tabExpanded ? 'flex': 'none'" [attr.aria-hidden]="_tabExpanded ? 'false': 'true'" class="tabList" role="tablist" (keydown)="onKey($event)">
 						<div role="presentation" *ngFor="let tab of _tabs">
 							<ng-container *ngIf="tab.type!=='group-header'">
 								<tab-header role="presentation" [active]="_activeTab === tab" [tab]="tab" [showIcon]="options.showIcon" (onSelectTab)='selectTab($event)' (onCloseTab)='closeTab($event)'></tab-header>

--- a/src/sql/base/browser/ui/panel/tabHeader.component.ts
+++ b/src/sql/base/browser/ui/panel/tabHeader.component.ts
@@ -21,8 +21,8 @@ import { CloseTabAction } from 'sql/base/browser/ui/panel/tabActions';
 	template: `
 		<div #actionHeader role="tab" [attr.aria-selected]="tab.active" [attr.aria-label]="tab.title" class="tab-header" style="flex: 0 0; flex-direction: row;" [class.active]="tab.active" tabindex="0" (click)="selectTab(tab)" (keyup)="onKey($event)">
 			<div class="tab" role="presentation">
-				<div #tabIcon></div>
-				<div class="tabLabel" [class.active]="tab.active" [title]="tab.title" #tabLabel></div>
+				<a #tabIcon></a>
+				<a class="tabLabel" [class.active]="tab.active" [title]="tab.title" #tabLabel></a>
 			</div>
 			<div #actionbar style="flex: 0 0 auto; align-self: end; margin-top: auto; margin-bottom: auto;" ></div>
 		</div>

--- a/src/sql/base/browser/ui/panel/tabHeader.component.ts
+++ b/src/sql/base/browser/ui/panel/tabHeader.component.ts
@@ -20,14 +20,11 @@ import { CloseTabAction } from 'sql/base/browser/ui/panel/tabActions';
 	selector: 'tab-header',
 	template: `
 		<div #actionHeader role="tab" [attr.aria-selected]="tab.active" [attr.aria-label]="tab.title" class="tab-header" style="flex: 0 0; flex-direction: row;" [class.active]="tab.active" tabindex="0" (click)="selectTab(tab)" (keyup)="onKey($event)">
-			<span class="tab" role="presentation">
-				<div role="presentation">
-					<a #tabIcon></a>
-					<a class="tabLabel" [class.active]="tab.active" #tabLabel>
-					</a>
-				</div>
-			</span>
-			<span #actionbar style="flex: 0 0 auto; align-self: end; margin-top: auto; margin-bottom: auto;" ></span>
+			<div class="tab" role="presentation">
+				<div #tabIcon></div>
+				<div class="tabLabel" [class.active]="tab.active" [title]="tab.title" #tabLabel></div>
+			</div>
+			<div #actionbar style="flex: 0 0 auto; align-self: end; margin-top: auto; margin-bottom: auto;" ></div>
 		</div>
 	`
 })


### PR DESCRIPTION
add max-width for tab label and scroll handling

max width - overflow ellipsis

<img width="301" alt="Screen Shot 2020-04-11 at 3 50 13 PM" src="https://user-images.githubusercontent.com/13777222/79056653-8837d180-7c0d-11ea-853f-5a6e84ba6077.png">

scroll:
<img width="724" alt="Screen Shot 2020-04-11 at 3 44 24 PM" src="https://user-images.githubusercontent.com/13777222/79056656-8f5edf80-7c0d-11ea-9764-55e54eeb8737.png">


also double checked to make sure no impact on the existing UI using panel
<img width="409" alt="Screen Shot 2020-04-11 at 4 04 24 PM" src="https://user-images.githubusercontent.com/13777222/79056739-3cd1f300-7c0e-11ea-8d5d-1220d9b47cdc.png">
<img width="255" alt="Screen Shot 2020-04-11 at 4 04 00 PM" src="https://user-images.githubusercontent.com/13777222/79056741-3e032000-7c0e-11ea-9f2a-261465a066f6.png">
<img width="567" alt="Screen Shot 2020-04-11 at 4 05 25 PM" src="https://user-images.githubusercontent.com/13777222/79056744-452a2e00-7c0e-11ea-9a16-d23b9660a2c5.png">
