### PR TITLE
Fixed query editor toolbar icons

### DIFF
--- a/src/sql/workbench/contrib/query/browser/media/queryEditor.css
+++ b/src/sql/workbench/contrib/query/browser/media/queryEditor.css
@@ -6,3 +6,8 @@
 .query-editor-view {
 	width: 100%;
 }
+
+.query-editor-view .monaco-action-bar .action-item .codicon {
+	display: inline-block;
+	align-items: stretch;
+}


### PR DESCRIPTION
Fixed the formatting of the buttons in the query toolbar and added more spacing

left side: old
right side: new
![newandold](https://user-images.githubusercontent.com/18150417/81454455-5a857000-915a-11ea-897e-1d0280216b36.jpg)



This PR fixes #9965 
