### PR TITLE
Fix HDFS node auth for non-root username

### DIFF
--- a/extensions/mssql/src/hdfs/webhdfs.ts
+++ b/extensions/mssql/src/hdfs/webhdfs.ts
@@ -228,6 +228,12 @@ export class WebHDFS {
 		let handler = (error: any, response: request.Response) => {
 			if (error && error.statusCode === 401 && this._requestParams.isKerberos) {
 				this.requestWithKerberosSync(requestParams, callback);
+			} else if (error && error.statusCode === 401 && this._requestParams.auth.user !== 'root') {
+				// Backwards compat code for pre-CU5 clusters which were set with root as the user.
+				// Since we already failed we just optimistically assume that it's a pre-CU5 cluster and
+				// try again. If that fails then we'll fall back to prompting for an updated username/password
+				this._requestParams.auth.user = 'root';
+				this.sendRequest(method, urlValue, opts, callback);
 			} else {
 				callback(error, response);
 			}

--- a/extensions/mssql/src/objectExplorerNodeProvider/connection.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/connection.ts
@@ -76,6 +76,12 @@ export class SqlClusterConnection {
 		return authType && authType.toLowerCase() === constants.integratedAuth;
 	}
 
+	public updateUsername(username: string): void {
+		if (username) {
+			this._user = username;
+		}
+	}
+
 	public updatePassword(password: string): void {
 		if (password) {
 			this._password = password;

--- a/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
@@ -117,10 +117,19 @@ export class MssqlObjectExplorerNodeProvider extends ProviderBase implements azd
 					// Only child returned when failure happens : When failed with 'Unauthorized' error, prompt for password.
 					if (children.length === 1 && this.hasExpansionError(children)) {
 						if (children[0].errorStatusCode === 401) {
-							//Prompt for password
-							let password: string = await this.promptPassword(localize('prmptPwd', "Please provide the password to connect to HDFS:"));
-							if (password && password.length > 0) {
-								session.sqlClusterConnection.updatePassword(password);
+							// First prompt for username (defaulting to existing username)
+							let username: string = await this.promptInput(localize('promptUsername', "Please provide the username to connect to HDFS:"), session.sqlClusterConnection.user);
+							// Only update the username if it's different than the original (the update functions ignore falsy values)
+							if (username === session.sqlClusterConnection.user) {
+								username = '';
+							}
+							session.sqlClusterConnection.updateUsername(username);
+
+							// And then prompt for password
+							const password: string = await this.promptPassword(localize('prmptPwd', "Please provide the password to connect to HDFS:"));
+							session.sqlClusterConnection.updatePassword(password);
+
+							if (username || password) {
 								await node.updateFileSource(session.sqlClusterConnection);
 								children = await node.getChildren(true);
 							}
@@ -139,6 +148,15 @@ export class MssqlObjectExplorerNodeProvider extends ProviderBase implements azd
 			expandResult.errorMessage = utils.getErrorMessage(error);
 		}
 		this.expandCompleteEmitter.fire(expandResult);
+	}
+
+	private async promptInput(promptMsg: string, defaultValue: string): Promise<string> {
+		return await this.prompter.promptSingle(<IQuestion>{
+			type: QuestionTypes.input,
+			name: 'inputPrompt',
+			message: promptMsg,
+			default: defaultValue
+		}).then(confirmed => <string>confirmed);
 	}
 
 	private async promptPassword(promptMsg: string): Promise<string> {

--- a/extensions/mssql/src/sqlClusterLookUp.ts
+++ b/extensions/mssql/src/sqlClusterLookUp.ts
@@ -94,7 +94,7 @@ async function createSqlClusterConnInfo(sqlConnInfo: azdata.IConnectionProfile |
 	clusterConnInfo.options[constants.knoxPortPropName] = hostAndIp.port || constants.defaultKnoxPort;
 	let authType = clusterConnInfo.options[constants.authenticationTypePropName] = sqlConnInfo.options[constants.authenticationTypePropName];
 	if (authType && authType.toLowerCase() !== constants.integratedAuth) {
-		clusterConnInfo.options[constants.userPropName] = 'root'; //should be the same user as sql master
+		clusterConnInfo.options[constants.userPropName] = sqlConnInfo.options[constants.userPropName]; //should be the same user as sql master
 		clusterConnInfo.options[constants.passwordPropName] = credentials.password;
 	}
 	clusterConnInfo = connToConnectionParam(clusterConnInfo);


### PR DESCRIPTION
Part of https://github.com/microsoft/azuredatastudio/issues/10525

- [x] HDFS Node in Servers view
- [x] Submit Spark Job

We default to SQL username now and if that fails we fall back and try root. If that still fails then we prompt the user for credentials.

Note this does not persist between sessions so if the connection is closed then we'll start the process over again.