### PR TITLE
Fix for "Run Current Query" keybind no longer behaving as expected (#…

### DIFF
--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -242,8 +242,8 @@ export class RunQueryAction extends QueryTaskbarAction {
 		if (this.isConnected(editor)) {
 			// if the selection isn't empty then execute the selection
 			// otherwise, either run the statement or the script depending on parameter
-			let selection = editor.getSelection();
-			if (runCurrentStatement && selection) {
+			let selection = editor.getSelection(false);
+			if (runCurrentStatement && selection && this.isCursorPosition(selection)) {
 				editor.input.runQueryStatement(selection);
 			} else {
 				// get the selection again this time with trimming
@@ -251,6 +251,11 @@ export class RunQueryAction extends QueryTaskbarAction {
 				editor.input.runQuery(selection);
 			}
 		}
+	}
+
+	protected isCursorPosition(selection: IRange) {
+		return selection.startLineNumber === selection.endLineNumber
+			&& selection.startColumn === selection.endColumn;
 	}
 }
 


### PR DESCRIPTION
…10538) (#10557)

* -"Run current" command runs the entire selection instead of only first statement in the selection

* -brought some logic back from the  old code to correct the behavior

* -Added unit tests for runCurrent command

* -Fixed a comment

* - Added checks for run input parameters

* -Added some extra checks

* -Fixed some spacing issue

* Changed to using verify instead of a counter variable

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
