### PR TITLE
Render before adding to the splitView

### DIFF
--- a/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
@@ -344,9 +344,10 @@ export class AccountDialog extends Modal {
 		attachPanelStyler(providerView, this._themeService);
 
 		const insertIndex = this._splitView.length;
+		providerView.render();
+
 		// Append the list view to the split view
 		this._splitView.addView(providerView, Sizing.Distribute, insertIndex);
-		providerView.render();
 		providerView.index = insertIndex;
 
 		this._splitView.layout(DOM.getContentHeight(this._container));


### PR DESCRIPTION
This PR fixes #10213

It looks like the adding to splitView depends on `this.body` of the AccountPanel to not be undefined. This field gets populated in the render() method: https://github.com/microsoft/azuredatastudio/blob/93f35ca321502702000f899928b2978a8e001e27/src/vs/base/browser/ui/splitview/paneview.ts#L229

So calling render before adding to the splitView should fix the problem.