### PR TITLE
Cleanup nbformat, more common tests

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/common/jsonext.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/common/jsonext.test.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { isPrimitive } from 'sql/workbench/services/notebook/common/jsonext';
+
+suite('jsonext', function (): void {
+	test('Validate null object is primitive', async function (): Promise<void> {
+		let object = null;
+		assert.equal(isPrimitive(object), true, 'null object should be primitive');
+		object = undefined;
+		assert.equal(isPrimitive(object), false, 'undefined object should not be primitive');
+	});
+	test('Validate boolean types are primitive', async function (): Promise<void> {
+		let object: boolean = false;
+		assert.equal(isPrimitive(object), true, 'false boolean object should be primitive');
+		object = true;
+		assert.equal(isPrimitive(object), true, 'true boolean object should be primitive');
+	});
+	test('Validate number types are primitive', async function (): Promise<void> {
+		let object: number = 0;
+		assert.equal(isPrimitive(object), true, 'number with value 0 should be primitive');
+		object = 1;
+		assert.equal(isPrimitive(object), true, 'number with value 1 should be primitive');
+	});
+	test('Validate string types are primitive', async function (): Promise<void> {
+		let object: string = '';
+		assert.equal(isPrimitive(object), true, 'empty strings should be primitive');
+		object = 'nonempty string';
+		assert.equal(isPrimitive(object), true, 'non-empty strings should be primitive');
+	});
+	test('custom object is not primitive', async function (): Promise<void> {
+		let object = {
+			prop1: 'val1'
+		};
+		assert.equal(isPrimitive(object), false, 'custom object should not be primitive');
+		object = undefined;
+		assert.equal(isPrimitive(object), false, 'undefined object should not be primitive');
+	});
+});

--- a/src/sql/workbench/contrib/notebook/test/common/nbformat.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/common/nbformat.test.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { nbformat } from 'sql/workbench/services/notebook/common/nbformat';
+import * as assert from 'assert';
+
+suite('nbformat', function (): void {
+	let sampleOutput: nbformat.IOutput = {
+		data: undefined,
+		ename: '',
+		evalue: undefined,
+		execution_count: 0,
+		name: undefined,
+		output_type: 'display_data'
+	};
+	test('Validate display_data Output Type', async function (): Promise<void> {
+		sampleOutput.output_type = 'display_data';
+		assert.equal(nbformat.isDisplayData(sampleOutput), true, 'display_data output type not recognized correctly');
+		assert.equal(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
+		assert.equal(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
+		assert.equal(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
+		assert.equal(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
+	});
+	test('Validate update_display_data Output Type', async function (): Promise<void> {
+		sampleOutput.output_type = 'update_display_data';
+		assert.equal(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
+		assert.equal(nbformat.isDisplayUpdate(sampleOutput), true, 'update_display_data output type not recognized correctly');
+		assert.equal(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
+		assert.equal(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
+		assert.equal(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
+	});
+	test('Validate error Output Type', async function (): Promise<void> {
+		sampleOutput.output_type = 'error';
+		assert.equal(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
+		assert.equal(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
+		assert.equal(nbformat.isError(sampleOutput), true, 'error output type not recognized correctly');
+		assert.equal(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
+		assert.equal(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
+	});
+	test('Validate execute_result Output Type', async function (): Promise<void> {
+		sampleOutput.output_type = 'execute_result';
+		assert.equal(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
+		assert.equal(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
+		assert.equal(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
+		assert.equal(nbformat.isExecuteResult(sampleOutput), true, 'execute_result output type not recognized correctly');
+		assert.equal(nbformat.isStream(sampleOutput), false, 'stream output type incorrectly recognized');
+	});
+	test('Validate stream Output Type', async function (): Promise<void> {
+		sampleOutput.output_type = 'stream';
+		assert.equal(nbformat.isDisplayData(sampleOutput), false, 'display_data output type incorrectly recognized');
+		assert.equal(nbformat.isDisplayUpdate(sampleOutput), false, 'update_display_data output type incorrectly recognized');
+		assert.equal(nbformat.isError(sampleOutput), false, 'error output type incorrectly recognized');
+		assert.equal(nbformat.isExecuteResult(sampleOutput), false, 'execute_result output type incorrectly recognized');
+		assert.equal(nbformat.isStream(sampleOutput), true, 'stream output type not recognized correctly');
+	});
+});

--- a/src/sql/workbench/services/notebook/common/nbformat.ts
+++ b/src/sql/workbench/services/notebook/common/nbformat.ts
@@ -91,57 +91,6 @@ export namespace nbformat {
 	export type OutputMetadata = JSONObject;
 
 	/**
-	 * Validate a mime type/value pair.
-	 *
-	 * @param type - The mimetype name.
-	 *
-	 * @param value - The value associated with the type.
-	 *
-	 * @returns Whether the type/value pair are valid.
-	 */
-	export function validateMimeValue(
-		type: string,
-		value: MultilineString | JSONObject
-	): boolean {
-		// Check if "application/json" or "application/foo+json"
-		const jsonTest = /^application\/(.*?)+\+json$/;
-		const isJSONType = type === 'application/json' || jsonTest.test(type);
-
-		let isString = (x: any) => {
-			return Object.prototype.toString.call(x) === '[object String]';
-		};
-
-		// If it is an array, make sure if is not a JSON type and it is an
-		// array of strings.
-		if (Array.isArray(value)) {
-			if (isJSONType) {
-				return false;
-			}
-			let valid = true;
-			(value as string[]).forEach(v => {
-				if (!isString(v)) {
-					valid = false;
-				}
-			});
-			return valid;
-		}
-
-		// If it is a string, make sure we are not a JSON type.
-		if (isString(value)) {
-			return !isJSONType;
-		}
-
-		// It is not a string, make sure it is a JSON type.
-		if (!isJSONType) {
-			return false;
-		}
-
-		// It is a JSON type, make sure it is a valid JSON object.
-		// return JSONExt.isObject(value);
-		return true;
-	}
-
-	/**
 	 * Cell-level metadata.
 	 */
 	export interface IBaseCellMetadata extends JSONObject {
@@ -281,27 +230,6 @@ export namespace nbformat {
 	 * A cell union type.
 	 */
 	export type ICell = IRawCell | IMarkdownCell | ICodeCell | IUnrecognizedCell;
-
-	/**
-	 * Test whether a cell is a raw cell.
-	 */
-	export function isRaw(cell: ICell): cell is IRawCell {
-		return cell.cell_type === 'raw';
-	}
-
-	/**
-	 * Test whether a cell is a markdown cell.
-	 */
-	export function isMarkdown(cell: ICell): cell is IMarkdownCell {
-		return cell.cell_type === 'markdown';
-	}
-
-	/**
-	 * Test whether a cell is a code cell.
-	 */
-	export function isCode(cell: ICell): cell is ICodeCell {
-		return cell.cell_type === 'code';
-	}
 
 	/**
 	 * A union metadata type.
@@ -486,9 +414,4 @@ export namespace nbformat {
 		| IDisplayData
 		| IStream
 		| IError;
-}
-
-export interface ICellOutputWithIdAndTrust extends nb.ICellOutput {
-	id: number;
-	trusted: boolean;
 }


### PR DESCRIPTION
Wanted to do just a small part in the testing realm this week.

Cleaning up some methods that weren't being used elsewhere from nbformat (and which I'm not sure we have any use for anyway), and adding a few simple tests for very simple methods in nbformat.ts and jsonext.ts.