### PR TITLE
Only filter preview extensions when preview feat disabled

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -300,7 +300,7 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 
 		this.loadNewTabs(allTabs.filter((tab) => tab.group === homeTabGroupId));
 
-		// If preview features are disabled only show the home tab
+		// If preview features are disabled filter out contributions from preview extensions
 		const extensionTabsEnabled = this.configurationService.getValue('workbench')['enablePreviewFeatures'];
 		if (!extensionTabsEnabled) {
 			allTabs = allTabs.filter(tab => !tab.preview);

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -303,7 +303,7 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		// If preview features are disabled only show the home tab
 		const extensionTabsEnabled = this.configurationService.getValue('workbench')['enablePreviewFeatures'];
 		if (!extensionTabsEnabled) {
-			allTabs = [];
+			allTabs = allTabs.filter(tab => !tab.preview);
 		}
 
 		// Load tab setting configs

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -300,10 +300,11 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 
 		this.loadNewTabs(allTabs.filter((tab) => tab.group === homeTabGroupId));
 
-		// If preview features are disabled filter out contributions from preview extensions
+		// If preview features are disabled only show the home tab since extension-contributed tabs
+		// are still under preview
 		const extensionTabsEnabled = this.configurationService.getValue('workbench')['enablePreviewFeatures'];
 		if (!extensionTabsEnabled) {
-			allTabs = allTabs.filter(tab => !tab.preview);
+			allTabs = [];
 		}
 
 		// Load tab setting configs

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution.ts
@@ -168,7 +168,7 @@ ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabCo
 			iconClass = createCSSRuleForIcon(icon, extension);
 		}
 		if (result) {
-			registerTab({ description, title, container, provider, when, id, alwaysShow, publisher, isHomeTab, group, iconClass, preview: extension.description.preview });
+			registerTab({ description, title, container, provider, when, id, alwaysShow, publisher, isHomeTab, group, iconClass });
 		}
 	}
 

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardTab.contribution.ts
@@ -167,9 +167,8 @@ ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabCo
 		if (isValidIcon(icon, extension)) {
 			iconClass = createCSSRuleForIcon(icon, extension);
 		}
-
 		if (result) {
-			registerTab({ description, title, container, provider, when, id, alwaysShow, publisher, isHomeTab, group, iconClass });
+			registerTab({ description, title, container, provider, when, id, alwaysShow, publisher, isHomeTab, group, iconClass, preview: extension.description.preview });
 		}
 	}
 

--- a/src/sql/workbench/services/dashboard/browser/common/interfaces.ts
+++ b/src/sql/workbench/services/dashboard/browser/common/interfaces.ts
@@ -15,7 +15,6 @@ export interface IDashboardTab {
 	isHomeTab?: boolean;
 	group?: string;
 	iconClass?: string;
-	preview?: boolean
 }
 
 export interface IDashboardTabGroup {

--- a/src/sql/workbench/services/dashboard/browser/common/interfaces.ts
+++ b/src/sql/workbench/services/dashboard/browser/common/interfaces.ts
@@ -15,6 +15,7 @@ export interface IDashboardTab {
 	isHomeTab?: boolean;
 	group?: string;
 	iconClass?: string;
+	preview?: boolean
 }
 
 export interface IDashboardTabGroup {

--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -246,8 +246,8 @@ export interface IExtensionDescription extends IExtensionManifest {
 	readonly isUnderDevelopment: boolean;
 	readonly extensionLocation: URI;
 	enableProposedApi?: boolean;
-	// {{ SQL CARBON EDIT }}
-	readonly forceReload?: boolean;
+	readonly forceReload?: boolean; // {{ SQL CARBON EDIT }}
+	readonly preview?: boolean; // {{ SQL CARBON EDIT }}
 }
 
 export function isLanguagePackExtension(manifest: IExtensionManifest): boolean {

--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -247,7 +247,6 @@ export interface IExtensionDescription extends IExtensionManifest {
 	readonly extensionLocation: URI;
 	enableProposedApi?: boolean;
 	readonly forceReload?: boolean; // {{ SQL CARBON EDIT }}
-	readonly preview?: boolean; // {{ SQL CARBON EDIT }}
 }
 
 export function isLanguagePackExtension(manifest: IExtensionManifest): boolean {


### PR DESCRIPTION
Currently we filter ALL contributed tabs when preview features are enabled. This makes more sense to scope down to just filtering out extensions that are actually marked as being in preview - other extensions should still be shown. 