### PR TITLE
Ensure Notebook Model Dirty State Can Be Triggered Before Session Start

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -42,6 +42,7 @@ export class NotebookEditorModel extends EditorModel {
 	private _notebookTextFileModel: NotebookTextFileModel;
 	private readonly _onDidChangeDirty: Emitter<void> = this._register(new Emitter<void>());
 	private _lastEditFullReplacement: boolean;
+	private _isFirstKernelChange: boolean = true;
 	constructor(public readonly notebookUri: URI,
 		private textEditorModel: ITextFileEditorModel | IUntitledTextEditorModel | ResourceEditorModel,
 		@INotebookService private notebookService: INotebookService,
@@ -110,6 +111,10 @@ export class NotebookEditorModel extends EditorModel {
 	}
 
 	public updateModel(contentChange?: NotebookContentChange, type?: NotebookChangeType): void {
+		if (type === NotebookChangeType.KernelChanged && this._isFirstKernelChange) {
+			this._isFirstKernelChange = false;
+			return;
+		}
 		this._lastEditFullReplacement = false;
 		if (contentChange && contentChange.changeType === NotebookChangeType.Saved) {
 			// We send the saved events out, so ignore. Otherwise we double-count this as a change

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -238,10 +238,10 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	private async doLoad(): Promise<void> {
 		try {
 			await this.createModelAndLoadContents();
-			await this.setNotebookManager();
-			await this.loadModel();
 			this._modelReadyDeferred.resolve(this._model);
 			this.notebookService.addNotebookEditor(this);
+			await this.setNotebookManager();
+			await this.loadModel();
 		} catch (error) {
 			if (error) {
 				// Offer to create a file from the error if we have a file not found and the name is valid


### PR DESCRIPTION
This PR fixes #10416.

Issue: we were waiting until a session was started  before calling the resolving the modelReady promise. This promise was awaited in a few places to get a reference to the notebook model, one of which was to hook up model contentChange (and kernelChange) events in notebookInput.

This was originally done because there is always a kernelChange event fired when a notebook is opened, so we didn't want to set the document to dirty incorrectly.

Tracking the first kernel change is straightforward, however, which is part of my change here.

Now, users should be able to open a notebook, immediately edit the notebook, and save it, before the session is loaded for the kernel.