### PR TITLE
Fix sql project generate script

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -201,11 +201,11 @@ export class ProjectsController {
 
 		const dacFxService = await ProjectsController.getDaxFxService();
 
-		if (profile as IDeploymentProfile) {
+		if ((<IDeploymentProfile>profile).upgradeExisting) {
 			return await dacFxService.deployDacpac(dacpacPath, profile.databaseName, (<IDeploymentProfile>profile).upgradeExisting, profile.connectionUri, TaskExecutionMode.execute, profile.sqlCmdVariables);
 		}
 		else {
-			return await dacFxService.generateDeployScript(dacpacPath, profile.databaseName, profile.connectionUri, TaskExecutionMode.execute, profile.sqlCmdVariables);
+			return await dacFxService.generateDeployScript(dacpacPath, profile.databaseName, profile.connectionUri, TaskExecutionMode.script, profile.sqlCmdVariables);
 		}
 	}
 

--- a/extensions/sql-database-projects/src/dialogs/deployDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/deployDatabaseDialog.ts
@@ -161,10 +161,10 @@ export class DeployDatabaseDialog {
 			sqlCmdVariables: this.project.sqlCmdVariables
 		};
 
+		azdata.window.closeDialog(this.dialog);
 		await this.deploy!(this.project, profile);
 
 		this.dispose();
-		azdata.window.closeDialog(this.dialog);
 	}
 
 	public async generateScriptClick(): Promise<void> {
@@ -173,12 +173,13 @@ export class DeployDatabaseDialog {
 			connectionUri: await this.getConnectionUri()
 		};
 
+		azdata.window.closeDialog(this.dialog);
+
 		if (this.generateScript) {
 			await this.generateScript!(this.project, profile);
 		}
 
 		this.dispose();
-		azdata.window.closeDialog(this.dialog);
 	}
 
 	private getTargetDatabaseName(): string {


### PR DESCRIPTION
This PR fixes #10668. This fixes clicking "generate script" in the deploy dialog calling deploy and also closes the dialog before build starts instead of after. Another issue I found was that the generated script wasn't being opened, so this PR fixes that too by setting the TaskExecutionMode to script instead of execute.  
