### PR TITLE
Fix arrow alignment for connection dialogs

### DIFF
--- a/src/sql/base/parts/editableDropdown/browser/media/dropdownList.css
+++ b/src/sql/base/parts/editableDropdown/browser/media/dropdownList.css
@@ -43,13 +43,3 @@
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
-
-.connection-input .monaco-dropdown .monaco-action-bar .action-label.codicon.dropdown-arrow {
-	background-position: 50%;
-	background-size: cover;
-}
-
-.connection-input .monaco-inputbox .monaco-action-bar .action-item .codicon {
-	width: 8px;
-	height: 8px;
-}

--- a/src/sql/workbench/services/connection/browser/media/connectionDialog.css
+++ b/src/sql/workbench/services/connection/browser/media/connectionDialog.css
@@ -153,3 +153,14 @@
 .hide-azure-tenants .azure-tenant-row {
 	display: none;
 }
+
+.connection-input .monaco-dropdown .monaco-action-bar .action-label.codicon.dropdown-arrow {
+	background-position: 50%;
+	background-size: cover;
+	display: inline-block;
+}
+
+.connection-input .monaco-inputbox .monaco-action-bar .action-item .codicon {
+	width: 8px;
+	height: 8px;
+}


### PR DESCRIPTION
Also moved connection dialog specific rules to the connection dialog CSS for better consolidation.

display: flex was added to the icons in a VS code merge a while back - setting it back to inline-block so it displays correctly. 

For #10063

![image](https://user-images.githubusercontent.com/28519865/79617197-bdd03500-80bb-11ea-988c-28093ad67087.png)
