### PR TITLE
Center properties widget collapse icon

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.css
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.css
@@ -50,3 +50,11 @@ dashboard-widget-wrapper .bottomActionbar {
 	margin-top: -27px;
 	display: none;
 }
+
+dashboard-widget-wrapper .bottomActionbar .actions-container .action-item a.action-label.codicon-chevron-up {
+	padding-left: 5px;
+}
+
+dashboard-widget-wrapper .bottomActionbar .actions-container .action-item a.action-label.codicon-chevron-down {
+	padding-left: 5px;
+}


### PR DESCRIPTION
before: 
![image](https://user-images.githubusercontent.com/31145923/79258389-e77d2800-7e3f-11ea-9baa-52353f5f6217.png)



fixed:
![image](https://user-images.githubusercontent.com/31145923/79258282-c6b4d280-7e3f-11ea-8c68-c3c55304acff.png)
![image](https://user-images.githubusercontent.com/31145923/79258293-ca485980-7e3f-11ea-8413-cfa83606eae8.png)
