### PR TITLE
Notebook UI - cell toolbar feature now behind preview flag

### DIFF
--- a/src/sql/base/browser/ui/buttonMenu/buttonMenu.css
+++ b/src/sql/base/browser/ui/buttonMenu/buttonMenu.css
@@ -3,10 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.button-menu .in-preview .monaco-dropdown {
-	height: auto;
-	padding: 0;
-}
 .button-menu.masked-pseudo-after.dropdown-arrow:after {
 	right: -2px;
 	width: 20px;

--- a/src/sql/workbench/contrib/notebook/browser/cellToggleMoreActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellToggleMoreActions.ts
@@ -1,0 +1,251 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ElementRef } from '@angular/core';
+
+import { localize } from 'vs/nls';
+import { ActionBar, ActionsOrientation, Separator } from 'vs/base/browser/ui/actionbar/actionbar';
+import { getErrorMessage } from 'vs/base/common/errors';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import * as DOM from 'vs/base/browser/dom';
+
+import { INotebookService } from 'sql/workbench/services/notebook/browser/notebookService';
+import { CellActionBase, CellContext } from 'sql/workbench/contrib/notebook/browser/cellViews/codeActions';
+import { CellTypes, CellType } from 'sql/workbench/services/notebook/common/contracts';
+import { NotebookModel } from 'sql/workbench/services/notebook/browser/models/notebookModel';
+import { ICellModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
+import { ToggleMoreWidgetAction } from 'sql/workbench/contrib/dashboard/browser/core/actions';
+import { CellModel } from 'sql/workbench/services/notebook/browser/models/cell';
+import { Action } from 'vs/base/common/actions';
+import { firstIndex } from 'vs/base/common/arrays';
+
+export const HIDDEN_CLASS = 'actionhidden';
+
+export class CellToggleMoreActions {
+	private _actions: (Action | CellActionBase)[] = [];
+	private _moreActions: ActionBar;
+	private _moreActionsElement: HTMLElement;
+	constructor(
+		@IInstantiationService private instantiationService: IInstantiationService) {
+		this._actions.push(
+			instantiationService.createInstance(RunCellsAction, 'runAllBefore', localize('runAllBefore', "Run Cells Before"), false),
+			instantiationService.createInstance(RunCellsAction, 'runAllAfter', localize('runAllAfter', "Run Cells After"), true),
+			new Separator(),
+			instantiationService.createInstance(AddCellFromContextAction, 'codeBefore', localize('codeBefore', "Insert Code Before"), CellTypes.Code, false),
+			instantiationService.createInstance(AddCellFromContextAction, 'codeAfter', localize('codeAfter', "Insert Code After"), CellTypes.Code, true),
+			new Separator(),
+			instantiationService.createInstance(AddCellFromContextAction, 'markdownBefore', localize('markdownBefore', "Insert Text Before"), CellTypes.Markdown, false),
+			instantiationService.createInstance(AddCellFromContextAction, 'markdownAfter', localize('markdownAfter', "Insert Text After"), CellTypes.Markdown, true),
+			new Separator(),
+			instantiationService.createInstance(CollapseCellAction, 'collapseCell', localize('collapseCell', "Collapse Cell"), true),
+			instantiationService.createInstance(CollapseCellAction, 'expandCell', localize('expandCell', "Expand Cell"), false),
+			new Separator(),
+			instantiationService.createInstance(ClearCellOutputAction, 'clear', localize('clear', "Clear Result")),
+			new Separator(),
+			instantiationService.createInstance(DeleteCellAction, 'delete', localize('delete', "Delete")),
+		);
+	}
+
+	public onInit(elementRef: ElementRef, model: NotebookModel, cellModel: ICellModel) {
+		let context = new CellContext(model, cellModel);
+		this._moreActionsElement = <HTMLElement>elementRef.nativeElement;
+		if (this._moreActionsElement.childNodes.length > 0) {
+			this._moreActionsElement.removeChild(this._moreActionsElement.childNodes[0]);
+		}
+		this._moreActions = new ActionBar(this._moreActionsElement, { orientation: ActionsOrientation.VERTICAL });
+		this._moreActions.context = { target: this._moreActionsElement };
+		let validActions = this._actions.filter(a => a instanceof Separator || a instanceof CellActionBase && a.canRun(context));
+		this.removeDuplicatedAndStartingSeparators(validActions);
+		this._moreActions.push(this.instantiationService.createInstance(ToggleMoreWidgetAction, validActions, context), { icon: true, label: false });
+	}
+
+	public toggleVisible(visible: boolean): void {
+		if (!this._moreActionsElement) {
+			return;
+		}
+		if (visible) {
+			DOM.addClass(this._moreActionsElement, HIDDEN_CLASS);
+		} else {
+			DOM.removeClass(this._moreActionsElement, HIDDEN_CLASS);
+		}
+	}
+
+	private removeDuplicatedAndStartingSeparators(actions: (Action | CellActionBase)[]): void {
+		let indexesToRemove: number[] = [];
+		for (let i = 0; i < actions.length; i++) {
+			// Never should have a separator at the beginning of the list
+			if (i === 0 && actions[i] instanceof Separator) {
+				indexesToRemove.push(0);
+			}
+			// Handle multiple separators in a row
+			if (i > 0 && actions[i] instanceof Separator && actions[i - 1] instanceof Separator) {
+				indexesToRemove.push(i);
+			}
+		}
+		if (indexesToRemove.length > 0) {
+			for (let i = indexesToRemove.length - 1; i >= 0; i--) {
+				actions.splice(indexesToRemove[i], 1);
+			}
+		}
+	}
+}
+
+export class AddCellFromContextAction extends CellActionBase {
+	constructor(
+		id: string, label: string, private cellType: CellType, private isAfter: boolean,
+		@INotificationService notificationService: INotificationService
+	) {
+		super(id, label, undefined, notificationService);
+	}
+
+	doRun(context: CellContext): Promise<void> {
+		try {
+			let model = context.model;
+			let index = firstIndex(model.cells, (cell) => cell.id === context.cell.id);
+			if (index !== undefined && this.isAfter) {
+				index += 1;
+			}
+			model.addCell(this.cellType, index);
+		} catch (error) {
+			let message = getErrorMessage(error);
+
+			this.notificationService.notify({
+				severity: Severity.Error,
+				message: message
+			});
+		}
+		return Promise.resolve();
+	}
+}
+
+export class DeleteCellAction extends CellActionBase {
+	constructor(id: string, label: string,
+		@INotificationService notificationService: INotificationService
+	) {
+		super(id, label, undefined, notificationService);
+	}
+
+	doRun(context: CellContext): Promise<void> {
+		try {
+			context.model.deleteCell(context.cell);
+		} catch (error) {
+			let message = getErrorMessage(error);
+
+			this.notificationService.notify({
+				severity: Severity.Error,
+				message: message
+			});
+		}
+		return Promise.resolve();
+	}
+}
+
+export class ClearCellOutputAction extends CellActionBase {
+	constructor(id: string, label: string,
+		@INotificationService notificationService: INotificationService
+	) {
+		super(id, label, undefined, notificationService);
+	}
+
+	public canRun(context: CellContext): boolean {
+		return context.cell && context.cell.cellType === CellTypes.Code;
+	}
+
+
+	doRun(context: CellContext): Promise<void> {
+		try {
+			let cell = context.cell || context.model.activeCell;
+			if (cell) {
+				(cell as CellModel).clearOutputs();
+			}
+		} catch (error) {
+			let message = getErrorMessage(error);
+
+			this.notificationService.notify({
+				severity: Severity.Error,
+				message: message
+			});
+		}
+		return Promise.resolve();
+	}
+
+}
+
+export class RunCellsAction extends CellActionBase {
+	constructor(id: string,
+		label: string,
+		private isAfter: boolean,
+		@INotificationService notificationService: INotificationService,
+		@INotebookService private notebookService: INotebookService,
+	) {
+		super(id, label, undefined, notificationService);
+	}
+
+	public canRun(context: CellContext): boolean {
+		return context.cell && context.cell.cellType === CellTypes.Code;
+	}
+
+	async doRun(context: CellContext): Promise<void> {
+		try {
+			let cell = context.cell || context.model.activeCell;
+			if (cell) {
+				let editor = this.notebookService.findNotebookEditor(cell.notebookModel.notebookUri);
+				if (editor) {
+					if (this.isAfter) {
+						await editor.runAllCells(cell, undefined);
+					} else {
+						await editor.runAllCells(undefined, cell);
+					}
+				}
+			}
+		} catch (error) {
+			let message = getErrorMessage(error);
+			this.notificationService.notify({
+				severity: Severity.Error,
+				message: message
+			});
+		}
+		return Promise.resolve();
+	}
+}
+
+export class CollapseCellAction extends CellActionBase {
+	constructor(id: string,
+		label: string,
+		private collapseCell: boolean,
+		@INotificationService notificationService: INotificationService
+	) {
+		super(id, label, undefined, notificationService);
+	}
+
+	public canRun(context: CellContext): boolean {
+		return context.cell && context.cell.cellType === CellTypes.Code;
+	}
+
+	async doRun(context: CellContext): Promise<void> {
+		try {
+			let cell = context.cell || context.model.activeCell;
+			if (cell) {
+				if (this.collapseCell) {
+					if (!cell.isCollapsed) {
+						cell.isCollapsed = true;
+					}
+				} else {
+					if (cell.isCollapsed) {
+						cell.isCollapsed = false;
+					}
+				}
+			}
+		} catch (error) {
+			let message = getErrorMessage(error);
+			this.notificationService.notify({
+				severity: Severity.Error,
+				message: message
+			});
+		}
+		return Promise.resolve();
+	}
+}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
@@ -17,6 +17,7 @@ import { DropdownMenuActionViewItem } from 'sql/base/browser/ui/buttonMenu/butto
 import { ICellModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { NotebookModel } from 'sql/workbench/services/notebook/browser/models/notebookModel';
 import { CellContext } from 'sql/workbench/contrib/notebook/browser/cellViews/codeActions';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export const CELL_TOOLBAR_SELECTOR: string = 'cell-toolbar-component';
 
@@ -38,16 +39,21 @@ export class CellToolbarComponent {
 	private _actionBar: Taskbar;
 	private _editCellAction: EditCellAction;
 	public _cellToggleMoreActions: CellToggleMoreActions;
+	public previewFeaturesEnabled: boolean = false;
 
 	constructor(
 		@Inject(IInstantiationService) private instantiationService: IInstantiationService,
-		@Inject(IContextMenuService) private contextMenuService: IContextMenuService
+		@Inject(IContextMenuService) private contextMenuService: IContextMenuService,
+		@Inject(IConfigurationService) private _configurationService: IConfigurationService,
 	) {
 		this._cellToggleMoreActions = this.instantiationService.createInstance(CellToggleMoreActions);
+		this.previewFeaturesEnabled = this._configurationService.getValue('workbench.enablePreviewFeatures');
 	}
 
 	ngOnInit() {
-		this.initActionBar();
+		if (this.previewFeaturesEnabled) {
+			this.initActionBar();
+		}
 	}
 
 	protected initActionBar(): void {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
@@ -11,6 +11,11 @@
 			<div style="flex: 1 1 auto; overflow: hidden;">
 				<div #editor class="editor"></div>
 			</div>
+
+			<!-- Remove after a11y -->
+			<div #moreactions class="moreActions" style="flex: 0 0 auto; flex-flow:column;width: 20px; min-height: 20px; max-height: 20px; padding-top: 0px; orientation: portrait"></div>
+			<!-- / -->
+
 		</div>
 		<collapse-component *ngIf="cellModel.cellType === 'code' && cellModel.source && cellModel.source.length > 1" [cellModel]="cellModel" [activeCellId]="activeCellId"></collapse-component>
 	</div>

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.html
@@ -11,7 +11,10 @@
 		</code-component>
 	</div>
 	<div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: row">
-		<div #preview link-handler [isTrusted]="isTrusted" [notebookUri]="notebookUri" class="notebook-preview" style="flex: 1 1 auto">
-		</div>
+		<div #preview link-handler [isTrusted]="isTrusted" [notebookUri]="notebookUri" class="notebook-preview" style="flex: 1 1 auto" (dblclick)="toggleEditMode()"></div>
+
+		<!-- Remove after a11y -->
+		<div #moreactions class="moreActions" style="flex: 0 0 auto; flex-flow:column;width: 20px; min-height: 20px; max-height: 20px; padding-top: 0px; orientation: portrait"></div>
+		<!-- / -->
 	</div>
 </div>

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.html
@@ -9,14 +9,44 @@
 	</div>
 	<div #container class="scrollable" style="flex: 1 1 auto; position: relative; outline: none" (click)="unselectActiveCell()" (scroll)="scrollHandler($event)">
 		<loading-spinner [loading]="isLoading"></loading-spinner>
+
+		<!-- Remove after a11y -->
+		<div class="hoverButtonsContainer" *ngIf="(cells && cells.length > 0) && !isLoading && previewFeaturesEnabled === false">
+			<span class="containerBackground"></span>
+			<button class="hoverButton" (click)="addCell('code', 0, $event)">
+				<div class="addCodeIcon"></div>
+				<span>{{addCodeLabel}}</span>
+			</button>
+			<button class="hoverButton" (click)="addCell('markdown', 0, $event)">
+				<div class="addTextIcon"></div>
+				<span>{{addTextLabel}}</span>
+			</button>
+		</div>
+		<!-- / -->
+
 		<div *ngFor="let cell of cells">
 			<div class="notebook-cell" (click)="selectCell(cell, $event)" [class.active]="cell.active">
-				<cell-toolbar-component *ngIf="cell.active" [cellModel]="cell" [model]="model"></cell-toolbar-component>
+				<cell-toolbar-component *ngIf="cell.active && previewFeaturesEnabled === true" [cellModel]="cell" [model]="model"></cell-toolbar-component>
 				<code-cell-component *ngIf="cell.cellType === 'code'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">
 				</code-cell-component>
 				<text-cell-component *ngIf="cell.cellType === 'markdown'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">
 				</text-cell-component>
 			</div>
+
+			<!-- Remove after a11y -->
+			<div class="hoverButtonsContainer" *ngIf="previewFeaturesEnabled === false">
+				<span class="containerBackground"></span>
+				<button class="hoverButton" (click)="addCell('code', findCellIndex(cell) + 1, $event)">
+					<div class="addCodeIcon"></div>
+					<span>{{addCodeLabel}}</span>
+				</button>
+				<button class="hoverButton" (click)="addCell('markdown', findCellIndex(cell) + 1, $event)">
+					<div class="addTextIcon"></div>
+					<span>{{addTextLabel}}</span>
+				</button>
+			</div>
+			<!-- / -->
+
 		</div>
 		<div class="notebook-cell" *ngIf="(!cells || !cells.length) && !isLoading">
 			<placeholder-cell-component [cellModel]="cell" [model]="model">

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -438,7 +438,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			let taskbar = <HTMLElement>this.toolbar.nativeElement;
 			this._actionBar = new Taskbar(taskbar, { actionViewItemProvider: action => this.actionItemProvider(action as Action) });
 			this._actionBar.context = this;
-			taskbar.classList.add('in-preview');
+			taskbar.parentNode.parentElement.classList.add('in-preview');
 
 			let buttonDropdownContainer = DOM.$('li.action-item');
 			buttonDropdownContainer.setAttribute('role', 'presentation');
@@ -460,8 +460,8 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 				{ element: buttonDropdownContainer },
 				{ action: this._runAllCellsAction },
 				{ element: Taskbar.createTaskbarSeparator() },
-				{ element: attachToContainer },
 				{ element: kernelContainer },
+				{ element: attachToContainer },
 				{ element: spacerElement },
 				{ action: collapseCellsAction },
 				{ action: clearResultsButton },

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -438,7 +438,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			let taskbar = <HTMLElement>this.toolbar.nativeElement;
 			this._actionBar = new Taskbar(taskbar, { actionViewItemProvider: action => this.actionItemProvider(action as Action) });
 			this._actionBar.context = this;
-			taskbar.parentNode.parentElement.classList.add('in-preview');
+			document.querySelector('.notebookEditor').classList.add('in-preview');
 
 			let buttonDropdownContainer = DOM.$('li.action-item');
 			buttonDropdownContainer.setAttribute('role', 'presentation');

--- a/src/sql/workbench/contrib/notebook/browser/notebook.css
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.css
@@ -6,7 +6,9 @@
 .notebookEditor .scrollable {
 	padding-top: 6px;
 }
-
+.notebookEditor.in-preview .scrollable {
+	padding-top: 16px;
+}
 .notebookEditor .taskbarSeparator {
 	margin: 0 16px 0 -8px;
 }
@@ -23,7 +25,9 @@
 	margin: 16px;
 	position: relative;
 }
-
+.notebookEditor.in-preview .notebook-cell {
+	margin: 8px;
+}
 .notebookEditor .notebook-info-label {
 	padding-right: 5px;
 	text-align: center;
@@ -49,21 +53,19 @@
 	font-size: 13px;
 	height: 21px;
 }
-.notebookEditor .in-preview .actions-container .action-item .notebook-button {
+.notebookEditor.in-preview .actions-container .action-item .notebook-button {
 	display: flex;
 	background-size: 16px;
 	height: 100%;
 }
 
-.notebookEditor
-	.in-preview
+.notebookEditor.in-preview
 	.actions-container
 	.action-item
 	.notebook-button.masked-pseudo {
 	padding-left: 30px;
 }
-.notebookEditor
-	.in-preview
+.notebookEditor.in-preview
 	.actions-container
 	.action-item
 	.notebook-button.masked-icon {
@@ -71,26 +73,26 @@
 	padding-left: 18px;
 	width: 16px;
 }
-.notebookEditor .in-preview .actions-container .action-item:last-child {
+.notebookEditor.in-preview
+	.editor-toolbar
+	.actions-container
+	.action-item:last-child {
 	margin-right: 8px;
 }
-.notebookEditor
-	.in-preview
+.notebookEditor.in-preview
 	.actions-container
 	.action-item:last-child
 	.notebook-button {
 	margin-right: 0;
 }
-.notebookEditor
-	.in-preview
+.notebookEditor.in-preview
 	.actions-container
 	.action-item:last-child
 	.notebook-button.fixed-width {
 	margin-left: 8px;
 	margin-right: -28px;
 }
-.notebookEditor
-	.in-preview
+.notebookEditor.in-preview
 	.actions-container
 	.action-item
 	.notebook-button.fixed-width {
@@ -106,86 +108,81 @@
 	vertical-align: bottom;
 }
 
-.notebookEditor .in-preview .labelOnLeftContainer {
+.notebookEditor.in-preview .labelOnLeftContainer {
 	margin-right: 14px;
 }
 
 /* non-preview */
-.notebookEditor :not(.in-preview) .notebook-button.icon-add {
+.notebookEditor:not(.in-preview) .notebook-button.icon-add {
 	background-image: url("./media/light/add.svg");
 }
 
-.vs-dark .notebookEditor :not(.in-preview) .notebook-button.icon-add,
-.hc-black .notebookEditor :not(.in-preview) .notebook-button.icon-add {
+.vs-dark .notebookEditor:not(.in-preview) .notebook-button.icon-add,
+.hc-black .notebookEditor:not(.in-preview) .notebook-button.icon-add {
 	background-image: url("./media/dark/add_inverse.svg");
 }
 
-.notebookEditor :not(.in-preview) .notebook-button.icon-run-cells {
+.notebookEditor:not(.in-preview) .notebook-button.icon-run-cells {
 	background-image: url("./media/light/run_cells.svg");
 }
 
-.vs-dark .notebookEditor :not(.in-preview) .notebook-button.icon-run-cells,
-.hc-black .notebookEditor :not(.in-preview) .notebook-button.icon-run-cells {
+.vs-dark .notebookEditor:not(.in-preview) .notebook-button.icon-run-cells,
+.hc-black .notebookEditor:not(.in-preview) .notebook-button.icon-run-cells {
 	background-image: url("./media/dark/run_cells_inverse.svg");
 }
 
-.notebookEditor :not(.in-preview) .notebook-button.icon-trusted {
+.notebookEditor:not(.in-preview) .notebook-button.icon-trusted {
 	background-image: url("./media/light/trusted.svg");
 }
 
-.vs-dark .notebookEditor :not(.in-preview) .notebook-button.icon-trusted,
-.hc-black .notebookEditor :not(.in-preview) .notebook-button.icon-trusted {
+.vs-dark .notebookEditor:not(.in-preview) .notebook-button.icon-trusted,
+.hc-black .notebookEditor:not(.in-preview) .notebook-button.icon-trusted {
 	background-image: url("./media/dark/trusted_inverse.svg");
 }
-.notebookEditor :not(.in-preview) .notebook-button.icon-notTrusted {
+.notebookEditor:not(.in-preview) .notebook-button.icon-notTrusted {
 	background-image: url("./media/light/nottrusted.svg");
 }
 
-.vs-dark .notebookEditor :not(.in-preview) .notebook-button.icon-notTrusted,
-.hc-black .notebookEditor :not(.in-preview) .notebook-button.icon-notTrusted {
+.vs-dark .notebookEditor:not(.in-preview) .notebook-button.icon-notTrusted,
+.hc-black .notebookEditor:not(.in-preview) .notebook-button.icon-notTrusted {
 	background-image: url("./media/dark/nottrusted_inverse.svg");
 }
 
-.notebookEditor :not(.in-preview) .notebook-button.icon-show-cells {
+.notebookEditor:not(.in-preview) .notebook-button.icon-show-cells {
 	background-image: url("./media/light/show_code.svg");
 }
 
-.vs-dark .notebookEditor :not(.in-preview) .notebook-button.icon-show-cells,
-.hc-black .notebookEditor :not(.in-preview) .notebook-button.icon-show-cells {
+.vs-dark .notebookEditor:not(.in-preview) .notebook-button.icon-show-cells,
+.hc-black .notebookEditor:not(.in-preview) .notebook-button.icon-show-cells {
 	background-image: url("./media/dark/show_code_inverse.svg");
 }
 
-.notebookEditor :not(.in-preview) .notebook-button.icon-hide-cells {
+.notebookEditor:not(.in-preview) .notebook-button.icon-hide-cells {
 	background-image: url("./media/light/hide_code.svg");
 }
 
-.vs-dark .notebookEditor :not(.in-preview) .notebook-button.icon-hide-cells,
-.hc-black .notebookEditor :not(.in-preview) .notebook-button.icon-hide-cells {
+.vs-dark .notebookEditor:not(.in-preview) .notebook-button.icon-hide-cells,
+.hc-black .notebookEditor:not(.in-preview) .notebook-button.icon-hide-cells {
 	background-image: url("./media/dark/hide_code_inverse.svg");
 }
 
-.notebookEditor :not(.in-preview) .notebook-button.icon-clear-results {
+.notebookEditor:not(.in-preview) .notebook-button.icon-clear-results {
 	background-image: url("./media/light/clear_results.svg");
 }
 
-.vs-dark .notebookEditor :not(.in-preview) .notebook-button.icon-clear-results,
-.hc-black
-	.notebookEditor
-	:not(.in-preview)
-	.notebook-button.icon-clear-results {
+.vs-dark .notebookEditor:not(.in-preview) .notebook-button.icon-clear-results,
+.hc-black .notebookEditor:not(.in-preview) .notebook-button.icon-clear-results {
 	background-image: url("./media/dark/clear_results_inverse.svg");
 }
 /* non-preview */
 
-.notebookEditor .in-preview .carbon-taskbar.monaco-toolbar .monaco-select-box {
+.notebookEditor.in-preview .carbon-taskbar.monaco-toolbar .monaco-select-box {
 	font-size: inherit;
 	border-radius: 0;
 	padding: 3px 22px 3px 6px;
 }
-.notebookEditor .in-preview .carbon-taskbar .action-item {
-	margin-right: 0;
-}
-.notebookEditor .in-preview .labelOnLeftContainer {
+
+.notebookEditor.in-preview .labelOnLeftContainer {
 	display: flex;
 	align-items: center;
 }
@@ -238,6 +235,58 @@
 	margin-right: 10px;
 }
 
+.monaco-workbench.mac .notebookEditor .select-container {
+	padding-top: 2px;
+}
+
+.notebookEditor .hoverButtonsContainer {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	padding: 0px 20px;
+	margin: 1px 0px;
+	box-sizing: border-box;
+}
+
+.notebookEditor .hoverButtonsContainer .containerBackground {
+	position: absolute;
+	width: auto;
+	left: 20px;
+	right: 20px;
+	height: 1px;
+	z-index: 0;
+	visibility: hidden;
+}
+
+.notebookEditor .hoverButtonsContainer:hover .containerBackground {
+	visibility: visible;
+}
+
+.notebookEditor .hoverButtonsContainer .hoverButton {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+	margin: 3px 2px;
+	padding: 4px 12px;
+	font-size: 12px;
+	box-sizing: border-box;
+	border-width: 1px;
+	border-style: solid;
+	z-index: 1;
+	visibility: hidden;
+}
+
+.notebookEditor .hoverButtonsContainer:hover .hoverButton {
+	visibility: visible;
+}
+
+.notebookEditor .hoverButton:active {
+	transform: scale(1.05);
+}
+
 .notebookEditor .hoverButton .addCodeIcon,
 .notebookEditor .hoverButton .addTextIcon {
 	display: inline-block;
@@ -249,6 +298,20 @@
 	margin-right: 4px;
 }
 
-.monaco-workbench.mac .notebookEditor .select-container {
-	padding-top: 2px;
+.notebookEditor .hoverButton .addCodeIcon {
+	background-image: url("./media/light/add_code.svg");
+}
+
+.vs-dark .notebookEditor .hoverButton .addCodeIcon,
+.hc-black .notebookEditor .hoverButton .addCodeIcon {
+	background-image: url("./media/dark/add_code_inverse.svg");
+}
+
+.notebookEditor .hoverButton .addTextIcon {
+	background-image: url("./media/light/add_text.svg");
+}
+
+.vs-dark .notebookEditor .hoverButton .addTextIcon,
+.hc-black .notebookEditor .hoverButton .addTextIcon {
+	background-image: url("./media/dark/add_text_inverse.svg");
 }

--- a/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
@@ -6,7 +6,7 @@ import 'vs/css!./notebook';
 
 import { registerThemingParticipant, IColorTheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
 import { SIDE_BAR_BACKGROUND, EDITOR_GROUP_HEADER_TABS_BACKGROUND } from 'vs/workbench/common/theme';
-import { activeContrastBorder, contrastBorder, buttonBackground, textLinkForeground, textLinkActiveForeground, textPreformatForeground, textBlockQuoteBackground, textBlockQuoteBorder, buttonForeground } from 'vs/platform/theme/common/colorRegistry';
+import { activeContrastBorder, contrastBorder, buttonBackground, textLinkForeground, textLinkActiveForeground, textPreformatForeground, textBlockQuoteBackground, textBlockQuoteBorder, buttonForeground, editorBackground, lighten } from 'vs/platform/theme/common/colorRegistry';
 import { editorLineHighlight, editorLineHighlightBorder } from 'vs/editor/common/view/editorColorRegistry';
 import { cellBorder, notebookToolbarIcon, notebookToolbarLines, buttonMenuArrow, dropdownArrow, markdownEditorBackground, splitBorder, codeEditorBackground, codeEditorBackgroundActive, codeEditorLineNumber, codeEditorToolbarIcon, codeEditorToolbarBackground, codeEditorToolbarBorder, toolbarBackground, toolbarIcon, toolbarBottomBorder, notebookToolbarSelectBackground } from 'sql/platform/theme/common/colorRegistry';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -34,6 +34,53 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean, conf
 			`);
 		}
 
+		// Remove after a11y
+		// \ /
+		if (buttonBackgroundColor) {
+			let lighterBackgroundColor = lighten(buttonBackgroundColor, 0.825)(theme);
+			collector.addRule(`
+				.notebookEditor .hoverButton {
+					border-color: ${buttonBackgroundColor};
+				}
+				.notebookEditor .hoverButton:active,
+				.notebookEditor .hoverButton:hover {
+					background-color: ${buttonBackgroundColor};
+				}
+				.notebookEditor .hoverButton {
+					color: ${buttonBackgroundColor};
+				}
+				.vs-dark .notebookEditor .hoverButton {
+					border-color: ${lighterBackgroundColor};
+				}
+				.vs-dark .notebookEditor .hoverButton:active,
+				.vs-dark .notebookEditor .hoverButton:hover {
+					background-color: ${lighterBackgroundColor};
+				}
+				.vs-dark .notebookEditor .hoverButton {
+					color: ${lighterBackgroundColor};
+				}
+			`);
+		}
+
+		const backgroundColor = theme.getColor(editorBackground);
+		if (backgroundColor) {
+			collector.addRule(`
+				.notebookEditor .hoverButton {
+					background-color: ${backgroundColor};
+				}
+				.notebookEditor .hoverButton:active,
+				.notebookEditor .hoverButton:hover {
+					color: ${backgroundColor};
+				}
+				.hc-black .notebookEditor .hoverButton:active,
+				.hc-black .notebookEditor .hoverButton:hover {
+					color: ${backgroundColor};
+				}
+			`);
+		}
+		// \ /
+
+
 		const inactiveBorder = theme.getColor(SIDE_BAR_BACKGROUND);
 		const notebookLineHighlight = theme.getColor(EDITOR_GROUP_HEADER_TABS_BACKGROUND);
 		// Code editor style overrides - only applied if user chooses this as preferred option
@@ -57,6 +104,12 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean, conf
 
 		// Inactive border
 		if (inactiveBorder) {
+
+			// Remove after a11y
+			collector.addRule(`.notebookEditor .hoverButtonsContainer .containerBackground {
+				background-color: ${inactiveBorder};
+			}`);
+
 			// Ensure there's always a line between editor and output
 			collector.addRule(`
 				.notebookEditor .notebook-cell.active code-component {
@@ -79,7 +132,19 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean, conf
 					outline-width: 1px;
 					outline-style: solid;
 				}
-			`);
+
+				.hc-black .notebookEditor .hoverButton {
+					This conversation was marked as resolved by halerankin  Show conversation
+					color: ${hcOutline};
+				}
+				.hc-black .notebookEditor .hoverButton:not(:active) {
+					border-color: ${hcOutline};
+				}
+				.hc-black .notebookEditor .hoverButton:active,
+				.hc-black .notebookEditor .hoverButton:hover {
+					background-color: ${hcOutline};
+				}
+			`); // Remove above hoverButton references after a11y
 		}
 
 		// Styling for tables in notebooks


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses the request that new UI features exist behind the preview features flag. 

When in non-preview mode, expected behavior is thus:
- cell toolbar will not display
- user can double-click on text cell to activate edit mode
- More Actions ellipses show on cell hover
- Add Cell as Text/Code hover buttons appear between cells 
