### PR TITLE
Check conda-forge channel first when installing conda packages.

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -625,7 +625,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		let versionSpecifier = useMinVersion ? '>=' : '==';
 		let packagesStr = packages.map(pkg => `"${pkg.name}${versionSpecifier}${pkg.version}"`).join(' ');
 		let condaExe = this.getCondaExePath();
-		let cmd = `"${condaExe}" install -y ${packagesStr}`;
+		let cmd = `"${condaExe}" install -c conda-forge -y ${packagesStr}`;
 		return this.executeStreamedCommand(cmd);
 	}
 


### PR DESCRIPTION
The latest version of Anaconda hangs for a long time when trying to install sparkmagic from the default package channels. The version of sparkmagic from the conda-forge channel installs without any issues, however. The conda-forge version also has the most recent version of sparkmagic, and has way more downloads than the default channel. So I think we should prefer the conda-forge channel for installing our conda packages in the future. According to the conda docs, the install will fall back on the default channels if a package isn't found, so there shouldn't be any issues here with missing packages.

https://docs.conda.io/projects/conda/en/latest/commands/install.html#Channel%20Customization

Fixes https://github.com/microsoft/azuredatastudio/issues/9815