### PR TITLE
Fix overflow toolbar for split views

### DIFF
--- a/src/sql/base/browser/ui/taskbar/overflowActionbar.ts
+++ b/src/sql/base/browser/ui/taskbar/overflowActionbar.ts
@@ -40,6 +40,12 @@ export class OverflowActionBar extends ActionBar {
 			}
 		}));
 
+		this._register(DOM.addDisposableListener(window, DOM.EventType.MOUSE_MOVE, e => {
+			if (this._actionsList) {
+				this.resizeToolbar();
+			}
+		}));
+
 		this._overflow = document.createElement('ul');
 		this._overflow.id = 'overflow';
 		this._overflow.className = 'overflow';

--- a/src/sql/base/browser/ui/taskbar/overflowActionbar.ts
+++ b/src/sql/base/browser/ui/taskbar/overflowActionbar.ts
@@ -40,6 +40,7 @@ export class OverflowActionBar extends ActionBar {
 			}
 		}));
 
+		// Needed so that toolbar gets resized properly with split views
 		this._register(DOM.addDisposableListener(window, DOM.EventType.MOUSE_MOVE, e => {
 			if (this._actionsList) {
 				this.resizeToolbar();


### PR DESCRIPTION
This PR fixes #10004. This adds a listener to mouse move like how query editor code recalculates the height based on the Window's mouse event, which Alan mentioned in this PR #10138 :)
