### PR TITLE
set context

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/contents/dashboardWidgetWrapper.component.ts
@@ -132,6 +132,7 @@ export class DashboardWidgetWrapper extends AngularDisposable implements OnInit 
 			}
 
 			if (this._actions && this.toggleMore) {
+				this._actionbar.context = { target: this._actionbarRef.nativeElement };
 				this._actionbar.push(this.instantiationService.createInstance(ToggleMoreWidgetAction, this._actions as Array<IAction>, this._component.actionsContext), { icon: true, label: false });
 			}
 		}


### PR DESCRIPTION
This PR fixes #10384 
This PR fixes #10386 
this seems to be caused by recent vscode merge, but i didn't find out how it broke this scenario, it turns out notebook is also using this action, and it is working properly because it has the context set.
https://github.com/microsoft/azuredatastudio/blob/master/src/sql/workbench/contrib/notebook/browser/cellToggleMoreActions.ts#L59

so i am just doing the same here.

<img width="842" alt="Screen Shot 2020-05-13 at 11 04 23 PM" src="https://user-images.githubusercontent.com/13777222/81899038-c7d83d00-956e-11ea-90bb-a7fdaf4ed6f8.png">
