### PR TITLE
Fix logging for angular bootstrapping errors

### DIFF
--- a/src/sql/workbench/services/bootstrap/browser/bootstrapService.ts
+++ b/src/sql/workbench/services/bootstrap/browser/bootstrapService.ts
@@ -46,6 +46,7 @@ export function bootstrapAngular<T>(accessor: ServicesAccessor, moduleType: IMod
 	let selector = document.createElement(uniqueSelectorString);
 	container.appendChild(selector);
 	const instantiationService = accessor.get(IInstantiationService);
+	const logService = accessor.get(ILogService);
 
 	if (!platform) {
 		instantiationService.invokeFunction((accessor) => {
@@ -67,7 +68,6 @@ export function bootstrapAngular<T>(accessor: ServicesAccessor, moduleType: IMod
 			callbackSetModule(moduleRef);
 		}
 	}).catch((e) => {
-		const logService = accessor.get(ILogService);
 		logService.error(e);
 	});
 


### PR DESCRIPTION
The accessor was throwing when calling within the catch because the function was ended by the time the catch callback was called. Instead we should capture the service so we have it in case we need it. 