### PR TITLE
Fix style of property name in properties widget

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import 'vs/css!./propertiesWidget';
 
 import { Component, Inject, forwardRef, ChangeDetectorRef, OnInit, ElementRef, ViewChild } from '@angular/core';
 

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.css
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.css
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.propertiesName {
+	opacity: 0.6;
+}
+
+.vs-dark .propertiesName,
+.hc-black .propertiesName {
+	opacity: 1;
+}


### PR DESCRIPTION
To match mockups, opacity of property name should be 0.6 for light theme.

old:
![image](https://user-images.githubusercontent.com/31145923/79160851-58b0d280-7d8f-11ea-8a18-d092617c09d2.png)

fixed:
![image](https://user-images.githubusercontent.com/31145923/79161009-9d3c6e00-7d8f-11ea-99f6-979f87994535.png)

