### PR TITLE
Uncheck unselected radio buttons in Configure Python wizard.

### DIFF
--- a/extensions/notebook/src/dialog/configurePython/configurePathPage.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePathPage.ts
@@ -134,6 +134,7 @@ export class ConfigurePathPage extends BasePage {
 				checked: !useExistingPython
 			}).component();
 		this.newInstallButton.onDidClick(() => {
+			this.existingInstallButton.checked = false;
 			this.updatePythonPathsDropdown(false)
 				.catch(err => {
 					this.instance.showErrorMessage(utils.getErrorMessage(err));
@@ -147,6 +148,7 @@ export class ConfigurePathPage extends BasePage {
 				checked: useExistingPython
 			}).component();
 		this.existingInstallButton.onDidClick(() => {
+			this.newInstallButton.checked = false;
 			this.updatePythonPathsDropdown(true)
 				.catch(err => {
 					this.instance.showErrorMessage(utils.getErrorMessage(err));


### PR DESCRIPTION
The buttons were showing checked==true, even when selecting other radio buttons in the same group.
