### PR TITLE
Don't do any extra parsing, put the responsibility on the caller

### DIFF
--- a/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
@@ -34,7 +34,7 @@ import { IEnvironmentService } from 'vs/platform/environment/common/environment'
 
 const connectAuthority = 'connect';
 
-interface SqlArgs {
+export interface SqlArgs {
 	_?: string[];
 	authenticationType?: string
 	database?: string;

--- a/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
@@ -36,9 +36,8 @@ const connectAuthority = 'connect';
 
 interface SqlArgs {
 	_?: string[];
-	aad?: boolean;
+	authenticationType?: string
 	database?: string;
-	integrated?: boolean;
 	server?: string;
 	user?: string;
 	command?: string;
@@ -220,11 +219,11 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 		let profile = new ConnectionProfile(this._capabilitiesService, null);
 		// We want connection store to use any matching password it finds
 		profile.savePassword = true;
-		profile.providerName = args.provider ? args.provider : Constants.mssqlProviderName;
+		profile.providerName = args.provider ?? Constants.mssqlProviderName;
 		profile.serverName = args.server;
-		profile.databaseName = args.database ? args.database : '';
-		profile.userName = args.user ? args.user : '';
-		profile.authenticationType = args.integrated ? Constants.integrated : args.aad ? Constants.azureMFA : (profile.userName.length > 0) ? Constants.sqlLogin : Constants.integrated;
+		profile.databaseName = args.database ?? '';
+		profile.userName = args.user ?? '';
+		profile.authenticationType = args.authenticationType ?? Constants.sqlLogin;
 		profile.connectionName = '';
 		profile.setOptionValue('applicationName', Constants.applicationName);
 		profile.setOptionValue('databaseDisplayName', profile.databaseName);

--- a/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
+++ b/src/sql/workbench/contrib/commandLine/electron-browser/commandLine.ts
@@ -223,7 +223,7 @@ export class CommandLineWorkbenchContribution implements IWorkbenchContribution,
 		profile.serverName = args.server;
 		profile.databaseName = args.database ?? '';
 		profile.userName = args.user ?? '';
-		profile.authenticationType = args.authenticationType ?? Constants.sqlLogin;
+		profile.authenticationType = args.authenticationType ?? Constants.integrated;
 		profile.connectionName = '';
 		profile.setOptionValue('applicationName', Constants.applicationName);
 		profile.setOptionValue('databaseDisplayName', profile.databaseName);

--- a/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
@@ -373,6 +373,7 @@ suite('commandLineService tests', () => {
 		args.server = 'myserver';
 		args.database = 'mydatabase';
 		args.user = 'myuser';
+		args.authenticationType = Constants.sqlLogin;
 		args._ = ['c:\\dir\\file.sql'];
 		connectionManagementService.setup((c) => c.showConnectionDialog()).verifiable(TypeMoq.Times.never());
 		connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());

--- a/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
@@ -8,7 +8,7 @@ import * as TypeMoq from 'typemoq';
 import * as azdata from 'azdata';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { ConnectionProfileGroup } from 'sql/platform/connection/common/connectionProfileGroup';
-import { CommandLineWorkbenchContribution } from 'sql/workbench/contrib/commandLine/electron-browser/commandLine';
+import { CommandLineWorkbenchContribution, SqlArgs } from 'sql/workbench/contrib/commandLine/electron-browser/commandLine';
 import * as Constants from 'sql/platform/connection/common/constants';
 import { ParsedArgs } from 'vs/platform/environment/node/argv';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
@@ -35,11 +35,9 @@ import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileE
 import { FileQueryEditorInput } from 'sql/workbench/contrib/query/common/fileQueryEditorInput';
 import { TestDialogService } from 'vs/platform/dialogs/test/common/testDialogService';
 
-class TestParsedArgs implements ParsedArgs {
+class TestParsedArgs implements ParsedArgs, SqlArgs {
 	[arg: string]: any;
 	_: string[];
-	aad?: boolean;
-	add?: boolean;
 	database?: string;
 	command?: string;
 	debugBrkPluginHost?: string;
@@ -67,7 +65,6 @@ class TestParsedArgs implements ParsedArgs {
 	help?: boolean;
 	'install-extension'?: string[];
 	'install-source'?: string;
-	integrated?: boolean;
 	'list-extensions'?: boolean;
 	locale?: string;
 	log?: string;
@@ -97,6 +94,7 @@ class TestParsedArgs implements ParsedArgs {
 	version?: boolean;
 	wait?: boolean;
 	waitMarkerFilePath?: string;
+	authenticationType?: string;
 }
 suite('commandLineService tests', () => {
 
@@ -197,6 +195,8 @@ suite('commandLineService tests', () => {
 		args.server = 'myserver';
 		args.database = 'mydatabase';
 		args.user = 'myuser';
+		args.authenticationType = Constants.sqlLogin;
+
 		connectionManagementService.setup((c) => c.showConnectionDialog()).verifiable(TypeMoq.Times.never());
 		connectionManagementService.setup(c => c.hasRegisteredServers()).returns(() => true).verifiable(TypeMoq.Times.atMostOnce());
 		connectionManagementService.setup(c => c.getConnectionGroups(TypeMoq.It.isAny())).returns(() => []);
@@ -436,7 +436,7 @@ suite('commandLineService tests', () => {
 
 		test('handleUrl opens a new connection if a server name is passed', async () => {
 			// Given a URI pointing to a server
-			let uri: URI = URI.parse('azuredatastudio://connect?server=myserver&database=mydatabase&user=myuser');
+			let uri: URI = URI.parse('azuredatastudio://connect?server=myserver&database=mydatabase&user=myuser&authenticationType=SqlLogin');
 
 			const connectionManagementService: TypeMoq.Mock<IConnectionManagementService>
 				= TypeMoq.Mock.ofType<IConnectionManagementService>(TestConnectionManagementService, TypeMoq.MockBehavior.Strict);
@@ -527,7 +527,7 @@ suite('commandLineService tests', () => {
 
 		test('handleUrl ignores commands and connects', async () => {
 			// Given I pass a command
-			let uri: URI = URI.parse('azuredatastudio://connect?command=mycommand&server=myserver&database=mydatabase&user=myuser');
+			let uri: URI = URI.parse('azuredatastudio://connect?command=mycommand&server=myserver&database=mydatabase&user=myuser&authenticationType=SqlLogin');
 
 			const connectionManagementService: TypeMoq.Mock<IConnectionManagementService>
 				= TypeMoq.Mock.ofType<IConnectionManagementService>(TestConnectionManagementService, TypeMoq.MockBehavior.Strict);


### PR DESCRIPTION
The responsibility to send valid URI should be on the caller. We shouldn't be doing weird parsing to try to make sense of it.

We should also avoid using 'boolean' for types of stuff that come externally. There is no guarantee they're a boolean in runtime. (e.g. in this case)