### PR TITLE
Put new welcome page behind preview features flag

### DIFF
--- a/src/sql/workbench/contrib/welcome2/gettingStarted/browser/abstractEnablePreviewFeatures.ts
+++ b/src/sql/workbench/contrib/welcome2/gettingStarted/browser/abstractEnablePreviewFeatures.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
+import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { localize } from 'vs/nls';
+import { onUnexpectedError } from 'vs/base/common/errors';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IHostService } from 'vs/workbench/services/host/browser/host';
+
+export abstract class AbstractEnablePreviewFeatures implements IWorkbenchContribution {
+
+	private static ENABLE_PREVIEW_FEATURES_SHOWN = 'workbench.enablePreviewFeaturesShown';
+
+	constructor(
+		@IStorageService private readonly storageService: IStorageService,
+		@INotificationService private readonly notificationService: INotificationService,
+		@IHostService private readonly hostService: IHostService,
+		@IConfigurationService private readonly configurationService: IConfigurationService
+	) { }
+
+	protected handlePreviewFeatures(): void {
+		let previewFeaturesEnabled = this.configurationService.getValue('workbench')['enablePreviewFeatures'];
+		if (previewFeaturesEnabled || this.storageService.get(AbstractEnablePreviewFeatures.ENABLE_PREVIEW_FEATURES_SHOWN, StorageScope.GLOBAL)) {
+			return;
+		}
+		Promise.all([
+			this.hostService.hasFocus,
+			this.getWindowCount()
+		]).then(async ([focused, count]) => {
+			if (!focused && count > 1) {
+				return null;
+			}
+			await this.configurationService.updateValue('workbench.enablePreviewFeatures', false);
+
+			const enablePreviewFeaturesNotice = localize('enablePreviewFeatures.notice', "Preview features are required in order for extensions to be fully supported and for some actions to be available.  Would you like to enable preview features?");
+			this.notificationService.prompt(
+				Severity.Info,
+				enablePreviewFeaturesNotice,
+				[{
+					label: localize('enablePreviewFeatures.yes', "Yes"),
+					run: () => {
+						this.configurationService.updateValue('workbench.enablePreviewFeatures', true).catch(e => onUnexpectedError(e));
+						this.storageService.store(AbstractEnablePreviewFeatures.ENABLE_PREVIEW_FEATURES_SHOWN, true, StorageScope.GLOBAL);
+					}
+				}, {
+					label: localize('enablePreviewFeatures.no', "No"),
+					run: () => {
+						this.configurationService.updateValue('workbench.enablePreviewFeatures', false).catch(e => onUnexpectedError(e));
+					}
+				}, {
+					label: localize('enablePreviewFeatures.never', "No, don't show again"),
+					run: () => {
+						this.configurationService.updateValue('workbench.enablePreviewFeatures', false).catch(e => onUnexpectedError(e));
+						this.storageService.store(AbstractEnablePreviewFeatures.ENABLE_PREVIEW_FEATURES_SHOWN, true, StorageScope.GLOBAL);
+					},
+					isSecondary: true
+				}]
+			);
+		}).catch(e => onUnexpectedError(e));
+	}
+
+	protected abstract getWindowCount(): Promise<number>;
+}

--- a/src/sql/workbench/contrib/welcome2/gettingStarted/browser/enablePreviewFeatures.ts
+++ b/src/sql/workbench/contrib/welcome2/gettingStarted/browser/enablePreviewFeatures.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AbstractEnablePreviewFeatures } from 'sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IHostService } from 'vs/workbench/services/host/browser/host';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+
+export class BrowserEnablePreviewFeatures extends AbstractEnablePreviewFeatures {
+
+	constructor(
+		@IStorageService storageService: IStorageService,
+		@INotificationService notificationService: INotificationService,
+		@IHostService hostService: IHostService,
+		@IConfigurationService configurationService: IConfigurationService
+	) {
+		super(storageService, notificationService, hostService, configurationService);
+
+		this.handlePreviewFeatures();
+	}
+
+	protected async getWindowCount(): Promise<number> {
+		return 1;
+	}
+}

--- a/src/sql/workbench/contrib/welcome2/gettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/sql/workbench/contrib/welcome2/gettingStarted/browser/gettingStarted.contribution.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Registry } from 'vs/platform/registry/common/platform';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
+import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
+import { BrowserEnablePreviewFeatures } from 'sql/workbench/contrib/welcome/gettingStarted/browser/enablePreviewFeatures';
+
+Registry
+	.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
+	.registerWorkbenchContribution(BrowserEnablePreviewFeatures, LifecyclePhase.Eventually);

--- a/src/sql/workbench/contrib/welcome2/gettingStarted/electron-browser/enablePreviewFeatures.ts
+++ b/src/sql/workbench/contrib/welcome2/gettingStarted/electron-browser/enablePreviewFeatures.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AbstractEnablePreviewFeatures } from 'sql/workbench/contrib/welcome/gettingStarted/browser/abstractEnablePreviewFeatures';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IHostService } from 'vs/workbench/services/host/browser/host';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IElectronService } from 'vs/platform/electron/node/electron';
+
+export class NativeEnablePreviewFeatures extends AbstractEnablePreviewFeatures {
+
+	constructor(
+		@IStorageService storageService: IStorageService,
+		@INotificationService notificationService: INotificationService,
+		@IHostService hostService: IHostService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IElectronService private readonly electronService: IElectronService
+	) {
+		super(storageService, notificationService, hostService, configurationService);
+
+		this.handlePreviewFeatures();
+	}
+
+	protected getWindowCount(): Promise<number> {
+		return this.electronService.getWindowCount();
+	}
+}

--- a/src/sql/workbench/contrib/welcome2/gettingStarted/electron-browser/gettingStarted.contribution.ts
+++ b/src/sql/workbench/contrib/welcome2/gettingStarted/electron-browser/gettingStarted.contribution.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Registry } from 'vs/platform/registry/common/platform';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
+import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
+import { NativeEnablePreviewFeatures } from 'sql/workbench/contrib/welcome/gettingStarted/electron-browser/enablePreviewFeatures';
+
+Registry
+	.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
+	.registerWorkbenchContribution(NativeEnablePreviewFeatures, LifecyclePhase.Eventually);

--- a/src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { escape } from 'vs/base/common/strings';
+import { localize } from 'vs/nls';
+
+export default () => `
+<div class="welcomePageContainer2">
+	<div class="welcomePage2">
+		<div class="title">
+			<h1 class="caption">${escape(localize('welcomePage.azdata', "Azure Data Studio"))}</h1>
+			<p class="subtitle detail"></p>
+		</div>
+		<div class="row">
+			<div class="splash">
+				<div class="section start">
+					<h2 class="caption">${escape(localize('welcomePage.start', "Start"))}</h2>
+					<ul>
+						<li><a href="command:registeredServers.addConnection">${escape(localize('welcomePage.newConnection', "New connection"))}</a></li>
+						<li><a href="command:workbench.action.files.newUntitledFile">${escape(localize('welcomePage.newQuery', "New query"))}</a></li>
+						<li><a href="command:notebook.command.new">${escape(localize('welcomePage.newNotebook', "New notebook"))}</a></li>
+						<li class="mac-only"><a href="command:workbench.action.files.openLocalFileFolder">${escape(localize('welcomePage.openFileMac', "Open file"))}</a></li>
+						<li class="windows-only linux-only"><a href="command:workbench.action.files.openFile">${escape(localize('welcomePage.openFileLinuxPC', "Open file"))}</a></li>
+					</ul>
+				</div>
+				<div class="section deploy">
+					<h2 class="caption">${escape(localize('welcomePage.deploy', "Deploy"))}</h2>
+					<ul>
+						<li><a href="command:azdata.resource.deploy">${escape(localize('welcomePage.newDeployment', "New Deployment…"))}</a></li>
+					</ul>
+				</div>
+				<div class="section recent">
+					<h2 class="caption">${escape(localize('welcomePage.recent', "Recent"))}</h2>
+					<ul class="list">
+						<!-- Filled programmatically -->
+						<li class="moreRecent"><a href="command:workbench.action.openRecent">${escape(localize('welcomePage.moreRecent', "More..."))}</a><span class="path detail if_shortcut" data-command="workbench.action.openRecent">(<span class="shortcut" data-command="workbench.action.openRecent"></span>)</span></li>
+					</ul>
+					<p class="none detail">${escape(localize('welcomePage.noRecentFolders', "No recent folders"))}</p>
+				</div>
+				<div class="section help">
+					<h2 class="caption">${escape(localize('welcomePage.help', "Help"))}</h2>
+					<ul>
+						<li><a href="https://aka.ms/get-started-azdata">${escape(localize('welcomePage.gettingStarted', "Getting started"))}</a></li>
+						<li><a href="https://aka.ms/azuredatastudio">${escape(localize('welcomePage.productDocumentation', "Documentation"))}</a></li>
+						<li><a href="https://github.com/Microsoft/azuredatastudio/issues/new/choose">${escape(localize('welcomePage.reportIssue', "Report issue or feature request"))}</a></li>
+						<li><a href="https://github.com/Microsoft/azuredatastudio">${escape(localize('welcomePage.gitHubRepository', "GitHub repository"))}</a></li>
+						<li><a href="https://aka.ms/azuredatastudio-releasenotes">${escape(localize('welcomePage.releaseNotes', "Release notes"))}</a></li>
+					</ul>
+				</div>
+				<p class="showOnStartup"><input type="checkbox" id="showOnStartup" class="checkbox"> <label class="caption" for="showOnStartup">${escape(localize('welcomePage.showOnStartup', "Show welcome page on startup"))}</label></p>
+			</div>
+			<div class="commands">
+				<div class="section customize">
+					<h2 class="caption">${escape(localize('welcomePage.customize', "Customize"))}</h2>
+					<div class="list">
+						<div class="item selectTheme"><button data-href="command:workbench.view.extensions"><h3 class="caption">${escape(localize('welcomePage.extensions', "Extensions"))}</h3> <span class="detail">${escape(localize('welcomePage.extensionDescription', "Download extensions that you need, including the SQL Server Admin pack and more"))}</span></button></div>
+						<div class="item selectTheme"><button data-href="command:workbench.action.openGlobalKeybindings"><h3 class="caption">${escape(localize('welcomePage.keyboardShortcut', "Keyboard Shortcuts"))}</h3> <span class="detail">${escape(localize('welcomePage.keyboardShortcutDescription', "Find your favorite commands and customize them"))}</span></button></div>
+						<div class="item selectTheme"><button data-href="command:workbench.action.selectTheme"><h3 class="caption">${escape(localize('welcomePage.colorTheme', "Color theme"))}</h3> <span class="detail">${escape(localize('welcomePage.colorThemeDescription', "Make the editor and your code look the way you love"))}</span></button></div>
+					</div>
+				</div>
+				<div class="section learn">
+					<h2 class="caption">${escape(localize('welcomePage.learn', "Learn"))}</h2>
+					<div class="list">
+						<div class="item showCommands"><button data-href="command:workbench.action.showCommands"><h3 class="caption">${escape(localize('welcomePage.showCommands', "Find and run all commands"))}</h3> <span class="detail">${escape(localize('welcomePage.showCommandsDescription', "Rapidly access and search commands from the Command Palette ({0})"))
+		.replace('{0}', '<span class="shortcut" data-command="workbench.action.showCommands"></span>')}</span></button></div>
+						<div class="item showInterfaceOverview"><button data-href="https://aka.ms/azdata-blog"><h3 class="caption">${escape(localize('welcomePage.azdataBlog', "Discover what's new in the latest release"))}</h3> <span class="detail">${escape(localize('welcomePage.azdataBlogDescription', "New monthly blog posts each month showcasing our new features"))}</span></button></div>
+						<div class="item showInteractivePlayground"><button data-href="https://twitter.com/azuredatastudio"><h3 class="caption">${escape(localize('welcomePage.followTwitter', "Follow us on Twitter"))}</h3> <span class="detail">${escape(localize('welcomePage.followTwitterDescription', "Keep up to date with how the community is using Azure Data Studio and to talk directly with the engineers."))}</span></button></div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+`;

--- a/src/vs/workbench/contrib/welcome/page/browser/welcomePage.css
+++ b/src/vs/workbench/contrib/welcome/page/browser/welcomePage.css
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-workbench .part.editor > .content .welcomePageContainer {
+.monaco-workbench .part.editor > .content .welcomePageContainer2 {
 	align-items: center;
 	display: flex;
 	justify-content: center;
@@ -11,51 +11,51 @@
 	min-height: 100%;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage {
+.monaco-workbench .part.editor > .content .welcomePage2 {
 	width: 90%;
 	max-width: 1200px;
 	font-size: 10px;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .row {
+.monaco-workbench .part.editor > .content .welcomePage2 .row {
 	display: flex;
 	flex-flow: row;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .row .section {
+.monaco-workbench .part.editor > .content .welcomePage2 .row .section {
 	overflow: hidden;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .row .splash {
+.monaco-workbench .part.editor > .content .welcomePage2 .row .splash {
 	overflow: hidden;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .row .commands {
+.monaco-workbench .part.editor > .content .welcomePage2 .row .commands {
 	overflow: hidden;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .row .commands .list {
+.monaco-workbench .part.editor > .content .welcomePage2 .row .commands .list {
 	overflow: hidden;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage p {
+.monaco-workbench .part.editor > .content .welcomePage2 p {
 	font-size: 1.3em;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .keyboard {
+.monaco-workbench .part.editor > .content .welcomePage2 .keyboard {
 	font-family: "Lucida Grande", sans-serif;/* Keyboard shortcuts */
 }
 
-.monaco-workbench .part.editor > .content .welcomePage a {
+.monaco-workbench .part.editor > .content .welcomePage2 a {
 	text-decoration: none;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage a:focus {
+.monaco-workbench .part.editor > .content .welcomePage2 a:focus {
 	outline: 1px solid -webkit-focus-ring-color;
 	outline-offset: -1px;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage h1 {
+.monaco-workbench .part.editor > .content .welcomePage2 h1 {
 	padding: 0;
 	margin: 0;
 	border: none;
@@ -64,28 +64,28 @@
 	white-space: nowrap;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .title {
+.monaco-workbench .part.editor > .content .welcomePage2 .title {
 	margin-top: 1em;
 	margin-bottom: 1em;
 	flex: 1 100%;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .subtitle {
+.monaco-workbench .part.editor > .content .welcomePage2 .subtitle {
 	margin-top: .8em;
 	font-size: 2.6em;
 	display: block;
 }
 
-.hc-black .monaco-workbench .part.editor > .content .welcomePage .subtitle {
+.hc-black .monaco-workbench .part.editor > .content .welcomePage2 .subtitle {
 	font-weight: 200;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .splash,
-.monaco-workbench .part.editor > .content .welcomePage .commands {
+.monaco-workbench .part.editor > .content .welcomePage2 .splash,
+.monaco-workbench .part.editor > .content .welcomePage2 .commands {
 	flex: 1 1 0;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage h2 {
+.monaco-workbench .part.editor > .content .welcomePage2 h2 {
 	font-weight: 200;
 	margin-top: 17px;
 	margin-bottom: 5px;
@@ -93,62 +93,62 @@
 	line-height: initial;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .splash .section {
+.monaco-workbench .part.editor > .content .welcomePage2 .splash .section {
 	margin-bottom: 5em;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .splash ul {
+.monaco-workbench .part.editor > .content .welcomePage2 .splash ul {
 	margin: 0;
 	font-size: 1.3em;
 	list-style: none;
 	padding: 0;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .splash li {
+.monaco-workbench .part.editor > .content .welcomePage2 .splash li {
 	min-width: 0;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage.emptyRecent .splash .recent .list {
+.monaco-workbench .part.editor > .content .welcomePage2.emptyRecent .splash .recent .list {
 	display: none;
 }
-.monaco-workbench .part.editor > .content .welcomePage .splash .recent .none {
+.monaco-workbench .part.editor > .content .welcomePage2 .splash .recent .none {
 	display: none;
 }
-.monaco-workbench .part.editor > .content .welcomePage.emptyRecent .splash .recent .none {
+.monaco-workbench .part.editor > .content .welcomePage2.emptyRecent .splash .recent .none {
 	display: initial;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .splash .recent li.moreRecent {
+.monaco-workbench .part.editor > .content .welcomePage2 .splash .recent li.moreRecent {
 	margin-top: 5px;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .splash .recent .path {
+.monaco-workbench .part.editor > .content .welcomePage2 .splash .recent .path {
 	padding-left: 1em;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .splash .title,
-.monaco-workbench .part.editor > .content .welcomePage .splash .showOnStartup {
+.monaco-workbench .part.editor > .content .welcomePage2 .splash .title,
+.monaco-workbench .part.editor > .content .welcomePage2 .splash .showOnStartup {
 	min-width: 0;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .splash .showOnStartup > .checkbox {
+.monaco-workbench .part.editor > .content .welcomePage2 .splash .showOnStartup > .checkbox {
 	vertical-align: bottom;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .commands .list {
+.monaco-workbench .part.editor > .content .welcomePage2 .commands .list {
 	list-style: none;
 	padding: 0;
 }
-.monaco-workbench .part.editor > .content .welcomePage .commands .item {
+.monaco-workbench .part.editor > .content .welcomePage2 .commands .item {
 	margin: 7px 0px;
 }
-.monaco-workbench .part.editor > .content .welcomePage .commands .item button {
+.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button {
 	margin: 1px;
 	padding: 12px 10px;
 	width: calc(100% - 2px);
@@ -160,7 +160,7 @@
 	font-family: inherit;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .commands .item button > span {
+.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button > span {
 	display: inline-block;
 	width:100%;
 	min-width: 0;
@@ -169,7 +169,7 @@
 	text-overflow: ellipsis;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .commands .item button h3 {
+.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button h3 {
 	font-weight: normal;
 	font-size: 1em;
 	margin: 0;
@@ -180,41 +180,41 @@
 	text-overflow: ellipsis;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .commands .item button {
+.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button {
 	border: none;
 }
 
-.hc-black .monaco-workbench .part.editor > .content .welcomePage .commands .item button > h3 {
+.hc-black .monaco-workbench .part.editor > .content .welcomePage2 .commands .item button > h3 {
 	font-weight: bold;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .commands .item button:focus {
+.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button:focus {
 	outline-style: solid;
 	outline-width: 1px;
 }
 
-.hc-black .monaco-workbench .part.editor > .content .welcomePage .commands .item button {
+.hc-black .monaco-workbench .part.editor > .content .welcomePage2 .commands .item button {
 	border-width: 1px;
 	border-style: solid;
 }
 
-.hc-black .monaco-workbench .part.editor > .content .welcomePage .commands .item button:hover {
+.hc-black .monaco-workbench .part.editor > .content .welcomePage2 .commands .item button:hover {
 	outline-width: 1px;
 	outline-style: dashed;
 	outline-offset: -5px;
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .commands .item button .enabledExtension {
+.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button .enabledExtension {
 	display: none;
 }
-.monaco-workbench .part.editor > .content .welcomePage .commands .item button .installExtension.installed {
+.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button .installExtension.installed {
 	display: none;
 }
-.monaco-workbench .part.editor > .content .welcomePage .commands .item button .enabledExtension.installed {
+.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button .enabledExtension.installed {
 	display: inline;
 }
 
-.monaco-workbench .part.editor > .content .welcomePageContainer.max-height-685px .title {
+.monaco-workbench .part.editor > .content .welcomePageContainer2.max-height-685px .title {
 	display: none;
 }
 
@@ -223,26 +223,26 @@
 	background-image: url('../../code-icon.svg');
 }
 
-.monaco-workbench .part.editor > .content .welcomePage .mac-only,
-.monaco-workbench .part.editor > .content .welcomePage .windows-only,
-.monaco-workbench .part.editor > .content .welcomePage .linux-only {
+.monaco-workbench .part.editor > .content .welcomePage2 .mac-only,
+.monaco-workbench .part.editor > .content .welcomePage2 .windows-only,
+.monaco-workbench .part.editor > .content .welcomePage2 .linux-only {
 	display: none;
 }
-.monaco-workbench.mac .part.editor > .content .welcomePage .mac-only {
+.monaco-workbench.mac .part.editor > .content .welcomePage2 .mac-only {
 	display: initial;
 }
-.monaco-workbench.windows .part.editor > .content .welcomePage .windows-only {
+.monaco-workbench.windows .part.editor > .content .welcomePage2 .windows-only {
 	display: initial;
 }
-.monaco-workbench.linux .part.editor > .content .welcomePage .linux-only {
+.monaco-workbench.linux .part.editor > .content .welcomePage2 .linux-only {
 	display: initial;
 }
-.monaco-workbench.mac .part.editor > .content .welcomePage li.mac-only {
+.monaco-workbench.mac .part.editor > .content .welcomePage2 li.mac-only {
 	display: list-item;
 }
-.monaco-workbench.windows .part.editor > .content .welcomePage li.windows-only {
+.monaco-workbench.windows .part.editor > .content .welcomePage2 li.windows-only {
 	display: list-item;
 }
-.monaco-workbench.linux .part.editor > .content .welcomePage li.linux-only {
+.monaco-workbench.linux .part.editor > .content .welcomePage2 li.linux-only {
 	display: list-item;
 }

--- a/src/vs/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/vs/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -278,7 +278,7 @@ class WelcomePage extends Disposable {
 		const resource = URI.parse(require.toUrl('./az_data_welcome_page'))
 			.with({
 				scheme: Schemas.walkThrough,
-				query: JSON.stringify({ moduleId: 'sql/workbench/contrib/welcome/page/browser/az_data_welcome_page' })
+				query: JSON.stringify({ moduleId: 'sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page' })
 			});
 		this.editorInput = this.instantiationService.createInstance(WalkThroughInput, {
 			typeId: welcomeInputTypeId,
@@ -303,7 +303,7 @@ class WelcomePage extends Disposable {
 			this.configurationService.updateValue(configurationKey, showOnStartup.checked ? 'welcomePage' : 'newUntitledFile', ConfigurationTarget.USER);
 		});
 
-		const prodName = container.querySelector('.welcomePage .title .caption') as HTMLElement;
+		const prodName = container.querySelector('.welcomePage2 .title .caption') as HTMLElement;
 		if (prodName) {
 			prodName.innerHTML = this.productService.nameLong;
 		}
@@ -312,7 +312,7 @@ class WelcomePage extends Disposable {
 			// Filter out the current workspace
 			workspaces = workspaces.filter(recent => !this.contextService.isCurrentWorkspace(isRecentWorkspace(recent) ? recent.workspace : recent.folderUri));
 			if (!workspaces.length) {
-				const recent = container.querySelector('.welcomePage') as HTMLElement;
+				const recent = container.querySelector('.welcomePage2') as HTMLElement;
 				recent.classList.add('emptyRecent');
 				return;
 			}
@@ -625,39 +625,39 @@ registerThemingParticipant((theme, collector) => {
 	}
 	const foregroundColor = theme.getColor(foreground);
 	if (foregroundColor) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage .caption { color: ${foregroundColor}; }`);
+		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage2 .caption { color: ${foregroundColor}; }`);
 	}
 	const descriptionColor = theme.getColor(descriptionForeground);
 	if (descriptionColor) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage .detail { color: ${descriptionColor}; }`);
+		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage2 .detail { color: ${descriptionColor}; }`);
 	}
 	const buttonColor = getExtraColor(theme, buttonBackground, { dark: 'rgba(0, 0, 0, .2)', extra_dark: 'rgba(200, 235, 255, .042)', light: 'rgba(0,0,0,.04)', hc: 'black' });
 	if (buttonColor) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage .commands .item button { background: ${buttonColor}; }`);
+		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button { background: ${buttonColor}; }`);
 	}
 	const buttonHoverColor = getExtraColor(theme, buttonHoverBackground, { dark: 'rgba(200, 235, 255, .072)', extra_dark: 'rgba(200, 235, 255, .072)', light: 'rgba(0,0,0,.10)', hc: null });
 	if (buttonHoverColor) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage .commands .item button:hover { background: ${buttonHoverColor}; }`);
+		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button:hover { background: ${buttonHoverColor}; }`);
 	}
 	const link = theme.getColor(textLinkForeground);
 	if (link) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage a { color: ${link}; }`);
+		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage2 a { color: ${link}; }`);
 	}
 	const activeLink = theme.getColor(textLinkActiveForeground);
 	if (activeLink) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage a:hover,
-			.monaco-workbench .part.editor > .content .welcomePage a:active { color: ${activeLink}; }`);
+		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage2 a:hover,
+			.monaco-workbench .part.editor > .content .welcomePage2 a:active { color: ${activeLink}; }`);
 	}
 	const focusColor = theme.getColor(focusBorder);
 	if (focusColor) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage a:focus { outline-color: ${focusColor}; }`);
+		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage2 a:focus { outline-color: ${focusColor}; }`);
 	}
 	const border = theme.getColor(contrastBorder);
 	if (border) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage .commands .item button { border-color: ${border}; }`);
+		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button { border-color: ${border}; }`);
 	}
 	const activeBorder = theme.getColor(activeContrastBorder);
 	if (activeBorder) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage .commands .item button:hover { outline-color: ${activeBorder}; }`);
+		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage2 .commands .item button:hover { outline-color: ${activeBorder}; }`);
 	}
 });


### PR DESCRIPTION
Only show the new welcome page if the preview flag is set to true when ADS is launched.

This addresses issue https://github.com/microsoft/azuredatastudio/issues/10100.