### PR TITLE
Stops caching the AAD token

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -778,9 +778,6 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			connection.options['azureAccountToken'] = undefined;
 			return true;
 		}
-		if (connection.options['azureAccountToken']) {
-			return true;
-		}
 		let azureResource = this.getAzureResourceForConnection(connection);
 		let accounts = (await this._accountManagementService.getAccounts()).filter(a => a.key.providerId.startsWith('azure'));
 		if (accounts && accounts.length > 0) {


### PR DESCRIPTION
Addresses https://github.com/microsoft/azuredatastudio/issues/9174

I'm not sure if this is a good solution. Do we a part of the code that will be hit when the connection was closed and we're attempting to re-establish the connection? I'd prefer to clear out the token then.