### PR TITLE
explorer widget dark theme fix

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/media/explorerWidget.css
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/media/explorerWidget.css
@@ -19,7 +19,7 @@ explorer-widget .list-row {
 }
 
 /**
- * The widget could be put in a grid container and get unexpected colors,
+ * The widget could be put into container with class name "grid" and inherit colors unexpectedly,
  * using this selector to force the cell to use the colors from parent elements
  */
 .grid .explorer-widget .slick-cell {

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/media/explorerWidget.css
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/media/explorerWidget.css
@@ -17,3 +17,13 @@ explorer-widget .list-row {
 .explorer-widget .slick-cell {
 	border-right-style: none;
 }
+
+/**
+ * The widget could be put in a grid container and get unexpected colors,
+ * using this selector to force the cell to use the colors from parent elements
+ */
+.grid .explorer-widget .slick-cell {
+	color: inherit;
+	background-color: inherit;
+	border-color: inherit;
+}


### PR DESCRIPTION
for for issue: #10439 

<img width="1069" alt="Screen Shot 2020-05-15 at 2 01 33 PM" src="https://user-images.githubusercontent.com/13777222/82097902-b00cd000-96b8-11ea-847e-b63579f17a60.png">
<img width="1041" alt="Screen Shot 2020-05-15 at 2 01 20 PM" src="https://user-images.githubusercontent.com/13777222/82097907-b26f2a00-96b8-11ea-9061-c2dd6f39cd2c.png">
