### PR TITLE
Add custom width to Python wizard to reduce wasted space.

### DIFF
--- a/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
@@ -67,7 +67,7 @@ export class ConfigurePythonWizard {
 		} else {
 			wizardTitle = localize('configurePython.wizardNameWithoutKernel', 'Configure Python to run kernels');
 		}
-		this._wizard = azdata.window.createWizard(wizardTitle);
+		this._wizard = azdata.window.createWizard(wizardTitle, 600);
 		let page0 = azdata.window.createWizardPage(localize('configurePython.page0Name', 'Configure Python Runtime'));
 		let page1 = azdata.window.createWizardPage(localize('configurePython.page1Name', 'Install Dependencies'));
 

--- a/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
@@ -63,13 +63,13 @@ export class ConfigurePythonWizard {
 
 		let wizardTitle: string;
 		if (kernelName) {
-			wizardTitle = localize('configurePython.wizardNameWithKernel', 'Configure Python to run {0} kernel', kernelName);
+			wizardTitle = localize('configurePython.wizardNameWithKernel', "Configure Python to run {0} kernel", kernelName);
 		} else {
-			wizardTitle = localize('configurePython.wizardNameWithoutKernel', 'Configure Python to run kernels');
+			wizardTitle = localize('configurePython.wizardNameWithoutKernel', "Configure Python to run kernels");
 		}
 		this._wizard = azdata.window.createWizard(wizardTitle, 600);
-		let page0 = azdata.window.createWizardPage(localize('configurePython.page0Name', 'Configure Python Runtime'));
-		let page1 = azdata.window.createWizardPage(localize('configurePython.page1Name', 'Install Dependencies'));
+		let page0 = azdata.window.createWizardPage(localize('configurePython.page0Name', "Configure Python Runtime"));
+		let page1 = azdata.window.createWizardPage(localize('configurePython.page1Name', "Install Dependencies"));
 
 		page0.registerContent(async (view) => {
 			let configurePathPage = new ConfigurePathPage(this.apiWrapper, this, page0, this.model, view);


### PR DESCRIPTION
This reduces the width of the wizard by half, so it removes a lot of empty space.