### PR TITLE
Add typing for TabbedPanelLayout and set defaults

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -412,6 +412,7 @@
                     "**/{vs,sql}/editor/{common,browser}/**",
                     "**/{vs,sql}/editor/contrib/**", // editor/contrib is equivalent to /browser/ by convention
                     "**/{vs,sql}/workbench/workbench.web.api",
+                    "**/{vs,sql}/workbench/api/**",
                     "**/{vs,sql}/workbench/{common,browser}/**",
                     "**/{vs,sql}/workbench/services/*/{common,browser}/**",
                     "assert"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -412,7 +412,6 @@
                     "**/{vs,sql}/editor/{common,browser}/**",
                     "**/{vs,sql}/editor/contrib/**", // editor/contrib is equivalent to /browser/ by convention
                     "**/{vs,sql}/workbench/workbench.web.api",
-                    "**/{vs,sql}/workbench/api/**",
                     "**/{vs,sql}/workbench/{common,browser}/**",
                     "**/{vs,sql}/workbench/services/*/{common,browser}/**",
                     "assert"

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -231,19 +231,19 @@ declare module 'azdata' {
 	 */
 	export interface TabbedPanelLayout {
 		/**
-		 * Tab orientation
+		 * Tab orientation. Default horizontal.
 		 */
-		orientation: TabOrientation;
+		orientation?: TabOrientation;
 
 		/**
-		 * Whether to show the tab icon
+		 * Whether to show the tab icon. Default false.
 		 */
-		showIcon: boolean;
+		showIcon?: boolean;
 
 		/**
-		 * Whether to show the tab navigation pane even when there is only one tab
+		 * Whether to show the tab navigation pane even when there is only one tab. Default false.
 		 */
-		alwaysShowTabs: boolean;
+		alwaysShowTabs?: boolean;
 	}
 
 	/**
@@ -289,12 +289,12 @@ declare module 'azdata' {
 	/**
 	 * Builder for TabbedPannelComponent
 	 */
-	export interface TabbedPanelComponentBuilder extends ContainerBuilder<TabbedPanelComponent, any, any> {
+	export interface TabbedPanelComponentBuilder extends ContainerBuilder<TabbedPanelComponent, TabbedPanelLayout, any> {
 		/**
 		 * Add the tabs to the component
 		 * @param tabs tabs/tab groups to be added
 		 */
-		withTabs(tabs: (Tab | TabGroup)[]): ContainerBuilder<TabbedPanelComponent, any, any>;
+		withTabs(tabs: (Tab | TabGroup)[]): ContainerBuilder<TabbedPanelComponent, TabbedPanelLayout, any>;
 	}
 
 	export interface InputBoxProperties extends ComponentProperties {

--- a/src/sql/workbench/api/common/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/common/extHostModelViewDialog.ts
@@ -13,6 +13,7 @@ import * as azdata from 'azdata';
 
 import { SqlMainContext, ExtHostModelViewDialogShape, MainThreadModelViewDialogShape, ExtHostModelViewShape, ExtHostBackgroundTaskManagementShape } from 'sql/workbench/api/common/sqlExtHost.protocol';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
+import { TabOrientation } from 'sql/workbench/api/common/sqlExtHostTypes';
 
 const DONE_LABEL = nls.localize('dialogDoneLabel', "Done");
 const CANCEL_LABEL = nls.localize('dialogCancelLabel', "Cancel");
@@ -481,7 +482,7 @@ class ModelViewDashboardImpl implements azdata.window.ModelViewDashboard {
 			const dashboardTabs = await handler(view);
 			const tabs = this.createTabs(dashboardTabs, view);
 			this._tabbedPanel = view.modelBuilder.tabbedPanel().withTabs(tabs).withLayout({
-				orientation: 'vertical',
+				orientation: TabOrientation.Vertical,
 				showIcon: this._options?.showIcon ?? true,
 				alwaysShowTabs: this._options?.alwaysShowTabs ?? false
 			}).component();

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -836,7 +836,6 @@ export enum TabOrientation {
 	Horizontal = 'horizontal'
 }
 
-
 export interface TabbedPanelLayout {
 	orientation: TabOrientation;
 	showIcon: boolean;

--- a/src/sql/workbench/browser/modelComponents/tabbedPanel.component.ts
+++ b/src/sql/workbench/browser/modelComponents/tabbedPanel.component.ts
@@ -5,13 +5,13 @@
 import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, forwardRef, Inject, Input, OnDestroy, ViewChild } from '@angular/core';
 import { NavigationBarLayout, PanelComponent } from 'sql/base/browser/ui/panel/panel.component';
 import { TabType } from 'sql/base/browser/ui/panel/tab.component';
-import { TabOrientation, TabbedPanelLayout } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { ContainerBase } from 'sql/workbench/browser/modelComponents/componentBase';
 import { ComponentEventType, IComponent, IComponentDescriptor, IModelStore } from 'sql/platform/dashboard/browser/interfaces';
 import 'vs/css!./media/tabbedPanel';
 import { IUserFriendlyIcon, createIconCssClass } from 'sql/workbench/browser/modelComponents/iconUtils';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { attachTabbedPanelStyler } from 'sql/workbench/common/styler';
+import { TabbedPanelLayout } from 'azdata';
 
 export interface TabConfig {
 	title: string;
@@ -26,6 +26,14 @@ interface Tab {
 	id?: string;
 	type: TabType;
 	iconClass?: string;
+}
+
+/**
+ * Defines the tab orientation of TabbedPanelComponent
+ */
+export enum TabOrientation {
+	Vertical = 'vertical',
+	Horizontal = 'horizontal'
 }
 
 @Component({

--- a/src/sql/workbench/browser/modelComponents/tabbedPanel.component.ts
+++ b/src/sql/workbench/browser/modelComponents/tabbedPanel.component.ts
@@ -5,7 +5,6 @@
 import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, forwardRef, Inject, Input, OnDestroy, ViewChild } from '@angular/core';
 import { NavigationBarLayout, PanelComponent } from 'sql/base/browser/ui/panel/panel.component';
 import { TabType } from 'sql/base/browser/ui/panel/tab.component';
-// eslint-disable-next-line code-import-patterns
 import { TabOrientation, TabbedPanelLayout } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { ContainerBase } from 'sql/workbench/browser/modelComponents/componentBase';
 import { ComponentEventType, IComponent, IComponentDescriptor, IModelStore } from 'sql/platform/dashboard/browser/interfaces';
@@ -62,9 +61,9 @@ export default class TabbedPanelComponent extends ContainerBase<TabConfig> imple
 
 	setLayout(layout: TabbedPanelLayout): void {
 		this._panel.options = {
-			alwaysShowTabs: layout.alwaysShowTabs,
-			layout: layout.orientation === TabOrientation.Horizontal ? NavigationBarLayout.horizontal : NavigationBarLayout.vertical,
-			showIcon: layout.showIcon
+			alwaysShowTabs: layout.alwaysShowTabs ?? false,
+			layout: (layout.orientation ?? TabOrientation.Horizontal) === TabOrientation.Horizontal ? NavigationBarLayout.horizontal : NavigationBarLayout.vertical,
+			showIcon: layout.showIcon ?? false
 		};
 	}
 


### PR DESCRIPTION
We weren't setting defaults so we'd get weird behavior if the value was left undefined. I fixed it so we get typings on the withLayout so that's less likely and then added appropriate defaults for the layout options (we should never require any layout options to be mandatory since we don't require calling withLayout to begin with - all layout options should have appropriate defaults). 

@anthonydresser The layering rules were complaining about the sqlExtHostTypes import - but I don't see any reason why that shouldn't be allowed. Does that look OK to you?

Fixes https://github.com/microsoft/azuredatastudio/issues/9947