### PR TITLE
Notebooks: Bring back hover buttons for adding cells

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.html
@@ -9,12 +9,34 @@
 	</div>
 	<div #container class="scrollable" style="flex: 1 1 auto; position: relative; outline: none" (click)="unselectActiveCell()" (scroll)="scrollHandler($event)">
 		<loading-spinner [loading]="isLoading"></loading-spinner>
+		<div class="hoverButtonsContainer" *ngIf="(cells && cells.length > 0) && !isLoading">
+			<span class="containerBackground"></span>
+			<button class="hoverButton" (click)="addCell('code', 0, $event)">
+				<div class="addCodeIcon"></div>
+				<span>{{addCodeLabel}}</span>
+			</button>
+			<button class="hoverButton" (click)="addCell('markdown', 0, $event)">
+				<div class="addTextIcon"></div>
+				<span>{{addTextLabel}}</span>
+			</button>
+		</div>
 		<div *ngFor="let cell of cells">
 			<div class="notebook-cell" (click)="selectCell(cell, $event)" [class.active]="cell.active">
 				<code-cell-component *ngIf="cell.cellType === 'code'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">
 				</code-cell-component>
 				<text-cell-component *ngIf="cell.cellType === 'markdown'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">
 				</text-cell-component>
+			</div>
+			<div class="hoverButtonsContainer">
+				<span class="containerBackground"></span>
+				<button class="hoverButton" (click)="addCell('code', findCellIndex(cell) + 1, $event)">
+					<div class="addCodeIcon"></div>
+					<span>{{addCodeLabel}}</span>
+				</button>
+				<button class="hoverButton" (click)="addCell('markdown', findCellIndex(cell) + 1, $event)">
+					<div class="addTextIcon"></div>
+					<span>{{addTextLabel}}</span>
+				</button>
 			</div>
 		</div>
 		<div class="notebook-cell" *ngIf="(!cells || !cells.length) && !isLoading">


### PR DESCRIPTION
#10008 

Talked with design + PM and decided to bring this back for April after doing some testing with the newest bits. 

Pretty simple change; literally just bringing this code back to what it was previously.