### PR TITLE
Add sql proj schema compare for dacpac

### DIFF
--- a/extensions/schema-compare/src/controllers/mainController.ts
+++ b/extensions/schema-compare/src/controllers/mainController.ts
@@ -30,7 +30,7 @@ export default class MainController implements vscode.Disposable {
 	}
 
 	private initializeSchemaCompareDialog(): void {
-		azdata.tasks.registerTask('schemaCompare.start', (profile: azdata.IConnectionProfile) => new SchemaCompareMainWindow(null, this.extensionContext).start(profile));
+		vscode.commands.registerCommand('schemaCompare.start', (context: any) => new SchemaCompareMainWindow(null, this.extensionContext).start(context));
 	}
 
 	public dispose(): void {

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -77,9 +77,14 @@ export class SchemaCompareMainWindow {
 		this.editor = azdata.workspace.createModelViewEditor(loc.SchemaCompareLabel, { retainContextWhenHidden: true, supportsSave: true, resourceName: schemaCompareResourceName });
 	}
 
+	// schema compare can get started with three contexts for the source:
+	// 1. undefined
+	// 2. connection profile
+	// 3. dacpac
 	public async start(context: any) {
 		// if schema compare was launched from a db, set that as the source
 		let profile = context ? <azdata.IConnectionProfile>context.connectionProfile : undefined;
+		let sourceDacpac = context as vscode.Uri;
 		if (profile) {
 			let ownerUri = await azdata.connection.getUriForConnection((profile.id));
 			this.sourceEndpointInfo = {
@@ -89,6 +94,16 @@ export class SchemaCompareMainWindow {
 				databaseName: profile.databaseName,
 				ownerUri: ownerUri,
 				packageFilePath: '',
+				connectionDetails: undefined
+			};
+		} else if (sourceDacpac) {
+			this.sourceEndpointInfo = {
+				endpointType: mssql.SchemaCompareEndpointType.Dacpac,
+				serverDisplayName: '',
+				serverName: '',
+				databaseName: '',
+				ownerUri: '',
+				packageFilePath: sourceDacpac.path,
 				connectionDetails: undefined
 			};
 		}

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -84,7 +84,7 @@ export class SchemaCompareMainWindow {
 	public async start(context: any) {
 		// if schema compare was launched from a db, set that as the source
 		let profile = context ? <azdata.IConnectionProfile>context.connectionProfile : undefined;
-		let sourceDacpac = context as vscode.Uri;
+		let sourceDacpac = context as string;
 		if (profile) {
 			let ownerUri = await azdata.connection.getUriForConnection((profile.id));
 			this.sourceEndpointInfo = {
@@ -103,7 +103,7 @@ export class SchemaCompareMainWindow {
 				serverName: '',
 				databaseName: '',
 				ownerUri: '',
-				packageFilePath: sourceDacpac.path,
+				packageFilePath: sourceDacpac,
 				connectionDetails: undefined
 			};
 		}

--- a/extensions/schema-compare/src/test/schemaCompare.test.ts
+++ b/extensions/schema-compare/src/test/schemaCompare.test.ts
@@ -99,6 +99,8 @@ describe('SchemaCompareResult.start', function (): void {
 
 		let result = new SchemaCompareMainWindow(sc, mockExtensionContext.object);
 		await result.start(undefined);
+		let promise = new Promise(resolve => setTimeout(resolve, 5000)); // to ensure comparison result view is initialized
+		await promise;
 
 		should.equal(result.sourceEndpointInfo, undefined);
 		should.equal(result.targetEndpointInfo, undefined);
@@ -109,6 +111,8 @@ describe('SchemaCompareResult.start', function (): void {
 
 		let result = new SchemaCompareMainWindow(sc, mockExtensionContext.object);
 		await result.start({connectionProfile: mockConnectionProfile});
+		let promise = new Promise(resolve => setTimeout(resolve, 5000)); // to ensure comparison result view is initialized
+		await promise;
 
 		should.notEqual(result.sourceEndpointInfo, undefined);
 		should.equal(result.sourceEndpointInfo.endpointType, mssql.SchemaCompareEndpointType.Database);
@@ -123,6 +127,8 @@ describe('SchemaCompareResult.start', function (): void {
 		let result = new SchemaCompareMainWindow(sc, mockExtensionContext.object);
 		const dacpacPath = 'C:\\users\\test\\test.dacpac';
 		await result.start(dacpacPath);
+		let promise = new Promise(resolve => setTimeout(resolve, 5000)); // to ensure comparison result view is initialized
+		await promise;
 
 		should.notEqual(result.sourceEndpointInfo, undefined);
 		should.equal(result.sourceEndpointInfo.endpointType, mssql.SchemaCompareEndpointType.Dacpac);

--- a/extensions/schema-compare/src/test/schemaCompare.test.ts
+++ b/extensions/schema-compare/src/test/schemaCompare.test.ts
@@ -93,4 +93,40 @@ describe('SchemaCompareResult.start', function (): void {
 		should(result.getComparisonResult() !== undefined);
 		should(result.getComparisonResult().operationId === 'Test Operation Id');
 	});
+
+	it('Should start with the source as undefined', async function (): Promise<void> {
+		let sc = new SchemaCompareTestService();
+
+		let result = new SchemaCompareMainWindow(sc, mockExtensionContext.object);
+		await result.start(undefined);
+
+		should.equal(result.sourceEndpointInfo, undefined);
+		should.equal(result.targetEndpointInfo, undefined);
+	});
+
+	it('Should start with the source as database', async function (): Promise<void> {
+		let sc = new SchemaCompareTestService();
+
+		let result = new SchemaCompareMainWindow(sc, mockExtensionContext.object);
+		await result.start({connectionProfile: mockConnectionProfile});
+
+		should.notEqual(result.sourceEndpointInfo, undefined);
+		should.equal(result.sourceEndpointInfo.endpointType, mssql.SchemaCompareEndpointType.Database);
+		should.equal(result.sourceEndpointInfo.serverName, mockConnectionProfile.serverName);
+		should.equal(result.sourceEndpointInfo.databaseName, mockConnectionProfile.databaseName);
+		should.equal(result.targetEndpointInfo, undefined);
+	});
+
+	it('Should start with the source as dacpac.', async function (): Promise<void> {
+		let sc = new SchemaCompareTestService();
+
+		let result = new SchemaCompareMainWindow(sc, mockExtensionContext.object);
+		const dacpacPath = 'C:\\users\\test\\test.dacpac';
+		await result.start(dacpacPath);
+
+		should.notEqual(result.sourceEndpointInfo, undefined);
+		should.equal(result.sourceEndpointInfo.endpointType, mssql.SchemaCompareEndpointType.Dacpac);
+		should.equal(result.sourceEndpointInfo.packageFilePath, dacpacPath);
+		should.equal(result.targetEndpointInfo, undefined);
+	});
 });

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -11,6 +11,7 @@ const localize = nls.loadMessageBundle();
 export const dataSourcesFileName = 'datasources.json';
 export const sqlprojExtension = '.sqlproj';
 export const initialCatalogSetting = 'Initial Catalog';
+export const schemaCompareExtensionId = 'microsoft.schema-compare';
 
 // UI Strings
 
@@ -50,6 +51,7 @@ export const unknownDataSourceType = localize('unknownDataSourceType', "Unknown 
 export const invalidSqlConnectionString = localize('invalidSqlConnectionString', "Invalid SQL connection string");
 export const projectNameRequired = localize('projectNameRequired', "Name is required to create a new database project.");
 export const projectLocationRequired = localize('projectLocationRequired', "Location is required to create a new database project.");
+export const schemaCompareNotInstalled = localize('schemaCompareNotInstalled', "Schema compare extension installation is required to run schema compare");
 export function projectAlreadyOpened(path: string) { return localize('projectAlreadyOpened', "Project '{0}' is already opened.", path); }
 export function projectAlreadyExists(name: string, path: string) { return localize('projectAlreadyExists', "A project named {0} already exists in {1}.", name, path); }
 export function mssqlNotFound(mssqlConfigDir: string) { return localize('mssqlNotFound', "Could not get mssql extension's install location at {0}", mssqlConfigDir); }

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -52,6 +52,7 @@ export const invalidSqlConnectionString = localize('invalidSqlConnectionString',
 export const projectNameRequired = localize('projectNameRequired', "Name is required to create a new database project.");
 export const projectLocationRequired = localize('projectLocationRequired', "Location is required to create a new database project.");
 export const schemaCompareNotInstalled = localize('schemaCompareNotInstalled', "Schema compare extension installation is required to run schema compare");
+export const buildDacpacNotFound = localize('buildDacpacNotFound', "Dacpac created from build not found");
 export function projectAlreadyOpened(path: string) { return localize('projectAlreadyOpened', "Project '{0}' is already opened.", path); }
 export function projectAlreadyExists(name: string, path: string) { return localize('projectAlreadyExists', "A project named {0} already exists in {1}.", name, path); }
 export function mssqlNotFound(mssqlConfigDir: string) { return localize('mssqlNotFound', "Could not get mssql extension's install location at {0}", mssqlConfigDir); }

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -5,6 +5,8 @@
 
 import * as vscode from 'vscode';
 import * as os from 'os';
+import { promises as fs } from 'fs';
+
 /**
  * Consolidates on the error message string
  */
@@ -73,4 +75,16 @@ export function getSafeWindowsPath(filePath: string): string {
 export function getSafeNonWindowsPath(filePath: string): string {
 	filePath = filePath.split('\\').join('/').split('"').join('');
 	return '"' + filePath + '"';
+}
+
+/**
+ * Checks if the folder or file exists @param path path of the folder/file
+*/
+export async function exists(path: string): Promise<boolean> {
+	try {
+		await fs.access(path);
+		return true;
+	} catch (e) {
+		return false;
+	}
 }

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -51,6 +51,7 @@ export default class MainController implements Disposable {
 
 		this.apiWrapper.registerCommand('sqlDatabaseProjects.build', async (node: BaseProjectTreeItem) => { await this.projectsController.buildProject(node); });
 		this.apiWrapper.registerCommand('sqlDatabaseProjects.deploy', async (node: BaseProjectTreeItem) => { await this.projectsController.deploy(node); });
+		this.apiWrapper.registerCommand('sqlDatabaseProjects.schemaCompare', async (node: BaseProjectTreeItem) => { await this.projectsController.schemaCompare(node); });
 		this.apiWrapper.registerCommand('sqlDatabaseProjects.import', async (node: BaseProjectTreeItem) => { await this.projectsController.import(node); });
 
 		this.apiWrapper.registerCommand('sqlDatabaseProjects.newScript', async (node: BaseProjectTreeItem) => { await this.projectsController.addItemPromptFromNode(node, templates.script); });

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -142,11 +142,12 @@ export class ProjectsController {
 		// check if schema compare extension is installed
 		if (this.apiWrapper.getExtension(constants.schemaCompareExtensionId)) {
 			// build project
-			const project = this.getProjectContextFromTreeNode(treeNode);
+			await this.buildProject(treeNode);
 
 			// start schema compare with the dacpac produced from build
-			const dacpacUri = undefined;
-			this.apiWrapper.executeCommand('schemaCompare.start', dacpacUri);
+			const project = this.getProjectContextFromTreeNode(treeNode);
+			const dacpacPath = path.join(project.projectFolderPath, 'bin', 'Debug', `${project.projectFileName}.dacpac`);
+			this.apiWrapper.executeCommand('schemaCompare.start', dacpacPath);
 		} else {
 			this.apiWrapper.showErrorMessage(constants.schemaCompareNotInstalled);
 		}

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -138,6 +138,20 @@ export class ProjectsController {
 		deployDatabaseDialog.openDialog();
 	}
 
+	public async schemaCompare(treeNode: BaseProjectTreeItem): Promise<void> {
+		// check if schema compare extension is installed
+		if (this.apiWrapper.getExtension(constants.schemaCompareExtensionId)) {
+			// build project
+			const project = this.getProjectContextFromTreeNode(treeNode);
+
+			// start schema compare with the dacpac produced from build
+			const dacpacUri = undefined;
+			this.apiWrapper.executeCommand('schemaCompare.start', dacpacUri);
+		} else {
+			this.apiWrapper.showErrorMessage(constants.schemaCompareNotInstalled);
+		}
+	}
+
 	public async import(treeNode: BaseProjectTreeItem) {
 		const project = this.getProjectContextFromTreeNode(treeNode);
 		await this.apiWrapper.showErrorMessage(`Import not yet implemented: ${project.projectFilePath}`); // TODO

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -6,7 +6,6 @@
 import * as path from 'path';
 import * as constants from '../common/constants';
 import * as dataSources from '../models/dataSources/dataSources';
-import * as fs from 'fs';
 import * as utils from '../common/utils';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
 import * as templates from '../templates/templates';
@@ -15,6 +14,7 @@ import { Uri, QuickPickItem } from 'vscode';
 import { ApiWrapper } from '../common/apiWrapper';
 import { Project } from '../models/project';
 import { SqlDatabaseProjectTreeViewProvider } from './databaseProjectTreeViewProvider';
+import { promises as fs } from 'fs';
 import { BaseProjectTreeItem } from '../models/tree/baseTreeItem';
 import { ProjectRootTreeItem } from '../models/tree/projectTreeItem';
 import { FolderNode } from '../models/tree/fileFolderTreeItem';
@@ -98,7 +98,7 @@ export class ProjectsController {
 
 		let fileExists = false;
 		try {
-			await fs.promises.access(newProjFilePath);
+			await fs.access(newProjFilePath);
 			fileExists = true;
 		}
 		catch { } // file doesn't already exist
@@ -107,8 +107,8 @@ export class ProjectsController {
 			throw new Error(constants.projectAlreadyExists(newProjFileName, folderUri.fsPath));
 		}
 
-		await fs.promises.mkdir(path.dirname(newProjFilePath), { recursive: true });
-		await fs.promises.writeFile(newProjFilePath, newProjFileContents);
+		await fs.mkdir(path.dirname(newProjFilePath), { recursive: true });
+		await fs.writeFile(newProjFilePath, newProjFileContents);
 
 		return newProjFilePath;
 	}
@@ -149,7 +149,7 @@ export class ProjectsController {
 			const dacpacPath = path.join(project.projectFolderPath, 'bin', 'Debug', `${project.projectFileName}.dacpac`);
 
 			// check that dacpac exists
-			if (fs.existsSync(dacpacPath)) {
+			if (await utils.exists(dacpacPath)) {
 				this.apiWrapper.executeCommand('schemaCompare.start', dacpacPath);
 			} else {
 				this.apiWrapper.showErrorMessage(constants.buildDacpacNotFound);


### PR DESCRIPTION
This adds basic support for schema compare for sql database projects by building the dacpac of the project and setting that as the source when the schema compare is opened
<img width="1168" alt="Screen Shot 2020-05-13 at 7 25 59 PM" src="https://user-images.githubusercontent.com/31145923/81885672-b29fe600-954f-11ea-8930-16f468c3da2f.png">

Error if schema compare extension isn't installed:
![Screen Shot 2020-05-13 at 5 08 36 PM](https://user-images.githubusercontent.com/31145923/81878860-086b9280-953e-11ea-9c9b-992e96ae18ed.png)

