### PR TITLE
Hyperlink Component improvements

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/constants.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/constants.ts
@@ -59,7 +59,6 @@ export class IconPathHelper {
 export namespace cssStyles {
 	export const title = { 'font-size': '14px', 'font-weight': '600' };
 	export const tableHeader = { 'text-align': 'left', 'font-weight': 'bold', 'text-transform': 'uppercase', 'font-size': '10px', 'user-select': 'text' };
-	export const hyperlink = { 'user-select': 'text', 'color': '#0078d4', 'text-decoration': 'underline', 'cursor': 'pointer' };
 	export const text = { 'margin-block-start': '0px', 'margin-block-end': '0px' };
 	export const overflowEllipsisText = { ...text, 'overflow': 'hidden', 'text-overflow': 'ellipsis' };
 	export const nonSelectableText = { ...cssStyles.text, 'user-select': 'none' };

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardOverviewPage.ts
@@ -363,7 +363,7 @@ export class BdcDashboardOverviewPage extends BdcDashboardPage {
 					.withProperties<azdata.HyperlinkComponentProperties>({
 						label: getServiceNameDisplayText(serviceStatus.serviceName),
 						url: '',
-						CSSStyles: { ...cssStyles.text, ...cssStyles.hyperlink }
+						CSSStyles: { ...cssStyles.text }
 					}).component();
 				nameCell.onDidClick(() => {
 					this.dashboard.switchToServiceTab(serviceStatus.serviceName);
@@ -458,7 +458,7 @@ function createEndpointComponent(modelBuilder: azdata.ModelBuilder, endpoint: En
 			.withProperties<azdata.HyperlinkComponentProperties>({
 				label: endpoint.endpoint,
 				title: endpoint.endpoint,
-				url: endpoint.endpoint, CSSStyles: { ...cssStyles.hyperlink }
+				url: endpoint.endpoint
 			})
 			.component();
 	}
@@ -468,7 +468,7 @@ function createEndpointComponent(modelBuilder: azdata.ModelBuilder, endpoint: En
 				title: endpoint.endpoint,
 				label: endpoint.endpoint,
 				url: '',
-				CSSStyles: { ...cssStyles.text, ...cssStyles.hyperlink }
+				CSSStyles: { ...cssStyles.text }
 			}).component();
 		endpointCell.onDidClick(async () => {
 			const connProfile = bdcModel.getSqlServerMasterConnectionProfile();

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/bdcDashboardResourceStatusPage.ts
@@ -304,7 +304,7 @@ export class BdcDashboardResourceStatusPage extends BdcDashboardPage {
 				url: instanceStatus.dashboards.nodeMetricsUrl,
 				title: instanceStatus.dashboards.nodeMetricsUrl,
 				ariaLabel: loc.viewNodeMetrics(instanceStatus.dashboards.nodeMetricsUrl),
-				CSSStyles: { ...cssStyles.text, ...cssStyles.hyperlink }
+				CSSStyles: { ...cssStyles.text }
 			}).component());
 		}
 
@@ -319,7 +319,7 @@ export class BdcDashboardResourceStatusPage extends BdcDashboardPage {
 					url: instanceStatus.dashboards.sqlMetricsUrl,
 					title: instanceStatus.dashboards.sqlMetricsUrl,
 					ariaLabel: loc.viewSqlMetrics(instanceStatus.dashboards.sqlMetricsUrl),
-					CSSStyles: { ...cssStyles.text, ...cssStyles.hyperlink }
+					CSSStyles: { ...cssStyles.text }
 				}).component());
 			}
 		}
@@ -332,7 +332,7 @@ export class BdcDashboardResourceStatusPage extends BdcDashboardPage {
 				url: instanceStatus.dashboards.logsUrl,
 				title: instanceStatus.dashboards.logsUrl,
 				ariaLabel: loc.viewLogs(instanceStatus.dashboards.logsUrl),
-				CSSStyles: { ...cssStyles.text, ...cssStyles.hyperlink }
+				CSSStyles: { ...cssStyles.text }
 			}).component());
 		}
 		return row;

--- a/src/sql/base/browser/ui/table/media/slickColorTheme.css
+++ b/src/sql/base/browser/ui/table/media/slickColorTheme.css
@@ -16,20 +16,15 @@
 	padding-left: 20px;
 }
 
-.slick-cell a, a:link {
+.slick-cell a,
+.slick-cell a:link,
+.resultsMessageValue a,
+.resultsMessageValue a:link {
 	color: var(--color-grid-link);
 	text-decoration: underline;
 }
 
-.slick-cell a:hover {
-	color: var(--color-grid-link-hover);
-}
-
-.resultsMessageValue a, a:link {
-	color: var(--color-grid-link);
-	text-decoration: underline;
-}
-
+.slick-cell a:hover,
 .resultsMessageValue a:hover {
 	color: var(--color-grid-link-hover);
 }


### PR DESCRIPTION
1. Clean up a few redundent get* methods
1. Use opener service instead of letting the browser handle opening
1. Fix slickgrid styles to not apply to all links in the document
1. Add theming support for hyperlink colors

Fixes https://github.com/microsoft/azuredatastudio/issues/7400

![image](https://user-images.githubusercontent.com/28519865/81456451-2bb1ce80-9147-11ea-9459-d71a8cbb90a9.png)

![image](https://user-images.githubusercontent.com/28519865/81456462-38cebd80-9147-11ea-8cfa-ce0a214f7596.png)

