### PR TITLE
Don't show empty dropdown when no data sources

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -38,6 +38,7 @@ export const dataSourceRadioButtonLabel = localize('dataSourceRadioButtonLabel',
 export const connectionRadioButtonLabel = localize('connectionRadioButtonLabel', "Connections");
 export const selectConnectionRadioButtonsTitle = localize('selectconnectionRadioButtonsTitle', "Specify connection from:");
 export const dataSourceDropdownTitle = localize('dataSourceDropdownTitle', "Data source");
+export const noDataSourcesText = localize('noDataSourcesText', "No data sources in this project");
 
 // Error messages
 

--- a/extensions/sql-database-projects/src/dialogs/deployDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/deployDatabaseDialog.ts
@@ -70,7 +70,7 @@ export class DeployDatabaseDialog {
 				ariaLabel: constants.databaseNameLabel
 			}).component();
 
-			this.dataSourcesFormComponent = this.createDataSourcesDropdown(view);
+			this.dataSourcesFormComponent = this.createDataSourcesFormComponent(view);
 
 			this.targetDatabaseTextBox.onTextChanged(() => {
 				this.tryEnableGenerateScriptAndOkButtons();
@@ -176,6 +176,18 @@ export class DeployDatabaseDialog {
 			component: this.targetConnectionTextBox,
 			actions: [editConnectionButton, clearButton]
 		};
+	}
+
+	private createDataSourcesFormComponent(view: azdata.ModelView): azdata.FormComponent {
+		if (this.project.dataSources.length > 0) {
+			return this.createDataSourcesDropdown(view);
+		} else {
+			const noDataSourcesText = view.modelBuilder.text().withProperties({ value: constants.noDataSourcesText }).component();
+			return {
+				title: constants.dataSourceDropdownTitle,
+				component: noDataSourcesText
+			};
+		}
 	}
 
 	private createDataSourcesDropdown(view: azdata.ModelView): azdata.FormComponent {


### PR DESCRIPTION
Update deploy dialog to show "No data sources in this project" instead of an empty dropdown when there aren't any data sources in the project
![image](https://user-images.githubusercontent.com/31145923/81981952-e4638c00-95e5-11ea-8b23-4b6951b678a0.png)

