### PR TITLE
Feature/dotnet popup

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -163,7 +163,6 @@
     }
   },
   "dependencies": {
-    "linux-release-info": "^2.0.0",
     "vscode-languageclient": "^5.3.0-next.1",
     "vscode-nls": "^3.2.1",
     "xmldom": "^0.3.0"

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -26,6 +26,17 @@
     "Microsoft.mssql"
   ],
   "contributes": {
+    "configuration": [
+      {
+        "title": "%sqlDatabaseProjects.Settings%",
+        "properties": {
+          "sqlDatabaseProjects.netCoreSDKLocation": {
+            "type": "string",
+            "description": "%sqlDatabaseProjects.netCoreInstallLocation%"
+          }
+        }
+      }
+    ],
     "commands": [
       {
         "command": "sqlDatabaseProjects.new",
@@ -152,6 +163,7 @@
     }
   },
   "dependencies": {
+    "linux-release-info": "^2.0.0",
     "vscode-languageclient": "^5.3.0-next.1",
     "vscode-nls": "^3.2.1",
     "xmldom": "^0.3.0"

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -12,5 +12,9 @@
 	"sqlDatabaseProjects.newView": "Add View",
 	"sqlDatabaseProjects.newStoredProcedure": "Add Stored Procedure",
 	"sqlDatabaseProjects.newItem": "Add Item...",
-	"sqlDatabaseProjects.newFolder": "Add Folder"
+	"sqlDatabaseProjects.newFolder": "Add Folder",
+
+
+	"sqlDatabaseProjects.Settings": "Database Projects",
+	"sqlDatabaseProjects.netCoreInstallLocation": "Full Path to .Net Core SDK on the machine."
 }

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -12,6 +12,7 @@ import { SqlDatabaseProjectTreeViewProvider } from './databaseProjectTreeViewPro
 import { getErrorMessage } from '../common/utils';
 import { ProjectsController } from './projectController';
 import { BaseProjectTreeItem } from '../models/tree/baseTreeItem';
+import { NetCoreTool } from '../tools/netcoreTool';
 
 const SQL_DATABASE_PROJECTS_VIEW_ID = 'sqlDatabaseProjectsView';
 
@@ -22,10 +23,12 @@ export default class MainController implements vscode.Disposable {
 	protected _context: vscode.ExtensionContext;
 	protected dbProjectTreeViewProvider: SqlDatabaseProjectTreeViewProvider = new SqlDatabaseProjectTreeViewProvider();
 	protected projectsController: ProjectsController;
+	protected netcoreTool: NetCoreTool;
 
 	public constructor(context: vscode.ExtensionContext) {
 		this._context = context;
 		this.projectsController = new ProjectsController(this.dbProjectTreeViewProvider);
+		this.netcoreTool = new NetCoreTool();
 	}
 
 	public get extensionContext(): vscode.ExtensionContext {
@@ -56,6 +59,9 @@ export default class MainController implements vscode.Disposable {
 		this.extensionContext.subscriptions.push(vscode.window.registerTreeDataProvider(SQL_DATABASE_PROJECTS_VIEW_ID, this.dbProjectTreeViewProvider));
 
 		await templates.loadTemplates(path.join(this._context.extensionPath, 'resources', 'templates'));
+
+		// ensure .net core is installed
+		this.netcoreTool.findOrInstallNetCore();
 	}
 
 	/**

--- a/extensions/sql-database-projects/src/test/netCoreTool.test.ts
+++ b/extensions/sql-database-projects/src/test/netCoreTool.test.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as should from 'should';
+import * as path from 'path';
+import * as os from 'os';
+import * as vscode from 'vscode';
+import * as baselines from './baselines/baselines';
+import * as templates from '../templates/templates';
+import { NetCoreTool, DBProjectConfigurationKey, NetCoreInstallLocationKey } from '../tools/netcoreTool';
+import { isNullOrUndefined } from 'util';
+
+
+describe('ProjectsController: project controller operations', function (): void {
+	before(async function (): Promise<void> {
+		await templates.loadTemplates(path.join(__dirname, '..', '..', 'resources', 'templates'));
+		await baselines.loadBaselines();
+	});
+
+	it('settings value should override default paths', async function (): Promise<void> {
+		try {
+			// update settings and validate
+			await vscode.workspace.getConfiguration(DBProjectConfigurationKey).update(NetCoreInstallLocationKey, 'test value path', true);
+			const netcoreTool = new NetCoreTool();
+			should(netcoreTool.netcoreInstallLocation).equal('test value path'); // the path in settings should be taken
+			should(netcoreTool.isNetCoreInstallationPresent).equal(false); // dotnet can not be present at dummy path in settings
+		}
+		finally {
+			// clean again
+			await vscode.workspace.getConfiguration(DBProjectConfigurationKey).update(NetCoreInstallLocationKey, '', true);
+		}
+	});
+
+	it('should find right default paths', async function (): Promise<void> {
+		const netcoreTool = new NetCoreTool();
+		netcoreTool.findOrInstallNetCore();
+
+		if (os.platform() === 'win32') {
+			let result = isNullOrUndefined(netcoreTool.netcoreInstallLocation) || netcoreTool.netcoreInstallLocation.toLowerCase().startsWith('c:\\program files');
+			should(result).true('dotnet is either not present or in pogramfiles by default');
+		}
+
+		if (os.platform() === 'linux' || os.platform() === 'darwin') {
+			let result = isNullOrUndefined(netcoreTool.netcoreInstallLocation) || netcoreTool.netcoreInstallLocation.toLowerCase().startsWith('/usr/local/share');
+			should(result).true('dotnet is either not present or in /usr/local/share by default');
+		}
+	});
+});
+
+export async function sleep(ms: number): Promise<{}> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/extensions/sql-database-projects/src/test/netCoreTool.test.ts
+++ b/extensions/sql-database-projects/src/test/netCoreTool.test.ts
@@ -9,8 +9,7 @@ import * as vscode from 'vscode';
 import { NetCoreTool, DBProjectConfigurationKey, NetCoreInstallLocationKey, NextCoreNonWindowsDefaultPath } from '../tools/netcoreTool';
 import { isNullOrUndefined } from 'util';
 
-
-describe('NetCoreTool: project controller operations', function (): void {
+describe('NetCoreTool: Net core install popup tests', function (): void {
 
 	it('settings value should override default paths', async function (): Promise<void> {
 		try {

--- a/extensions/sql-database-projects/src/test/netCoreTool.test.ts
+++ b/extensions/sql-database-projects/src/test/netCoreTool.test.ts
@@ -4,20 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as should from 'should';
-import * as path from 'path';
 import * as os from 'os';
 import * as vscode from 'vscode';
-import * as baselines from './baselines/baselines';
-import * as templates from '../templates/templates';
-import { NetCoreTool, DBProjectConfigurationKey, NetCoreInstallLocationKey } from '../tools/netcoreTool';
+import { NetCoreTool, DBProjectConfigurationKey, NetCoreInstallLocationKey, NextCoreNonWindowsDefaultPath } from '../tools/netcoreTool';
 import { isNullOrUndefined } from 'util';
 
 
-describe('ProjectsController: project controller operations', function (): void {
-	before(async function (): Promise<void> {
-		await templates.loadTemplates(path.join(__dirname, '..', '..', 'resources', 'templates'));
-		await baselines.loadBaselines();
-	});
+describe('NetCoreTool: project controller operations', function (): void {
 
 	it('settings value should override default paths', async function (): Promise<void> {
 		try {
@@ -38,12 +31,14 @@ describe('ProjectsController: project controller operations', function (): void 
 		netcoreTool.findOrInstallNetCore();
 
 		if (os.platform() === 'win32') {
+			// check that path should start with c:\program files
 			let result = isNullOrUndefined(netcoreTool.netcoreInstallLocation) || netcoreTool.netcoreInstallLocation.toLowerCase().startsWith('c:\\program files');
 			should(result).true('dotnet is either not present or in pogramfiles by default');
 		}
 
 		if (os.platform() === 'linux' || os.platform() === 'darwin') {
-			let result = isNullOrUndefined(netcoreTool.netcoreInstallLocation) || netcoreTool.netcoreInstallLocation.toLowerCase().startsWith('/usr/local/share');
+			//check that path should start with /usr/local/share
+			let result = isNullOrUndefined(netcoreTool.netcoreInstallLocation) || netcoreTool.netcoreInstallLocation.toLowerCase().startsWith(NextCoreNonWindowsDefaultPath);
 			should(result).true('dotnet is either not present or in /usr/local/share by default');
 		}
 	});

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { isNullOrUndefined } from 'util';
+import * as nls from 'vscode-nls';
+const localize = nls.loadMessageBundle();
+
+export const DBProjectConfigurationKey: string = 'sqlDatabaseProjects';
+export const NetCoreInstallLocationKey: string = 'netCoreSDKLocation';
+export const NetCoreInstallationConfirmation: string = localize('sqlDatabaseProjects.NetCoreInstallationConfirmation', "The .NET Core SDK cannnot be located. Please install the same or update the .Net Core SDK location in settings if already installed.");
+export const UpdateNetCoreLocation: string = localize('sqlDatabaseProjects.UpdateNetCoreLocation', "Update .Net Core loctaion");
+export const InstallNetCore: string = localize('sqlDatabaseProjects.InstallNetCore', "Install .Net Core SDK.");
+
+export class NetCoreTool {
+
+	public findOrInstallNetCore(): void {
+		if (!this.isNetCoreInstallationPresent) {
+			this.showInstallDialog();
+		}
+	}
+
+	private showInstallDialog(): void {
+		vscode.window.showInformationMessage(NetCoreInstallationConfirmation, UpdateNetCoreLocation, InstallNetCore).then(async (result) => {
+			if (result === UpdateNetCoreLocation) {
+				//open settings
+				vscode.commands.executeCommand('workbench.action.openGlobalSettings');
+			}
+			else if (result === InstallNetCore) {
+				//open install link
+				const dotnetcoreURL = 'https://dotnet.microsoft.com/download/dotnet-core/3.1';
+				vscode.env.openExternal(vscode.Uri.parse(dotnetcoreURL));
+			}
+		});
+	}
+
+	public get isNetCoreInstallationPresent(): Boolean {
+		return (!isNullOrUndefined(this.netcoreInstallLocation) && fs.existsSync(this.netcoreInstallLocation));
+	}
+
+	public get netcoreInstallLocation(): string {
+		return vscode.workspace.getConfiguration(DBProjectConfigurationKey)[NetCoreInstallLocationKey] ||
+			this.defaultLocalInstallLocationByDistribution;
+	}
+
+	private get defaultLocalInstallLocationByDistribution(): string | undefined {
+		const osPlatform: string = os.platform();
+		return (osPlatform === 'win32') ? this.defaultWindowsLocation :
+			(osPlatform === 'darwin' || osPlatform === 'linux') ? this.defaultnonWindowsLocation :
+				undefined;
+	}
+
+	private get defaultnonWindowsLocation(): string | undefined {
+		const macPath = path.join('/usr/local/share/dotnet');
+		return fs.existsSync(macPath) ? macPath : undefined;
+	}
+
+	private get defaultWindowsLocation(): string | undefined {
+		return this.getDotnetPathIfPresent(process.env['ProgramW6432']) ||
+			this.getDotnetPathIfPresent(process.env['ProgramFiles(x86)']) ||
+			this.getDotnetPathIfPresent(process.env['ProgramFiles']);
+	}
+
+	private getDotnetPathIfPresent(folderPath: string | undefined): string | undefined {
+		if (!isNullOrUndefined(folderPath) && fs.existsSync(path.join(folderPath, 'dotnet'))) {
+			return path.join(folderPath, 'dotnet');
+		}
+		return undefined;
+	}
+}

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -13,6 +13,7 @@ const localize = nls.loadMessageBundle();
 
 export const DBProjectConfigurationKey: string = 'sqlDatabaseProjects';
 export const NetCoreInstallLocationKey: string = 'netCoreSDKLocation';
+export const NextCoreNonWindowsDefaultPath = '/usr/local/share';
 export const NetCoreInstallationConfirmation: string = localize('sqlDatabaseProjects.NetCoreInstallationConfirmation', "The .NET Core SDK cannnot be located. Project build will not work. Please install the same or update the .Net Core SDK location in settings if already installed.");
 export const UpdateNetCoreLocation: string = localize('sqlDatabaseProjects.UpdateNetCoreLocation', "Update .Net Core location");
 export const InstallNetCore: string = localize('sqlDatabaseProjects.InstallNetCore', "Install .Net Core SDK");
@@ -56,7 +57,7 @@ export class NetCoreTool {
 	}
 
 	private get defaultnonWindowsLocation(): string | undefined {
-		const defaultNonWindowsInstallLocation = '/usr/local/share'; //default folder for net core sdk
+		const defaultNonWindowsInstallLocation = NextCoreNonWindowsDefaultPath; //default folder for net core sdk
 		return this.getDotnetPathIfPresent(defaultNonWindowsInstallLocation) ||
 			this.getDotnetPathIfPresent(os.homedir()) ||
 			undefined;

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -13,9 +13,9 @@ const localize = nls.loadMessageBundle();
 
 export const DBProjectConfigurationKey: string = 'sqlDatabaseProjects';
 export const NetCoreInstallLocationKey: string = 'netCoreSDKLocation';
-export const NetCoreInstallationConfirmation: string = localize('sqlDatabaseProjects.NetCoreInstallationConfirmation', "The .NET Core SDK cannnot be located. Please install the same or update the .Net Core SDK location in settings if already installed.");
-export const UpdateNetCoreLocation: string = localize('sqlDatabaseProjects.UpdateNetCoreLocation', "Update .Net Core loctaion");
-export const InstallNetCore: string = localize('sqlDatabaseProjects.InstallNetCore', "Install .Net Core SDK.");
+export const NetCoreInstallationConfirmation: string = localize('sqlDatabaseProjects.NetCoreInstallationConfirmation', "The .NET Core SDK cannnot be located. Project build will not work. Please install the same or update the .Net Core SDK location in settings if already installed.");
+export const UpdateNetCoreLocation: string = localize('sqlDatabaseProjects.UpdateNetCoreLocation', "Update .Net Core location");
+export const InstallNetCore: string = localize('sqlDatabaseProjects.InstallNetCore', "Install .Net Core SDK");
 
 export class NetCoreTool {
 

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -56,8 +56,10 @@ export class NetCoreTool {
 	}
 
 	private get defaultnonWindowsLocation(): string | undefined {
-		const macPath = path.join('/usr/local/share/dotnet');
-		return fs.existsSync(macPath) ? macPath : undefined;
+		const defaultNonWindowsInstallLocation = '/usr/local/share'; //default folder for net core sdk
+		return this.getDotnetPathIfPresent(defaultNonWindowsInstallLocation) ||
+			this.getDotnetPathIfPresent(os.homedir()) ||
+			undefined;
 	}
 
 	private get defaultWindowsLocation(): string | undefined {


### PR DESCRIPTION
Added changes to pop up for Net core installation or path update if not present in default path. Pops up at only activate for now, will integrate with build when enabled.

This is how it looks

![image](https://user-images.githubusercontent.com/46980425/80754583-1ce27080-8ae4-11ea-936b-530d1a70c914.png)

For reference : this is how C# extn. in Vscode looks

![image](https://user-images.githubusercontent.com/46980425/80753955-0e478980-8ae3-11ea-8087-8d8a25945499.png)


and the settings
![image](https://user-images.githubusercontent.com/46980425/80769261-7f963500-8b01-11ea-8245-9789402efbd0.png)
