### PR TITLE
fix the issue that loading spinner is always taking space

### DIFF
--- a/src/sql/base/browser/ui/loadingSpinner/media/loadingComponent.css
+++ b/src/sql/base/browser/ui/loadingSpinner/media/loadingComponent.css
@@ -5,7 +5,6 @@
 
 loading-spinner {
 	width: 100%;
-	display: inline-block;
 }
 
 loading-spinner .loading-spinner-container {


### PR DESCRIPTION
setting the display to inline-block will make it take the space circled in red below.
<img width="805" alt="Screen Shot 2020-04-28 at 8 19 17 PM" src="https://user-images.githubusercontent.com/13777222/80558201-5dc87100-898e-11ea-9d59-377e898dc9b3.png">

removing it fixes the problem, I tested and didn't notice any issues.
<img width="805" alt="Screen Shot 2020-04-28 at 8 20 14 PM" src="https://user-images.githubusercontent.com/13777222/80558206-61f48e80-898e-11ea-823a-99ef4bb4e161.png">
