### PR TITLE
Fix sql project build on mac

### DIFF
--- a/extensions/sql-database-projects/resources/templates/newSqlProjectTemplate.xml
+++ b/extensions/sql-database-projects/resources/templates/newSqlProjectTemplate.xml
@@ -59,6 +59,6 @@
     <Folder Include="Properties" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/extensions/sql-database-projects/resources/templates/newSqlProjectTemplate.xml
+++ b/extensions/sql-database-projects/resources/templates/newSqlProjectTemplate.xml
@@ -58,4 +58,7 @@
   <ItemGroup>
     <Folder Include="Properties" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/extensions/sql-database-projects/src/test/baselines/newSqlProjectBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/newSqlProjectBaseline.xml
@@ -59,6 +59,6 @@
     <Folder Include="Properties" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/extensions/sql-database-projects/src/test/baselines/newSqlProjectBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/newSqlProjectBaseline.xml
@@ -58,4 +58,7 @@
   <ItemGroup>
     <Folder Include="Properties" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Sql proj build previously wasn't working on mac because some reference assemblies couldn't be found. This PR fixes #10464.
