### PR TITLE
Notebooks: Stop Altering DOTNET_ROOT

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -333,11 +333,6 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		delete env['Path']; // Delete extra 'Path' variable for Windows, just in case.
 		env['PATH'] = this.pythonEnvVarPath;
 
-		// We don't want Jupyter to know about DOTNET_ROOT, as it's been modified by the liveshare experience
-		// Without this, won't be able to find the ASP.NET bits
-		if (process.env['DOTNET_ROOT']) {
-			delete env['DOTNET_ROOT'];
-		}
 		this.execOptions = {
 			env: env
 		};

--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -348,11 +348,6 @@ export class JupyterSession implements nb.ISession {
 			}
 			for (let i = 0; i < Object.keys(process.env).length; i++) {
 				let key = Object.keys(process.env)[i];
-				// DOTNET_ROOT gets set as part of the liveshare experience, but confuses the dotnet interactive kernel
-				// Not setting this environment variable for notebooks removes this issue
-				if (key.toLowerCase() === 'dotnet_root') {
-					continue;
-				}
 				if (key.toLowerCase() === 'path' && this._pythonEnvVarPath) {
 					allCode += `%set_env ${key}=${this._pythonEnvVarPath}${EOL}`;
 				} else {


### PR DESCRIPTION
I was wrong on my initial diagnosis here. Worked with one of the folks from the powershell team, and he mentioned that he had problems finding the dotnet root in ADS (and the dotnet kernels weren't loading properly on his machine).

Just tried this on my machine, and I can load other kernels just fine; what I previously. saw was actually due to a machine configuration problem. Clearing out DOTNET_ROOT actually helped in my (misconfigured) python case, but it's the wrong fix if a machine is actually configured correctly. When my machine was in a bad state, I couldn't load the dotnet kernels even from the Jupyter UI. Reinstalling anaconda fixed my problem.