### PR TITLE
Update TabbedPanel API

### DIFF
--- a/samples/sqlservices/src/controllers/modelViewDashboard.ts
+++ b/samples/sqlservices/src/controllers/modelViewDashboard.ts
@@ -72,11 +72,11 @@ export async function openModelViewDashboard(context: vscode.ExtensionContext): 
 
 
 		addTabButton.onDidClick(() => {
-			tabbedPanel.updateTabs([nestedTab1, nestedTab2, nestedTab3]);
+			tabbedPanel.setTabs([nestedTab1, nestedTab2, nestedTab3]);
 		});
 
 		removeTabButton.onDidClick(() => {
-			tabbedPanel.updateTabs([nestedTab1, nestedTab3]);
+			tabbedPanel.setTabs([nestedTab1, nestedTab3]);
 		});
 
 		const settingsTab: azdata.DashboardTab = {
@@ -103,7 +103,7 @@ export async function openModelViewDashboard(context: vscode.ExtensionContext): 
 			icon: context.asAbsolutePath('images/default.svg')
 		};
 		button.onDidClick(() => {
-			dashboard.updateTabs([homeTab, databasesTab, securityTabGroup]);
+			dashboard.setTabs([homeTab, databasesTab, securityTabGroup]);
 		});
 
 		return [

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -213,14 +213,14 @@ declare module 'azdata' {
 		onTabChanged: vscode.Event<string>;
 
 		/**
-		 * update the tabs.
-		 * @param tabs new tabs
+		 * Sets the tabs for this dashboard, clearing out any existing ones first
+		 * @param tabs The tabs to set
 		 */
 		setTabs(tabs: (Tab | TabGroup)[]): void;
 
 		/**
-		 * Adds new tabs to the panel
-		 * @param tabs The new tabs to add
+		 * Adds the specified tabs to the end of the existing tab list
+		 * @param tabs The tabs to add
 		 */
 		addTabs(tabs: (Tab | TabGroup)[]): void;
 	}
@@ -352,9 +352,24 @@ declare module 'azdata' {
 
 	export namespace window {
 		export interface ModelViewDashboard {
+			/**
+			 *  Registers the initial set of tabs to populate the dashboard with
+			 * @param handler
+			 */
 			registerTabs(handler: (view: ModelView) => Thenable<(DashboardTab | DashboardTabGroup)[]>): void;
+			/**
+			 * Opens the dashboard editor
+			 */
 			open(): Thenable<void>;
+			/**
+			 * Sets the tabs for this dashboard, clearing out any existing ones first
+			 * @param tabs The tabs to set
+			 */
 			setTabs(tabs: (DashboardTab | DashboardTabGroup)[]): void;
+			/**
+			 * Adds the specified tabs to the end of the existing tab list
+			 * @param tabs The tabs to add
+			 */
 			addTabs(tabs: (DashboardTab | DashboardTabGroup)[]): void;
 		}
 

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -216,7 +216,13 @@ declare module 'azdata' {
 		 * update the tabs.
 		 * @param tabs new tabs
 		 */
-		updateTabs(tabs: (Tab | TabGroup)[]): void;
+		setTabs(tabs: (Tab | TabGroup)[]): void;
+
+		/**
+		 * Adds new tabs to the panel
+		 * @param tabs The new tabs to add
+		 */
+		addTabs(tabs: (Tab | TabGroup)[]): void;
 	}
 
 	/**
@@ -348,7 +354,8 @@ declare module 'azdata' {
 		export interface ModelViewDashboard {
 			registerTabs(handler: (view: ModelView) => Thenable<(DashboardTab | DashboardTabGroup)[]>): void;
 			open(): Thenable<void>;
-			updateTabs(tabs: (DashboardTab | DashboardTabGroup)[]): void;
+			setTabs(tabs: (DashboardTab | DashboardTabGroup)[]): void;
+			addTabs(tabs: (DashboardTab | DashboardTabGroup)[]): void;
 		}
 
 		export function createModelViewDashboard(title: string, options?: ModelViewDashboardOptions): ModelViewDashboard;

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1740,8 +1740,12 @@ class TabbedPanelComponentWrapper extends ComponentWrapper implements azdata.Tab
 		this.properties = {};
 		this._emitterMap.set(ComponentEventType.onDidChange, new Emitter<string>());
 	}
-	updateTabs(tabs: (azdata.Tab | azdata.TabGroup)[]): void {
+	setTabs(tabs: (azdata.Tab | azdata.TabGroup)[]): void {
 		this.clearItems();
+		this.addTabs(tabs);
+	}
+
+	addTabs(tabs: (azdata.Tab | azdata.TabGroup)[]): void {
 		const itemConfigs = createFromTabs(tabs);
 		itemConfigs.forEach(itemConfig => {
 			this.addItem(itemConfig.component, itemConfig.config);

--- a/src/sql/workbench/api/common/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/common/extHostModelViewDialog.ts
@@ -468,12 +468,20 @@ class ModelViewDashboardImpl implements azdata.window.ModelViewDashboard {
 	) {
 	}
 
-	updateTabs(tabs: (azdata.DashboardTab | azdata.DashboardTabGroup)[]): void {
+	setTabs(tabs: (azdata.DashboardTab | azdata.DashboardTabGroup)[]): void {
 		if (this._tabbedPanel === undefined || this._view === undefined) {
 			throw new Error(nls.localize('dashboardNotInitialized', "Tabs are not initialized"));
 		}
 
-		this._tabbedPanel.updateTabs(this.createTabs(tabs, this._view));
+		this._tabbedPanel.setTabs(this.createTabs(tabs, this._view));
+	}
+
+	addTabs(tabs: (azdata.DashboardTab | azdata.DashboardTabGroup)[]): void {
+		if (this._tabbedPanel === undefined || this._view === undefined) {
+			throw new Error(nls.localize('dashboardNotInitialized', "Tabs are not initialized"));
+		}
+
+		this._tabbedPanel.addTabs(this.createTabs(tabs, this._view));
 	}
 
 	registerTabs(handler: (view: azdata.ModelView) => Thenable<(azdata.DashboardTab | azdata.DashboardTabGroup)[]>): void {


### PR DESCRIPTION
This is addressing a problem where updating the tabs is 

1. Resetting the selected index to the first tab
2. Breaking some existing tabs if they have things like loading components (this is likely a separate bug though)

In general I wanted to add this since it's also nice not to have to go through the overhead of recreating the tabs every single time. And the only use cases we have right now we only really need to add tabs (and not in a specific order) so I didn't bring over the other TabbedPanel methods like removeTab and adding a tab at a specific index. Those can be added later if needed. 