### PR TITLE
use inbuilt codicon instead of image

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -146,10 +146,7 @@
       {
         "command": "azure.resource.startterminal",
         "title": "%azure.resource.startterminal.title%",
-        "icon": {
-          "dark": "resources/dark/console.svg",
-          "light": "resources/light/console.svg"
-        }
+        "icon": "$(console)"
       },
       {
         "command": "azure.resource.openInAzurePortal",

--- a/extensions/azurecore/resources/dark/console.svg
+++ b/extensions/azurecore/resources/dark/console.svg
@@ -1,3 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M1 1H15V15H1V1ZM2 14H14V2H2V14ZM4.00008 5.70709L4.70718 4.99999L8.24272 8.53552L7.53561 9.24263L7.53558 9.2426L4.70711 12.0711L4 11.364L6.82848 8.53549L4.00008 5.70709Z" fill="#C5C5C5"/>
-</svg>

--- a/extensions/azurecore/resources/light/console.svg
+++ b/extensions/azurecore/resources/light/console.svg
@@ -1,3 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M1 1H15V15H1V1ZM2 14H14V2H2V14ZM4.00008 5.70709L4.70718 4.99999L8.24272 8.53552L7.53561 9.24263L7.53558 9.2426L4.70711 12.0711L4 11.364L6.82848 8.53549L4.00008 5.70709Z" fill="#424242"/>
-</svg>


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/10504

Removed the `console.svg` file that was the same for both light and dark and use inbuilt codicons instead which are theme aware.

<img width="482" alt="Screen Shot 2020-06-01 at 1 23 48 PM" src="https://user-images.githubusercontent.com/6411451/83451392-b5358300-a40b-11ea-9fef-890a1a6c3030.png">

