### PR TITLE
force the isDirty flag to always be false

### DIFF
--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -120,6 +120,7 @@ export interface IDetailData {
 export class ProfilerEditor extends BaseEditor {
 	public static readonly ID: string = 'workbench.editor.profiler';
 
+	private _untitledTextEditorModel: UntitledTextEditorModel;
 	private _editor: ProfilerResourceEditor;
 	private _editorModel: ITextModel;
 	private _editorInput: UntitledTextEditorInput;
@@ -319,6 +320,7 @@ export class ProfilerEditor extends BaseEditor {
 			let data = this.input.data.getItem(args.rows[0]);
 			if (data) {
 				this._modelService.updateModel(this._editorModel, data['TextData']);
+				this._untitledTextEditorModel.setDirty(false);
 				this._detailTableData.clear();
 				this._detailTableData.push(Object.keys(data).filter(key => {
 					return data[key] !== ' ';
@@ -436,8 +438,8 @@ export class ProfilerEditor extends BaseEditor {
 		editorContainer.className = 'profiler-editor';
 		this._editor.create(editorContainer);
 		this._editor.setVisible(true);
-		const model = this._instantiationService.createInstance(UntitledTextEditorModel, URI.from({ scheme: Schemas.untitled }), false, undefined, 'sql', undefined);
-		this._editorInput = this._instantiationService.createInstance(UntitledTextEditorInput, model);
+		this._untitledTextEditorModel = this._instantiationService.createInstance(UntitledTextEditorModel, URI.from({ scheme: Schemas.untitled }), false, undefined, 'sql', undefined);
+		this._editorInput = this._instantiationService.createInstance(UntitledTextEditorInput, this._untitledTextEditorModel);
 		this._editor.setInput(this._editorInput, undefined);
 		this._editorInput.resolve().then(model => this._editorModel = model.textEditorModel);
 		return editorContainer;


### PR DESCRIPTION
This PR fixes #10282 

ADS is trying to restore it because the editor was set to be dirty when we select different rows. so i am setting the dirty attribute to false everyone time we update its content. I don't fully understand how the whole editor works, this does seem to fix the problem for me, i can no longer repro the issue. please let me know if there is a more proper fix.