### PR TITLE
Add Always Encrypted Parameterization Option

### DIFF
--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -522,6 +522,11 @@ const registryProperties: { [path: string]: IConfigurationPropertySchema; } = {
 		'type': 'boolean',
 		'default': true,
 		'description': localize('mssql.query.ansiNulls', "Enable SET ANSI_NULLS")
+	},
+	'mssql.query.alwaysEncryptedParameterization': {
+		'type': 'boolean',
+		'default': false,
+		'description': localize('mssql.query.alwaysEncryptedParameterization', "Enable Parameterization for Always Encrypted")
 	}
 };
 


### PR DESCRIPTION
**Problem**
In Azure Data Studio, queries that insert or update encrypted columns are not supported. Additionally, Selecting data while filtering on encrypted column values in the WHERE clause is not supported.

**Why?**
Azure Data Studio sends the query in the exact same text that was originally typed into the query window by the user, including the values of the data to be inserted, updated, or filtered upon in a SELECT query. As a result, the query fails with an encryption scheme mismatch error because SQL Server expects the values correlating to encrypted columns to be encrypted, not in plain text.

**Solution:**
Implement parameterization of T-SQL variables with inline declarations. Expose a checkbox to enable parameterization. The design needs to include the ability for a user to receive notifications about which variables gets parameterized and how (and error messages).

**This PR**
On the ADS side, the only work that needs to be done is to add the feature switch to user settings, that is, to expose a checkbox to enable parameterization. That is what this PR is about. The remainder, and the bulk of the work, will be done on the STS side. That work can be found in [this PR for STS](https://github.com/microsoft/sqltoolsservice/pull/953)

**Preview**
![image](https://user-images.githubusercontent.com/4079568/80432730-ec16f700-88a9-11ea-8eda-ccc78a05ee48.png)
