### PR TITLE
Fix overflow menu disappearing

### DIFF
--- a/src/sql/base/browser/ui/taskbar/overflowActionbar.ts
+++ b/src/sql/base/browser/ui/taskbar/overflowActionbar.ts
@@ -28,6 +28,7 @@ export class OverflowActionBar extends ActionBar {
 	private _overflow: HTMLElement;
 	private _moreItemElement: HTMLElement;
 	private _moreActionsElement: HTMLElement;
+	private _previousWidth: number;
 
 	constructor(container: HTMLElement, options: IActionBarOptions = defaultOptions) {
 		super(container, options);
@@ -83,7 +84,7 @@ export class OverflowActionBar extends ActionBar {
 					break;
 				}
 			}
-		} else if (this._overflow?.hasChildNodes()) { // uncollapse actions if there is space for it
+		} else if (this._overflow?.hasChildNodes() && width > this._previousWidth) { // uncollapse actions if there is space for it
 			while (width === fullWidth && this._overflow.hasChildNodes()) {
 				// move placeholder in this._items
 				let placeHolderItem = this._items.splice(this._actionsList.childNodes.length - 1, 1);
@@ -106,6 +107,8 @@ export class OverflowActionBar extends ActionBar {
 				}
 			}
 		}
+
+		this._previousWidth = width;
 	}
 
 	private collapseItem(): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #10181. The overflow menu started disappearing after the listener on mouse move for resizing was added in #10155. It would try to add back the first action in the overflow to the toolbar, which would then trigger the focus out listener(because focus was on the first action) to hide the overflow. Previously, it would try to add an action, then if there wasn't enough space for it, move it back to the overflow. This fixes that by only trying to restore an action from the overflow to the toolbar when the width has increased. 
