### PR TITLE
Removing quality addition in naming and move to compile step

### DIFF
--- a/build/azure-pipelines/darwin/sql-publish.ps1
+++ b/build/azure-pipelines/darwin/sql-publish.ps1
@@ -17,8 +17,4 @@ $ZipName = "azuredatastudio-darwin.zip"
 $Zip = "$artifactsDir\darwin\archive\$ZipName"
 $UploadName = "azuredatastudio-macos-$Version"
 
-If (-NOT ($Quality -eq "stable")) {
-	$UploadName = "$UploadName-$Quality"
-}
-
 node $sourcesDir\build\azure-pipelines\common\publish.js $Quality darwin archive "$UploadName.zip" $Version true $Zip $CommitId

--- a/build/azure-pipelines/linux/createDrop.sh
+++ b/build/azure-pipelines/linux/createDrop.sh
@@ -11,12 +11,6 @@ BUILD="$ROOT/$BUILDNAME"
 TARBALL_FILENAME="azuredatastudio-$PLATFORM_LINUX.tar.gz"
 TARBALL_PATH="$REPO/.build/linux/archive/$TARBALL_FILENAME"
 
-# create version
-PACKAGEJSON="$BUILD/resources/app/package.json"
-VERSION=$(node -p "require(\"$PACKAGEJSON\").version")
-COMMIT_ID=$(git rev-parse HEAD)
-echo -e "{  \"version\": \"$VERSION\", \"quality\": \"$VSCODE_QUALITY\", \"commit\": \"$COMMIT_ID\" }" > "$REPO/.build/version.json"
-
 rm -rf $ROOT/code-*.tar.*
 (cd $ROOT && tar -czf $TARBALL_PATH $BUILDNAME)
 

--- a/build/azure-pipelines/linux/sql-publish.ps1
+++ b/build/azure-pipelines/linux/sql-publish.ps1
@@ -20,10 +20,6 @@ $TarballFilename = "azuredatastudio-linux-$Arch.tar.gz"
 $TarballPath = "$artifactsDir\linux\archive\$TarballFilename"
 $TarballUploadName = "azuredatastudio-linux-$Version"
 
-If (-NOT ($Quality -eq "stable")) {
-	$TarballUploadName = "$TarballUploadName-$Quality"
-}
-
 node $sourcesDir\build\azure-pipelines\common\publish.js $Quality $PlatformLinux archive-unsigned "$TarballUploadName.tar.gz" $Version true $TarballPath $CommitId
 
 # Publish DEB
@@ -32,10 +28,6 @@ $DebFilename = "$(Get-ChildItem -File -Name $artifactsDir\linux\deb\amd64\deb\*.
 $DebPath = "$artifactsDir\linux\deb\amd64\deb\$DebFilename"
 $DebUploadName = "azuredatastudio-linux-$Version"
 
-If (-NOT ($Quality -eq "stable")) {
-	$DebUploadName = "$DebUploadName-$Quality"
-}
-
 node $sourcesDir\build\azure-pipelines\common\publish.js $Quality $PlatformDeb package "$DebUploadName.deb" $Version true $DebPath $CommitId
 
 # Publish RPM
@@ -43,9 +35,5 @@ $PlatformRpm = "linux-rpm-$Arch"
 $RpmFilename = "$(Get-ChildItem -File -Name $artifactsDir\linux\rpm\x86_64\*.rpm)"
 $RpmPath = "$artifactsDir\linux\rpm\x86_64\$RpmFilename"
 $RpmUploadName = "azuredatastudio-linux-$Version"
-
-If (-NOT ($Quality -eq "stable")) {
-	$RpmUploadName = "$RpmUploadName-$Quality"
-}
 
 node $sourcesDir\build\azure-pipelines\common\publish.js $Quality $PlatformRpm package "$RpmUploadName.rpm" $Version true $RpmPath $CommitId

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -119,8 +119,8 @@ steps:
     node build/azure-pipelines/common/copyArtifacts.js
   displayName: Write Version Information
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: drop'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: drop'
 
 - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
   inputs:

--- a/build/azure-pipelines/sql-product-compile.yml
+++ b/build/azure-pipelines/sql-product-compile.yml
@@ -104,6 +104,24 @@ steps:
   displayName: Compile
   condition: and(succeeded(), ne(variables['CacheRestored-Compilation'], 'true'))
 
+- script: |
+    set -e
+
+    VERSION=$(node -p "require(\"./package.json\").version")
+
+    if [ "$VSCODE_QUALITY" != "stable" ]
+    then
+      VERSION="$VERSION-$VSCODE_QUALITY"
+    fi
+
+    echo -e "{  \"version\": \"$VERSION\", \"quality\": \"$VSCODE_QUALITY\", \"commit\": \"$BUILD_SOURCEVERSION\" }" > ".build/version.json"
+
+    node build/azure-pipelines/common/copyArtifacts.js
+  displayName: Write Version Information
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+
 - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
   inputs:
     keyfile: 'build/.cachesalt, .build/commit, .build/quality'

--- a/build/azure-pipelines/win32/sql-publish.ps1
+++ b/build/azure-pipelines/win32/sql-publish.ps1
@@ -24,12 +24,6 @@ $ZipUploadName = "azuredatastudio-windows-$Version"
 $SetupUploadName = "azuredatastudio-windows-setup-$Version"
 $UserUploadName = "azuredatastudio-windows-user-setup-$Version"
 
-If (-NOT ($Quality -eq "stable")) {
-	$ZipUploadName = "$ZipUploadName-$Quality"
-	$SetupUploadName = "$SetupUploadName-$Quality"
-	$UserUploadName = "$UserUploadName-$Quality"
-}
-
 $assetPlatform = "win32-x64"
 
 node $sourcesDir/build/azure-pipelines/common/publish.js $Quality "$assetPlatform-archive" archive "$ZipUploadName.zip" $Version true $Zip $CommitId


### PR DESCRIPTION
the quality is already part of the version, so remove that part, and move the version generation to the compile step which is guaranteed to always run