### PR TITLE
Notebooks: Update Python Mac Download URL

### DIFF
--- a/extensions/notebook/src/common/constants.ts
+++ b/extensions/notebook/src/common/constants.ts
@@ -50,5 +50,5 @@ export enum PythonPkgType {
 }
 
 export const pythonWindowsInstallUrl = 'https://go.microsoft.com/fwlink/?linkid=2110625';
-export const pythonMacInstallUrl = 'https://go.microsoft.com/fwlink/?linkid=2110525';
+export const pythonMacInstallUrl = 'https://go.microsoft.com/fwlink/?linkid=2128152';
 export const pythonLinuxInstallUrl = 'https://go.microsoft.com/fwlink/?linkid=2110524';


### PR DESCRIPTION
Fixes #9836 to point to latest version of Python with latest dependencies for notebooks.