### PR TITLE
Only reveal items in the books viewlet if the viewlet is visible.

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -110,11 +110,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				this.currentBook = existingBook;
 			} else {
 				await this.createAndAddBookModel(bookPath, !!isNotebook);
-				let bookViewer = vscode.window.createTreeView(this.viewId, { showCollapseAll: true, treeDataProvider: this });
 				this.currentBook = this.books.find(book => book.bookPath === bookPath);
-				if (this._bookViewer.visible) {
-					bookViewer.reveal(this.currentBook.bookItems[0], { expand: vscode.TreeItemCollapsibleState.Expanded, focus: true, select: true });
-				}
 			}
 
 			if (showPreview) {

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -112,7 +112,9 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				await this.createAndAddBookModel(bookPath, !!isNotebook);
 				let bookViewer = vscode.window.createTreeView(this.viewId, { showCollapseAll: true, treeDataProvider: this });
 				this.currentBook = this.books.find(book => book.bookPath === bookPath);
-				bookViewer.reveal(this.currentBook.bookItems[0], { expand: vscode.TreeItemCollapsibleState.Expanded, focus: true, select: true });
+				if (this._bookViewer.visible) {
+					bookViewer.reveal(this.currentBook.bookItems[0], { expand: vscode.TreeItemCollapsibleState.Expanded, focus: true, select: true });
+				}
 			}
 
 			if (showPreview) {


### PR DESCRIPTION
Currently, whenever we open any folder that contains notebooks/books in the explorer viewlet, the books viewlet captures the focus afterwards. This is because we "reveal" any item that gets added to the viewlet, which opens the viewlet and focuses on the new item. This change only reveals a book item if the viewlet itself is visible.
