### PR TITLE
Notebook UI - Fixes navigation offset

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -664,14 +664,17 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 
 	navigateToSection(id: string): void {
 		id = id.toLowerCase();
+		let chromeHeight: number = 0;
 		let elBody: HTMLElement = document.body;
 		let tabBar = elBody.querySelector('.title.tabs') as HTMLElement;
 		let actionBar = elBody.querySelector('.editor-toolbar.actionbar-container') as HTMLElement;
 		let section = find(this.getSectionElements(), s => s.relativeUri && s.relativeUri.toLowerCase() === id);
 		if (section) {
 			// Scroll this section to the top of the header instead of just bringing header into view.
-			let chromeHeight: number = tabBar.scrollHeight + actionBar.scrollHeight + 10;
-			let scrollTop: number = section.headerEl.getBoundingClientRect().top - chromeHeight;
+			if (tabBar && actionBar) {
+				chromeHeight = tabBar.scrollHeight + actionBar.scrollHeight;
+			}
+			let scrollTop: number = section.headerEl.getBoundingClientRect().top - (chromeHeight + 10);
 			(<HTMLElement>this.container.nativeElement).scrollTo({
 				top: scrollTop,
 				behavior: 'smooth'

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -664,10 +664,14 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 
 	navigateToSection(id: string): void {
 		id = id.toLowerCase();
+		let elBody: HTMLElement = document.body;
+		let tabBar = elBody.querySelector('.title.tabs') as HTMLElement;
+		let actionBar = elBody.querySelector('.editor-toolbar.actionbar-container') as HTMLElement;
 		let section = find(this.getSectionElements(), s => s.relativeUri && s.relativeUri.toLowerCase() === id);
 		if (section) {
 			// Scroll this section to the top of the header instead of just bringing header into view.
-			let scrollTop = section.headerEl.offsetTop;
+			let chromeHeight: number = tabBar.scrollHeight + actionBar.scrollHeight + 10;
+			let scrollTop: number = section.headerEl.getBoundingClientRect().top - chromeHeight;
 			(<HTMLElement>this.container.nativeElement).scrollTo({
 				top: scrollTop,
 				behavior: 'smooth'


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

Replaced scrollTop with getBoundingClientRect().top. Created an offset that accounts for the combined height of the tab bar and action bar at top.

This PR addresses #10062
