### PR TITLE
show databases for azure server

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -493,7 +493,7 @@
         "description": "%mssql.tabs.databases%",
         "provider": "*",
         "title": "%mssql.tabs.databases%",
-        "when": "dashboardContext == 'server'",
+        "when": "dashboardContext == 'server' && !mssql:iscloud && mssql:engineedition != 11",
         "group": "home",
         "icon": "resources/database.svg",
         "container": {

--- a/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution.ts
@@ -93,6 +93,16 @@ const defaultVal = [
 		widget: {
 			'all-database-size-server-insight': null
 		}
+	}, {
+		name: nls.localize('explorerWidgetsTitle', "Search"),
+		gridItemConfig: {
+			sizex: 2,
+			sizey: 2
+		},
+		when: 'mssql:engineedition == 11 || mssql:iscloud',
+		widget: {
+			'explorer-widget': {}
+		}
 	}
 ];
 


### PR DESCRIPTION
This PR fixes #9831 

for Azure server and managed instance, for now show the databases widget on the home page.
<img width="1001" alt="Screen Shot 2020-04-13 at 3 42 05 PM" src="https://user-images.githubusercontent.com/13777222/79167913-75ec9d80-7d9d-11ea-9ab8-f2005e09cac4.png">

