### PR TITLE
remove table setActive

### DIFF
--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -230,10 +230,6 @@ export class Table<T extends Slick.SlickData> extends Widget implements IDisposa
 		this._grid.setActiveCell(row, cell);
 	}
 
-	setActive(): void {
-		this._grid.setActiveCell(0, 1);
-	}
-
 	get activeCell(): Slick.Cell | null {
 		return this._grid.getActiveCell();
 	}

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -453,7 +453,7 @@ export class EditDataGridPanel extends GridParentComponent {
 
 	private setActive() {
 		if (this.firstRender && this.table) {
-			this.table.setActive();
+			this.table.setActiveCell(0, 1);
 			this.firstRender = false;
 		}
 	}

--- a/src/sql/workbench/contrib/editData/browser/gridParentComponent.ts
+++ b/src/sql/workbench/contrib/editData/browser/gridParentComponent.ts
@@ -438,7 +438,7 @@ export abstract class GridParentComponent extends Disposable {
 		}
 		setTimeout(() => {
 			self.resizeGrids();
-			self.table.setActive();
+			self.table.setActiveCell(0, 1);
 		});
 	}
 

--- a/src/sql/workbench/contrib/editData/browser/gridParentComponent.ts
+++ b/src/sql/workbench/contrib/editData/browser/gridParentComponent.ts
@@ -415,7 +415,7 @@ export abstract class GridParentComponent extends Disposable {
 		return (gridIndex: number) => {
 			self.activeGrid = gridIndex;
 			let grid = self.table;
-			grid.setActive();
+			grid.setActiveCell(0, 1);
 			grid.setSelectedRows(true);
 		};
 	}


### PR DESCRIPTION

this method was added by @smartguest 
in this pr: https://github.com/microsoft/azuredatastudio/commit/32a89676f1b650c886304fd7507150a3d6417e3c#diff-e2b4ff5553a9b7d236f3159d8fd2c1f9

it doesn't seem to be a specific logic (row 0 cell 1) for edit data and shouldn't be added to the table component.
 