### PR TITLE
Move smoke tests out of the normal build

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -114,14 +114,14 @@ steps:
       APP_NAME="`ls $APP_ROOT | head -n 1`"
       yarn smoketest --build "$APP_ROOT/$APP_NAME" --screenshots "$(build.artifactstagingdirectory)/smokeshots"
     displayName: Run smoke tests (Electron)
-    condition: and(succeeded(), eq(variables['VSCODE_STEP_ON_IT'], 'false'))
+    condition: and(succeeded(), eq(variables['RUN_SMOKE_TESTS'], 'true'))
 
   - script: |
       set -e
       VSCODE_REMOTE_SERVER_PATH="$(agent.builddirectory)/azuredatastudio-reh-web-darwin" \
       yarn smoketest --web --headless  --screenshots "$(build.artifactstagingdirectory)/smokeshots"
     displayName: Run smoke tests (Browser)
-    condition: and(succeeded(), eq(variables['VSCODE_STEP_ON_IT'], 'false'))
+    condition: and(succeeded(), eq(variables['RUN_SMOKE_TESTS'], 'true'))
 
   - script: |
       set -e


### PR DESCRIPTION
This PR fixes #

Let's have a different variable for it so we can control it for adhoc.

We can make this true by default for product builds. I've just seen the build fail twice for this and that's a little expensive.
