### PR TITLE
Remove dacpac references baseline

### DIFF
--- a/extensions/sql-database-projects/src/test/baselines/baselines.ts
+++ b/extensions/sql-database-projects/src/test/baselines/baselines.ts
@@ -12,7 +12,6 @@ export let openProjectFileBaseline: string;
 export let openDataSourcesBaseline: string;
 export let SSDTProjectFileBaseline: string;
 export let SSDTProjectAfterUpdateBaseline: string;
-export let dacpacReferencesProjectFileBaseline: string;
 
 const baselineFolderPath = __dirname;
 
@@ -22,7 +21,6 @@ export async function loadBaselines() {
 	openDataSourcesBaseline = await loadBaseline(baselineFolderPath, 'openDataSourcesBaseline.json');
 	SSDTProjectFileBaseline = await loadBaseline(baselineFolderPath, 'SSDTProjectBaseline.xml');
 	SSDTProjectAfterUpdateBaseline = await loadBaseline(baselineFolderPath, 'SSDTProjectAfterUpdateBaseline.xml');
-	dacpacReferencesProjectFileBaseline = await loadBaseline(baselineFolderPath, 'dacpacReferencesSqlProjectBaseline.xml');
 }
 
 async function loadBaseline(baselineFolderPath: string, fileName: string): Promise<string> {


### PR DESCRIPTION
I ended up not adding a dacpac references baseline file in this PR #10684 to add dacpac references functionality, but forgot to remove this so some tests were failing because this file couldn't be found. I'll add the test for this back after I fix the test to work for both windows and mac.