### PR TITLE
fix profiler not launch issue

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget.ts
+++ b/src/sql/workbench/contrib/notebook/browser/find/notebookFindWidget.ts
@@ -452,9 +452,12 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		let findPart = document.createElement('div');
 		findPart.className = 'find-part';
 		findPart.appendChild(this._findInput.domNode);
-		findPart.appendChild(this._matchesCount);
-		findPart.appendChild(this._prevBtn.domNode);
-		findPart.appendChild(this._nextBtn.domNode);
+		let actionsContainer = document.createElement('div');
+		findPart.appendChild(actionsContainer);
+		actionsContainer.className = 'find-actions';
+		actionsContainer.appendChild(this._matchesCount);
+		actionsContainer.appendChild(this._prevBtn.domNode);
+		actionsContainer.appendChild(this._nextBtn.domNode);
 
 		// Close button
 		this._closeBtn = this._register(new SimpleButton({
@@ -466,7 +469,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 			onKeyDown: () => { }
 		}));
 
-		findPart.appendChild(this._closeBtn.domNode);
+		actionsContainer.appendChild(this._closeBtn.domNode);
 
 		return findPart;
 	}

--- a/src/sql/workbench/contrib/profiler/browser/profilerFindWidget.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerFindWidget.ts
@@ -15,7 +15,7 @@ import { IContextViewProvider } from 'vs/base/browser/ui/contextview/contextview
 import { FindInput, IFindInputStyles } from 'vs/base/browser/ui/findinput/findInput';
 import { IMessage as InputBoxMessage } from 'vs/base/browser/ui/inputbox/inputBox';
 import { Widget } from 'vs/base/browser/ui/widget';
-import { Sash, IHorizontalSashLayoutProvider, ISashEvent, Orientation } from 'vs/base/browser/ui/sash/sash';
+import { Sash, ISashEvent, Orientation, IVerticalSashLayoutProvider } from 'vs/base/browser/ui/sash/sash';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IOverlayWidget, IOverlayWidgetPosition, OverlayWidgetPositionPreference } from 'vs/editor/browser/editorBrowser';
 import { FIND_IDS, CONTEXT_FIND_INPUT_FOCUSED } from 'vs/editor/contrib/find/findModel';
@@ -61,7 +61,7 @@ export interface IConfigurationChangedEvent {
 	layoutInfo?: boolean;
 }
 
-export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSashLayoutProvider {
+export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashLayoutProvider {
 	private static ID = 'editor.contrib.findWidget';
 	private _tableController: ITableController;
 	private _state: FindReplaceState;
@@ -349,14 +349,8 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 	}
 
 	// ----- sash
-	public getHorizontalSashTop(sash: Sash): number {
+	public getVerticalSashLeft(sash: Sash): number {
 		return 0;
-	}
-	public getHorizontalSashLeft?(sash: Sash): number {
-		return 0;
-	}
-	public getHorizontalSashWidth?(sash: Sash): number {
-		return 500;
 	}
 
 	// ----- initialization
@@ -427,7 +421,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 		// Previous button
 		this._prevBtn = this._register(new SimpleButton({
 			label: NLS_PREVIOUS_MATCH_BTN_LABEL + this._keybindingLabelFor(FIND_IDS.PreviousMatchFindAction),
-			className: 'previous',
+			className: 'codicon codicon-arrow-up',
 			onTrigger: () => {
 				this._tableController.getAction(ACTION_IDS.FIND_PREVIOUS).run().then(null, onUnexpectedError);
 			},
@@ -437,7 +431,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 		// Next button
 		this._nextBtn = this._register(new SimpleButton({
 			label: NLS_NEXT_MATCH_BTN_LABEL + this._keybindingLabelFor(FIND_IDS.NextMatchFindAction),
-			className: 'next',
+			className: 'codicon codicon-arrow-down',
 			onTrigger: () => {
 				this._tableController.getAction(ACTION_IDS.FIND_NEXT).run().then(null, onUnexpectedError);
 			},
@@ -447,21 +441,24 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 		let findPart = document.createElement('div');
 		findPart.className = 'find-part';
 		findPart.appendChild(this._findInput.domNode);
-		findPart.appendChild(this._matchesCount);
-		findPart.appendChild(this._prevBtn.domNode);
-		findPart.appendChild(this._nextBtn.domNode);
+		let actionsContainer = document.createElement('div');
+		findPart.appendChild(actionsContainer);
+		actionsContainer.className = 'find-actions';
+		actionsContainer.appendChild(this._matchesCount);
+		actionsContainer.appendChild(this._prevBtn.domNode);
+		actionsContainer.appendChild(this._nextBtn.domNode);
 
 		// Close button
 		this._closeBtn = this._register(new SimpleButton({
 			label: NLS_CLOSE_BTN_LABEL + this._keybindingLabelFor(FIND_IDS.CloseFindWidgetCommand),
-			className: 'close-fw',
+			className: 'codicon codicon-close',
 			onTrigger: () => {
 				this._state.change({ isRevealed: false, searchScope: null }, false);
 			},
 			onKeyDown: () => { }
 		}));
 
-		findPart.appendChild(this._closeBtn.domNode);
+		actionsContainer.appendChild(this._closeBtn.domNode);
 
 		return findPart;
 	}


### PR DESCRIPTION
This PR fixes #10729 

recent vscode merge changes the way sash works, we've being using the vertical layout but we only implemented the horizontal layout, now it is requiring the method related to vertical layout, implementing that fixes the problem.

during this i also noticed a couple more issues:
1. the previous, next, close buttons are not visible, it has been like this for a while since the codicon change was introduced. updating the class name fixes the issue
1. the icons are not aligned vertically and turns out find widget for notebook also have similar issue (maybe @MaddyDev copied the code 😃 ), i looked at the vscode find widget, and realized they are using a div container for the actions, the css class 'find-actions' is responsible for centering the items.

**before** - the actions are more closer to the upper border
![Screen Shot 2020-06-04 at 4 29 26 PM](https://user-images.githubusercontent.com/13777222/83823265-6fd1b980-a688-11ea-8bae-e61ee1f07b12.png)
**after**
![Screen Shot 2020-06-04 at 4 41 27 PM](https://user-images.githubusercontent.com/13777222/83823270-719b7d00-a688-11ea-9823-5d67387be473.png)
