### PR TITLE
Only show Create Insight button in Query Editor charts.

### DIFF
--- a/src/sql/workbench/contrib/charts/browser/chartView.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartView.ts
@@ -86,7 +86,7 @@ export class ChartView extends Disposable implements IPanelView {
 	public readonly onOptionsChange: Event<IInsightOptions> = this._onOptionsChange.event;
 
 	constructor(
-		private readonly _renderOptionsInline: boolean,
+		private readonly _isQueryEditorChart: boolean,
 		@IContextViewService private _contextViewService: IContextViewService,
 		@IThemeService private _themeService: IThemeService,
 		@IInstantiationService private _instantiationService: IInstantiationService,
@@ -102,15 +102,15 @@ export class ChartView extends Disposable implements IPanelView {
 		this.typeControls = DOM.$('div.type-controls');
 		this.optionsControl.appendChild(this.typeControls);
 
-		this._createInsightAction = this._instantiationService.createInstance(CreateInsightAction);
 		this._copyAction = this._instantiationService.createInstance(CopyAction);
 		this._saveAction = this._instantiationService.createInstance(SaveImageAction);
 
-		if (this._renderOptionsInline) {
+		if (this._isQueryEditorChart) {
+			this._createInsightAction = this._instantiationService.createInstance(CreateInsightAction);
 			this.taskbar.setContent([{ action: this._createInsightAction }]);
 		} else {
 			this._configureChartAction = this._instantiationService.createInstance(ConfigureChartAction, this);
-			this.taskbar.setContent([{ action: this._createInsightAction }, { action: this._configureChartAction }]);
+			this.taskbar.setContent([{ action: this._configureChartAction }]);
 		}
 
 		const self = this;
@@ -177,7 +177,7 @@ export class ChartView extends Disposable implements IPanelView {
 			this.container.appendChild(this.taskbarContainer);
 			this.container.appendChild(this.chartingContainer);
 			this.chartingContainer.appendChild(this.insightContainer);
-			if (this._renderOptionsInline) {
+			if (this._isQueryEditorChart) {
 				this.chartingContainer.appendChild(this.optionsControl);
 			}
 			this.insight = new Insight(this.insightContainer, this._options, this._instantiationService);
@@ -301,14 +301,15 @@ export class ChartView extends Disposable implements IPanelView {
 		if (this.insight && this.insight.isCopyable) {
 			this.taskbar.context = { insight: this.insight.insight, options: this._options };
 			actions = [
-				{ action: this._createInsightAction },
 				{ action: this._copyAction },
 				{ action: this._saveAction }
 			];
 		} else {
-			actions = [{ action: this._createInsightAction }];
+			actions = [];
 		}
-		if (!this._renderOptionsInline) {
+		if (this._isQueryEditorChart) {
+			actions.unshift({ action: this._createInsightAction });
+		} else {
 			actions.push({ action: this._configureChartAction });
 		}
 		this.taskbar.setContent(actions);

--- a/src/sql/workbench/contrib/charts/test/browser/chartView.test.ts
+++ b/src/sql/workbench/contrib/charts/test/browser/chartView.test.ts
@@ -34,12 +34,12 @@ suite('Chart View', () => {
 	});
 });
 
-function createChartView(renderOptions: boolean): ChartView {
+function createChartView(isQueryEditorChart: boolean): ChartView {
 	const layoutService = new TestLayoutService();
 	const contextViewService = new ContextViewService(layoutService);
 	const themeService = new TestThemeService();
 	const instantiationService = new TestInstantiationService();
 	const notificationService = new TestNotificationService();
 	instantiationService.stub(IThemeService, themeService);
-	return new ChartView(renderOptions, contextViewService, themeService, instantiationService, notificationService);
+	return new ChartView(isQueryEditorChart, contextViewService, themeService, instantiationService, notificationService);
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/9964

The Create Insight action passes the actual .sql file as part of the InsightsConfig, so the action isn't compatible with notebook files without extracting the notebook cell contents and creating a standalone .sql file. Removing this button for now.
