### PR TITLE
Re-enable CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,13 @@ name: CI
 
 on:
   push:
-    branches-ignore:
-      - '**'
-  # push:
-  #   branches:
-  #     - master
-  #     - release/*
-  # pull_request:
-  #   branches:
-  #     - master
-  #     - release/*
+    branches:
+      - master
+      - release/*
+  pull_request:
+    branches:
+      - master
+      - release/*
 
 jobs:
   linux:


### PR DESCRIPTION
Disabled in https://github.com/microsoft/azuredatastudio/commit/1868a7d3705e4dc32b438ab24303052ed2cc9f09 but there doesn't seem to be a clear reason why so re-enabling this unless we find a reason for us to also keep it disabled. 