### PR TITLE
Fix/find context correction

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -298,16 +298,14 @@ export class NotebookEditor extends BaseEditor implements IFindNotebookControlle
 			// if the search scope changes remove the prev
 			if (this._notebookModel && this._findState.searchString) {
 				let findScope = this._findDecorations.getFindScope();
-				if (this._findState.searchString === this.notebookFindModel.findExpression && findScope !== null && !e.matchCase && !e.wholeWord && !e.searchScope) {
-					if (findScope) {
-						this._updateFinderMatchState();
-						this._findState.changeMatchInfo(
-							this.notebookFindModel.getFindIndex(),
-							this._findDecorations.getCount(),
-							this._currentMatch
-						);
-						this._setCurrentFindMatch(findScope);
-					}
+				if (this._findState.searchString === this.notebookFindModel.findExpression && findScope && !e.matchCase && !e.wholeWord && !e.searchScope) {
+					this._updateFinderMatchState();
+					this._findState.changeMatchInfo(
+						this.notebookFindModel.getFindIndex(),
+						this._findDecorations.getCount(),
+						this._currentMatch
+					);
+					this._setCurrentFindMatch(findScope);
 				} else {
 					this.notebookInput.notebookFindModel.clearDecorations();
 					this.notebookFindModel.findExpression = this._findState.searchString;

--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -283,58 +283,58 @@ export class NotebookEditor extends BaseEditor implements IFindNotebookControlle
 			} else {
 				this._finder.getDomNode().style.visibility = 'hidden';
 				this._findDecorations.clearDecorations();
+				return;
 			}
 		} else {
 			if (!this._findState.isRevealed) {
 				this._finder.getDomNode().style.visibility = 'hidden';
 				this._findDecorations.clearDecorations();
+				return;
 			}
 		}
 
 		if (e.searchString || e.matchCase || e.wholeWord) {
 			this._findDecorations.clearDecorations();
 			// if the search scope changes remove the prev
-			if (this._notebookModel) {
-				if (this._findState.searchString) {
-					let findScope = this._findDecorations.getFindScope();
-					if (this._findState.searchString === this.notebookFindModel.findExpression && findScope !== null && !e.matchCase && !e.wholeWord && !e.searchScope) {
-						if (findScope) {
-							this._updateFinderMatchState();
-							this._findState.changeMatchInfo(
-								this.notebookFindModel.getFindIndex(),
-								this._findDecorations.getCount(),
-								this._currentMatch
-							);
-							this._setCurrentFindMatch(findScope);
-						}
-					} else {
-						this.notebookInput.notebookFindModel.clearDecorations();
-						this.notebookFindModel.findExpression = this._findState.searchString;
-						this.notebookInput.notebookFindModel.find(this._findState.searchString, this._findState.matchCase, this._findState.wholeWord, NOTEBOOK_MAX_MATCHES).then(findRange => {
-							if (findRange) {
-								this.updatePosition(findRange);
-							} else if (this.notebookFindModel.findMatches.length > 0) {
-								this.updatePosition(this.notebookFindModel.findMatches[0].range);
-							} else {
-								this.notebookInput.notebookFindModel.clearFind();
-								this._updateFinderMatchState();
-								this._finder.focusFindInput();
-								return;
-							}
-							this._updateFinderMatchState();
-							this._finder.focusFindInput();
-							this._findDecorations.set(this.notebookFindModel.findMatches, this._currentMatch);
-							this._findState.changeMatchInfo(
-								this.notebookFindModel.getFindIndex(),
-								this._findDecorations.getCount(),
-								this._currentMatch
-							);
-							this._setCurrentFindMatch(this._currentMatch);
-						});
+			if (this._notebookModel && this._findState.searchString) {
+				let findScope = this._findDecorations.getFindScope();
+				if (this._findState.searchString === this.notebookFindModel.findExpression && findScope !== null && !e.matchCase && !e.wholeWord && !e.searchScope) {
+					if (findScope) {
+						this._updateFinderMatchState();
+						this._findState.changeMatchInfo(
+							this.notebookFindModel.getFindIndex(),
+							this._findDecorations.getCount(),
+							this._currentMatch
+						);
+						this._setCurrentFindMatch(findScope);
 					}
 				} else {
-					this.notebookFindModel.clearFind();
+					this.notebookInput.notebookFindModel.clearDecorations();
+					this.notebookFindModel.findExpression = this._findState.searchString;
+					this.notebookInput.notebookFindModel.find(this._findState.searchString, this._findState.matchCase, this._findState.wholeWord, NOTEBOOK_MAX_MATCHES).then(findRange => {
+						if (findRange) {
+							this.updatePosition(findRange);
+						} else if (this.notebookFindModel.findMatches.length > 0) {
+							this.updatePosition(this.notebookFindModel.findMatches[0].range);
+						} else {
+							this.notebookInput.notebookFindModel.clearFind();
+							this._updateFinderMatchState();
+							this._finder.focusFindInput();
+							return;
+						}
+						this._updateFinderMatchState();
+						this._finder.focusFindInput();
+						this._findDecorations.set(this.notebookFindModel.findMatches, this._currentMatch);
+						this._findState.changeMatchInfo(
+							this.notebookFindModel.getFindIndex(),
+							this._findDecorations.getCount(),
+							this._currentMatch
+						);
+						this._setCurrentFindMatch(this._currentMatch);
+					});
 				}
+			} else {
+				this.notebookFindModel.clearFind();
 			}
 		}
 		if (e.searchScope) {
@@ -378,6 +378,7 @@ export class NotebookEditor extends BaseEditor implements IFindNotebookControlle
 			this._onFindStateChange(changeEvent).catch(onUnexpectedError);
 		}));
 		this._register(this._notebookService.onNotebookEditorAdd(async (e) => {
+			// wait for the model to be ready and trigger input change
 			await e.modelReady;
 			this._triggerInputChange();
 		}));

--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -377,6 +377,10 @@ export class NotebookEditor extends BaseEditor implements IFindNotebookControlle
 		this._register(this._notebookModel.contentChanged(e => {
 			this._onFindStateChange(changeEvent).catch(onUnexpectedError);
 		}));
+		this._register(this._notebookService.onNotebookEditorAdd(async (e) => {
+			await e.modelReady;
+			this._triggerInputChange();
+		}));
 	}
 
 	public setSelection(range: NotebookRange): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->
Issue: When find is active on an open notebook, if user opens a new notebook, find doesn't refresh its context and shows previous active editor results.
Fix: when a new notebook editor is open, trigger the input change event that refreshes the context correctly.

This PR fixes #9551 

Will be adding tests around this in a different PR.
