### PR TITLE
Add readOnly property to InputBoxComponent

### DIFF
--- a/extensions/arc/src/ui/components/keyValueContainer.ts
+++ b/extensions/arc/src/ui/components/keyValueContainer.ts
@@ -62,7 +62,7 @@ export class InputKeyValue extends KeyValue {
 	getValueComponent(modelBuilder: azdata.ModelBuilder): azdata.Component {
 		const container = modelBuilder.flexContainer().withLayout({ alignItems: 'center' }).component();
 		container.addItem(modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
-			value: this.value // TODO: Add a readOnly property to input boxes
+			value: this.value, readOnly: true
 		}).component());
 
 		const copy = modelBuilder.button().withProperties<azdata.ButtonProperties>({

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -309,6 +309,7 @@ declare module 'azdata' {
 
 	export interface InputBoxProperties extends ComponentProperties {
 		validationErrorMessage?: string;
+		readOnly?: boolean;
 	}
 
 	export interface CheckBoxProperties {

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -244,6 +244,7 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 		}
 
 		input.inputElement.required = this.required;
+		input.inputElement.readOnly = this.readOnly;
 	}
 
 	// CSS-bound properties
@@ -314,6 +315,14 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 
 	public set multiline(newValue: boolean) {
 		this.setPropertyFromUI<azdata.InputBoxProperties, boolean>((props, value) => props.multiline = value, newValue);
+	}
+	
+	public get readOnly(): boolean {	
+		return this.getPropertyOrDefault<azdata.InputBoxProperties, boolean>((props) => props.readOnly, false);	
+	}	
+
+	public set readOnly(newValue: boolean) {	
+		this.setPropertyFromUI<azdata.InputBoxProperties, boolean>((props, value) => props.readOnly = value, newValue);	
 	}
 
 	public get required(): boolean {

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -316,13 +316,13 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 	public set multiline(newValue: boolean) {
 		this.setPropertyFromUI<azdata.InputBoxProperties, boolean>((props, value) => props.multiline = value, newValue);
 	}
-	
-	public get readOnly(): boolean {	
-		return this.getPropertyOrDefault<azdata.InputBoxProperties, boolean>((props) => props.readOnly, false);	
-	}	
 
-	public set readOnly(newValue: boolean) {	
-		this.setPropertyFromUI<azdata.InputBoxProperties, boolean>((props, value) => props.readOnly = value, newValue);	
+	public get readOnly(): boolean {
+		return this.getPropertyOrDefault<azdata.InputBoxProperties, boolean>((props) => props.readOnly, false);
+	}
+
+	public set readOnly(newValue: boolean) {
+		this.setPropertyFromUI<azdata.InputBoxProperties, boolean>((props, value) => props.readOnly = value, newValue);
 	}
 
 	public get required(): boolean {


### PR DESCRIPTION
Adds a readOnly property to InputBoxComponent.  Used for inputs that the user should select/copy but not edit.