### PR TITLE
Add and fix notebook extension unit tests

### DIFF
--- a/extensions/notebook/src/common/utils.ts
+++ b/extensions/notebook/src/common/utils.ts
@@ -177,7 +177,7 @@ export function comparePackageVersions(first: string, second: string): number {
 	return 0;
 }
 
-export function sortPackageVersions(versions: string[], ascending: boolean = true) {
+export function sortPackageVersions(versions: string[], ascending: boolean = true): string[] {
 	return versions.sort((first, second) => {
 		let compareResult = comparePackageVersions(first, second);
 		if (ascending) {
@@ -186,14 +186,6 @@ export function sortPackageVersions(versions: string[], ascending: boolean = tru
 			return compareResult * -1;
 		}
 	});
-}
-
-// PRIVATE HELPERS /////////////////////////////////////////////////////////
-function outputDataChunk(data: string | Buffer, outputChannel: vscode.OutputChannel, header: string): void {
-	data.toString().split(/\r?\n/)
-		.forEach(line => {
-			outputChannel.appendLine(header + line);
-		});
 }
 
 export function isEditorTitleFree(title: string): boolean {
@@ -272,6 +264,14 @@ export function debounce(delay: number): Function {
 			this[timerKey] = setTimeout(() => fn.apply(this, args), delay);
 		};
 	});
+}
+
+// PRIVATE HELPERS /////////////////////////////////////////////////////////
+function outputDataChunk(data: string | Buffer, outputChannel: vscode.OutputChannel, header: string): void {
+	data.toString().split(/\r?\n/)
+		.forEach(line => {
+			outputChannel.appendLine(header + line);
+		});
 }
 
 function decorate(decorator: (fn: Function, key: string) => Function): Function {

--- a/extensions/notebook/src/dialog/managePackages/managePackagesDialogModel.ts
+++ b/extensions/notebook/src/dialog/managePackages/managePackagesDialogModel.ts
@@ -132,8 +132,8 @@ export class ManagePackagesDialogModel {
 	/**
 	 * Returns the default location
 	 */
-	public get defaultLocation(): string {
-		return this.options.defaultLocation || this.targetLocationTypes[0];
+	public get defaultLocation(): string | undefined {
+		return this.options.defaultLocation || this.targetLocationTypes.length > 0 ? this.targetLocationTypes[0] : undefined;
 	}
 
 	/**
@@ -169,7 +169,10 @@ export class ManagePackagesDialogModel {
 	 */
 	public getPackageTypes(targetLocation?: string): ProviderPackageType[] {
 		targetLocation = targetLocation || this.defaultLocation;
-		let providers = this._packageTypes.get(targetLocation);
+		if (!this._packageTypes.has(targetLocation)) {
+			return [];
+		}
+		const providers = this._packageTypes.get(targetLocation);
 		return providers.map(x => {
 			return {
 				providerId: x.providerId,
@@ -181,7 +184,7 @@ export class ManagePackagesDialogModel {
 	/**
 	 * Returns a map of providerId to package types for given location
 	 */
-	public getDefaultPackageType(): ProviderPackageType {
+	public getDefaultPackageType(): ProviderPackageType | undefined {
 		let defaultProviderId = this.defaultProviderId;
 		let packageTypes = this.getPackageTypes();
 		return packageTypes.find(x => x.providerId === defaultProviderId);
@@ -191,12 +194,8 @@ export class ManagePackagesDialogModel {
 	 * returns the list of packages for current provider
 	 */
 	public async listPackages(): Promise<IPackageDetails[]> {
-		let provider = this.currentPackageManageProvider;
-		if (provider) {
-			return await provider.listPackages(this._currentLocation);
-		} else {
-			throw new Error('Current Provider is not set');
-		}
+		const provider = this.currentPackageManageProvider;
+		return await provider?.listPackages(this._currentLocation) ?? [];
 	}
 
 	/**

--- a/extensions/notebook/src/test/book/book.test.ts
+++ b/extensions/notebook/src/test/book/book.test.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import * as should from 'should';
 import * as path from 'path';
@@ -199,11 +198,11 @@ describe('BookTreeViewProviderTests', function () {
 			it('should set notebooks trusted to true on trustBook', async () => {
 				let notebook1Path = path.join(rootFolderPath, 'Book', 'content', 'notebook1.ipynb');
 				let bookTrustManager: BookTrustManager = new BookTrustManager(bookTreeViewProvider.books, appContext.apiWrapper);
-				let isTrusted = bookTrustManager.isNotebookTrustedByDefault(notebook1Path);
+				let isTrusted = bookTrustManager.isNotebookTrustedByDefault(vscode.Uri.file(notebook1Path).fsPath);
 				should(isTrusted).equal(false, 'Notebook should not be trusted by default');
 
 				bookTreeViewProvider.trustBook(bookTreeViewProvider.currentBook.bookItems[0]);
-				isTrusted = bookTrustManager.isNotebookTrustedByDefault(notebook1Path);
+				isTrusted = bookTrustManager.isNotebookTrustedByDefault(vscode.Uri.file(notebook1Path).fsPath);
 				should(isTrusted).equal(true, 'Failed to set trust on trustBook');
 
 			});
@@ -212,11 +211,10 @@ describe('BookTreeViewProviderTests', function () {
 				let notebook1Path = path.join(rootFolderPath, 'Book', 'content', 'notebook1.ipynb');
 				let notebook2Path = path.join(rootFolderPath, 'Book', 'content', 'notebook2.ipynb');
 				let notebook3Path = path.join(rootFolderPath, 'Book', 'content', 'notebook3.ipynb');
-				let result: azdata.nb.NavigationResult;
-				await bookTreeViewProvider.currentBook.getNavigation(vscode.Uri.file(notebook2Path)).then(navigationResult => { result = navigationResult;});
+				const result = await bookTreeViewProvider.currentBook.getNavigation(vscode.Uri.file(notebook2Path));
 				should(result.hasNavigation).be.true('getNavigation failed to get previous and next urls');
-				should(result.next.fsPath).equal(notebook3Path, 'getNavigation failed to get the next url');
-				should(result.previous.fsPath).equal(notebook1Path, 'getNavigation failed to get the previous url');
+				should(result.next.fsPath).equal(vscode.Uri.file(notebook3Path).fsPath, 'getNavigation failed to get the next url');
+				should(result.previous.fsPath).equal(vscode.Uri.file(notebook1Path).fsPath, 'getNavigation failed to get the previous url');
 
 			});
 
@@ -264,7 +262,7 @@ describe('BookTreeViewProviderTests', function () {
 		it('should ignore toc.yml files not in _data folder', async () => {
 			await bookTreeViewProvider.currentBook.loadTableOfContentFiles(rootFolderPath);
 			let path = bookTreeViewProvider.currentBook.tableOfContentsPath;
-			should(path.toLocaleLowerCase()).equal(tableOfContentsFile.replace(/\\/g, '/').toLocaleLowerCase());
+			should(vscode.Uri.file(path).fsPath).equal(vscode.Uri.file(tableOfContentsFile).fsPath);
 		});
 
 		this.afterAll(async function (): Promise<void> {

--- a/extensions/notebook/src/test/book/bookTrustManager.test.ts
+++ b/extensions/notebook/src/test/book/bookTrustManager.test.ts
@@ -130,8 +130,8 @@ describe('BookTrustManagerTests', function () {
 			let isNotebook1Trusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri1);
 			let isNotebook2Trusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri2);
 
-			should(isNotebook1Trusted).be.true("Notebook 1 should be trusted");
-			should(isNotebook2Trusted).be.true("Notebook 2 should be trusted");
+			should(isNotebook1Trusted).be.true('Notebook 1 should be trusted');
+			should(isNotebook2Trusted).be.true('Notebook 2 should be trusted');
 
 		});
 
@@ -139,42 +139,42 @@ describe('BookTrustManagerTests', function () {
 			let notebookUri = path.join(path.sep,'temp','SubFolder2','content', 'sample', 'notebook.ipynb');
 			let isNotebookTrusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrusted).be.false("Notebook should be trusted");
+			should(isNotebookTrusted).be.false('Notebook should be trusted');
 		});
 
 		it('should trust notebook after book has been trusted within a workspace', async () => {
 			let notebookUri = path.join(path.sep,'temp','SubFolder2','content', 'sample', 'notebook.ipynb');
 			let isNotebookTrustedBeforeChange = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrustedBeforeChange).be.false("Notebook should NOT be trusted");
+			should(isNotebookTrustedBeforeChange).be.false('Notebook should NOT be trusted');
 
 			// add another book subfolder
 			bookTrustManager.setBookAsTrusted('/SubFolder2/');
 
 			let isNotebookTrustedAfterChange = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrustedAfterChange).be.true("Notebook should be trusted");
+			should(isNotebookTrustedAfterChange).be.true('Notebook should be trusted');
 		});
 
 		it('should NOT trust a notebook when untrusting a book within a workspace', async () => {
 			let notebookUri = path.join(path.sep,'temp','SubFolder','content', 'sample', 'notebook.ipynb');
 			let isNotebookTrusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrusted).be.true("Notebook should be trusted");
+			should(isNotebookTrusted).be.true('Notebook should be trusted');
 
 			// remove trusted subfolders
 			trustedSubFolders = [];
 
 			let isNotebookTrustedAfterChange = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrustedAfterChange).be.false("Notebook should not be trusted after book removal");
+			should(isNotebookTrustedAfterChange).be.false('Notebook should not be trusted after book removal');
 		});
 
 		it('should NOT trust an unknown book within a workspace', async () => {
 			let notebookUri = path.join(path.sep, 'randomfolder', 'randomsubfolder', 'content', 'randomnotebook.ipynb');
 			let isNotebookTrusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrusted).be.false("Random notebooks should not be trusted");
+			should(isNotebookTrusted).be.false('Random notebooks should not be trusted');
 		});
 
 		it('should NOT trust notebook inside trusted subfolder when absent in table of contents ', async () => {
@@ -183,7 +183,7 @@ describe('BookTrustManagerTests', function () {
 			let notebookUri = path.join(path.sep, 'temp', 'SubFolder', 'content', 'sample', 'notInToc.ipynb');
 			let isNotebookTrusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrusted).be.false("Notebook should NOT be trusted");
+			should(isNotebookTrusted).be.false('Notebook should NOT be trusted');
 		});
 	});
 
@@ -274,8 +274,8 @@ describe('BookTrustManagerTests', function () {
 			let isNotebook1Trusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri1);
 			let isNotebook2Trusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri2);
 
-			should(isNotebook1Trusted).be.true("Notebook 1 should be trusted");
-			should(isNotebook2Trusted).be.true("Notebook 2 should be trusted");
+			should(isNotebook1Trusted).be.true('Notebook 1 should be trusted');
+			should(isNotebook2Trusted).be.true('Notebook 2 should be trusted');
 
 		});
 
@@ -283,20 +283,20 @@ describe('BookTrustManagerTests', function () {
 			let notebookUri = path.join(path.sep,'temp','SubFolder2','content', 'sample', 'notebook.ipynb');
 			let isNotebookTrusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrusted).be.false("Notebook should be trusted");
+			should(isNotebookTrusted).be.false('Notebook should be trusted');
 		});
 
 		it('should trust notebook after book has been added to a folder', async () => {
 			let notebookUri = path.join(path.sep,'temp','SubFolder2','content', 'sample','notebook.ipynb');
 			let isNotebookTrustedBeforeChange = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrustedBeforeChange).be.false("Notebook should NOT be trusted");
+			should(isNotebookTrustedBeforeChange).be.false('Notebook should NOT be trusted');
 
 			bookTrustManager.setBookAsTrusted('/temp/SubFolder2/');
 
 			let isNotebookTrustedAfterChange = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrustedAfterChange).be.true("Notebook should be trusted");
+			should(isNotebookTrustedAfterChange).be.true('Notebook should be trusted');
 		});
 
 		it('should NOT trust a notebook when untrusting a book in folder', async () => {
@@ -304,20 +304,20 @@ describe('BookTrustManagerTests', function () {
 			let notebookUri = path.join(path.sep,'temp','SubFolder','content', 'sample', 'notebook.ipynb');
 			let isNotebookTrusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrusted).be.true("Notebook should be trusted");
+			should(isNotebookTrusted).be.true('Notebook should be trusted');
 
 			trustedFolders = [];
 
 			let isNotebookTrustedAfterChange = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrustedAfterChange).be.false("Notebook should not be trusted after book removal");
+			should(isNotebookTrustedAfterChange).be.false('Notebook should not be trusted after book removal');
 		});
 
 		it('should NOT trust an unknown book', async () => {
 			let notebookUri = path.join(path.sep, 'randomfolder', 'randomsubfolder', 'content', 'randomnotebook.ipynb');
 			let isNotebookTrusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrusted).be.false("Random notebooks should not be trusted");
+			should(isNotebookTrusted).be.false('Random notebooks should not be trusted');
 		});
 
 		it('should NOT trust notebook inside trusted subfolder when absent in table of contents ', async () => {
@@ -326,7 +326,7 @@ describe('BookTrustManagerTests', function () {
 			let notebookUri =  path.join(path.sep, 'temp', 'SubFolder', 'content', 'sample', 'notInToc.ipynb');
 			let isNotebookTrusted = bookTrustManager.isNotebookTrustedByDefault(notebookUri);
 
-			should(isNotebookTrusted).be.false("Notebook should NOT be trusted");
+			should(isNotebookTrusted).be.false('Notebook should NOT be trusted');
 		});
 
 	});

--- a/extensions/notebook/src/test/common/stubs.ts
+++ b/extensions/notebook/src/test/common/stubs.ts
@@ -27,23 +27,23 @@ export class MockOutputChannel implements vscode.OutputChannel {
 	name: string;
 
 	append(value: string): void {
-		throw new Error('Method not implemented.');
+
 	}
 	appendLine(value: string): void {
-		throw new Error('Method not implemented.');
+
 	}
 	clear(): void {
-		throw new Error('Method not implemented.');
+
 	}
 	show(preserveFocus?: boolean): void;
 	show(column?: vscode.ViewColumn, preserveFocus?: boolean): void;
 	show(column?: any, preserveFocus?: any): void {
-		throw new Error('Method not implemented.');
+
 	}
 	hide(): void {
-		throw new Error('Method not implemented.');
+
 	}
 	dispose(): void {
-		throw new Error('Method not implemented.');
+
 	}
 }

--- a/extensions/notebook/src/test/common/utils.test.ts
+++ b/extensions/notebook/src/test/common/utils.test.ts
@@ -1,0 +1,140 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as should from 'should';
+import { promises as fs } from 'fs';
+import * as uuid from 'uuid';
+import * as os from 'os';
+import * as path from 'path';
+import * as utils from '../../common/utils';
+import { MockOutputChannel } from './stubs';
+
+describe('Utils Tests', function () {
+
+	it('getKnoxUrl', () => {
+		const host = '127.0.0.1';
+		const port = '8080';
+		should(utils.getKnoxUrl(host, port)).endWith('/gateway');
+	});
+
+	it('getLivyUrl', () => {
+		const host = '127.0.0.1';
+		const port = '8080';
+		should(utils.getLivyUrl(host, port)).endWith('/gateway/default/livy/v1/');
+	});
+
+	it('mkDir', async () => {
+		const dirPath = path.join(os.tmpdir(), uuid.v4());
+		await should(fs.stat(dirPath)).be.rejected();
+		await utils.mkDir(dirPath, new MockOutputChannel());
+		should.exist(await fs.stat(dirPath), `Folder ${dirPath} did not exist after creation`);
+	});
+
+	it('getErrorMessage Error', () => {
+		const errMsg = 'Test Error';
+		should(utils.getErrorMessage(new Error(errMsg))).equal(errMsg);
+	});
+
+	it('getErrorMessage string', () => {
+		const errMsg = 'Test Error';
+		should(utils.getErrorMessage(errMsg)).equal(errMsg);
+	});
+
+	it('getOSPlatform', async () => {
+		should(utils.getOSPlatform()).not.throw();
+	});
+
+	it('getOSPlatformId', async () => {
+		should(utils.getOSPlatformId()).not.throw();
+	});
+
+	describe('comparePackageVersions', () => {
+		const version1 = '1.0.0.0';
+		const version1Revision = '1.0.0.1';
+		const version2 = '2.0.0.0';
+		const shortVersion1 = '1';
+
+		it('same id', () => {
+			should(utils.comparePackageVersions(version1, version1)).equal(0);
+		});
+
+		it('first version lower', () => {
+			should(utils.comparePackageVersions(version1, version2)).equal(-1);
+		});
+
+		it('second version lower', () => {
+			should(utils.comparePackageVersions(version2, version1)).equal(1);
+		});
+
+		it('short first version is padded correctly', () => {
+			should(utils.comparePackageVersions(shortVersion1, version1)).equal(0);
+		});
+
+		it('short second version is padded correctly when', () => {
+			should(utils.comparePackageVersions(version1, shortVersion1)).equal(0);
+		});
+
+		it('correctly compares version with only minor version difference', () => {
+			should(utils.comparePackageVersions(version1Revision, version1)).equal(1);
+		});
+	});
+
+	describe('sortPackageVersions', () => {
+
+		it('empty', () => {
+			should(utils.sortPackageVersions([])).deepEqual([]);
+		});
+
+		it('single', () => {
+			const single = ['1'];
+			should(utils.sortPackageVersions(single)).deepEqual(single);
+		});
+
+		it('inorder', () => {
+			const inorder = ['1', '2', '3'];
+			should(utils.sortPackageVersions(inorder)).deepEqual(inorder);
+		});
+
+		it('inorder descending', () => {
+			const inorder = ['1', '2', '3'];
+			const inorderSortedDescending = ['3', '2', '1'];
+			should(utils.sortPackageVersions(inorder, false)).deepEqual(inorderSortedDescending);
+		});
+
+		it('reverse order', () => {
+			const reverseOrder = ['3', '2', '1'];
+			const reverseOrderSorted = ['1', '2', '3'];
+			should(utils.sortPackageVersions(reverseOrder)).deepEqual(reverseOrderSorted);
+		});
+
+		it('reverse order descending', () => {
+			const reverseOrder = ['3', '2', '1'];
+			const reverseOrderSortedDescending = ['3', '2', '1'];
+			should(utils.sortPackageVersions(reverseOrder, false)).deepEqual(reverseOrderSortedDescending);
+		});
+
+		it('random', () => {
+			const random = ['1', '42', '100', '0'];
+			const randomSorted = ['0', '1', '42', '100'];
+			should(utils.sortPackageVersions(random)).deepEqual(randomSorted);
+		});
+
+		it('random descending', () => {
+			const random = ['1', '42', '100', '0'];
+			const randomSortedDescending = ['100', '42', '1', '0'];
+			should(utils.sortPackageVersions(random, false)).deepEqual(randomSortedDescending);
+		});
+
+		it('different lengths', () => {
+			const random = ['1.0.0', '42', '100.0', '0.1', '1.0.1'];
+			const randomSorted = ['0.1', '1.0.0', '1.0.1', '42', '100.0']
+			should(utils.sortPackageVersions(random)).deepEqual(randomSorted);
+		});
+	});
+
+	describe('getClusterEndpoints', () => {
+
+	});
+});

--- a/extensions/notebook/src/test/managePackages/managePackagesDialogModel.test.ts
+++ b/extensions/notebook/src/test/managePackages/managePackagesDialogModel.test.ts
@@ -31,7 +31,7 @@ describe('Manage Packages', () => {
 		should.throws(() => { new ManagePackagesDialogModel(jupyterServerInstallation, providers); }, 'Invalid list of package manager providers');
 	});
 
-	it('Should not throw exception given undefined options', async function (): Promise<void> {
+	it('Should have expected behavior given undefined options', async function (): Promise<void> {
 		let testContext = createContext();
 		testContext.provider.listPackages = () => {
 			return Promise.resolve(undefined);
@@ -39,8 +39,33 @@ describe('Manage Packages', () => {
 		let provider = createProvider(testContext);
 		let providers = new Map<string, IPackageManageProvider>();
 		providers.set(provider.providerId, provider);
+		const model = new ManagePackagesDialogModel(jupyterServerInstallation, providers, undefined);
+		should.equal(model.currentPackageType, undefined, 'Current Package Type expected to be undefined');
+		should.deepEqual(model.options, { defaultLocation: undefined, defaultProviderId: undefined }, 'Options should be default options');
+		should.deepEqual(model.packageManageProviders, providers, 'Package Manage Providers should exist');
+		should.equal(model.currentPackageManageProvider, undefined, 'Current Package Manage Provider should be undefined');
+		should.equal(model.currentPackageType, undefined, 'Current Package Type should be undefined');
+		should.deepEqual(model.targetLocationTypes, [], 'Target Location Types should be an empty array');
+		should.equal(model.defaultLocation, undefined, 'Default Location should be undefined');
+		should.equal(model.defaultProviderId, provider.providerId, 'Default Provider ID should be correct');
+		should.deepEqual(model.getPackageTypes(), [], 'Undefined location should return empty array when calling getPackageTypes');
+		should.deepEqual(model.getPackageTypes('location1'), [],'Valid location should return empty array when calling getPackageTypes');
+		should.equal(model.getDefaultPackageType(), undefined, 'Default Package Type should be undefined');
+		should.deepEqual(await model.listPackages(), [], 'Packages list should be empty');
+		await should(model.installPackages([])).rejected();
+		await should(model.uninstallPackages([])).rejected();
+		should.equal(await model.getLocations(), undefined, 'Get Locations should be undefined before provider is set');
+		should(model.getPackageOverview('package')).rejected();
 
-		should.doesNotThrow(() => { new ManagePackagesDialogModel(jupyterServerInstallation, providers, undefined); });
+		// Change provider and then retest functions which throw without valid provider
+		model.changeProvider(provider.providerId);
+
+		await should(model.installPackages([])).resolved();
+		await should(model.uninstallPackages([])).resolved();
+		should.deepEqual(await model.getLocations(), await provider.getLocations(), 'Get Locations should be valid after provider is set');
+		should(model.getPackageOverview('p1')).resolved();
+		model.changeLocation('location1');
+
 	});
 
 	it('Init should throw exception given invalid default location', async function (): Promise<void> {
@@ -82,7 +107,7 @@ describe('Manage Packages', () => {
 		should.equal(model.defaultProviderId, provider.providerId);
 	});
 
-	it('Init should set default provider Id given valid options', async function (): Promise<void> {
+	it('Init should have expected defaults given valid options', async function (): Promise<void> {
 		let testContext1 = createContext();
 		testContext1.provider.providerId = 'providerId1';
 		testContext1.provider.packageTarget = {
@@ -108,6 +133,9 @@ describe('Manage Packages', () => {
 		await model.init();
 		should.equal(model.defaultLocation, testContext2.provider.packageTarget.location);
 		should.equal(model.defaultProviderId, testContext2.provider.providerId);
+		should.equal(model.getDefaultPackageType().packageType, testContext2.provider.packageTarget.packageType);
+		should.equal(model.currentPackageType, testContext2.provider.packageTarget.packageType);
+		should.equal(model.jupyterInstallation, jupyterServerInstallation);
 	});
 
 	it('Should create a cache for multiple providers successfully', async function (): Promise<void> {
@@ -247,7 +275,7 @@ describe('Manage Packages', () => {
 		let model = new ManagePackagesDialogModel(jupyterServerInstallation, providers, undefined);
 
 		should.equal(model.currentPackageManageProvider, undefined);
-		await should(model.listPackages()).rejected();
+		await should(model.listPackages()).resolvedWith([]);
 		await should(model.installPackages(TypeMoq.It.isAny())).rejected();
 		await should(model.uninstallPackages(TypeMoq.It.isAny())).rejected();
 	});


### PR DESCRIPTION
The utils tests are pretty dumb for the most part but they're mostly there for code coverage since there isn't much to test in a lot of those. 

Slightly changed some of the behavior of the managePackageDialogModel as well to be more consistent in how it behaves (when it throws vs returns undefined/empty array)