### PR TITLE
Update extensions for release 1.18

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1,3205 +1,3205 @@
 {
-	"results": [
-		{
-			"extensions": [
-				{
-					"extensionId": "10",
-					"extensionName": "agent",
-					"displayName": "SQL Server Agent",
-					"shortDescription": "Manage and troubleshoot SQL Agent jobs",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.47.0",
-							"lastUpdated": "4/16/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/agent/agent-0.47.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/agent/images/extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/agent/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/agent/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.8.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "11",
-					"extensionName": "whoisactive",
-					"displayName": "whoisactive",
-					"shortDescription": "sp_whoisactive for Azure Data Studio",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.1.4",
-							"lastUpdated": "4/27/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/whoisactive/whoisactive-0.1.4.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/samples/sp_whoIsActive/images/extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/sp_whoIsActive/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/sp_whoIsActive/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/sp_whoIsActive/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "12",
-					"extensionName": "server-report",
-					"displayName": "Server Reports",
-					"shortDescription": "Server Reports for Azure Data Studio provides server health insights",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.2.2",
-							"lastUpdated": "4/27/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ServerReports/server-report-0.2.2.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/samples/serverReports/images/extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/serverReports/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/serverReports/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/serverReports/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "13",
-					"extensionName": "ssmskeymap",
-					"displayName": "SSMS Keymap",
-					"shortDescription": "This extension ports popular SSMS keyboard shortcuts to Azure Data Studio",
-					"publisher": {
-						"displayName": "Kevin Cunnane",
-						"publisherId": "kevcunnane",
-						"publisherName": "kevcunnane"
-					},
-					"versions": [
-						{
-							"version": "1.1.0",
-							"lastUpdated": "01/02/2018",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/kevcunnane/ssmskeymap/releases/tag/1.1.0"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/visualstudio-keyboard.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/kevcunnane/ssmskeymap"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "14",
-					"extensionName": "sql-search",
-					"displayName": "Redgate SQL Search",
-					"shortDescription": "Search across multiple databases",
-					"publisher": {
-						"displayName": "Redgate",
-						"publisherId": "Redgate",
-						"publisherName": "Redgate"
-					},
-					"versions": [
-						{
-							"version": "0.4.0",
-							"lastUpdated": "02/18/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://www.redgatefoundry.com/SQLSearch"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://foundrylabssqlsearch.blob.core.windows.net/sqlops-sql-search-insiders/metadata/gatebase.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://foundrylabssqlsearch.blob.core.windows.net/sqlops-sql-search-insiders/metadata/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://foundrylabssqlsearch.blob.core.windows.net/sqlops-sql-search-insiders/metadata/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://www.red-gate.com/support/license/"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://www.redgatefoundry.com/"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "15",
-					"extensionName": "alwayson-insights",
-					"displayName": "AlwaysOn Insights",
-					"shortDescription": "Sql Server AlwaysOn insights",
-					"publisher": {
-						"displayName": "matticusau",
-						"publisherId": "matticusau",
-						"publisherName": "matticusau"
-					},
-					"versions": [
-						{
-							"version": "0.2.1",
-							"lastUpdated": "04/21/2018",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/Matticusau/sqlops-alwayson-insights/releases/tag/0.2.1"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-alwayson-insights/master/src/images/icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-alwayson-insights/master/src/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-alwayson-insights/master/src/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-alwayson-insights/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Matticusau/sqlops-alwayson-insights"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "16",
-					"extensionName": "mssql-instance-insights",
-					"displayName": "MSSQL Instance Insights",
-					"shortDescription": "Sql Server Instance insights",
-					"publisher": {
-						"displayName": "matticusau",
-						"publisherId": "matticusau",
-						"publisherName": "matticusau"
-					},
-					"versions": [
-						{
-							"version": "0.2.1",
-							"lastUpdated": "04/21/2018",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/Matticusau/sqlops-mssql-instance-insights/releases/tag/0.2.1"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-instance-insights/master/src/images/icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-instance-insights/master/src/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-instance-insights/master/src/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-instance-insights/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Matticusau/sqlops-mssql-instance-insight"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "17",
-					"extensionName": "mssql-db-insights",
-					"displayName": "MSSQL Db Insights",
-					"shortDescription": "Sql Server Database insights",
-					"publisher": {
-						"displayName": "matticusau",
-						"publisherId": "matticusau",
-						"publisherName": "matticusau"
-					},
-					"versions": [
-						{
-							"version": "0.2.2",
-							"lastUpdated": "06/29/2018",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/Matticusau/sqlops-mssql-db-insights/releases/tag/0.2.2"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-db-insights/master/src/images/icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-db-insights/master/src/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-db-insights/master/src/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-db-insights/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Matticusau/sqlops-mssql-db-insights"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "18",
-					"extensionName": "profiler",
-					"displayName": "SQL Server Profiler",
-					"shortDescription": "SQL Server Profiler for Azure Data Studio",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.11.0",
-							"lastUpdated": "12/16/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/profiler/profiler-0.11.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/profiler/images/extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/profiler/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/profiler/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": "Microsoft.mssql"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.3"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "19",
-					"extensionName": "sqldw-insights",
-					"displayName": "Azure SQL Data Warehouse Insights",
-					"shortDescription": "Azure SQL Data Warehouse Insights for Azure Data Studio",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.0.1",
-							"lastUpdated": "5/31/2018",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sqldwInsights/sql-dw-0.0.1.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.github.com/Microsoft/sql-data-warehouse-samples/master/samples/sqlops/MonitoringScripts/sqldw_icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.github.com/Microsoft/sql-data-warehouse-samples/master/samples/sqlops/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.github.com/Microsoft/sql-data-warehouse-samples/master/samples/sqlops/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/sql-data-warehouse-samples/tree/master/samples/sqlops/MonitoringScripts"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "21",
-					"extensionName": "sqlops-combine-scripts",
-					"displayName": "Combine Scripts",
-					"shortDescription": "Create a single combined script from several files.",
-					"publisher": {
-						"displayName": "Bateleur IO",
-						"publisherId": "BateleurIO",
-						"publisherName": "BateleurIO"
-					},
-					"versions": [
-						{
-							"version": "2.0.1",
-							"lastUpdated": "6/7/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/BateleurIO/azuredatastudio-combine-scripts/releases/tag/v2.0.1"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/BateleurIO/azuredatastudio-combine-scripts/master/icons/main-icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/BateleurIO/azuredatastudio-combine-scripts/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/BateleurIO/azuredatastudio-combine-scripts/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/BateleurIO/azuredatastudio-combine-scripts/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/BateleurIO/azuredatastudio-combine-scripts"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": ""
-				},
-				{
-					"extensionId": "22",
-					"extensionName": "firstresponderkit",
-					"displayName": "First Responder Kit",
-					"shortDescription": "Access current versions of scripts from the First Responder Kit",
-					"publisher": {
-						"displayName": "Drew Skwiers-Koballa",
-						"publisherId": "drewsk",
-						"publisherName": "drewsk"
-					},
-					"versions": [
-						{
-							"version": "0.5.0",
-							"lastUpdated": "9/8/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/dzsquared/sqlops-firstresponderkit/releases/tag/0.5.0"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/dzsquared/sqlops-firstresponderkit/master/images/first-responder-kit-sqlops-extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/dzsquared/sqlops-firstresponderkit/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/dzsquared/sqlops-firstresponderkit/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/dzsquared/sqlops-firstresponderkit/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/dzsquared/sqlops-firstresponderkit"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.9.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "23",
-					"extensionName": "import",
-					"displayName": "SQL Server Import",
-					"shortDescription": "SQL Server Import for Azure Data Studio supports importing CSV or JSON files into SQL Server.",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.15.0",
-							"lastUpdated": "5/15/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/import/import-0.15.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/import/images/extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/import/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/import/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/import/Microsoft_SQL_Server_Import_Extension_and_Tools_Import_Flat_File_Preview.docx"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "24",
-					"extensionName": "sql-vnext",
-					"displayName": "SQL Server 2019 (Deprecated)",
-					"shortDescription": "This has been replaced by the Data Virtualization extension",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.17.0",
-							"lastUpdated": "10/31/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-vnext/sql-vnext-0.17.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/Microsoft/vscode-mssql/master/images/sqlserver.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-vnext/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-vnext/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-vnext/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.33.1"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://docs.microsoft.com/sql/azure-data-studio/sql-server-2019-extension"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "25",
-					"extensionName": "pastetheplan",
-					"displayName": "Paste the Plan",
-					"shortDescription": "Send XML execution plans to Paste the Plan",
-					"publisher": {
-						"displayName": "Drew Skwiers-Koballa",
-						"publisherId": "drewsk",
-						"publisherName": "drewsk"
-					},
-					"versions": [
-						{
-							"version": "0.2.0",
-							"lastUpdated": "10/21/2018",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/dzsquared/sqlops-pastetheplan/releases/tag/0.2.0"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/dzsquared/sqlops-pastetheplan/master/images/pastetheplan-sqlops-extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/dzsquared/sqlops-pastetheplan/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/dzsquared/sqlops-pastetheplan/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/dzsquared/sqlops-pastetheplan/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/dzsquared/sqlops-pastetheplan"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "26",
-					"extensionName": "hcq--high-color-queries-",
-					"displayName": "HCQ (High Color Queries)",
-					"shortDescription": "Theme Pair of Dark and Light Themes for TSQL in Azure Data Studio. Dark theme uses bright colors and light theme is SSMS-esque.",
-					"publisher": {
-						"displayName": "Drew Skwiers-Koballa",
-						"publisherId": "drewsk",
-						"publisherName": "drewsk"
-					},
-					"versions": [
-						{
-							"version": "0.0.6",
-							"lastUpdated": "12/28/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/dzsquared/high-color-queries/releases/tag/0.0.6"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/dzsquared/high-color-queries/master/images/hcq_icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/dzsquared/high-color-queries/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/dzsquared/high-color-queries/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/dzsquared/high-color-queries/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/dzsquared/high-color-queries"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "27",
-					"extensionName": "newdatabase",
-					"displayName": "New Database",
-					"shortDescription": "Adds a 'New Database' command. Right-click on the Databases for a connection in Object Explorer, or run 'New Database' from the command palette.",
-					"publisher": {
-						"displayName": "Kevin Cunnane",
-						"publisherId": "kevcunnane",
-						"publisherName": "kevcunnane"
-					},
-					"versions": [
-						{
-							"version": "1.0.0",
-							"lastUpdated": "10/28/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/kevcunnane/azuredatastudio-newdatabase/releases/tag/1.0.0"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/kevcunnane/azuredatastudio-newdatabase/master/images/sqlserver.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/kevcunnane/azuredatastudio-newdatabase/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/kevcunnane/azuredatastudio-newdatabase/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/kevcunnane/azuredatastudio-newdatabase/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/kevcunnane/azuredatastudio-newdatabase"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": ""
-				},
-				{
-					"extensionId": "28",
-					"extensionName": "sp_executesqlToSQL",
-					"displayName": "sp_executesql to SQL",
-					"shortDescription": "Convert sp_executesql to sql",
-					"publisher": {
-						"displayName": "Pejman Nikram",
-						"publisherId": "pejmannikram",
-						"publisherName": "pejmannikram"
-					},
-					"versions": [
-						{
-							"version": "1.0.1",
-							"lastUpdated": "10/3/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/PejmanNik/sqlops-spexecutesql-to-sql/releases/tag/v1.0.1"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/PejmanNik/sqlops-spexecutesql-to-sql/master/images/icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/PejmanNik/sqlops-spexecutesql-to-sql/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/PejmanNik/sqlops-spexecutesql-to-sql/master/package.json"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/PejmanNik/sqlops-spexecutesql-to-sql"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "29",
-					"extensionName": "sqldm-performance-insights",
-					"displayName": "Idera SQL DM Performance Insights",
-					"shortDescription": "SQL Diagnostic Manager performance insights dashboard",
-					"publisher": {
-						"displayName": "Idera Inc",
-						"publisherId": "IDERA",
-						"publisherName": "IDERA"
-					},
-					"versions": [
-						{
-							"version": "0.4.0",
-							"lastUpdated": "12/3/2018",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://www.idera.com/productssolutions/freetools/sqldmperformanceinsights"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://www.idera.com/AppVisor/icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://www.idera.com/AppVisor/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://www.idera.com/AppVisor/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://www.idera.com/AppVisor/license.rtf"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://www.idera.com/"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "30",
-					"extensionName": "sqlops-theme-onedark",
-					"displayName": "Atom One Dark Theme",
-					"shortDescription": "Azure Data Studio Theme based on Atom's One Dark theme",
-					"publisher": {
-						"displayName": "Michael Wolfenden",
-						"publisherId": "michael-wolfenden",
-						"publisherName": "michael-wolfenden"
-					},
-					"versions": [
-						{
-							"version": "1.0.0",
-							"lastUpdated": "01/11/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/michael-wolfenden/sqlops-theme-onedark/releases/tag/v1.0.0"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/michael-wolfenden/sqlops-theme-onedark/master/assets/logo.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/michael-wolfenden/sqlops-theme-onedark/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/michael-wolfenden/sqlops-theme-onedark/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/michael-wolfenden/sqlops-theme-onedark/master/LICENSE.md"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/michael-wolfenden/sqlops-theme-onedark"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "31",
-					"extensionName": "poor-sql-formatter",
-					"displayName": "Poor SQL Formatter",
-					"shortDescription": "T-SQL Formatter & Beautifier.",
-					"publisher": {
-						"displayName": "WSR Publishing, Inc.",
-						"publisherId": "WSRPublishing",
-						"publisherName": "WSRPublishing"
-					},
-					"versions": [
-						{
-							"version": "0.1.0",
-							"lastUpdated": "01/23/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/wsr-publishing/azure-poor-formatter/releases/tag/v0.1.0"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/wsr-publishing/azure-poor-formatter/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/wsr-publishing/azure-poor-formatter/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/wsr-publishing/azure-poor-formatter/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/wsr-publishing/azure-poor-formatter"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "32",
-					"extensionName": "admin-pack",
-					"displayName": "Admin Pack for SQL Server",
-					"shortDescription": "Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server.",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.0.2",
-							"lastUpdated": "3/15/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/admin-pack/admin-pack-0.0.2.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/admin-pack/images/extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/admin-pack/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/admin-pack/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionPack",
-									"value": "Microsoft.agent,Microsoft.profiler,Microsoft.import,Microsoft.dacpac"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "33",
-					"extensionName": "dacpac",
-					"displayName": "SQL Server Dacpac",
-					"shortDescription": "Manage data-tier applications",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.4.0",
-							"lastUpdated": "4/16/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.4.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/dacpac/images/extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/dacpac/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/dacpac/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": ""
-				},
-				{
-					"extensionId": "34",
-					"extensionName": "azuredatastudio-postgresql",
-					"displayName": "PostgreSQL",
-					"shortDescription": "PostgreSQL extension for Azure Data Studio",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.2.6",
-							"lastUpdated": "5/1/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/postgresql/azuredatastudio-postgresql-0.2.6.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio-postgresql/master/images/extension-icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio-postgresql/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio-postgresql/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio-postgresql/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.16.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio-postgresql/"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "35",
-					"extensionName": "powershell",
-					"displayName": "PowerShell",
-					"shortDescription": "Develop PowerShell scripts in Azure Data Studio",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "2020.4.0",
-							"lastUpdated": "4/28/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/ms-vscode.PowerShell-2020.4.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/images/PowerShell_icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/docs/azure_data_studio/README_FOR_MARKETPLACE.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/PowerShell/vscode-powershell/"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "36",
-					"extensionName": "palenight-theme-dataazurestudio-version",
-					"displayName": "Palenight Theme",
-					"shortDescription": "Palenight Theme - Azure Data Studio Version Theme (based on vscode version)",
-					"publisher": {
-						"displayName": "JoseRocha",
-						"publisherId": "JoseRocha",
-						"publisherName": "JoseRocha"
-					},
-					"versions": [
-						{
-							"version": "0.0.2",
-							"lastUpdated": "04/06/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/joserocha/azdatastudio-material-palenight-theme/releases/tag/0.0.2"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Links.Source",
-									"source": "https://github.com/joserocha/azdatastudio-material-palenight-theme/"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/joserocha/azdatastudio-material-palenight-theme/master/icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/joserocha/azdatastudio-material-palenight-theme/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/joserocha/azdatastudio-material-palenight-theme/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/joserocha/azdatastudio-material-palenight-theme/master/License.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "37",
-					"extensionName": "schema-compare",
-					"displayName": "SQL Server Schema Compare",
-					"shortDescription": "Schema Compare tool for dacpac and databases",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.4.0",
-							"lastUpdated": "4/16/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-1.4.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/schema-compare/images/extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/schema-compare/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/schema-compare/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.13.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": ""
-				},
-				{
-					"extensionId": "38",
-					"extensionName": "azdata-sanddance",
-					"displayName": "SandDance for Azure Data Studio",
-					"shortDescription": "Visually explore, understand, and present your data.",
-					"publisher": {
-						"displayName": "msrvida",
-						"publisherId": "msrvida",
-						"publisherName": "msrvida"
-					},
-					"versions": [
-						{
-							"version": "1.3.9",
-							"lastUpdated": "10/14/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sanddance/azdata-sanddance-1.3.9.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/packages/azdata-sanddance/sanddance-logo.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/packages/azdata-sanddance/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/packages/azdata-sanddance/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/SandDance"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "39",
-					"extensionName": "managed-instance-dashboard",
-					"displayName": "Managed Instance Dashboard",
-					"shortDescription": "Managed Instance Dashboard",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.4.1",
-							"lastUpdated": "03/08/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/managed-instance-dashboard/managed-instance-dashboard-0.4.1.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/JocaPC/AzureDataStudio-Managed-Instance/master/images/ManagedInstanceLogo.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/JocaPC/AzureDataStudio-Managed-Instance/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/JocaPC/AzureDataStudio-Managed-Instance/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/JocaPC/AzureDataStudio-Managed-Instance"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "40",
-					"extensionName": "cms",
-					"displayName": "Central Management Servers",
-					"shortDescription": "Central Management Servers",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.8.0",
-							"lastUpdated": "3/10/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/cms/cms-0.8.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/cms/images/extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/cms/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/cms/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.8.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "41",
-					"extensionName": "admin-tool-ext-win",
-					"displayName": "Database Administration Tool Extensions for Windows",
-					"shortDescription": "Provides additional Windows-specific functionality to Azure Data Studio",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.0.2",
-							"lastUpdated": "9/12/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/admin-tool-ext-win/admin-tool-ext-win-0.0.2.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/admin-tool-ext-win/images/extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/admin-tool-ext-win/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/admin-tool-ext-win/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.8.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "42",
-					"extensionName": "ads-language-pack-de",
-					"displayName": "German Language Pack for Azure Data Studio",
-					"shortDescription": "Language pack extension for German",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.9.0",
-							"lastUpdated": "6/24/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-de-1.9.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-de/languagepack.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-de/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-de/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.9.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
-									"value": "de"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "43",
-					"extensionName": "ads-language-pack-es",
-					"displayName": "Spanish Language Pack for Azure Data Studio",
-					"shortDescription": "Language pack extension for Spanish",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.9.0",
-							"lastUpdated": "6/24/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-es-1.9.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-es/languagepack.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-es/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-es/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.9.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
-									"value": "es"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "44",
-					"extensionName": "ads-language-pack-fr",
-					"displayName": "French Language Pack for Azure Data Studio",
-					"shortDescription": "Language pack extension for French",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.9.0",
-							"lastUpdated": "6/24/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-fr-1.9.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-fr/languagepack.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-fr/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-fr/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.9.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
-									"value": "fr"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "45",
-					"extensionName": "ads-language-pack-it",
-					"displayName": "Italian Language Pack for Azure Data Studio",
-					"shortDescription": "Language pack extension for Italian",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.9.0",
-							"lastUpdated": "6/24/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-it-1.9.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-it/languagepack.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-it/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-it/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.9.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
-									"value": "it"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "46",
-					"extensionName": "ads-language-pack-ko",
-					"displayName": "Korean Language Pack for Azure Data Studio",
-					"shortDescription": "Language pack extension for Korean",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.9.0",
-							"lastUpdated": "6/24/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-ko-1.9.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ko/languagepack.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ko/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ko/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.9.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
-									"value": "ko"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "47",
-					"extensionName": "ads-language-pack-pt-br",
-					"displayName": "Portuguese (Brazil) Language Pack for Azure Data Studio",
-					"shortDescription": "Language pack extension for Portuguese (Brazil)",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.9.0",
-							"lastUpdated": "6/24/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-pt-br-1.9.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-pt-BR/languagepack.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-pt-BR/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-pt-BR/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.9.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
-									"value": "pt-br"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "48",
-					"extensionName": "ads-language-pack-ru",
-					"displayName": "Russian Language Pack for Azure Data Studio",
-					"shortDescription": "Language pack extension for Russian",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.9.0",
-							"lastUpdated": "6/24/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-ru-1.9.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ru/languagepack.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ru/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ru/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.9.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
-									"value": "ru"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "49",
-					"extensionName": "ads-language-pack-zh-hans",
-					"displayName": "Chinese (Simplified) Language Pack for Azure Data Studio",
-					"shortDescription": "Language pack extension for Chinese (Simplified)",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.9.0",
-							"lastUpdated": "6/24/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-zh-hans-1.9.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hans/languagepack.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hans/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hans/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.9.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
-									"value": "zh-cn"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "50",
-					"extensionName": "ads-language-pack-zh-hant",
-					"displayName": "Chinese (Traditional) Language Pack for Azure Data Studio",
-					"shortDescription": "Language pack extension for Chinese (Traditional)",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.9.0",
-							"lastUpdated": "6/24/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-zh-hant-1.9.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hant/languagepack.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hant/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hant/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.9.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
-									"value": "zh-tw"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "51",
-					"extensionName": "ads-language-pack-ja",
-					"displayName": "Japanese Language Pack for Azure Data Studio",
-					"shortDescription": "Language pack extension for Japanese",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.9.0",
-							"lastUpdated": "6/24/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-ja-1.9.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ja/languagepack.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ja/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-ja/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.9.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
-									"value": "ja"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "52",
-					"extensionName": "plan-explorer",
-					"displayName": "SentryOne Plan Explorer",
-					"shortDescription": "Simplify query analysis and tuning",
-					"publisher": {
-						"displayName": "SentryOne",
-						"publisherId": "SentryOne",
-						"publisherName": "SentryOne"
-					},
-					"versions": [
-						{
-							"version": "0.9.7",
-							"lastUpdated": "3/3/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://www.sentryone.com/products/sentryone-plan-explorer-extension-azure-data-studio"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://downloads.sentryone.com/downloads/ads/s1logo.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://downloads.sentryone.com/downloads/ads/readme.0.9.7.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://sentryone.com/eula"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.8.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://extensions.sentryone.com/"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "53",
-					"extensionName": "query-editor-boost",
-					"displayName": "Query Editor Boost",
-					"shortDescription": "Helpful add-ons for query editing",
-					"publisher": {
-						"displayName": "Drew Skwiers-Koballa",
-						"publisherId": "drewsk",
-						"publisherName": "drewsk"
-					},
-					"versions": [
-						{
-							"version": "0.4.0",
-							"lastUpdated": "1/5/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/dzsquared/query-editor-boost/releases/tag/0.4.0"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/dzsquared/query-editor-boost/master/images/QEboost200.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/dzsquared/query-editor-boost/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/dzsquared/query-editor-boost/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/dzsquared/query-editor-boost/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/dzsquared/query-editor-boost"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.8.0"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "54",
-					"extensionName": "delete-database",
-					"displayName": "Delete database",
-					"shortDescription": "Adds 'Delete' option when right clicking on a database",
-					"publisher": {
-						"displayName": "AlexP",
-						"publisherId": "alx-ppv",
-						"publisherName": "alx-ppv"
-					},
-					"versions": [
-						{
-							"version": "0.0.3",
-							"lastUpdated": "08/14/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/alx-ppv/ADS-delete-database/releases/tag/0.0.3"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/logo.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/alx-ppv/ADS-delete-database"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "55",
-					"extensionName": "query-history",
-					"displayName": "Query History",
-					"shortDescription": "Adds a Query History panel for viewing and running past executed queries.",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.1.0",
-							"lastUpdated": "10/2/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/query-history/query-history-0.1.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/query-history/images/extension.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/query-history/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/query-history/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.12.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "56",
-					"extensionName": "simple-data-scripter",
-					"displayName": "Simple Data Scripter",
-					"shortDescription": "Adds ability to script data for a table",
-					"publisher": {
-						"displayName": "Sean Price",
-						"publisherId": "ecirpnaes",
-						"publisherName": "ecirpnaes"
-					},
-					"versions": [
-						{
-							"version": "0.1.3",
-							"lastUpdated": "12/19/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/ecirpnaes/SimpleDataScripter/releases/tag/0.1.3"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/ecirpnaes/SimpleDataScripter/master/images/logo.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/ecirpnaes/SimpleDataScripter/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/ecirpnaes/SimpleDataScripter/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/ecirpnaes/SimpleDataScripter/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/ecirpnaes/simpledatascripter"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "57",
-					"extensionName": "vscodeintellicode",
-					"displayName": "Visual Studio IntelliCode",
-					"shortDescription": "AI-assisted development",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "visualstudioexptteam"
-					},
-					"versions": [
-						{
-							"version": "1.2.1",
-							"lastUpdated": "10/29/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/vscodeintellicode-1.2.1.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/icon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.29.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.12.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/MicrosoftDocs/intellicode"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": ""
-				},
-				{
-					"extensionId": "58",
-					"extensionName": "datavirtualization",
-					"displayName": "Data Virtualization",
-					"shortDescription": "Support for Data Virtualization in SQL Server, including Create External Data wizards.",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "1.4.0",
-							"lastUpdated": "4/16/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/datavirtualization-1.4.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/Microsoft/vscode-mssql/master/images/sqlserver.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/content/1.4.0/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/content/1.4.0/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/content/1.4.0/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.33.1"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://aka.ms/ads-datavirt"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": ""
-				},
-				{
-					"extensionId": "59",
-					"extensionName": "demo-mode",
-					"displayName": "Demo Mode",
-					"shortDescription": "Fast font embiggen for presentations and over the shoulder demos",
-					"publisher": {
-						"displayName": "Drew Skwiers-Koballa",
-						"publisherId": "drewsk",
-						"publisherName": "drewsk"
-					},
-					"versions": [
-						{
-							"version": "1.1.0",
-							"lastUpdated": "11/16/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/dzsquared/demo-mode/releases/tag/1.1.0"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/dzsquared/demo-mode/master/images/monitor256.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/dzsquared/demo-mode/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/dzsquared/demo-mode/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/dzsquared/demo-mode/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/dzsquared/demo-mode"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "60",
-					"extensionName": "db-snapshot-creator",
-					"displayName": "DB Snapshot Creator",
-					"shortDescription": "Adds ability to create a snaphot of a database",
-					"publisher": {
-						"displayName": "Sean Price",
-						"publisherId": "ecirpnaes",
-						"publisherName": "ecirpnaes"
-					},
-					"versions": [
-						{
-							"version": "0.1.0",
-							"lastUpdated": "12/19/2019",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/ecirpnaes/DbSnapshotCreator/releases/tag/0.1.0"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/ecirpnaes/DbSnapshotCreator/master/images/logo.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/ecirpnaes/DbSnapshotCreator/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/ecirpnaes/DbSnapshotCreator/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/ecirpnaes/DbSnapshotCreator/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/ecirpnaes/DbSnapshotCreator"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "61",
-					"extensionName": "tsqlchecker",
-					"displayName": "TSQL Checker",
-					"shortDescription": "Adds checks for bad practice to the TSQL query window.",
-					"publisher": {
-						"displayName": "Daniel Janik",
-						"publisherId": "DanielJanik",
-						"publisherName": "DanielJanik"
-					},
-					"versions": [
-						{
-							"version": "0.0.1",
-							"lastUpdated": "02/06/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/DanielJanik/tsqlchecker_adsextension/releases/tag/0.0.1"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/danieljanik/tsqlchecker_adsextension/master/tsqlhelp.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/danieljanik/tsqlchecker_adsextension/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/danieljanik/tsqlchecker_adsextension/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/danieljanik/tsqlchecker_adsextension/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/DanielJanik/tsqlchecker_adsextension"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "61",
-					"extensionName": "schema-visualization",
-					"displayName": "Schema Visualization",
-					"shortDescription": "Visualization of databases",
-					"publisher": {
-						"displayName": "Jens Hunt",
-						"publisherId": "R0tenur",
-						"publisherName": "R0tenur"
-					},
-					"versions": [
-						{
-							"version": "0.2.0",
-							"lastUpdated": "2/2/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.SQLOps.DownloadPage",
-									"source": "https://github.com/R0tenur/visualization/releases/tag/v0.2.0"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/R0tenur/visualization/master/images/logo.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/R0tenur/visualization/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/R0tenur/visualization/master/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/R0tenur/visualization/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/R0tenur/visualization"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": ""
-				},
-				{
-					"extensionId": "64",
-					"extensionName": "qpi",
-					"displayName": "Query Performance Insight",
-					"shortDescription": "ADS UI for the latest version of QPI library",
-					"publisher": {
-						"displayName": "Jovan Popovic",
-						"publisherId": "jocapc",
-						"publisherName": "jocapc"
-					},
-					"versions": [
-						{
-							"version": "0.1.6",
-							"lastUpdated": "03/08/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/qpi/qpi-0.1.6.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/jocapc/AzureDataStudio-QPI/master/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/jocapc/AzureDataStudio-QPI/master/LICENSE"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/jocapc/AzureDataStudio-QPI"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": "*"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				},
-				{
-					"extensionId": "65",
-					"extensionName": "machine-learning",
-					"displayName": "Machine Learning",
-					"shortDescription": "Machine Learning for SQL Databases",
-					"publisher": {
-						"displayName": "Microsoft",
-						"publisherId": "Microsoft",
-						"publisherName": "Microsoft"
-					},
-					"versions": [
-						{
-							"version": "0.1.0",
-							"lastUpdated": "05/05/2020",
-							"assetUri": "",
-							"fallbackAssetUri": "fallbackAssetUri",
-							"files": [
-								{
-									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/machine-learning/machine-learning-0.1.0.vsix"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/machine-learning/images/extensionIcon.png"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/machine-learning/README.md"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/machine-learning/package.json"
-								},
-								{
-									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
-								}
-							],
-							"properties": [
-								{
-									"key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
-									"value": ""
-								},
-								{
-									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
-								},
-								{
-									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.18.0"
-								},
-								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								}
-							]
-						}
-					],
-					"statistics": [],
-					"flags": "preview"
-				}
-			],
-			"resultMetadata": [
-				{
-					"metadataType": "ResultCount",
-					"metadataItems": [
-						{
-							"name": "TotalCount",
-							"count": 54
-						}
-					]
-				}
-			]
-		}
-	]
+    "results": [
+        {
+            "extensions": [
+                {
+                    "extensionId": "10",
+                    "extensionName": "agent",
+                    "displayName": "SQL Server Agent",
+                    "shortDescription": "Manage and troubleshoot SQL Agent jobs",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.48.0",
+                            "lastUpdated": "4/16/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/agent/agent-0.47.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/agent/images/extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/agent/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/agent/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.8.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "11",
+                    "extensionName": "whoisactive",
+                    "displayName": "whoisactive",
+                    "shortDescription": "sp_whoisactive for Azure Data Studio",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.1.4",
+                            "lastUpdated": "4/27/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/whoisactive/whoisactive-0.1.4.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/samples/sp_whoIsActive/images/extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/sp_whoIsActive/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/sp_whoIsActive/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/sp_whoIsActive/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "12",
+                    "extensionName": "server-report",
+                    "displayName": "Server Reports",
+                    "shortDescription": "Server Reports for Azure Data Studio provides server health insights",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.2.2",
+                            "lastUpdated": "4/27/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/ServerReports/server-report-0.2.2.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/samples/serverReports/images/extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/serverReports/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/serverReports/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/samples/serverReports/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "13",
+                    "extensionName": "ssmskeymap",
+                    "displayName": "SSMS Keymap",
+                    "shortDescription": "This extension ports popular SSMS keyboard shortcuts to Azure Data Studio",
+                    "publisher": {
+                        "displayName": "Kevin Cunnane",
+                        "publisherId": "kevcunnane",
+                        "publisherName": "kevcunnane"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.1.0",
+                            "lastUpdated": "01/02/2018",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/kevcunnane/ssmskeymap/releases/tag/1.1.0"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/visualstudio-keyboard.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/kevcunnane/ssmskeymap"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "14",
+                    "extensionName": "sql-search",
+                    "displayName": "Redgate SQL Search",
+                    "shortDescription": "Search across multiple databases",
+                    "publisher": {
+                        "displayName": "Redgate",
+                        "publisherId": "Redgate",
+                        "publisherName": "Redgate"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.4.0",
+                            "lastUpdated": "02/18/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://www.redgatefoundry.com/SQLSearch"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://foundrylabssqlsearch.blob.core.windows.net/sqlops-sql-search-insiders/metadata/gatebase.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://foundrylabssqlsearch.blob.core.windows.net/sqlops-sql-search-insiders/metadata/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://foundrylabssqlsearch.blob.core.windows.net/sqlops-sql-search-insiders/metadata/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://www.red-gate.com/support/license/"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://www.redgatefoundry.com/"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "15",
+                    "extensionName": "alwayson-insights",
+                    "displayName": "AlwaysOn Insights",
+                    "shortDescription": "Sql Server AlwaysOn insights",
+                    "publisher": {
+                        "displayName": "matticusau",
+                        "publisherId": "matticusau",
+                        "publisherName": "matticusau"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.2.1",
+                            "lastUpdated": "04/21/2018",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/Matticusau/sqlops-alwayson-insights/releases/tag/0.2.1"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-alwayson-insights/master/src/images/icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-alwayson-insights/master/src/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-alwayson-insights/master/src/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-alwayson-insights/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Matticusau/sqlops-alwayson-insights"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "16",
+                    "extensionName": "mssql-instance-insights",
+                    "displayName": "MSSQL Instance Insights",
+                    "shortDescription": "Sql Server Instance insights",
+                    "publisher": {
+                        "displayName": "matticusau",
+                        "publisherId": "matticusau",
+                        "publisherName": "matticusau"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.2.1",
+                            "lastUpdated": "04/21/2018",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/Matticusau/sqlops-mssql-instance-insights/releases/tag/0.2.1"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-instance-insights/master/src/images/icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-instance-insights/master/src/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-instance-insights/master/src/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-instance-insights/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Matticusau/sqlops-mssql-instance-insight"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "17",
+                    "extensionName": "mssql-db-insights",
+                    "displayName": "MSSQL Db Insights",
+                    "shortDescription": "Sql Server Database insights",
+                    "publisher": {
+                        "displayName": "matticusau",
+                        "publisherId": "matticusau",
+                        "publisherName": "matticusau"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.2.2",
+                            "lastUpdated": "06/29/2018",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/Matticusau/sqlops-mssql-db-insights/releases/tag/0.2.2"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-db-insights/master/src/images/icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-db-insights/master/src/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-db-insights/master/src/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Matticusau/sqlops-mssql-db-insights/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Matticusau/sqlops-mssql-db-insights"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "18",
+                    "extensionName": "profiler",
+                    "displayName": "SQL Server Profiler",
+                    "shortDescription": "SQL Server Profiler for Azure Data Studio",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.12.0",
+                            "lastUpdated": "12/16/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/profiler/profiler-0.11.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/profiler/images/extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/profiler/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/profiler/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": "Microsoft.mssql"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.3"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "19",
+                    "extensionName": "sqldw-insights",
+                    "displayName": "Azure SQL Data Warehouse Insights",
+                    "shortDescription": "Azure SQL Data Warehouse Insights for Azure Data Studio",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.0.1",
+                            "lastUpdated": "5/31/2018",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/sqldwInsights/sql-dw-0.0.1.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.github.com/Microsoft/sql-data-warehouse-samples/master/samples/sqlops/MonitoringScripts/sqldw_icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.github.com/Microsoft/sql-data-warehouse-samples/master/samples/sqlops/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.github.com/Microsoft/sql-data-warehouse-samples/master/samples/sqlops/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/sql-data-warehouse-samples/tree/master/samples/sqlops/MonitoringScripts"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "21",
+                    "extensionName": "sqlops-combine-scripts",
+                    "displayName": "Combine Scripts",
+                    "shortDescription": "Create a single combined script from several files.",
+                    "publisher": {
+                        "displayName": "Bateleur IO",
+                        "publisherId": "BateleurIO",
+                        "publisherName": "BateleurIO"
+                    },
+                    "versions": [
+                        {
+                            "version": "2.0.1",
+                            "lastUpdated": "6/7/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/BateleurIO/azuredatastudio-combine-scripts/releases/tag/v2.0.1"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/BateleurIO/azuredatastudio-combine-scripts/master/icons/main-icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/BateleurIO/azuredatastudio-combine-scripts/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/BateleurIO/azuredatastudio-combine-scripts/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/BateleurIO/azuredatastudio-combine-scripts/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/BateleurIO/azuredatastudio-combine-scripts"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": ""
+                },
+                {
+                    "extensionId": "22",
+                    "extensionName": "firstresponderkit",
+                    "displayName": "First Responder Kit",
+                    "shortDescription": "Access current versions of scripts from the First Responder Kit",
+                    "publisher": {
+                        "displayName": "Drew Skwiers-Koballa",
+                        "publisherId": "drewsk",
+                        "publisherName": "drewsk"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.5.0",
+                            "lastUpdated": "9/8/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/dzsquared/sqlops-firstresponderkit/releases/tag/0.5.0"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/sqlops-firstresponderkit/master/images/first-responder-kit-sqlops-extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/sqlops-firstresponderkit/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/sqlops-firstresponderkit/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/sqlops-firstresponderkit/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/dzsquared/sqlops-firstresponderkit"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.9.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "23",
+                    "extensionName": "import",
+                    "displayName": "SQL Server Import",
+                    "shortDescription": "SQL Server Import for Azure Data Studio supports importing CSV or JSON files into SQL Server.",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.15.0",
+                            "lastUpdated": "5/15/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/import/import-0.15.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/import/images/extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/import/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/import/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/import/Microsoft_SQL_Server_Import_Extension_and_Tools_Import_Flat_File_Preview.docx"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "24",
+                    "extensionName": "sql-vnext",
+                    "displayName": "SQL Server 2019 (Deprecated)",
+                    "shortDescription": "This has been replaced by the Data Virtualization extension",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.17.0",
+                            "lastUpdated": "10/31/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-vnext/sql-vnext-0.17.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/vscode-mssql/master/images/sqlserver.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-vnext/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-vnext/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-vnext/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.33.1"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://docs.microsoft.com/sql/azure-data-studio/sql-server-2019-extension"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "25",
+                    "extensionName": "pastetheplan",
+                    "displayName": "Paste the Plan",
+                    "shortDescription": "Send XML execution plans to Paste the Plan",
+                    "publisher": {
+                        "displayName": "Drew Skwiers-Koballa",
+                        "publisherId": "drewsk",
+                        "publisherName": "drewsk"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.2.0",
+                            "lastUpdated": "10/21/2018",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/dzsquared/sqlops-pastetheplan/releases/tag/0.2.0"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/sqlops-pastetheplan/master/images/pastetheplan-sqlops-extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/sqlops-pastetheplan/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/sqlops-pastetheplan/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/sqlops-pastetheplan/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/dzsquared/sqlops-pastetheplan"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "26",
+                    "extensionName": "hcq--high-color-queries-",
+                    "displayName": "HCQ (High Color Queries)",
+                    "shortDescription": "Theme Pair of Dark and Light Themes for TSQL in Azure Data Studio. Dark theme uses bright colors and light theme is SSMS-esque.",
+                    "publisher": {
+                        "displayName": "Drew Skwiers-Koballa",
+                        "publisherId": "drewsk",
+                        "publisherName": "drewsk"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.0.6",
+                            "lastUpdated": "12/28/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/dzsquared/high-color-queries/releases/tag/0.0.6"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/high-color-queries/master/images/hcq_icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/high-color-queries/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/high-color-queries/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/high-color-queries/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/dzsquared/high-color-queries"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "27",
+                    "extensionName": "newdatabase",
+                    "displayName": "New Database",
+                    "shortDescription": "Adds a 'New Database' command. Right-click on the Databases for a connection in Object Explorer, or run 'New Database' from the command palette.",
+                    "publisher": {
+                        "displayName": "Kevin Cunnane",
+                        "publisherId": "kevcunnane",
+                        "publisherName": "kevcunnane"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.0.0",
+                            "lastUpdated": "10/28/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/kevcunnane/azuredatastudio-newdatabase/releases/tag/1.0.0"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/kevcunnane/azuredatastudio-newdatabase/master/images/sqlserver.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/kevcunnane/azuredatastudio-newdatabase/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/kevcunnane/azuredatastudio-newdatabase/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/kevcunnane/azuredatastudio-newdatabase/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/kevcunnane/azuredatastudio-newdatabase"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": ""
+                },
+                {
+                    "extensionId": "28",
+                    "extensionName": "sp_executesqlToSQL",
+                    "displayName": "sp_executesql to SQL",
+                    "shortDescription": "Convert sp_executesql to sql",
+                    "publisher": {
+                        "displayName": "Pejman Nikram",
+                        "publisherId": "pejmannikram",
+                        "publisherName": "pejmannikram"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.0.1",
+                            "lastUpdated": "10/3/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/PejmanNik/sqlops-spexecutesql-to-sql/releases/tag/v1.0.1"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/PejmanNik/sqlops-spexecutesql-to-sql/master/images/icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/PejmanNik/sqlops-spexecutesql-to-sql/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/PejmanNik/sqlops-spexecutesql-to-sql/master/package.json"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/PejmanNik/sqlops-spexecutesql-to-sql"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "29",
+                    "extensionName": "sqldm-performance-insights",
+                    "displayName": "Idera SQL DM Performance Insights",
+                    "shortDescription": "SQL Diagnostic Manager performance insights dashboard",
+                    "publisher": {
+                        "displayName": "Idera Inc",
+                        "publisherId": "IDERA",
+                        "publisherName": "IDERA"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.4.0",
+                            "lastUpdated": "12/3/2018",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://www.idera.com/productssolutions/freetools/sqldmperformanceinsights"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://www.idera.com/AppVisor/icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://www.idera.com/AppVisor/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://www.idera.com/AppVisor/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://www.idera.com/AppVisor/license.rtf"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://www.idera.com/"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "30",
+                    "extensionName": "sqlops-theme-onedark",
+                    "displayName": "Atom One Dark Theme",
+                    "shortDescription": "Azure Data Studio Theme based on Atom's One Dark theme",
+                    "publisher": {
+                        "displayName": "Michael Wolfenden",
+                        "publisherId": "michael-wolfenden",
+                        "publisherName": "michael-wolfenden"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.0.0",
+                            "lastUpdated": "01/11/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/michael-wolfenden/sqlops-theme-onedark/releases/tag/v1.0.0"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/michael-wolfenden/sqlops-theme-onedark/master/assets/logo.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/michael-wolfenden/sqlops-theme-onedark/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/michael-wolfenden/sqlops-theme-onedark/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/michael-wolfenden/sqlops-theme-onedark/master/LICENSE.md"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/michael-wolfenden/sqlops-theme-onedark"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "31",
+                    "extensionName": "poor-sql-formatter",
+                    "displayName": "Poor SQL Formatter",
+                    "shortDescription": "T-SQL Formatter & Beautifier.",
+                    "publisher": {
+                        "displayName": "WSR Publishing, Inc.",
+                        "publisherId": "WSRPublishing",
+                        "publisherName": "WSRPublishing"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.1.0",
+                            "lastUpdated": "01/23/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/wsr-publishing/azure-poor-formatter/releases/tag/v0.1.0"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/wsr-publishing/azure-poor-formatter/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/wsr-publishing/azure-poor-formatter/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/wsr-publishing/azure-poor-formatter/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/wsr-publishing/azure-poor-formatter"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "32",
+                    "extensionName": "admin-pack",
+                    "displayName": "Admin Pack for SQL Server",
+                    "shortDescription": "Admin Pack for SQL Server is a collection of popular database administration extensions to help you manage SQL Server.",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.1.0",
+                            "lastUpdated": "3/15/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/admin-pack/admin-pack-0.0.2.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/admin-pack/images/extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/admin-pack/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/admin-pack/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionPack",
+                                    "value": "Microsoft.agent,Microsoft.profiler,Microsoft.import,Microsoft.dacpac"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "33",
+                    "extensionName": "dacpac",
+                    "displayName": "SQL Server Dacpac",
+                    "shortDescription": "Manage data-tier applications",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.5.0",
+                            "lastUpdated": "4/16/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.4.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/dacpac/images/extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/dacpac/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/dacpac/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": ""
+                },
+                {
+                    "extensionId": "34",
+                    "extensionName": "azuredatastudio-postgresql",
+                    "displayName": "PostgreSQL",
+                    "shortDescription": "PostgreSQL extension for Azure Data Studio",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.2.6",
+                            "lastUpdated": "5/1/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/postgresql/azuredatastudio-postgresql-0.2.6.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio-postgresql/master/images/extension-icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio-postgresql/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio-postgresql/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio-postgresql/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.16.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio-postgresql/"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "35",
+                    "extensionName": "powershell",
+                    "displayName": "PowerShell",
+                    "shortDescription": "Develop PowerShell scripts in Azure Data Studio",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "2020.4.0",
+                            "lastUpdated": "4/28/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/ms-vscode.PowerShell-2020.4.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/images/PowerShell_icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/docs/azure_data_studio/README_FOR_MARKETPLACE.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/PowerShell/vscode-powershell/"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "36",
+                    "extensionName": "palenight-theme-dataazurestudio-version",
+                    "displayName": "Palenight Theme",
+                    "shortDescription": "Palenight Theme - Azure Data Studio Version Theme (based on vscode version)",
+                    "publisher": {
+                        "displayName": "JoseRocha",
+                        "publisherId": "JoseRocha",
+                        "publisherName": "JoseRocha"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.0.2",
+                            "lastUpdated": "04/06/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/joserocha/azdatastudio-material-palenight-theme/releases/tag/0.0.2"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "source": "https://github.com/joserocha/azdatastudio-material-palenight-theme/"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/joserocha/azdatastudio-material-palenight-theme/master/icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/joserocha/azdatastudio-material-palenight-theme/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/joserocha/azdatastudio-material-palenight-theme/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/joserocha/azdatastudio-material-palenight-theme/master/License.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "37",
+                    "extensionName": "schema-compare",
+                    "displayName": "SQL Server Schema Compare",
+                    "shortDescription": "Schema Compare tool for dacpac and databases",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.5.0",
+                            "lastUpdated": "4/16/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/schema-compare/schema-compare-1.4.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/schema-compare/images/extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/schema-compare/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/schema-compare/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.13.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": ""
+                },
+                {
+                    "extensionId": "38",
+                    "extensionName": "azdata-sanddance",
+                    "displayName": "SandDance for Azure Data Studio",
+                    "shortDescription": "Visually explore, understand, and present your data.",
+                    "publisher": {
+                        "displayName": "msrvida",
+                        "publisherId": "msrvida",
+                        "publisherName": "msrvida"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.3.9",
+                            "lastUpdated": "10/14/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/sanddance/azdata-sanddance-1.3.9.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/packages/azdata-sanddance/sanddance-logo.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/packages/azdata-sanddance/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/SandDance/master/packages/azdata-sanddance/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/SandDance"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "39",
+                    "extensionName": "managed-instance-dashboard",
+                    "displayName": "Managed Instance Dashboard",
+                    "shortDescription": "Managed Instance Dashboard",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.4.1",
+                            "lastUpdated": "03/08/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/managed-instance-dashboard/managed-instance-dashboard-0.4.1.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/JocaPC/AzureDataStudio-Managed-Instance/master/images/ManagedInstanceLogo.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/JocaPC/AzureDataStudio-Managed-Instance/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/JocaPC/AzureDataStudio-Managed-Instance/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/JocaPC/AzureDataStudio-Managed-Instance"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "40",
+                    "extensionName": "cms",
+                    "displayName": "Central Management Servers",
+                    "shortDescription": "Central Management Servers",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.9.0",
+                            "lastUpdated": "3/10/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/cms/cms-0.8.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/cms/images/extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/cms/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/cms/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.8.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "41",
+                    "extensionName": "admin-tool-ext-win",
+                    "displayName": "Database Administration Tool Extensions for Windows",
+                    "shortDescription": "Provides additional Windows-specific functionality to Azure Data Studio",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.1.0",
+                            "lastUpdated": "9/12/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/admin-tool-ext-win/admin-tool-ext-win-0.0.2.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/admin-tool-ext-win/images/extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/admin-tool-ext-win/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/admin-tool-ext-win/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.30.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.8.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "42",
+                    "extensionName": "ads-language-pack-de",
+                    "displayName": "German Language Pack for Azure Data Studio",
+                    "shortDescription": "Language pack extension for German",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.9.0",
+                            "lastUpdated": "6/24/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-de-1.9.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-de/languagepack.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-de/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-de/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.30.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.9.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
+                                    "value": "de"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "43",
+                    "extensionName": "ads-language-pack-es",
+                    "displayName": "Spanish Language Pack for Azure Data Studio",
+                    "shortDescription": "Language pack extension for Spanish",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.9.0",
+                            "lastUpdated": "6/24/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-es-1.9.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-es/languagepack.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-es/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-es/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.30.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.9.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
+                                    "value": "es"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "44",
+                    "extensionName": "ads-language-pack-fr",
+                    "displayName": "French Language Pack for Azure Data Studio",
+                    "shortDescription": "Language pack extension for French",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.9.0",
+                            "lastUpdated": "6/24/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-fr-1.9.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-fr/languagepack.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-fr/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-fr/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.30.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.9.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
+                                    "value": "fr"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "45",
+                    "extensionName": "ads-language-pack-it",
+                    "displayName": "Italian Language Pack for Azure Data Studio",
+                    "shortDescription": "Language pack extension for Italian",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.9.0",
+                            "lastUpdated": "6/24/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-it-1.9.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-it/languagepack.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-it/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-it/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.30.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.9.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
+                                    "value": "it"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "46",
+                    "extensionName": "ads-language-pack-ko",
+                    "displayName": "Korean Language Pack for Azure Data Studio",
+                    "shortDescription": "Language pack extension for Korean",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.9.0",
+                            "lastUpdated": "6/24/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-ko-1.9.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ko/languagepack.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ko/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ko/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.30.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.9.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
+                                    "value": "ko"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "47",
+                    "extensionName": "ads-language-pack-pt-br",
+                    "displayName": "Portuguese (Brazil) Language Pack for Azure Data Studio",
+                    "shortDescription": "Language pack extension for Portuguese (Brazil)",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.9.0",
+                            "lastUpdated": "6/24/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-pt-br-1.9.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-pt-BR/languagepack.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-pt-BR/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-pt-BR/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.30.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.9.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
+                                    "value": "pt-br"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "48",
+                    "extensionName": "ads-language-pack-ru",
+                    "displayName": "Russian Language Pack for Azure Data Studio",
+                    "shortDescription": "Language pack extension for Russian",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.9.0",
+                            "lastUpdated": "6/24/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-ru-1.9.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ru/languagepack.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ru/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ru/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.30.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.9.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
+                                    "value": "ru"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "49",
+                    "extensionName": "ads-language-pack-zh-hans",
+                    "displayName": "Chinese (Simplified) Language Pack for Azure Data Studio",
+                    "shortDescription": "Language pack extension for Chinese (Simplified)",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.9.0",
+                            "lastUpdated": "6/24/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-zh-hans-1.9.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hans/languagepack.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hans/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hans/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.30.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.9.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
+                                    "value": "zh-cn"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "50",
+                    "extensionName": "ads-language-pack-zh-hant",
+                    "displayName": "Chinese (Traditional) Language Pack for Azure Data Studio",
+                    "shortDescription": "Language pack extension for Chinese (Traditional)",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.9.0",
+                            "lastUpdated": "6/24/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-zh-hant-1.9.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hant/languagepack.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hant/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-zh-hant/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.30.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.9.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
+                                    "value": "zh-tw"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "51",
+                    "extensionName": "ads-language-pack-ja",
+                    "displayName": "Japanese Language Pack for Azure Data Studio",
+                    "shortDescription": "Language pack extension for Japanese",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.9.0",
+                            "lastUpdated": "6/24/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.9.0/ads-language-pack-ja-1.9.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ja/languagepack.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-pack-ja/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/i18n/language-ja/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.30.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.9.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.LocalizedLanguages",
+                                    "value": "ja"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "52",
+                    "extensionName": "plan-explorer",
+                    "displayName": "SentryOne Plan Explorer",
+                    "shortDescription": "Simplify query analysis and tuning",
+                    "publisher": {
+                        "displayName": "SentryOne",
+                        "publisherId": "SentryOne",
+                        "publisherName": "SentryOne"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.9.7",
+                            "lastUpdated": "3/3/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://www.sentryone.com/products/sentryone-plan-explorer-extension-azure-data-studio"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://downloads.sentryone.com/downloads/ads/s1logo.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://downloads.sentryone.com/downloads/ads/readme.0.9.7.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://sentryone.com/eula"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.8.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://extensions.sentryone.com/"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "53",
+                    "extensionName": "query-editor-boost",
+                    "displayName": "Query Editor Boost",
+                    "shortDescription": "Helpful add-ons for query editing",
+                    "publisher": {
+                        "displayName": "Drew Skwiers-Koballa",
+                        "publisherId": "drewsk",
+                        "publisherName": "drewsk"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.4.0",
+                            "lastUpdated": "1/5/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/dzsquared/query-editor-boost/releases/tag/0.4.0"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/query-editor-boost/master/images/QEboost200.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/query-editor-boost/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/query-editor-boost/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/query-editor-boost/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/dzsquared/query-editor-boost"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.8.0"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "54",
+                    "extensionName": "delete-database",
+                    "displayName": "Delete database",
+                    "shortDescription": "Adds 'Delete' option when right clicking on a database",
+                    "publisher": {
+                        "displayName": "AlexP",
+                        "publisherId": "alx-ppv",
+                        "publisherName": "alx-ppv"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.0.3",
+                            "lastUpdated": "08/14/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/alx-ppv/ADS-delete-database/releases/tag/0.0.3"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/logo.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/alx-ppv/ADS-delete-database/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/alx-ppv/ADS-delete-database"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "55",
+                    "extensionName": "query-history",
+                    "displayName": "Query History",
+                    "shortDescription": "Adds a Query History panel for viewing and running past executed queries.",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.2.0",
+                            "lastUpdated": "10/2/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/query-history/query-history-0.1.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/query-history/images/extension.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/query-history/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/query-history/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.12.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "56",
+                    "extensionName": "simple-data-scripter",
+                    "displayName": "Simple Data Scripter",
+                    "shortDescription": "Adds ability to script data for a table",
+                    "publisher": {
+                        "displayName": "Sean Price",
+                        "publisherId": "ecirpnaes",
+                        "publisherName": "ecirpnaes"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.1.3",
+                            "lastUpdated": "12/19/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/ecirpnaes/SimpleDataScripter/releases/tag/0.1.3"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/ecirpnaes/SimpleDataScripter/master/images/logo.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/ecirpnaes/SimpleDataScripter/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/ecirpnaes/SimpleDataScripter/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/ecirpnaes/SimpleDataScripter/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/ecirpnaes/simpledatascripter"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "57",
+                    "extensionName": "vscodeintellicode",
+                    "displayName": "Visual Studio IntelliCode",
+                    "shortDescription": "AI-assisted development",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "visualstudioexptteam"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.2.1",
+                            "lastUpdated": "10/29/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/vscodeintellicode-1.2.1.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/icon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/intellicode/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=1.29.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.12.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/MicrosoftDocs/intellicode"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": ""
+                },
+                {
+                    "extensionId": "58",
+                    "extensionName": "datavirtualization",
+                    "displayName": "Data Virtualization",
+                    "shortDescription": "Support for Data Virtualization in SQL Server, including Create External Data wizards.",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.4.0",
+                            "lastUpdated": "4/16/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/datavirtualization-1.4.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/vscode-mssql/master/images/sqlserver.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/content/1.4.0/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/content/1.4.0/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/datavirtualization/content/1.4.0/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.33.1"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://aka.ms/ads-datavirt"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": ""
+                },
+                {
+                    "extensionId": "59",
+                    "extensionName": "demo-mode",
+                    "displayName": "Demo Mode",
+                    "shortDescription": "Fast font embiggen for presentations and over the shoulder demos",
+                    "publisher": {
+                        "displayName": "Drew Skwiers-Koballa",
+                        "publisherId": "drewsk",
+                        "publisherName": "drewsk"
+                    },
+                    "versions": [
+                        {
+                            "version": "1.1.0",
+                            "lastUpdated": "11/16/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/dzsquared/demo-mode/releases/tag/1.1.0"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/demo-mode/master/images/monitor256.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/demo-mode/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/demo-mode/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/dzsquared/demo-mode/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/dzsquared/demo-mode"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "60",
+                    "extensionName": "db-snapshot-creator",
+                    "displayName": "DB Snapshot Creator",
+                    "shortDescription": "Adds ability to create a snaphot of a database",
+                    "publisher": {
+                        "displayName": "Sean Price",
+                        "publisherId": "ecirpnaes",
+                        "publisherName": "ecirpnaes"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.1.0",
+                            "lastUpdated": "12/19/2019",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/ecirpnaes/DbSnapshotCreator/releases/tag/0.1.0"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/ecirpnaes/DbSnapshotCreator/master/images/logo.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/ecirpnaes/DbSnapshotCreator/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/ecirpnaes/DbSnapshotCreator/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/ecirpnaes/DbSnapshotCreator/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/ecirpnaes/DbSnapshotCreator"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "61",
+                    "extensionName": "tsqlchecker",
+                    "displayName": "TSQL Checker",
+                    "shortDescription": "Adds checks for bad practice to the TSQL query window.",
+                    "publisher": {
+                        "displayName": "Daniel Janik",
+                        "publisherId": "DanielJanik",
+                        "publisherName": "DanielJanik"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.0.1",
+                            "lastUpdated": "02/06/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/DanielJanik/tsqlchecker_adsextension/releases/tag/0.0.1"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/danieljanik/tsqlchecker_adsextension/master/tsqlhelp.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/danieljanik/tsqlchecker_adsextension/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/danieljanik/tsqlchecker_adsextension/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/danieljanik/tsqlchecker_adsextension/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/DanielJanik/tsqlchecker_adsextension"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "61",
+                    "extensionName": "schema-visualization",
+                    "displayName": "Schema Visualization",
+                    "shortDescription": "Visualization of databases",
+                    "publisher": {
+                        "displayName": "Jens Hunt",
+                        "publisherId": "R0tenur",
+                        "publisherName": "R0tenur"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.2.0",
+                            "lastUpdated": "2/2/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.SQLOps.DownloadPage",
+                                    "source": "https://github.com/R0tenur/visualization/releases/tag/v0.2.0"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/R0tenur/visualization/master/images/logo.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/R0tenur/visualization/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/R0tenur/visualization/master/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/R0tenur/visualization/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/R0tenur/visualization"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": ""
+                },
+                {
+                    "extensionId": "64",
+                    "extensionName": "qpi",
+                    "displayName": "Query Performance Insight",
+                    "shortDescription": "ADS UI for the latest version of QPI library",
+                    "publisher": {
+                        "displayName": "Jovan Popovic",
+                        "publisherId": "jocapc",
+                        "publisherName": "jocapc"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.1.6",
+                            "lastUpdated": "03/08/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/qpi/qpi-0.1.6.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/jocapc/AzureDataStudio-QPI/master/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/jocapc/AzureDataStudio-QPI/master/LICENSE"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/jocapc/AzureDataStudio-QPI"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": "*"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                },
+                {
+                    "extensionId": "65",
+                    "extensionName": "machine-learning",
+                    "displayName": "Machine Learning",
+                    "shortDescription": "Machine Learning for SQL Databases",
+                    "publisher": {
+                        "displayName": "Microsoft",
+                        "publisherId": "Microsoft",
+                        "publisherName": "Microsoft"
+                    },
+                    "versions": [
+                        {
+                            "version": "0.1.0",
+                            "lastUpdated": "05/05/2020",
+                            "assetUri": "",
+                            "fallbackAssetUri": "fallbackAssetUri",
+                            "files": [
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+                                    "source": "https://sqlopsextensions.blob.core.windows.net/extensions/machine-learning/machine-learning-0.1.0.vsix"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+                                    "source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/master/extensions/machine-learning/images/extensionIcon.png"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.Details",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/machine-learning/README.md"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Code.Manifest",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/extensions/machine-learning/package.json"
+                                },
+                                {
+                                    "assetType": "Microsoft.VisualStudio.Services.Content.License",
+                                    "source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/master/LICENSE.txt"
+                                }
+                            ],
+                            "properties": [
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.ExtensionDependencies",
+                                    "value": ""
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Code.Engine",
+                                    "value": ">=0.32.1"
+                                },
+                                {
+                                    "key": "Microsoft.AzDataEngine",
+                                    "value": ">=1.18.0"
+                                },
+                                {
+                                    "key": "Microsoft.VisualStudio.Services.Links.Source",
+                                    "value": "https://github.com/Microsoft/azuredatastudio"
+                                }
+                            ]
+                        }
+                    ],
+                    "statistics": [],
+                    "flags": "preview"
+                }
+            ],
+            "resultMetadata": [
+                {
+                    "metadataType": "ResultCount",
+                    "metadataItems": [
+                        {
+                            "name": "TotalCount",
+                            "count": 54
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
Updated agent from 0.47.0 to 0.48.0
Updated profiler from 0.11.0 to 0.12.0
Updated admin-pack from 0.0.2 to 0.1.0
Updated dacpac from 1.4.0 to 1.5.0
Updated schema-compare from 1.4.0 to 1.5.0
Updated cms from 0.8.0 to 0.9.0
Updated admin-tool-ext-win from 0.0.2 to 0.1.0
Updated query-history from 0.1.0 to 0.2.0