### PR TITLE
Fix for edit data sizing of table

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/media/editData.css
+++ b/src/sql/workbench/contrib/editData/browser/media/editData.css
@@ -6,7 +6,6 @@
 .editDataGridPanel.slickgridContainer {
 	height: 100%;
 	width: 100%;
-	display: inline-block;
 }
 
 

--- a/src/sql/workbench/contrib/editData/browser/media/editData.css
+++ b/src/sql/workbench/contrib/editData/browser/media/editData.css
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 .editDataGridPanel.slickgridContainer {
-	height: 447px;
-	width: 632px;
+	height: 100%;
+	width: 100%;
+	display: inline-block;
 }
 
 


### PR DESCRIPTION
height and width for editdata now sizes to 100% to fix for tables with more than ten columns.
This PR fixes #9967
