### PR TITLE
Fix for edit data grid not showing

### DIFF
--- a/src/sql/workbench/contrib/query/browser/flexibleSash.ts
+++ b/src/sql/workbench/contrib/query/browser/flexibleSash.ts
@@ -95,7 +95,7 @@ export class HorizontalFlexibleSash extends Disposable implements IHorizontalSas
 	}
 
 	public getHorizontalSashWidth?(): number {
-		return this.dimension ? this.dimension.width : 0;
+		return this.dimension?.width ?? 0;
 	}
 
 	public setDimension(dimension: Dimension) {

--- a/src/sql/workbench/contrib/query/browser/flexibleSash.ts
+++ b/src/sql/workbench/contrib/query/browser/flexibleSash.ts
@@ -95,7 +95,10 @@ export class HorizontalFlexibleSash extends Disposable implements IHorizontalSas
 	}
 
 	public getHorizontalSashWidth?(): number {
-		return this.dimension.width;
+		if (this.dimension) {
+			return this.dimension.width;
+		}
+		return 0;
 	}
 
 	public setDimension(dimension: Dimension) {

--- a/src/sql/workbench/contrib/query/browser/flexibleSash.ts
+++ b/src/sql/workbench/contrib/query/browser/flexibleSash.ts
@@ -95,10 +95,7 @@ export class HorizontalFlexibleSash extends Disposable implements IHorizontalSas
 	}
 
 	public getHorizontalSashWidth?(): number {
-		if (this.dimension) {
-			return this.dimension.width;
-		}
-		return 0;
+		return this.dimension ? this.dimension.width : 0;
 	}
 
 	public setDimension(dimension: Dimension) {


### PR DESCRIPTION
Since the dimension is not set initially for flexibleSash, there must be a null check done to return a result for getHorizontalSashWidth when the Sash for it is being created.

This PR fixes #10730
