### PR TITLE
Switch to DownloadBuildArtifacts task

### DIFF
--- a/build/azure-pipelines/docker/sql-product-build-docker.yml
+++ b/build/azure-pipelines/docker/sql-product-build-docker.yml
@@ -68,7 +68,7 @@ steps:
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: 'current'
-      targetPath: '$(Build.SourcesDirectory)/.build'
+      downloadPath: '$(Build.SourcesDirectory)/.build'
       artifactName: drop
       itemPattern: |
         drop/linux/server/*.tar.gz

--- a/build/azure-pipelines/docker/sql-product-build-docker.yml
+++ b/build/azure-pipelines/docker/sql-product-build-docker.yml
@@ -65,7 +65,7 @@ steps:
       node build/azure-pipelines/mixin
     displayName: Mix in quality
 
-  - task: DownloadPipelineArtifact@2
+  - task: DownloadBuildArtifacts@0
     inputs:
       buildType: 'current'
       targetPath: '$(Build.SourcesDirectory)/.build'

--- a/build/azure-pipelines/docker/sql-product-build-docker.yml
+++ b/build/azure-pipelines/docker/sql-product-build-docker.yml
@@ -75,7 +75,7 @@ steps:
 
   - script: |
       set -e
-      for f in $(Build.SourcesDirectory)/.build/linux/server/*.tar.gz
+      for f in $(Build.SourcesDirectory)/.build/drop/linux/server/*.tar.gz
       do
         tar -C $(agent.builddirectory) -zxvf $f
         rm $f


### PR DESCRIPTION
This was generating a warning in our builds :

https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=65787&view=logs&j=1c8ce01e-97de-5be9-a863-648419f09741&t=b41ce4de-7bca-5dd5-8638-dc7f5a7157ca&l=11

`##[warning]Please use Download Build Artifact task for downloading Build Artifact type artifact. https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/download-build-artifacts?view=azure-devops`