### PR TITLE
Check treeItem first when building search path in searchJupyterBooks. (#10083)

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -327,11 +327,20 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	}
 
 	public async searchJupyterBooks(treeItem?: BookTreeItem): Promise<void> {
-		if (this.currentBook && this.currentBook.bookPath) {
-			let folderToSearch = this.currentBook.bookPath;
-			if (treeItem && treeItem.uri) {
-				folderToSearch = path.join(folderToSearch, Content, path.dirname(treeItem.uri));
+		let folderToSearch: string;
+		if (treeItem && treeItem.book.type !== BookTreeItemType.Notebook) {
+			if (treeItem.uri) {
+				folderToSearch = path.join(treeItem.root, Content, path.dirname(treeItem.uri));
+			} else {
+				folderToSearch = path.join(treeItem.root, Content);
 			}
+		} else if (this.currentBook && !this.currentBook.isNotebook) {
+			folderToSearch = path.join(this.currentBook.bookPath, Content);
+		} else {
+			vscode.window.showErrorMessage(loc.noBooksSelectedError);
+		}
+
+		if (folderToSearch) {
 			let filesToIncludeFiltered = path.join(folderToSearch, '**', '*.md') + ',' + path.join(folderToSearch, '**', '*.ipynb');
 			vscode.commands.executeCommand('workbench.action.findInFiles', { filesToInclude: filesToIncludeFiltered, query: '' });
 		}

--- a/extensions/notebook/src/common/localizedConstants.ts
+++ b/extensions/notebook/src/common/localizedConstants.ts
@@ -26,6 +26,7 @@ export const msgBookAlreadyTrusted = localize('msgBookAlreadyTrusted', "Book is 
 export const msgBookUntrusted = localize('msgBookUntrusted', "Book is no longer trusted in this workspace");
 export const msgBookAlreadyUntrusted = localize('msgBookAlreadyUntrusted', "Book is already untrusted in this workspace.");
 export const missingTocError = localize('bookInitializeFailed', "Failed to find a Table of Contents file in the specified book.");
+export const noBooksSelectedError = localize('noBooksSelected', "No books are currently selected in the viewlet.");
 
 export function missingFileError(title: string): string { return localize('missingFileError', "Missing file : {0}", title); }
 export function invalidTocFileError(): string { return localize('InvalidError.tocFile', "Invalid toc file"); }


### PR DESCRIPTION
Porting to rel branch.
