### PR TITLE
Skip Python Install Integration Tests By Default

### DIFF
--- a/scripts/sql-test-integration.bat
+++ b/scripts/sql-test-integration.bat
@@ -37,6 +37,10 @@ if "%ADS_TEST_GREP%" == "" (
 	set ADS_TEST_GREP=@UNSTABLE@
 	SET ADS_TEST_INVERT_GREP=1
 )
+:: Default to skipping Python install tests
+if "%SKIP_PYTHON_INSTALL_TEST%" == "" (
+	set SKIP_PYTHON_INSTALL_TEST=1
+)
 
 if "%SKIP_PYTHON_INSTALL_TEST%" == "1" (
 	echo Skipping Python installation tests.

--- a/scripts/sql-test-integration.sh
+++ b/scripts/sql-test-integration.sh
@@ -37,6 +37,11 @@ cd $ROOT
 echo VSCODEUSERDATADIR=$VSCODEUSERDATADIR
 echo VSCODEEXTDIR=$VSCODEEXTDIR
 
+# Skip Python install tests by default due to flakiness
+if [[ "$SKIP_PYTHON_INSTALL_TEST" == "" ]]; then
+	export SKIP_PYTHON_INSTALL_TEST=1
+fi
+
 if [[ "$SKIP_PYTHON_INSTALL_TEST" == "1" ]]; then
 	echo Skipping Python installation tests.
 else


### PR DESCRIPTION
The Python tests are flaky and shouldn't be enabled by default. This saves devs from having to set this flag on their machines (to match the behavior of the build machines).