### PR TITLE
Change use of ctrl + alt default keybinding

### DIFF
--- a/src/vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode.ts
+++ b/src/vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode.ts
@@ -5,7 +5,7 @@
 
 import * as nls from 'vs/nls';
 import { alert } from 'vs/base/browser/ui/aria/aria';
-import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { KeyCode, KeyMod, KeyChord } from 'vs/base/common/keyCodes';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorAction, ServicesAccessor, registerEditorAction } from 'vs/editor/browser/editorExtensions';
 import { TabFocus } from 'vs/editor/common/config/commonEditorConfig';
@@ -23,7 +23,7 @@ export class ToggleTabFocusModeAction extends EditorAction {
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: null,
-				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_M, // {{SQL CARBON EDIT}} We use Ctrl+M already so move this to an unused binding
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_M), // {{SQL CARBON EDIT}} We use Ctrl+M already so move this to an unused binding
 				mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.KEY_M },
 				weight: KeybindingWeight.EditorContrib
 			}


### PR DESCRIPTION
The use of ctrl + alt default keybindings is discouraged on Windows since it conflicts with ISO keyboards that use that for accent characters. 

There aren't a lot of open options anymore - ctrl + m (the original mapping from VS Code) is currently mapped to "Run query with actual execution plan" which seems more generally useful so I chose to update this one instead.