### PR TITLE
Fix Taskbar separator sometimes disappearing

### DIFF
--- a/src/sql/base/browser/ui/taskbar/media/taskbar.css
+++ b/src/sql/base/browser/ui/taskbar/media/taskbar.css
@@ -74,7 +74,7 @@
 }
 
 .taskbarSeparator {
-	width: 1px;
+	padding-left: 1px;
 	background-color:#A5A5A5;
 	margin: 6px 8px;
 }

--- a/src/sql/base/browser/ui/taskbar/media/taskbar.css
+++ b/src/sql/base/browser/ui/taskbar/media/taskbar.css
@@ -74,7 +74,7 @@
 }
 
 .taskbarSeparator {
-	padding-left: 1px;
+	min-width: 1px;
 	background-color:#A5A5A5;
 	margin: 6px 8px;
 }


### PR DESCRIPTION
This PR fixes #10001. The width of the toolbar separator was becoming zero sometimes when resizing the toolbar. Setting the padding-left to 1px instead looks the same and doesn't disappear when resizing. 

Previous:
![Capture](https://user-images.githubusercontent.com/28519865/79392031-7e70df80-7f27-11ea-9250-6ba443edd11e.gif)

fixed:
![disappearingSeparator](https://user-images.githubusercontent.com/31145923/79923286-048a9b80-83ea-11ea-8877-d9bdecaae974.gif)

