### PR TITLE
Temporary fix to make Kusto queries work in unsaved query editor

### DIFF
--- a/src/sql/workbench/browser/scriptingUtils.ts
+++ b/src/sql/workbench/browser/scriptingUtils.ts
@@ -45,8 +45,7 @@ export async function scriptSelect(connectionProfile: IConnectionProfile, metada
 	let paramDetails: azdata.ScriptingParamDetails = getScriptingParamDetails(connectionService, connectionResult, metadata);
 	const result = await scriptingService.script(connectionResult, metadata, ScriptOperation.Select, paramDetails);
 	if (result && result.script) {
-		// const owner = await queryEditorService.newSqlEditor(result.script, connectionProfile.providerName);	//TODOKusto: Verify changes after merge.
-		const owner = await queryEditorService.newSqlEditor({ initalContent: result.script });
+		const owner = await queryEditorService.newSqlEditor({ initalContent: result.script }, connectionProfile.providerName);	//TODOKusto: Verify changes after Anthony's fix.
 		// Connect our editor to the input connection
 		let options: IConnectionCompletionOptions = {
 			params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.executeQuery, input: owner },

--- a/src/sql/workbench/contrib/query/browser/queryInputFactory.ts
+++ b/src/sql/workbench/contrib/query/browser/queryInputFactory.ts
@@ -27,7 +27,7 @@ const editorInputFactoryRegistry = Registry.as<IEditorInputFactoryRegistry>(Edit
 
 export class QueryEditorLanguageAssociation implements ILanguageAssociation {
 	static readonly isDefault = true;
-	static readonly languages = ['sql', 'kusto'];
+	static readonly languages = ['sql', 'kusto'];			//TODOKusto Add language id here for new languages supported in query editor. Make it easier if possible.
 
 	constructor(@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IObjectExplorerService private readonly objectExplorerService: IObjectExplorerService,

--- a/src/sql/workbench/services/queryEditor/common/queryEditorService.ts
+++ b/src/sql/workbench/services/queryEditor/common/queryEditorService.ts
@@ -33,8 +33,8 @@ export interface IQueryEditorService {
 
 	_serviceBrand: undefined;
 
-	// Creates new untitled document for SQL queries and opens it in a new editor tab
-	newSqlEditor(options?: INewSqlEditorOptions): Promise<IConnectableInput>;
+	// Creates new untitled document for SQL/KUSTO queries and opens it in a new editor tab
+	newSqlEditor(options?: INewSqlEditorOptions, connectionProviderName?: string): Promise<IConnectableInput>;		//TODOKusto: Verify after Anthony's fix.
 
 	// Creates new edit data session
 	newEditDataEditor(schemaName: string, tableName: string, queryString: string): Promise<IConnectableInput>;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
Kusto queries to run in unsaved query editor when user clicks "Select Top 1000" by right clicking on Kusto table