### PR TITLE
Notebooks: Fix Cell Margins to Match Previous Releases

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.css
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.css
@@ -15,7 +15,7 @@
 	border-color: transparent;
 	border-style: solid;
 	border-width: 1px 1px 1px 4px;
-	margin: 24px 20px;
+	margin: 1px 20px;
 	position: relative;
 }
 


### PR DESCRIPTION
Fixes #10191 to bring back the notebook cell margins to previous levels until we have the cell toolbar (in which case we can get rid of the Add code/Add text buttons, and have our desired cell margins).

March release:
![image](https://user-images.githubusercontent.com/40371649/80828462-26c6ab00-8b9a-11ea-86c8-f5054d87655e.png)

April Release:
![image](https://user-images.githubusercontent.com/40371649/80828318-ed8e3b00-8b99-11ea-85e4-6c598935b5a6.png)

This fix:
![image](https://user-images.githubusercontent.com/40371649/80828255-d6e7e400-8b99-11ea-9b59-454e4d9c257d.png)
