### PR TITLE
dacpac extension fixes

### DIFF
--- a/extensions/dacpac/src/wizard/api/basePage.ts
+++ b/extensions/dacpac/src/wizard/api/basePage.ts
@@ -76,7 +76,14 @@ export abstract class BasePage {
 				usr = loc.defaultText;
 			}
 
-			let finalName = `${srv} (${usr})`;
+			let finalName;
+			// show connection name if there is one
+			if (c.options.connectionName) {
+				finalName = `${c.options.connectionName}`;
+			} else {
+				finalName = `${srv} (${usr})`;
+			}
+
 			return {
 				connection: c,
 				displayName: finalName,

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -108,7 +108,7 @@ export abstract class DacFxConfigPage extends BasePage {
 
 		// Handle database changes
 		this.databaseDropdown.onValueChanged(async () => {
-			this.model.database = (<azdata.CategoryValue>this.databaseDropdown.value).name;
+			this.model.database = <string>this.databaseDropdown.value;
 			this.fileTextBox.value = this.generateFilePathFromDatabaseAndTimestamp();
 			this.model.filePath = this.fileTextBox.value;
 		});

--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -98,9 +98,15 @@ export class DataTierApplicationWizard {
 
 		this.connection = await azdata.connection.getCurrentConnection();
 		if (!this.connection || (profile && this.connection.connectionId !== profile.id)) {
-			// @TODO: remove cast once azdata update complete - karlb 3/1/2019
-			this.connection = <azdata.connection.ConnectionProfile><any>await azdata.connection.openConnectionDialog(undefined, profile);
-
+			// check if there are any active connections
+			const connections = await azdata.connection.getConnections(true);
+			if (connections.length > 0) {
+				// set connection to the first one in the list
+				this.connection = connections[0];
+			} else {
+				// @TODO: remove cast once azdata update complete - karlb 3/1/2019
+				this.connection = <azdata.connection.ConnectionProfile><any>await azdata.connection.openConnectionDialog(undefined, profile);
+			}
 			// don't open the wizard if connection dialog is cancelled
 			if (!this.connection) {
 				return;


### PR DESCRIPTION
This PR fixes #7097. There are a few fixes for the dacpac extension in this PR:
- show connection name if there is one instead of server name
- don't open connection dialog if there are active connections, even if there is no "current connection"
- database dropdown was not changing selected database correctly because the database dropdown values got changed to string from CategoryValue in #8909
