### PR TITLE
show username for azure sql db

### DIFF
--- a/src/sql/workbench/contrib/profiler/browser/profiler.contribution.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profiler.contribution.ts
@@ -57,7 +57,7 @@ const profilerViewTemplateSchema: IJSONSchema = {
 				},
 				{
 					name: 'LoginName',
-					eventsMapped: ['server_principal_name']
+					eventsMapped: ['server_principal_name', 'username']
 				},
 				{
 					name: 'ClientProcessID',
@@ -159,7 +159,7 @@ const profilerViewTemplateSchema: IJSONSchema = {
 				},
 				{
 					name: 'LoginName',
-					eventsMapped: ['server_principal_name']
+					eventsMapped: ['server_principal_name', 'username']
 				}
 			]
 		},
@@ -184,7 +184,7 @@ const profilerViewTemplateSchema: IJSONSchema = {
 				},
 				{
 					name: 'LoginName',
-					eventsMapped: ['server_principal_name']
+					eventsMapped: ['server_principal_name', 'username']
 				},
 				{
 					name: 'ClientProcessID',


### PR DESCRIPTION
This PR fixes #10393 

sqlserver.username field is being captured by our default azure session templates but the field is not added to the view mapping, with this change the username will be displayed:

<img width="1005" alt="Screen Shot 2020-06-02 at 10 39 50 AM" src="https://user-images.githubusercontent.com/13777222/83551673-81b33100-a4bd-11ea-9a49-c912fb8b51b7.png">

