### PR TITLE
Revert "reduce max memory (#10775)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "watch-client": "gulp watch-client --max_old_space_size=4095",
     "mocha": "mocha test/unit/node/all.js --delay",
     "precommit": "node build/gulpfile.hygiene.js",
-    "gulp": "gulp --max_old_space_size=4095",
+    "gulp": "gulp --max_old_space_size=8192",
     "electron": "node build/lib/electron",
     "7z": "7z",
     "update-grammars": "node build/npm/update-all-grammars.js",


### PR DESCRIPTION
This reverts commit d62bb1e9fced81565e56c8ac67c7f42902a3c8a6.

as per ADO team, there was an outage last Thursday and Friday. now the issue has been resolved, I queued a test build last night against release/1.18 branch and it passed:
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=66911&view=results

seems like we can revert the change I made earlier now. Lets see how the PR validation build goes.
