### PR TITLE
Add support for target location in tasks

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "2.0.0-release.56",
+	"version": "2.0.0-release.61",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -384,5 +384,9 @@ declare module 'azdata' {
 		 */
 		alwaysShowTabs?: boolean;
 	}
+
+	export interface TaskInfo {
+		targetLocation?: string;
+	}
 }
 

--- a/src/sql/workbench/contrib/tasks/browser/tasksRenderer.ts
+++ b/src/sql/workbench/contrib/tasks/browser/tasksRenderer.ts
@@ -103,11 +103,18 @@ export class TaskHistoryRenderer implements IRenderer {
 			templateData.label.textContent = element.taskName + ' ' + taskStatus;
 			templateData.label.title = templateData.label.textContent;
 
+			let description: string;
 			// Determine the target name and set hover text equal to that
-			let description = element.serverName;
-			if (element.databaseName) {
-				description += ' | ' + element.databaseName;
+			// show target location if there is one, otherwise show server and database name
+			if (element.targetLocation) {
+				description = element.targetLocation;
+			} else {
+				description = element.serverName;
+				if (element.databaseName) {
+					description += ' | ' + element.databaseName;
+				}
 			}
+
 			templateData.description.textContent = description;
 			templateData.description.title = templateData.description.textContent;
 

--- a/src/sql/workbench/services/tasks/common/tasksNode.ts
+++ b/src/sql/workbench/services/tasks/common/tasksNode.ts
@@ -44,6 +44,11 @@ export class TaskNode {
 	public databaseName?: string;
 
 	/**
+	 * Target Location
+	 */
+	public targetLocation?: string;
+
+	/**
 	 * Provider Name
 	 */
 	public providerName?: string;
@@ -99,7 +104,7 @@ export class TaskNode {
 	 */
 	public script?: string;
 
-	constructor(taskName: string, serverName?: string, databaseName?: string, taskId: string | undefined = undefined, taskExecutionMode: TaskExecutionMode = TaskExecutionMode.execute, isCancelable: boolean = true) {
+	constructor(taskName: string, serverName?: string, databaseName?: string, taskId: string | undefined = undefined, taskExecutionMode: TaskExecutionMode = TaskExecutionMode.execute, isCancelable: boolean = true, targetLocation?: string) {
 		this.id = taskId || generateUuid();
 
 		this.taskName = taskName;
@@ -111,5 +116,6 @@ export class TaskNode {
 		this.hasChildren = false;
 		this.taskExecutionMode = taskExecutionMode;
 		this.isCancelable = isCancelable;
+		this.targetLocation = targetLocation;
 	}
 }

--- a/src/sql/workbench/services/tasks/common/tasksService.ts
+++ b/src/sql/workbench/services/tasks/common/tasksService.ts
@@ -88,7 +88,7 @@ export class TaskService implements ITaskService {
 				serverName = connectionProfile.serverName;
 			}
 		}
-		let node: TaskNode = new TaskNode(taskInfo.name, serverName, databaseName, taskInfo.taskId, taskInfo.taskExecutionMode, taskInfo.isCancelable);
+		let node: TaskNode = new TaskNode(taskInfo.name, serverName, databaseName, taskInfo.taskId, taskInfo.taskExecutionMode, taskInfo.isCancelable, taskInfo.targetLocation);
 		node.providerName = taskInfo.providerName;
 		this.handleNewTask(node);
 	}


### PR DESCRIPTION
Add support for target location for tasks being added in https://github.com/microsoft/sqltoolsservice/pull/936. Showing file location for extract and export operations because it's more useful than showing the server and database name. Intermediate fix for microsoft/azuredatastudio#9057

![image](https://user-images.githubusercontent.com/31145923/77214294-c25cfa00-6acb-11ea-8e74-c4d9e283c81d.png)

