### PR TITLE
Fix horizontal scroll bug

### DIFF
--- a/src/sql/workbench/contrib/query/browser/messagePanel.ts
+++ b/src/sql/workbench/contrib/query/browser/messagePanel.ts
@@ -12,7 +12,7 @@ import { generateUuid } from 'vs/base/common/uuid';
 import { attachListStyler } from 'vs/platform/theme/common/styler';
 import { IThemeService, IColorTheme } from 'vs/platform/theme/common/themeService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { WorkbenchDataTree } from 'vs/platform/list/browser/listService';
+import { WorkbenchDataTree, horizontalScrollingKey } from 'vs/platform/list/browser/listService';
 import { isArray, isString } from 'vs/base/common/types';
 import { Disposable, DisposableStore, dispose } from 'vs/base/common/lifecycle';
 import { $, Dimension, createStyleSheet, addStandardDisposableGenericMouseDownListner } from 'vs/base/browser/dom';
@@ -32,6 +32,7 @@ import { QueryEditor } from 'sql/workbench/contrib/query/browser/queryEditor';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IDataTreeViewState } from 'vs/base/browser/ui/tree/dataTree';
 import { IRange } from 'vs/editor/common/core/range';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export interface IResultMessageIntern {
 	id?: string;
@@ -101,9 +102,11 @@ export class MessagePanel extends Disposable {
 		@IThemeService private readonly themeService: IThemeService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IClipboardService private readonly clipboardService: IClipboardService,
-		@ITextResourcePropertiesService private readonly textResourcePropertiesService: ITextResourcePropertiesService
+		@ITextResourcePropertiesService private readonly textResourcePropertiesService: ITextResourcePropertiesService,
+		@IConfigurationService private configurationService: IConfigurationService
 	) {
 		super();
+		const horizontalScrollEnabled = this.configurationService.getValue(horizontalScrollingKey) || false;
 		this.tree = <WorkbenchDataTree<Model, IResultMessageIntern, FuzzyScore>>instantiationService.createInstance(
 			WorkbenchDataTree,
 			'MessagePanel',
@@ -119,7 +122,7 @@ export class MessagePanel extends Disposable {
 				accessibilityProvider: new AccessibilityProvider(),
 				mouseSupport: false,
 				setRowLineHeight: false,
-				supportDynamicHeights: true,
+				supportDynamicHeights: !horizontalScrollEnabled,
 				identityProvider: new IdentityProvider()
 			});
 		this._register(this.tree.onContextMenu(e => this.onContextMenu(e)));


### PR DESCRIPTION
This fixes https://github.com/microsoft/azuredatastudio/issues/10378

Issue: horizontal scrolling and dynamic heights aren't supported simultaneously (https://github.com/microsoft/azuredatastudio/blob/master/src/vs/base/browser/ui/list/listView.ts#L247), and we had dynamic heights to true by default in the message panel. So it would break if a user enabled horizontal scolling.

Fix: Look for user settings for horizontal scrolling and set dynamic height to its opposite.