### PR TITLE
Adjusted + Cell element height to fix layout on Mac and Windows.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.css
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.css
@@ -52,6 +52,7 @@
 .notebookEditor .in-preview .actions-container .action-item .notebook-button {
 	display: flex;
 	background-size: 16px;
+	height: 100%;
 }
 
 .notebookEditor


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes a bug in ADS Notebook UI where the word "Cell" appears misaligned with the remainder of the notebook toolbar text.
<img width="891" alt="image" src="https://user-images.githubusercontent.com/12279161/83562028-b7f8ac80-a4cd-11ea-85c4-f20b300be510.png">