### PR TITLE
Properly initialize scenario recommendations

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionRecommendationsService.ts
@@ -84,6 +84,7 @@ export class ExtensionRecommendationsService extends Disposable implements IExte
 		this.dynamicWorkspaceRecommendations = instantiationService.createInstance(DynamicWorkspaceRecommendations, isExtensionAllowedToBeRecommended);
 		this.keymapRecommendations = instantiationService.createInstance(KeymapRecommendations, isExtensionAllowedToBeRecommended);
 		this.staticRecommendations = instantiationService.createInstance(StaticRecommendations, isExtensionAllowedToBeRecommended); // {{SQL CARBON EDIT}} add ours
+		this.scenarioRecommendations = instantiationService.createInstance(ScenarioRecommendations, isExtensionAllowedToBeRecommended); // {{SQL CARBON EDIT}} add ours
 
 		if (!this.isEnabled()) {
 			this.sessionSeed = 0;
@@ -99,6 +100,7 @@ export class ExtensionRecommendationsService extends Disposable implements IExte
 		this.experimentalRecommendations.activate();
 		this.keymapRecommendations.activate();
 		this.staticRecommendations.activate(); // {{SQL CARBON EDIT}} add ours
+		this.scenarioRecommendations.activate(); // {{SQL CARBON EDIT}} add ours
 		if (!this.configurationService.getValue<boolean>(ShowRecommendationsOnlyOnDemandKey)) {
 			lifecycleService.when(LifecyclePhase.Eventually).then(() => this.activateProactiveRecommendations());
 		}


### PR DESCRIPTION
This is related to https://github.com/microsoft/azuredatastudio/issues/10425.  It looks like the scenario recommender isn't being initialized which causes charts to fail since it wants to recommend SandDance.
