### PR TITLE
use listdatabases for sqlondemand

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -478,17 +478,7 @@
             {
               "displayName": "%databasesListProperties.name%",
               "value": "name",
-              "widthWeight": 60
-            },
-            {
-              "displayName": "%databasesListProperties.status%",
-              "value": "state",
-              "widthWeight": 20
-            },
-            {
-              "displayName": "%databasesListProperties.size%",
-              "value": "sizeInMB",
-              "widthWeight": 20
+              "widthWeight": 100
             }
           ]
         }

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
@@ -27,6 +27,7 @@ import { IEditorProgressService } from 'vs/platform/progress/common/progress';
 import { attachInputBoxStyler } from 'vs/platform/theme/common/styler';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
+import { DatabaseEngineEdition } from 'sql/workbench/api/common/sqlExtHostTypes';
 
 @Component({
 	selector: 'explorer-widget',
@@ -108,8 +109,7 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 			)));
 		} else {
 			// TODO: remove this ADS side workaround for SQL On-Demand and handle it in SQL Tools Service
-			// engineEditionId === 11 means this is a SQL on-demand server
-			if (this._bootstrap.connectionManagementService.connectionInfo.serverInfo.engineEditionId === 11) {
+			if (this._bootstrap.connectionManagementService.connectionInfo.serverInfo.engineEditionId === DatabaseEngineEdition.SqlOnDemand) {
 				this.connectionManagementService.listDatabases(this._bootstrap.connectionManagementService.connectionInfo.ownerUri).then(
 					result => {
 						// Sort the databases: system databases first and then the sorted list of other databases

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
@@ -26,6 +26,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { IEditorProgressService } from 'vs/platform/progress/common/progress';
 import { attachInputBoxStyler } from 'vs/platform/theme/common/styler';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 
 @Component({
 	selector: 'explorer-widget',
@@ -51,6 +52,7 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 		@Inject(IMenuService) private readonly menuService: IMenuService,
 		@Inject(IContextKeyService) private readonly contextKeyService: IContextKeyService,
 		@Inject(IEditorProgressService) private readonly progressService: IEditorProgressService,
+		@Inject(IConnectionManagementService) private readonly connectionManagementService: IConnectionManagementService,
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef
 	) {
 		super(changeRef);
@@ -95,7 +97,6 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 			this._register(subscriptionToDisposable(this._bootstrap.metadataService.metadata.subscribe(
 				data => {
 					if (data) {
-
 						const objectData = ObjectMetadataWrapper.createFromObjectMetadata(data.objectMetadata);
 						objectData.sort(ObjectMetadataWrapper.sort);
 						this.updateTable(objectData);
@@ -106,32 +107,53 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 				}
 			)));
 		} else {
-			this._register(subscriptionToDisposable(this._bootstrap.metadataService.databases.subscribe(
-				data => {
-					// Handle the case where there is no metadata service
-					data = data || [];
-					if (isStringArray(data)) {
-						data = data.map(item => {
-							const dbInfo: DatabaseInfo = { options: {} };
-							dbInfo.options[NameProperty] = item;
-							return dbInfo;
-						});
+			// TODO: remove this ADS side workaround for SQL On-Demand and handle it in SQL Tools Service
+			if (this._bootstrap.connectionManagementService.connectionInfo.serverInfo.engineEditionId === 11) {
+				this.connectionManagementService.listDatabases(this._bootstrap.connectionManagementService.connectionInfo.ownerUri).then(
+					result => {
+						// Sort the databases: system databases first and then the sorted list of other databases
+						const sysDatabases = ['master', 'model', 'msdb', 'tempdb'];
+						const databaseNames = result.databaseNames.filter(db => sysDatabases.indexOf(db) !== -1).
+							concat(result.databaseNames.filter(db => sysDatabases.indexOf(db) === -1).sort());
+						this.handleServerContextResults(databaseNames);
+					},
+					error => {
+						this.showErrorMessage(nls.localize('dashboard.explorer.databaseError', "Unable to load databases"));
 					}
-
-					const currentProfile = this._bootstrap.connectionManagementService.connectionInfo.connectionProfile;
-					this.updateTable(data.map(d => {
-						const item = assign({}, d.options);
-						const profile = currentProfile.toIConnectionProfile();
-						profile.databaseName = d.options[NameProperty];
-						item[ConnectionProfilePropertyName] = profile;
-						return item;
-					}));
-				},
-				error => {
-					this.showErrorMessage(nls.localize('dashboard.explorer.databaseError', "Unable to load databases"));
-				}
-			)));
+				);
+			}
+			else {
+				this._register(subscriptionToDisposable(this._bootstrap.metadataService.databases.subscribe(
+					data => {
+						this.handleServerContextResults(data);
+					},
+					error => {
+						this.showErrorMessage(nls.localize('dashboard.explorer.databaseError', "Unable to load databases"));
+					}
+				)));
+			}
 		}
+	}
+
+	private handleServerContextResults(data: string[] | DatabaseInfo[]): void {
+		// Handle the case where there is no metadata service
+		data = data || [];
+		if (isStringArray(data)) {
+			data = data.map(item => {
+				const dbInfo: DatabaseInfo = { options: {} };
+				dbInfo.options[NameProperty] = item;
+				return dbInfo;
+			});
+		}
+
+		const currentProfile = this._bootstrap.connectionManagementService.connectionInfo.connectionProfile;
+		this.updateTable(data.map(d => {
+			const item = assign({}, d.options);
+			const profile = currentProfile.toIConnectionProfile();
+			profile.databaseName = d.options[NameProperty];
+			item[ConnectionProfilePropertyName] = profile;
+			return item;
+		}));
 	}
 
 	private updateTable(data: Slick.SlickData[]) {

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
@@ -108,6 +108,7 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 			)));
 		} else {
 			// TODO: remove this ADS side workaround for SQL On-Demand and handle it in SQL Tools Service
+			// engineEditionId === 11 means this is a SQL on-demand server
 			if (this._bootstrap.connectionManagementService.connectionInfo.serverInfo.engineEditionId === 11) {
 				this.connectionManagementService.listDatabases(this._bootstrap.connectionManagementService.connectionInfo.ownerUri).then(
 					result => {


### PR DESCRIPTION
fix for #10397 

root cause: SQL on demand servers do not have the views that we need to get the database size and the request will fail

fix: ideally the fix should be made in SQL tools service, i just checked that the STS version in master branch is already higher than the one in release 1.18 branch, to reduce the risk, i am implementing the changes in ADS as a workaround for now and will make proper fix in STS and remove this workaround.

connection service's listdatabases() and the method we use to get databases in this widget are both calling the same request with different parameters, so for now i am using the listdatabases which will only return the database names for sql on demand edition.

<img width="1043" alt="Screen Shot 2020-05-14 at 11 32 25 AM" src="https://user-images.githubusercontent.com/13777222/81974322-44eccc00-95da-11ea-94af-3dfd63d1487a.png">
