### PR TITLE
Add overflow option for ModelView toolbar

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -131,26 +131,30 @@ export class SchemaCompareMainWindow {
 			this.createSourceAndTargetButtons(view);
 			this.resetButtons(ResetButtonState.noSourceTarget);
 
-			let toolBar = view.modelBuilder.toolbarContainer();
-			toolBar.addToolbarItems([{
-				component: this.compareButton
-			}, {
-				component: this.cancelCompareButton
-			}, {
-				component: this.generateScriptButton
-			}, {
-				component: this.applyButton
-			}, {
-				component: this.optionsButton,
-				toolbarSeparatorAfter: true
-			}, {
-				component: this.switchButton,
-				toolbarSeparatorAfter: true
-			}, {
-				component: this.openScmpButton
-			}, {
-				component: this.saveScmpButton
-			}]);
+			let toolBar = view.modelBuilder.toolbarContainer().withToolbarItems(
+				[{
+					component: this.compareButton
+				}, {
+					component: this.cancelCompareButton
+				}, {
+					component: this.generateScriptButton
+				}, {
+					component: this.applyButton
+				}, {
+					component: this.optionsButton,
+					toolbarSeparatorAfter: true
+				}, {
+					component: this.switchButton,
+					toolbarSeparatorAfter: true
+				}, {
+					component: this.openScmpButton
+				}, {
+					component: this.saveScmpButton
+				}]
+			).withLayout({
+				orientation: azdata.Orientation.Horizontal,
+				overflow: true
+			});
 
 			let sourceLabel = view.modelBuilder.text().withProperties({
 				value: loc.sourceTitle,

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -352,5 +352,9 @@ declare module 'azdata' {
 		 */
 		alwaysShowTabs?: boolean;
 	}
+
+	export interface ToolbarLayout {
+		overflow?: boolean;
+	}
 }
 

--- a/src/sql/base/browser/ui/taskbar/media/taskbar.css
+++ b/src/sql/base/browser/ui/taskbar/media/taskbar.css
@@ -91,7 +91,7 @@
 	background-size: 11px;
 }
 
-.carbon-taskbar .toolbarOverflow {
+.carbon-taskbar .toolbar-overflow {
 	position:absolute;
 	right:0;
 	display: none;
@@ -101,24 +101,24 @@
 	margin-right: 5px;
 }
 
-.vs-dark .carbon-taskbar .toolbarOverflow {
+.vs-dark .carbon-taskbar .toolbar-overflow {
 	box-sizing: border-box;
 }
 
-.hc-black .carbon-taskbar .toolbarOverflow {
+.hc-black .carbon-taskbar .toolbar-overflow {
 	box-shadow: none;
 }
 
-.carbon-taskbar .toolbarOverflow li {
+.carbon-taskbar .toolbar-overflow li {
 	padding: 5px;
 	margin-right: 0;
 }
 
-.carbon-taskbar .toolbarOverflow li.focused a.action-label {
+.carbon-taskbar .toolbar-overflow li.focused a.action-label {
 	outline: none;
 }
 
-.carbon-taskbar .toolbarOverflow a {
+.carbon-taskbar .toolbar-overflow a {
 	padding-left: 20px;
 }
 
@@ -129,12 +129,12 @@
 	padding-right: 20px;
 }
 
-.carbon-taskbar .toolbarOverflow .action-item .action-label{
+.carbon-taskbar .toolbar-overflow .action-item .action-label{
 	background-size: 16px;
 	background-position: left;
 }
 
-.toolbarOverflow .taskbarSeparator {
+.carbon-taskbar .toolbar-overflow .taskbarSeparator {
 	height: 1px;
 	width: 100%;
 	margin-left: 0;

--- a/src/sql/base/browser/ui/taskbar/media/taskbar.css
+++ b/src/sql/base/browser/ui/taskbar/media/taskbar.css
@@ -91,34 +91,34 @@
 	background-size: 11px;
 }
 
-.carbon-taskbar .overflow {
+.carbon-taskbar .toolbarOverflow {
 	position:absolute;
 	right:0;
-	display:none;
+	display: none;
 	z-index: 3;
 	padding-left: 0;
 	margin-top: 6px;
 	margin-right: 5px;
 }
 
-.vs-dark .carbon-taskbar .overflow {
+.vs-dark .carbon-taskbar .toolbarOverflow {
 	box-sizing: border-box;
 }
 
-.hc-black .carbon-taskbar .overflow {
+.hc-black .carbon-taskbar .toolbarOverflow {
 	box-shadow: none;
 }
 
-.carbon-taskbar .overflow li {
+.carbon-taskbar .toolbarOverflow li {
 	padding: 5px;
 	margin-right: 0;
 }
 
-.carbon-taskbar .overflow li.focused a.action-label {
+.carbon-taskbar .toolbarOverflow li.focused a.action-label {
 	outline: none;
 }
 
-.carbon-taskbar .overflow a {
+.carbon-taskbar .toolbarOverflow a {
 	padding-left: 20px;
 }
 
@@ -129,12 +129,12 @@
 	padding-right: 20px;
 }
 
-.carbon-taskbar .overflow .action-item .action-label{
+.carbon-taskbar .toolbarOverflow .action-item .action-label{
 	background-size: 16px;
 	background-position: left;
 }
 
-.overflow .taskbarSeparator {
+.toolbarOverflow .taskbarSeparator {
 	height: 1px;
 	width: 100%;
 	margin-left: 0;

--- a/src/sql/base/browser/ui/taskbar/overflowActionbar.ts
+++ b/src/sql/base/browser/ui/taskbar/overflowActionbar.ts
@@ -42,7 +42,7 @@ export class OverflowActionBar extends ActionBar {
 
 		this._overflow = document.createElement('ul');
 		this._overflow.id = 'toolbarOverflow';
-		this._overflow.className = 'toolbarOverflow';
+		this._overflow.className = 'toolbar-overflow';
 		this._overflow.setAttribute('role', 'menu');
 		this._domNode.appendChild(this._overflow);
 

--- a/src/sql/base/browser/ui/taskbar/overflowActionbar.ts
+++ b/src/sql/base/browser/ui/taskbar/overflowActionbar.ts
@@ -41,8 +41,8 @@ export class OverflowActionBar extends ActionBar {
 		}));
 
 		this._overflow = document.createElement('ul');
-		this._overflow.id = 'overflow';
-		this._overflow.className = 'overflow';
+		this._overflow.id = 'toolbarOverflow';
+		this._overflow.className = 'toolbarOverflow';
 		this._overflow.setAttribute('role', 'menu');
 		this._domNode.appendChild(this._overflow);
 

--- a/src/sql/base/browser/ui/taskbar/overflowActionbarStyles.ts
+++ b/src/sql/base/browser/ui/taskbar/overflowActionbarStyles.ts
@@ -13,28 +13,28 @@ import { focusBorder } from 'vs/platform/theme/common/colorRegistry';
 registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {
 	const overflowBackground = theme.getColor(EDITOR_PANE_BACKGROUND);
 	if (overflowBackground) {
-		collector.addRule(`.toolbarOverflow {
+		collector.addRule(`.carbon-taskbar .toolbar-overflow {
 			background-color: ${overflowBackground};
 		}`);
 	}
 
 	const overflowShadow = theme.getColor(TOOLBAR_OVERFLOW_SHADOW);
 	if (overflowShadow) {
-		collector.addRule(`.toolbarOverflow {
+		collector.addRule(`.carbon-taskbar .toolbar-overflow {
 			box-shadow: 0px 4px 4px ${overflowShadow};
 		}`);
 	}
 
 	const border = theme.getColor(DASHBOARD_BORDER);
 	if (border) {
-		collector.addRule(`.toolbarOverflow {
+		collector.addRule(`.carbon-taskbar .toolbar-overflow {
 			border: 1px solid ${border};
 		}`);
 	}
 
 	const activeOutline = theme.getColor(focusBorder);
 	if (activeOutline) {
-		collector.addRule(`.carbon-taskbar .toolbarOverflow li.focused {
+		collector.addRule(`.carbon-taskbar .toolbar-overflow li.focused {
 			outline: 1px solid;
 			outline-offset: -3px;
 			outline-color: ${activeOutline}

--- a/src/sql/base/browser/ui/taskbar/overflowActionbarStyles.ts
+++ b/src/sql/base/browser/ui/taskbar/overflowActionbarStyles.ts
@@ -13,28 +13,28 @@ import { focusBorder } from 'vs/platform/theme/common/colorRegistry';
 registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {
 	const overflowBackground = theme.getColor(EDITOR_PANE_BACKGROUND);
 	if (overflowBackground) {
-		collector.addRule(`.carbon-taskbar .overflow {
+		collector.addRule(`.toolbarOverflow {
 			background-color: ${overflowBackground};
 		}`);
 	}
 
 	const overflowShadow = theme.getColor(TOOLBAR_OVERFLOW_SHADOW);
 	if (overflowShadow) {
-		collector.addRule(`.carbon-taskbar .overflow {
+		collector.addRule(`.toolbarOverflow {
 			box-shadow: 0px 4px 4px ${overflowShadow};
 		}`);
 	}
 
 	const border = theme.getColor(DASHBOARD_BORDER);
 	if (border) {
-		collector.addRule(`.carbon-taskbar .overflow {
+		collector.addRule(`.toolbarOverflow {
 			border: 1px solid ${border};
 		}`);
 	}
 
 	const activeOutline = theme.getColor(focusBorder);
 	if (activeOutline) {
-		collector.addRule(`.carbon-taskbar .overflow li.focused {
+		collector.addRule(`.carbon-taskbar .toolbarOverflow li.focused {
 			outline: 1px solid;
 			outline-offset: -3px;
 			outline-color: ${activeOutline}

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -385,6 +385,7 @@ export enum DatabaseEngineEdition {
 
 export interface ToolbarLayout {
 	orientation: Orientation;
+	overflow?: boolean;
 }
 
 export class TreeComponentItem extends vsExtTypes.TreeItem {

--- a/src/sql/workbench/browser/modelComponents/media/toolbarLayout.css
+++ b/src/sql/workbench/browser/modelComponents/media/toolbarLayout.css
@@ -8,7 +8,6 @@
 	justify-content: flex-start;
 	line-height: 1.4em;
 	white-space: nowrap;
-	flex-wrap: wrap;
 	padding: 3px 0px;
 }
 
@@ -22,6 +21,14 @@
 
 .modelview-toolbar-container.toolbar-vertical {
 	flex-direction: column;
+}
+
+.modelview-toolbar-container .toolbar-overflow {
+	flex-wrap: none;
+}
+
+.modelview-toolbar-container .toolbar-wrap {
+	flex-wrap: wrap;
 }
 
 .modelview-toolbar-container .modelview-toolbar-item {
@@ -71,4 +78,27 @@
 	-moz-transform: scale(1.272019649, 1.272019649);
 	-o-transform: scale(1.272019649, 1.272019649);
 	transform: scale(1.272019649, 1.272019649);
+}
+
+modelview-toolbarcontainer .toolbarOverflow modelview-button a.monaco-button.monaco-text-button.icon {
+	background-size: 16px;
+}
+
+modelview-toolbarcontainer .toolbarOverflow {
+	display: none;
+	width: 150px;
+	position: fixed;
+	right: 0;
+	z-index: 3;
+	padding: 5px 5px 0 0;
+	margin-right: 5px;
+}
+
+modelview-toolbarcontainer .toolbarOverflow > .modelview-toolbar-item {
+	padding-left: 5px;
+}
+
+modelview-toolbarcontainer .moreActions {
+	padding-left: 30px;
+	display: none;
 }

--- a/src/sql/workbench/browser/modelComponents/media/toolbarLayout.css
+++ b/src/sql/workbench/browser/modelComponents/media/toolbarLayout.css
@@ -23,11 +23,11 @@
 	flex-direction: column;
 }
 
-.modelview-toolbar-container .toolbar-overflow {
+.modelview-toolbar-container .overflow {
 	flex-wrap: none;
 }
 
-.modelview-toolbar-container .toolbar-wrap {
+.modelview-toolbar-container .wrap {
 	flex-wrap: wrap;
 }
 
@@ -80,11 +80,11 @@
 	transform: scale(1.272019649, 1.272019649);
 }
 
-modelview-toolbarcontainer .toolbarOverflow modelview-button a.monaco-button.monaco-text-button.icon {
+modelview-toolbarcontainer .toolbar-overflow modelview-button a.monaco-button.monaco-text-button.icon {
 	background-size: 16px;
 }
 
-modelview-toolbarcontainer .toolbarOverflow {
+modelview-toolbarcontainer .toolbar-overflow {
 	display: none;
 	width: 150px;
 	position: fixed;
@@ -94,7 +94,13 @@ modelview-toolbarcontainer .toolbarOverflow {
 	margin-right: 5px;
 }
 
-modelview-toolbarcontainer .toolbarOverflow > .modelview-toolbar-item {
+modelview-toolbarcontainer .toolbar-overflow .taskbarSeparator {
+	height: 1px;
+	width: 100%;
+	margin-left: 0;
+}
+
+modelview-toolbarcontainer .toolbar-overflow > .modelview-toolbar-item {
 	padding-left: 5px;
 }
 

--- a/src/sql/workbench/browser/modelComponents/toolbarContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/toolbarContainer.component.ts
@@ -4,13 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 import 'vs/css!./media/toolbarLayout';
 
+import * as DOM from 'vs/base/browser/dom';
+
 import {
 	Component, Input, Inject, ChangeDetectorRef, forwardRef,
-	ElementRef, OnDestroy, AfterViewInit
+	ElementRef, OnDestroy, AfterViewInit, ViewChild
 } from '@angular/core';
 
 import { ContainerBase } from 'sql/workbench/browser/modelComponents/componentBase';
 import { IComponentDescriptor, IComponent, IModelStore } from 'sql/platform/dashboard/browser/interfaces';
+import { debounce } from 'vs/base/common/decorators';
+import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 
 export enum Orientation {
 	Horizontal = 'horizontal',
@@ -19,6 +24,7 @@ export enum Orientation {
 
 export interface ToolbarLayout {
 	orientation: Orientation;
+	overflow?: boolean;
 }
 
 export interface ToolbarItemConfig {
@@ -47,14 +53,22 @@ export class ToolbarItem {
 				</div>
 			</div>
 			</ng-container>
+			<a #moreActionsButton class="moreActions action-label codicon toggle-more" role="button" tabindex="0" aria-haspopup="true"> </a>
+		</div>
+		<div #overflow class="toolbarOverflow" role="menu">
 		</div>
 	`
 })
 export default class ToolbarContainer extends ContainerBase<ToolbarItemConfig> implements IComponent, OnDestroy, AfterViewInit {
 	@Input() descriptor: IComponentDescriptor;
 	@Input() modelStore: IModelStore;
+	@ViewChild('container', { read: ElementRef }) private _container: ElementRef;
+	@ViewChild('overflow', { read: ElementRef }) private _overflowContainer: ElementRef;
+	@ViewChild('moreActionsButton', { read: ElementRef }) private _moreAcionsButton: ElementRef;
 
 	private _orientation: Orientation;
+	private _overflow: boolean = false;
+	private _overflowCurrentIndex;
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef,
@@ -74,10 +88,166 @@ export default class ToolbarContainer extends ContainerBase<ToolbarItemConfig> i
 	ngAfterViewInit(): void {
 	}
 
+	@debounce(300)
+	private resizeToolbar(): void {
+		let width = this._container.nativeElement.offsetWidth;
+		let fullWidth = this._container.nativeElement.scrollWidth;
+
+		if (width < fullWidth) {
+			this._moreAcionsButton.nativeElement.style.display = 'block';
+			while (width < fullWidth) {
+				let index = this.items.length - 1;
+				if (index > -1) {
+					this.collapseItem();
+					fullWidth = this._container.nativeElement.scrollWidth;
+				} else {
+					break;
+				}
+			}
+		} else if (this._overflowContainer.nativeElement.children.length > 0) {
+			do {
+				this.unCollapseItem();
+
+				// too big
+				if (this._container.nativeElement.scrollWidth > this._container.nativeElement.offsetWidth) {
+					this.collapseItem();
+					break;
+				}
+			} while (width === fullWidth && this._overflowContainer.nativeElement.children.length > 0);
+
+			if (this._overflowContainer.nativeElement.children.length === 0) {
+				this._moreAcionsButton.nativeElement.style.display = 'none';
+			}
+		}
+	}
+
+	private collapseItem(): void {
+		let lastChild = this._container.nativeElement.children[this._container.nativeElement.childElementCount - 2];
+		let element = this._container.nativeElement.removeChild(lastChild);
+		this._overflowContainer.nativeElement.insertBefore(element, this._overflowContainer.nativeElement.firstChild);
+
+		this._register(DOM.addDisposableListener(element, DOM.EventType.CLICK, (e => { this.hideOverflowDisplay(); })));
+
+		// change role to menuItem when it's in the overflow
+		let item = this.findFocusableElement(element);
+		item.setAttribute('role', 'menuItem');
+	}
+
+	private unCollapseItem(): void {
+		let firstChild = this._overflowContainer.nativeElement.children[0];
+		let element = this._overflowContainer.nativeElement.removeChild(firstChild);
+		this._container.nativeElement.insertBefore(element, this._container.nativeElement.lastElementChild);
+
+		// change role to back to button when it's in the toolbar
+		let item = this.findFocusableElement(element);
+		item.setAttribute('role', 'button');
+	}
+
+	private hideOverflowDisplay(): void {
+		this._overflowContainer.nativeElement.style.display = 'none';
+	}
+
+	private moreElementOnClick(event: MouseEvent | StandardKeyboardEvent): void {
+		this._overflowContainer.nativeElement.style.display = this._overflowContainer.nativeElement.style.display === 'block' ? 'none' : 'block';
+		this._overflowCurrentIndex = undefined;
+		if (this._overflowContainer.nativeElement.style.display === 'block') {
+			this.focusNext();
+		}
+		DOM.EventHelper.stop(event, true);
+	}
+
+	private focusNext(): void {
+		if (this._overflowCurrentIndex === undefined) {
+			this._overflowCurrentIndex = this._overflowContainer.nativeElement.children.length - 1;
+		}
+
+		let startIndex = this._overflowCurrentIndex;
+		// down arrow on last element should move focus to the first element of the overflow
+		do {
+			this._overflowCurrentIndex = (this._overflowCurrentIndex + 1) % this._overflowContainer.nativeElement.children.length;
+		} while (this._overflowCurrentIndex !== startIndex && !this.isEnabled(this.findFocusableElement(this._overflowContainer.nativeElement.children[this._overflowCurrentIndex])));
+
+		let current = this._overflowContainer.nativeElement.children[this._overflowCurrentIndex];
+		current = this.findFocusableElement(current);
+		(<HTMLElement>current).focus();
+	}
+
+	private focusPrevious(): void {
+		let startIndex = this._overflowCurrentIndex;
+		// up arrow on first element in overflow should move focus to the bottom of the overflow
+		do {
+			--this._overflowCurrentIndex;
+			if (this._overflowCurrentIndex < 0) {
+				this._overflowCurrentIndex = this._overflowContainer.nativeElement.children.length - 1;
+			}
+		} while (this._overflowCurrentIndex !== startIndex && !this.isEnabled(this.findFocusableElement(this._overflowContainer.nativeElement.children[this._overflowCurrentIndex])));
+
+		let current = this._overflowContainer.nativeElement.children[this._overflowCurrentIndex];
+		current = this.findFocusableElement(current);
+		(<HTMLElement>current).focus();
+	}
+
+	private findFocusableElement(element: any): HTMLElement {
+		let current = element;
+		while (current.children && current.children[0]) {
+			current = current.children[0];
+		}
+
+		return current;
+	}
+
+	private isEnabled(element: HTMLElement): boolean {
+		return !element.className.includes('disabled');
+	}
+
+	private addOverflowListeners(): void {
+		this._register(DOM.addDisposableListener(window, DOM.EventType.RESIZE, e => {
+			this.resizeToolbar();
+		}));
+
+		this._register(DOM.addDisposableListener(this._overflowContainer.nativeElement, DOM.EventType.FOCUS_OUT, e => {
+			if (this._overflowContainer && !DOM.isAncestor(e.relatedTarget as HTMLElement, this._overflowContainer.nativeElement) && e.relatedTarget !== this._moreAcionsButton.nativeElement) {
+				this.hideOverflowDisplay();
+			}
+		}));
+
+		this._register(DOM.addDisposableListener(this._overflowContainer.nativeElement, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			let event = new StandardKeyboardEvent(e);
+
+			if (event.equals(KeyCode.UpArrow)) {
+				this.focusPrevious();
+			} else if (event.equals(KeyCode.DownArrow)) {
+				this.focusNext();
+			} else if (event.equals(KeyMod.Shift | KeyCode.Tab)) {
+				this.hideOverflowDisplay();
+				(<HTMLElement>this._moreAcionsButton.nativeElement).focus();
+			} else if (event.equals(KeyCode.Tab)) {
+				this.hideOverflowDisplay();
+			}
+			DOM.EventHelper.stop(event, true);
+		}));
+
+		this._register(DOM.addDisposableListener(this._moreAcionsButton.nativeElement, DOM.EventType.KEY_UP, (ev => {
+			let event = new StandardKeyboardEvent(ev);
+			if (event.keyCode === KeyCode.Enter || event.keyCode === KeyCode.Space) {
+				this.moreElementOnClick(event);
+			}
+		})));
+
+		this._register(DOM.addDisposableListener(this._moreAcionsButton.nativeElement, DOM.EventType.CLICK, (e => { this.moreElementOnClick(e); })));
+	}
+
 	/// IComponent implementation
 
 	public setLayout(layout: ToolbarLayout): void {
 		this._orientation = layout.orientation ? layout.orientation : Orientation.Horizontal;
+		this._overflow = layout.overflow ? layout.overflow : true;
+
+		if (this._overflow) {
+			this.addOverflowListeners();
+			this.resizeToolbar();
+		}
+
 		this.layout();
 	}
 
@@ -111,6 +281,12 @@ export default class ToolbarContainer extends ContainerBase<ToolbarItemConfig> i
 			classes.push('toolbar-horizontal');
 		} else {
 			classes.push('toolbar-vertical');
+		}
+
+		if (this._overflow) {
+			classes.push('toolbar-overflow');
+		} else {
+			classes.push('toolbar-wrap');
 		}
 		return classes.join(' ');
 	}

--- a/src/sql/workbench/browser/modelComponents/toolbarContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/toolbarContainer.component.ts
@@ -16,6 +16,8 @@ import { IComponentDescriptor, IComponent, IModelStore } from 'sql/platform/dash
 import { debounce } from 'vs/base/common/decorators';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { registerThemingParticipant, IColorTheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
+import { EDITOR_PANE_BACKGROUND, TOOLBAR_OVERFLOW_SHADOW, DASHBOARD_BORDER } from 'vs/workbench/common/theme';
 
 export enum Orientation {
 	Horizontal = 'horizontal',
@@ -55,7 +57,7 @@ export class ToolbarItem {
 			</ng-container>
 			<a #moreActionsButton class="moreActions action-label codicon toggle-more" role="button" tabindex="0" aria-haspopup="true"> </a>
 		</div>
-		<div #overflow class="toolbarOverflow" role="menu">
+		<div #overflow class="toolbar-overflow" role="menu">
 		</div>
 	`
 })
@@ -284,9 +286,9 @@ export default class ToolbarContainer extends ContainerBase<ToolbarItemConfig> i
 		}
 
 		if (this._overflow) {
-			classes.push('toolbar-overflow');
+			classes.push('overflow');
 		} else {
-			classes.push('toolbar-wrap');
+			classes.push('wrap');
 		}
 		return classes.join(' ');
 	}
@@ -295,3 +297,26 @@ export default class ToolbarContainer extends ContainerBase<ToolbarItemConfig> i
 		return this._orientation === Orientation.Horizontal;
 	}
 }
+
+registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) => {
+	const overflowBackground = theme.getColor(EDITOR_PANE_BACKGROUND);
+	if (overflowBackground) {
+		collector.addRule(`modelview-toolbarcontainer .toolbar-overflow {
+			background-color: ${overflowBackground};
+		}`);
+	}
+
+	const overflowShadow = theme.getColor(TOOLBAR_OVERFLOW_SHADOW);
+	if (overflowShadow) {
+		collector.addRule(`modelview-toolbarcontainer .toolbar-overflow {
+			box-shadow: 0px 4px 4px ${overflowShadow};
+		}`);
+	}
+
+	const border = theme.getColor(DASHBOARD_BORDER);
+	if (border) {
+		collector.addRule(`modelview-toolbarcontainer .toolbar-overflow {
+			border: 1px solid ${border};
+		}`);
+	}
+});


### PR DESCRIPTION
Add overflow as an option for ModelView toolbar. The default behavior is still wrapping. Overflow can be specified like this:
```
let toolBar = view.modelBuilder.toolbarContainer().withLayout({
    orientation: azdata.Orientation.Horizontal,
    overflow: true
});
```

![modelviewToolbarOverflow](https://user-images.githubusercontent.com/31145923/79812487-f5461800-832d-11ea-9f8e-3917a7df30d3.gif)

