### PR TITLE
fix explorer widget dark theme

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/media/explorerWidget.css
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/media/explorerWidget.css
@@ -19,7 +19,7 @@ explorer-widget .list-row {
 }
 
 /**
- * The widget could be put in a grid container and get unexpected colors,
+ * The widget could be put into container with class name "grid" and inherit colors unexpectedly,
  * using this selector to force the cell to use the colors from parent elements
  */
 .grid .explorer-widget .slick-cell {

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/media/explorerWidget.css
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/media/explorerWidget.css
@@ -17,3 +17,13 @@ explorer-widget .list-row {
 .explorer-widget .slick-cell {
 	border-right-style: none;
 }
+
+/**
+ * The widget could be put in a grid container and get unexpected colors,
+ * using this selector to force the cell to use the colors from parent elements
+ */
+.grid .explorer-widget .slick-cell {
+	color: inherit;
+	background-color: inherit;
+	border-color: inherit;
+}


### PR DESCRIPTION
This PR fixes #10439 
<img width="1041" alt="Screen Shot 2020-05-15 at 2 01 20 PM" src="https://user-images.githubusercontent.com/13777222/82101517-8c9a5300-96c1-11ea-9e42-876e4015d87a.png">

<img width="1069" alt="Screen Shot 2020-05-15 at 2 01 33 PM" src="https://user-images.githubusercontent.com/13777222/82101513-899f6280-96c1-11ea-837f-4ef34d26c59a.png">
