### PR TITLE
Ensure ipynb is associated with notebook editor

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/nodebookInputFactory.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/nodebookInputFactory.ts
@@ -17,7 +17,7 @@ import { NotebookInput } from 'sql/workbench/contrib/notebook/browser/models/not
 const editorInputFactoryRegistry = Registry.as<IEditorInputFactoryRegistry>(EditorInputExtensions.EditorInputFactories);
 
 export class NotebookEditorInputAssociation implements ILanguageAssociation {
-	static readonly languages = ['notebook'];
+	static readonly languages = ['notebook', 'ipynb'];
 
 	constructor(@IInstantiationService private readonly instantiationService: IInstantiationService) { }
 


### PR DESCRIPTION
This addresses #10027.

No file association was found for ipynb on launch, so the default file editor was shown.

Tested following scenarios:
- Notebook opened on first launch (just edited launch.json to provide file path as another parameter
- Opened existing notebook
- Created new notebook + saved it
- Changed language of file from plain text to Notebook

We definitely have cleanup to do here in the future, especially with regards to what the extension contributes file association-wise.