### PR TITLE
Notebooks: Refactor Empty Session Classes

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -36,7 +36,8 @@ const msgLoadingContexts = localize('loadingContexts', "Loading contexts...");
 const msgChangeConnection = localize('changeConnection', "Change Connection");
 const msgSelectConnection = localize('selectConnection', "Select Connection");
 const msgLocalHost = localize('localhost', "localhost");
-const noKernel: string = localize('noKernel', "No Kernel");
+
+export const noKernel: string = localize('noKernel', "No Kernel");
 
 // Action to add a cell to notebook based on cell type(code/markdown).
 export class AddCellAction extends Action {

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -14,7 +14,6 @@ import { SelectBox, ISelectBoxOptionsWithLabel } from 'sql/base/browser/ui/selec
 import { IConnectionManagementService, ConnectionType } from 'sql/platform/connection/common/connectionManagement';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
-import { noKernel } from 'sql/workbench/services/notebook/browser/sessionManager';
 import { IConnectionDialogService } from 'sql/workbench/services/connection/common/connectionDialogService';
 import { NotebookModel } from 'sql/workbench/services/notebook/browser/models/notebookModel';
 import { ICommandService } from 'vs/platform/commands/common/commands';
@@ -37,6 +36,7 @@ const msgLoadingContexts = localize('loadingContexts', "Loading contexts...");
 const msgChangeConnection = localize('changeConnection', "Change Connection");
 const msgSelectConnection = localize('selectConnection', "Select Connection");
 const msgLocalHost = localize('localhost', "localhost");
+const noKernel: string = localize('noKernel', "No Kernel");
 
 // Action to add a cell to notebook based on cell type(code/markdown).
 export class AddCellAction extends Action {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -12,7 +12,7 @@ import * as objects from 'vs/base/common/objects';
 import { CellTypes } from 'sql/workbench/services/notebook/common/contracts';
 import { ModelFactory } from 'sql/workbench/services/notebook/browser/models/modelFactory';
 import { NotebookModelStub, ClientSessionStub, KernelStub, FutureStub } from 'sql/workbench/contrib/notebook/test/stubs';
-import { EmptyFuture } from 'sql/workbench/services/notebook/browser/sessionManager';
+import { EmptyFuture } from 'sql/workbench/contrib/notebook/test/emptySessionClasses';
 import { ICellModel, ICellModelOptions, IClientSession, INotebookModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { Deferred } from 'sql/base/common/promise';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/clientSession.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/clientSession.test.ts
@@ -12,7 +12,7 @@ import { TestNotificationService } from 'vs/platform/notification/test/common/te
 import { URI } from 'vs/base/common/uri';
 
 import { ClientSession } from 'sql/workbench/services/notebook/browser/models/clientSession';
-import { SessionManager, EmptySession } from 'sql/workbench/services/notebook/browser/sessionManager';
+import { SessionManager, EmptySession } from 'sql/workbench/contrib/notebook/test/emptySessionClasses';
 import { NotebookManagerStub, ServerManagerStub } from 'sql/workbench/contrib/notebook/test/stubs';
 import { isUndefinedOrNull } from 'vs/base/common/types';
 

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -31,7 +31,7 @@ import { TestConnectionManagementService } from 'sql/platform/connection/test/co
 import { isUndefinedOrNull } from 'vs/base/common/types';
 import { assign } from 'vs/base/common/objects';
 import { NotebookEditorContentManager } from 'sql/workbench/contrib/notebook/browser/models/notebookInput';
-import { SessionManager } from 'sql/workbench/services/notebook/browser/sessionManager';
+import { SessionManager } from 'sql/workbench/contrib/notebook/test/emptySessionClasses';
 import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { uriPrefixes } from 'sql/platform/connection/common/utils';

--- a/src/sql/workbench/contrib/notebook/test/emptySessionClasses.ts
+++ b/src/sql/workbench/contrib/notebook/test/emptySessionClasses.ts
@@ -2,13 +2,14 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+
 import { nb } from 'azdata';
 import { localize } from 'vs/nls';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import type { FutureInternal } from 'sql/workbench/services/notebook/browser/interfaces';
 
-const runNotebookDisabled = localize('runNotebookDisabled', "Cannot run cells as no kernel has been configured");
 const noKernel: string = localize('noKernel', "No Kernel");
+const runNotebookDisabled = localize('runNotebookDisabled', "Cannot run cells as no kernel has been configured");
 
 let noKernelSpec: nb.IKernelSpec = ({
 	name: noKernel,

--- a/src/sql/workbench/contrib/notebook/test/emptySessionClasses.ts
+++ b/src/sql/workbench/contrib/notebook/test/emptySessionClasses.ts
@@ -2,14 +2,13 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-
 import { nb } from 'azdata';
 import { localize } from 'vs/nls';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import type { FutureInternal } from 'sql/workbench/services/notebook/browser/interfaces';
 
-export const noKernel: string = localize('noKernel', "No Kernel");
 const runNotebookDisabled = localize('runNotebookDisabled', "Cannot run cells as no kernel has been configured");
+const noKernel: string = localize('noKernel', "No Kernel");
 
 let noKernelSpec: nb.IKernelSpec = ({
 	name: noKernel,

--- a/src/sql/workbench/contrib/notebook/test/emptySessionClasses.ts
+++ b/src/sql/workbench/contrib/notebook/test/emptySessionClasses.ts
@@ -7,8 +7,8 @@ import { nb } from 'azdata';
 import { localize } from 'vs/nls';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import type { FutureInternal } from 'sql/workbench/services/notebook/browser/interfaces';
+import { noKernel } from 'sql/workbench/contrib/notebook/browser/notebookActions';
 
-const noKernel: string = localize('noKernel', "No Kernel");
 const runNotebookDisabled = localize('runNotebookDisabled', "Cannot run cells as no kernel has been configured");
 
 let noKernelSpec: nb.IKernelSpec = ({


### PR DESCRIPTION
Besides 1 string, we had a file that should've lived in a test folder, as all references were from other test files. Just doing a little refactor here.