### PR TITLE
Remove properties widget height calculations

### DIFF
--- a/src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component.ts
+++ b/src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/loadingComponent';
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, Inject, forwardRef, ElementRef } from '@angular/core';
 import * as nls from 'vs/nls';
 import { status } from 'vs/base/browser/ui/aria/aria';
+import * as DOM from 'vs/base/browser/dom';
 
 const DefaultLoadingMessage = nls.localize('loadingMessage', "Loading");
 const DefaultLoadingCompletedMessage = nls.localize('loadingCompletedMessage', "Loading completed");
@@ -14,12 +15,16 @@ const DefaultLoadingCompletedMessage = nls.localize('loadingCompletedMessage', "
 @Component({
 	selector: 'loading-spinner',
 	template: `
-		<div class="loading-spinner-container" *ngIf="loading">
+		<div class="loading-spinner-container">
 			<div class="loading-spinner codicon in-progress" *ngIf="loading" [title]="_loadingMessage" #spinnerElement></div>
 		</div>
 	`
 })
 export default class LoadingSpinner implements OnChanges {
+
+	constructor(
+		@Inject(forwardRef(() => ElementRef)) private _el: ElementRef
+	) { }
 
 	ngOnChanges(changes: SimpleChanges): void {
 		if (changes.loading !== undefined) {
@@ -34,6 +39,10 @@ export default class LoadingSpinner implements OnChanges {
 
 	get _loadingCompletedMessage(): string {
 		return this.loadingCompletedMessage ? this.loadingCompletedMessage : DefaultLoadingCompletedMessage;
+	}
+
+	public get height(): number {
+		return DOM.getTotalHeight(<HTMLElement>this._el.nativeElement);
 	}
 
 	@Input()

--- a/src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component.ts
+++ b/src/sql/base/browser/ui/loadingSpinner/loadingSpinner.component.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/loadingComponent';
-import { Component, Input, OnChanges, SimpleChanges, Inject, forwardRef, ElementRef } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import * as nls from 'vs/nls';
 import { status } from 'vs/base/browser/ui/aria/aria';
-import * as DOM from 'vs/base/browser/dom';
 
 const DefaultLoadingMessage = nls.localize('loadingMessage', "Loading");
 const DefaultLoadingCompletedMessage = nls.localize('loadingCompletedMessage', "Loading completed");
@@ -22,10 +21,6 @@ const DefaultLoadingCompletedMessage = nls.localize('loadingCompletedMessage', "
 })
 export default class LoadingSpinner implements OnChanges {
 
-	constructor(
-		@Inject(forwardRef(() => ElementRef)) private _el: ElementRef
-	) { }
-
 	ngOnChanges(changes: SimpleChanges): void {
 		if (changes.loading !== undefined) {
 			const message = this.loading ? this._loadingMessage : this._loadingCompletedMessage;
@@ -39,10 +34,6 @@ export default class LoadingSpinner implements OnChanges {
 
 	get _loadingCompletedMessage(): string {
 		return this.loadingCompletedMessage ? this.loadingCompletedMessage : DefaultLoadingCompletedMessage;
-	}
-
-	public get height(): number {
-		return DOM.getTotalHeight(<HTMLElement>this._el.nativeElement);
 	}
 
 	@Input()

--- a/src/sql/base/browser/ui/loadingSpinner/media/loadingComponent.css
+++ b/src/sql/base/browser/ui/loadingSpinner/media/loadingComponent.css
@@ -3,6 +3,11 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+loading-spinner {
+	width: 100%;
+	display: inline-block;
+}
+
 loading-spinner .loading-spinner-container {
 	display: flex;
 	flex-direction: row;

--- a/src/sql/base/browser/ui/propertiesContainer/media/propertiesContainer.css
+++ b/src/sql/base/browser/ui/propertiesContainer/media/propertiesContainer.css
@@ -3,6 +3,19 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+properties-container {
+	display: block;
+}
+
+properties-container .grid-container {
+	width: 100%;
+	display: grid;
+}
+
+properties-container .property {
+	display:flex;
+}
+
 properties-container .twoColumns.grid-container {
 	grid-template-columns: 50% 50%;
 }

--- a/src/sql/base/browser/ui/propertiesContainer/propertiesContainer.component.ts
+++ b/src/sql/base/browser/ui/propertiesContainer/propertiesContainer.component.ts
@@ -5,7 +5,7 @@
 
 import 'vs/css!./media/propertiesContainer';
 import { Component, Inject, forwardRef, ChangeDetectorRef, OnInit, ElementRef, OnDestroy } from '@angular/core';
-import { EventType, addDisposableListener } from 'vs/base/browser/dom';
+import * as DOM from 'vs/base/browser/dom';
 import { Disposable } from 'vs/base/common/lifecycle';
 
 enum GridDisplayLayout {
@@ -23,10 +23,6 @@ export interface PropertyItem {
 	value: string;
 }
 
-const collapseHeight = 25;
-const horizontalPropertyHeight = 28;
-const verticalPropertyHeight = 46;
-
 @Component({
 	selector: 'properties-container',
 	templateUrl: decodeURI(require.toUrl('./propertiesContainer.component.html'))
@@ -34,18 +30,17 @@ const verticalPropertyHeight = 46;
 export class PropertiesContainer extends Disposable implements OnInit, OnDestroy {
 	public gridDisplayLayout = GridDisplayLayout.twoColumns;
 	public propertyLayout = PropertyLayoutDirection.row;
-	public height: number;
 	private _propertyItems: PropertyItem[] = [];
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
-		@Inject(forwardRef(() => ElementRef)) el: ElementRef
+		@Inject(forwardRef(() => ElementRef)) private _el: ElementRef
 	) {
 		super();
 	}
 
 	ngOnInit() {
-		this._register(addDisposableListener(window, EventType.RESIZE, () => this.layoutPropertyItems()));
+		this._register(DOM.addDisposableListener(window, DOM.EventType.RESIZE, () => this.layoutPropertyItems()));
 		this._changeRef.detectChanges();
 	}
 
@@ -61,15 +56,12 @@ export class PropertiesContainer extends Disposable implements OnInit, OnDestroy
 		if (window.innerWidth >= 1366) {
 			this.gridDisplayLayout = GridDisplayLayout.twoColumns;
 			this.propertyLayout = PropertyLayoutDirection.row;
-			this.height = Math.ceil(this.propertyItems.length / 2) * horizontalPropertyHeight + collapseHeight;
 		} else if (window.innerWidth < 1366 && window.innerWidth >= 1024) {
 			this.gridDisplayLayout = GridDisplayLayout.twoColumns;
 			this.propertyLayout = PropertyLayoutDirection.column;
-			this.height = Math.ceil(this.propertyItems.length / 2) * verticalPropertyHeight + collapseHeight;
 		} else if (window.innerWidth < 1024) {
 			this.gridDisplayLayout = GridDisplayLayout.oneColumn;
 			this.propertyLayout = PropertyLayoutDirection.column;
-			this.height = this.propertyItems.length * verticalPropertyHeight + collapseHeight;
 		}
 
 		this._changeRef.detectChanges();
@@ -82,5 +74,9 @@ export class PropertiesContainer extends Disposable implements OnInit, OnDestroy
 
 	public get propertyItems(): PropertyItem[] {
 		return this._propertyItems;
+	}
+
+	public get height(): number {
+		return DOM.getTotalHeight(<HTMLElement>this._el.nativeElement);
 	}
 }

--- a/src/sql/base/browser/ui/propertiesContainer/propertiesContainer.component.ts
+++ b/src/sql/base/browser/ui/propertiesContainer/propertiesContainer.component.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/propertiesContainer';
-import { Component, Inject, forwardRef, ChangeDetectorRef, OnInit, ElementRef, OnDestroy } from '@angular/core';
+import { Component, Inject, forwardRef, ChangeDetectorRef, OnInit, OnDestroy } from '@angular/core';
 import * as DOM from 'vs/base/browser/dom';
 import { Disposable } from 'vs/base/common/lifecycle';
 
@@ -33,8 +33,7 @@ export class PropertiesContainer extends Disposable implements OnInit, OnDestroy
 	private _propertyItems: PropertyItem[] = [];
 
 	constructor(
-		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
-		@Inject(forwardRef(() => ElementRef)) private _el: ElementRef
+		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef
 	) {
 		super();
 	}
@@ -74,9 +73,5 @@ export class PropertiesContainer extends Disposable implements OnInit, OnDestroy
 
 	public get propertyItems(): PropertyItem[] {
 		return this._propertyItems;
-	}
-
-	public get height(): number {
-		return DOM.getTotalHeight(<HTMLElement>this._el.nativeElement);
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/media/propertiesContainer.css
+++ b/src/sql/workbench/browser/modelComponents/media/propertiesContainer.css
@@ -1,15 +1,9 @@
-<!--
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
--->
-<div class="grid-container {{gridDisplayLayout}}">
-	<ng-template ngFor let-item [ngForOf]="propertyItems">
-		<div class="property {{propertyLayout}}">
-			<div class="propertyName">{{item.displayName}}</div>
-			<div class="splitter">:</div>
-			<div class="propertyValue">{{item.value}}</div>
-		</div>
-	</ng-template>
-</div>
+
+modelview-properties-container properties-container {
+	display: inline-block;
+	width: 100%;
+}

--- a/src/sql/workbench/browser/modelComponents/propertiesContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/propertiesContainer.component.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import 'vs/css!./media/propertiesContainer';
 import {
 	Component, Input, Inject, ChangeDetectorRef, forwardRef,
 	ViewChild, ElementRef, OnDestroy

--- a/src/sql/workbench/contrib/dashboard/browser/containers/dashboardHomeContainer.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/containers/dashboardHomeContainer.component.ts
@@ -90,7 +90,8 @@ export class DashboardHomeContainer extends DashboardWidgetContainer {
 
 	public getHeight(): number {
 		if (this._propertiesClass && (<PropertiesWidgetComponent>this._propertiesClass.component).height) {
-			this.height = (<PropertiesWidgetComponent>this._propertiesClass.component).height;
+			// Give a little extra room on the bottom or the properties are cut off by the collapse bar
+			this.height = (<PropertiesWidgetComponent>this._propertiesClass.component).height + 20;
 		}
 
 		return this.height;

--- a/src/sql/workbench/contrib/dashboard/browser/containers/dashboardHomeContainer.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/containers/dashboardHomeContainer.component.ts
@@ -23,7 +23,6 @@ import { DASHBOARD_BORDER } from 'vs/workbench/common/theme';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { contrastBorder } from 'vs/platform/theme/common/colorRegistry';
-import { PropertiesWidgetComponent } from 'sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component';
 
 @Component({
 	selector: 'dashboard-home-container',
@@ -46,8 +45,6 @@ export class DashboardHomeContainer extends DashboardWidgetContainer {
 	@ViewChild('propertiesClass') private _propertiesClass: DashboardWidgetWrapper;
 	@ViewChild('propertiesContainer') private _propertiesContainer: ElementRef;
 	@ViewChild(ScrollableDirective) private _scrollable: ScrollableDirective;
-
-	private height = 75; // default initial height
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) _cd: ChangeDetectorRef,

--- a/src/sql/workbench/contrib/dashboard/browser/containers/dashboardHomeContainer.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/containers/dashboardHomeContainer.component.ts
@@ -32,8 +32,7 @@ import { PropertiesWidgetComponent } from 'sql/workbench/contrib/dashboard/brows
 		<div class="fullsize" style="display: flex; flex-direction: column">
 			<div scrollable [horizontalScroll]="${ScrollbarVisibility.Hidden}" [verticalScroll]="${ScrollbarVisibility.Auto}">
 				<div #propertiesContainer>
-					<dashboard-widget-wrapper #propertiesClass *ngIf="properties" [collapsable]="true" [bottomCollapse]="true" [toggleMore]="false" [_config]="properties"
-						class="properties" [style.height.px]="_propertiesClass?.collapsed ? '30' : getHeight()">
+					<dashboard-widget-wrapper #propertiesClass *ngIf="properties" [collapsable]="true" [bottomCollapse]="true" [toggleMore]="false" [_config]="properties" class="properties">
 					</dashboard-widget-wrapper>
 				</div>
 				<widget-content style="flex: 1" [scrollContent]="false" [widgets]="widgets" [originalConfig]="tab.originalConfig" [context]="tab.context">
@@ -86,15 +85,6 @@ export class DashboardHomeContainer extends DashboardWidgetContainer {
 		this._register(DOM.addDisposableListener(window, DOM.EventType.RESIZE, e => {
 			this._cd.detectChanges();
 		}));
-	}
-
-	public getHeight(): number {
-		if (this._propertiesClass && (<PropertiesWidgetComponent>this._propertiesClass.component).height) {
-			// Give a little extra room on the bottom or the properties are cut off by the collapse bar
-			this.height = (<PropertiesWidgetComponent>this._propertiesClass.component).height + 20;
-		}
-
-		return this.height;
 	}
 
 	public layout() {

--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.html
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.html
@@ -17,5 +17,5 @@
 		<ng-template component-host>
 		</ng-template>
 	</ng-template>
-	<span #bottomActionbar class="bottomActionbar"></span>
+	<span #bottomActionbar class="bottomActionbar {{collapsed ? 'collapsed' : ''}}"></span>
 </div>

--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.css
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.css
@@ -40,15 +40,16 @@ dashboard-widget-wrapper .noTitle {
 }
 
 dashboard-widget-wrapper .actionbar {
-	flex: 0 0 auto;
 	align-self: end;
 }
 
 dashboard-widget-wrapper .bottomActionbar {
-	flex: 0 0 auto;
 	align-self: center;
-	margin-top: -27px;
 	display: none;
+}
+
+dashboard-widget-wrapper .bottomActionbar.collapsed {
+	margin-top: -27px;
 }
 
 dashboard-widget-wrapper .bottomActionbar .actions-container .action-item a.action-label.codicon-chevron-up {

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
@@ -16,7 +16,6 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { ILogService } from 'vs/platform/log/common/log';
 import { subscriptionToDisposable } from 'sql/base/browser/lifecycle';
 import { PropertiesContainer, PropertyItem } from 'sql/base/browser/ui/propertiesContainer/propertiesContainer.component';
-import LoadingSpinner from 'sql/base/browser/ui/loadingSpinner/loadingSpinner.component';
 
 export interface PropertiesConfig {
 	properties: Array<Property>;
@@ -54,11 +53,10 @@ const dashboardRegistry = Registry.as<IDashboardRegistry>(DashboardExtensions.Da
 	selector: 'properties-widget',
 	template: `
 	<loading-spinner *ngIf="_loading" [loading]="_loading" [loadingMessage]="loadingMessage" [loadingCompletedMessage]="loadingCompletedMessage"></loading-spinner>
-	<properties-container></properties-container>`
+	<properties-container [style.display]="_loading ? 'none' : ''"></properties-container>`
 })
 export class PropertiesWidgetComponent extends DashboardWidget implements IDashboardWidget, OnInit {
 	@ViewChild(PropertiesContainer) private _propertiesContainer: PropertiesContainer;
-	@ViewChild(LoadingSpinner) private _loadingSpinner: LoadingSpinner;
 	public loadingMessage: string = nls.localize('loadingProperties', "Loading properties");
 	public loadingCompletedMessage: string = nls.localize('loadingPropertiesCompleted', "Loading properties completed");
 	private _connection: ConnectionManagementInfo;
@@ -244,9 +242,5 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 			val = defaultVal;
 		}
 		return val;
-	}
-
-	public get height(): number {
-		return (this._propertiesContainer.height || this._loadingSpinner.height) + 25;
 	}
 }

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
@@ -16,7 +16,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { ILogService } from 'vs/platform/log/common/log';
 import { subscriptionToDisposable } from 'sql/base/browser/lifecycle';
 import { PropertiesContainer, PropertyItem } from 'sql/base/browser/ui/propertiesContainer/propertiesContainer.component';
-import { convertSizeToNumber } from 'sql/base/browser/dom';
+import LoadingSpinner from 'sql/base/browser/ui/loadingSpinner/loadingSpinner.component';
 
 export interface PropertiesConfig {
 	properties: Array<Property>;
@@ -53,11 +53,12 @@ const dashboardRegistry = Registry.as<IDashboardRegistry>(DashboardExtensions.Da
 @Component({
 	selector: 'properties-widget',
 	template: `
-	<loading-spinner [loading]="_loading" [loadingMessage]="loadingMessage" [loadingCompletedMessage]="loadingCompletedMessage"></loading-spinner>
+	<loading-spinner *ngIf="_loading" [loading]="_loading" [loadingMessage]="loadingMessage" [loadingCompletedMessage]="loadingCompletedMessage"></loading-spinner>
 	<properties-container></properties-container>`
 })
 export class PropertiesWidgetComponent extends DashboardWidget implements IDashboardWidget, OnInit {
 	@ViewChild(PropertiesContainer) private _propertiesContainer: PropertiesContainer;
+	@ViewChild(LoadingSpinner) private _loadingSpinner: LoadingSpinner;
 	public loadingMessage: string = nls.localize('loadingProperties', "Loading properties");
 	public loadingCompletedMessage: string = nls.localize('loadingPropertiesCompleted', "Loading properties completed");
 	private _connection: ConnectionManagementInfo;
@@ -207,10 +208,6 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 				value: propertyObject
 			};
 		});
-
-		if (this._inited) {
-			this._changeRef.detectChanges();
-		}
 	}
 
 	private getConditionResult(item: FlavorProperties, conditionItem: ConditionProperties): boolean {
@@ -250,6 +247,6 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 	}
 
 	public get height(): number {
-		return convertSizeToNumber(this._propertiesContainer.height);
+		return (this._propertiesContainer.height || this._loadingSpinner.height) + 25;
 	}
 }


### PR DESCRIPTION
We were manually calculating the height of the properties component which was being used by the properties widget to set the height correctly. This was necessary because the layout wasn't being done in such a way that the height of the containers could actually be calculated so this PR is fixing that so the containers actually take up the space that their contents do. 

This makes it a lot easier to include the component in other pieces of the UI - specifically in the dashboards I'm working on.

There were a bunch of other layout changes that needed to be made - but this should be relatively safe since this is really the only place the properties container and this specific loading spinner component is used. 

![Capture](https://user-images.githubusercontent.com/28519865/80162546-80bae580-8588-11ea-8aa1-6d1cb7df8447.gif)
