### PR TITLE
Notebooks: Ensure Other Schemes Beyond Files Work for Link Handler

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
@@ -65,14 +65,16 @@ export class LinkHandlerDirective {
 			if (uri.fragment && uri.fragment.length > 0 && uri.fsPath === this.workbenchFilePath.fsPath) {
 				this.notebookService.navigateTo(this.notebookUri, uri.fragment);
 			} else {
-				let exists = await this.fileService.exists(uri);
-				if (!exists) {
-					let relPath = relative(this.workbenchFilePath.fsPath, uri.fsPath);
-					let path = resolve(this.notebookUri.fsPath, relPath);
-					try {
-						uri = URI.file(path);
-					} catch (error) {
-						onUnexpectedError(error);
+				if (uri.scheme === 'file') {
+					let exists = await this.fileService.exists(uri);
+					if (!exists) {
+						let relPath = relative(this.workbenchFilePath.fsPath, uri.fsPath);
+						let path = resolve(this.notebookUri.fsPath, relPath);
+						try {
+							uri = URI.file(path);
+						} catch (error) {
+							onUnexpectedError(error);
+						}
 					}
 				}
 				if (this.forceOpenExternal(uri)) {


### PR DESCRIPTION
#10091.

Non file schemes didn't work because we were checking the fileService for other schemes (e.g. https). Just a simple check here.

![image](https://user-images.githubusercontent.com/40371649/79806016-4baa5b00-831c-11ea-9758-c5ba742ab86e.png)
