### PR TITLE
Remove config update from subscription filter

### DIFF
--- a/extensions/azurecore/src/azureResource/services/subscriptionFilterService.ts
+++ b/extensions/azurecore/src/azureResource/services/subscriptionFilterService.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WorkspaceConfiguration, ConfigurationTarget } from 'vscode';
 import { Account } from 'azdata';
 
 import { azureResource } from '../azure-resource';
@@ -53,25 +52,8 @@ export class AzureResourceSubscriptionFilterService implements IAzureResourceSub
 		for (const accountId in selectedSubscriptionsCache) {
 			filters.push(...selectedSubscriptionsCache[accountId].map((subcription) => `${accountId}/${subcription.id}/${subcription.name}`));
 		}
-
-		const resourceFilterConfig = this._config.inspect<string[]>(AzureResourceSubscriptionFilterService.filterConfigName);
-		let configTarget = ConfigurationTarget.Global;
-		if (resourceFilterConfig) {
-			if (resourceFilterConfig.workspaceFolderValue) {
-				configTarget = ConfigurationTarget.WorkspaceFolder;
-			} else if (resourceFilterConfig.workspaceValue) {
-				configTarget = ConfigurationTarget.Workspace;
-			} else if (resourceFilterConfig.globalValue) {
-				configTarget = ConfigurationTarget.Global;
-			}
-		}
-
-		await this._config.update(AzureResourceSubscriptionFilterService.filterConfigName, filters, configTarget);
 	}
 
-	private _config: WorkspaceConfiguration = undefined;
 	private _cacheService: IAzureResourceCacheService = undefined;
 	private _cacheKey: string = undefined;
-
-	private static readonly filterConfigName = 'azure.resource.config.filter';
 }


### PR DESCRIPTION
For #10438

Not exactly sure why this has just recently started appearing - my best initial guess though is that the Tree used to display the Azure accounts was updated in a recent VS Code merge to cause these to be surfaced. This code has always been broken as far as I can tell from its original implementation (we never were setting the config) and the error itself is also nothing new.

We might want to relook at how we're storing this since currently it's tied to the workspace - but this fix at least gets rid of the error and isn't going to change any existing behavior. 