### PR TITLE
Fix some issues with book tree view

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -86,7 +86,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				if (notebookDocuments) {
 					// update trust state of opened items
 					notebookDocuments.forEach(document => {
-						let notebook = this.currentBook.getNotebook(document.uri.fsPath);
+						let notebook = this.currentBook?.getNotebook(document.uri.fsPath);
 						if (notebook && this._bookTrustManager.isNotebookTrustedByDefault(document.uri.fsPath)) {
 							document.setTrusted(true);
 						}
@@ -235,10 +235,10 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		if (!uri) {
 			let openDocument = azdata.nb.activeNotebookEditor;
 			if (openDocument) {
-				bookItem = this.currentBook.getNotebook(openDocument.document.uri.fsPath);
+				bookItem = this.currentBook?.getNotebook(openDocument.document.uri.fsPath);
 			}
 		} else if (uri.fsPath) {
-			bookItem = this.currentBook.getNotebook(uri.fsPath);
+			bookItem = this.currentBook?.getNotebook(uri.fsPath);
 		}
 		if (bookItem) {
 			// Select + focus item in viewlet if books viewlet is already open, or if we pass in variable
@@ -276,7 +276,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	}
 
 	async saveJupyterBooks(): Promise<void> {
-		if (this.currentBook.bookPath) {
+		if (this.currentBook?.bookPath) {
 			const allFilesFilter = loc.allFiles;
 			let filter: any = {};
 			filter[allFilesFilter] = '*';


### PR DESCRIPTION
currentBook might be undefined and these functions were being invoked even if a book wasn't opened - which would cause errors to show up in the logs. I noticed this writing some tests - separating it out for easier reviewing.

There didn't seem to be any functional issues here - this is just clean up to avoid extra errors in the logs. 