### PR TITLE
bump SqlToolsService to 2.0.0-release.68

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "2.0.0-release.65",
+	"version": "2.0.0-release.68",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.2.zip",
 		"Windows_64": "win-x64-netcoreapp2.2.zip",


### PR DESCRIPTION
Update sqltoolsservice to get DacFx fix for importing/deploying users with external logins to on prem. This PR fixes #9522, fixes #9217
