### PR TITLE
Only show edit cell action for markdown cells

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
@@ -7,7 +7,7 @@ import 'vs/css!./cellToolbar';
 import * as DOM from 'vs/base/browser/dom';
 import { Component, Inject, ViewChild, ElementRef, Input } from '@angular/core';
 import { localize } from 'vs/nls';
-import { Taskbar } from 'sql/base/browser/ui/taskbar/taskbar';
+import { Taskbar, ITaskbarContent } from 'sql/base/browser/ui/taskbar/taskbar';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { DeleteCellAction, EditCellAction, CellToggleMoreActions } from 'sql/workbench/contrib/notebook/browser/cellToolbarActions';
@@ -87,11 +87,14 @@ export class CellToolbarComponent {
 		dropdownMenuActionViewItem.render(buttonDropdownContainer);
 		dropdownMenuActionViewItem.setActionContext(context);
 
-		this._actionBar.setContent([
-			{ action: this._editCellAction },
-			{ element: buttonDropdownContainer },
+		let taskbarContent: ITaskbarContent[] = [];
+		if (this.cellModel?.cellType === CellTypes.Markdown) {
+			taskbarContent.push({ action: this._editCellAction });
+		}
+		taskbarContent.push({ element: buttonDropdownContainer },
 			{ action: deleteButton },
-			{ element: moreActionsContainer }
-		]);
+			{ element: moreActionsContainer });
+
+		this._actionBar.setContent(taskbarContent);
 	}
 }


### PR DESCRIPTION
This PR addresses #10713. The edit cell action should only appear for text cells.

Text cell toolbar:
![image](https://user-images.githubusercontent.com/40371649/83699730-b3a9bd80-a5b9-11ea-8883-28b3a8c789af.png)
![image](https://user-images.githubusercontent.com/40371649/83699735-ba383500-a5b9-11ea-962d-ac552e03cf44.png)

Code cell toolbar:
![image](https://user-images.githubusercontent.com/40371649/83699718-aab8ec00-a5b9-11ea-84cd-22d02f4ff954.png)

