### PR TITLE
Fixed notebook toolbar icon issue in Dark and High Contrast themes.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.css
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.css
@@ -171,14 +171,13 @@
 }
 
 .vs-dark .notebookEditor :not(.in-preview) .notebook-button.icon-clear-results,
-.hc-black
-	.notebookEditor
-	:not(.in-preview)
-	.notebook-button.icon-clear-results {
+.hc-black .notebookEditor :not(.in-preview) .notebook-button.icon-clear-results {
 	background-image: url("./media/dark/clear_results_inverse.svg");
 }
 
-.notebookEditor .in-preview .notebook-button.masked-icon {
+.notebookEditor .in-preview .notebook-button.masked-icon,
+.vs-dark .notebookEditor .in-preview .notebook-button.icon-clear-results,
+.hc-black .notebookEditor .in-preview .notebook-button.icon-clear-results {
 	background-image: none;
 }
 /* non-preview */


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses 10801
Modified style rules to make sure no image is being added to the background. This prevents to double icon appearance.

![image](https://user-images.githubusercontent.com/12279161/84085015-841ffa00-a999-11ea-8cc5-32d834384329.png)
![image](https://user-images.githubusercontent.com/12279161/84085020-86825400-a999-11ea-9c0a-2f05e2c0fb00.png)
