### PR TITLE
highlight correct notebook on navigation.

### DIFF
--- a/extensions/notebook/src/book/bookModel.ts
+++ b/extensions/notebook/src/book/bookModel.ts
@@ -51,7 +51,7 @@ export class BookModel implements azdata.nb.NavigationProvider {
 	}
 
 	public getNotebook(uri: string): BookTreeItem | undefined {
-		return this._allNotebooks.get(uri);
+		return this._allNotebooks.get(this.openAsUntitled ? path.basename(uri) : uri);
 	}
 
 	public async loadTableOfContentFiles(folderPath: string): Promise<void> {
@@ -190,8 +190,8 @@ export class BookModel implements azdata.nb.NavigationProvider {
 						if (this.openAsUntitled) {
 							if (!this._allNotebooks.get(path.basename(pathToNotebook))) {
 								this._allNotebooks.set(path.basename(pathToNotebook), notebook);
-								notebooks.push(notebook);
 							}
+							notebooks.push(notebook);
 						} else {
 							// convert to URI to avoid casing issue with drive letters when getting navigation links
 							let uriToNotebook: vscode.Uri = vscode.Uri.file(pathToNotebook);

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -178,14 +178,6 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			this.currentBook = book;
 		}
 		this._bookViewer = this._apiWrapper.createTreeView(this.viewId, { showCollapseAll: true, treeDataProvider: this });
-		this._bookViewer.onDidChangeVisibility(e => {
-			if (e.visible) {
-				this.revealActiveDocumentInViewlet();
-			}
-		});
-		azdata.nb.onDidChangeActiveNotebookEditor(e => {
-			this.revealActiveDocumentInViewlet(e.document.uri, false);
-		});
 	}
 
 	async showPreviewFile(urlToOpen?: string): Promise<void> {
@@ -235,10 +227,12 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		if (!uri) {
 			let openDocument = azdata.nb.activeNotebookEditor;
 			if (openDocument) {
-				bookItem = this.currentBook?.getNotebook(openDocument.document.uri.fsPath);
+				let book = this.books.find(b => openDocument.document.uri.fsPath.replace(/\\/g, '/').toLowerCase().indexOf(b.bookPath.toLowerCase()) > -1);
+				bookItem = book?.getNotebook(openDocument.document.uri.fsPath);
 			}
 		} else if (uri.fsPath) {
-			bookItem = this.currentBook?.getNotebook(uri.fsPath);
+			let book = this.books.find(b => uri.fsPath.replace(/\\/g, '/').toLowerCase().indexOf(b.bookPath.toLowerCase()) > -1);
+			bookItem = book?.getNotebook(uri.fsPath);
 		}
 		if (bookItem) {
 			// Select + focus item in viewlet if books viewlet is already open, or if we pass in variable

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -51,8 +51,6 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		this.viewId = view;
 		this.prompter = new CodeAdapter();
 		this._bookTrustManager = new BookTrustManager(this.books, _apiWrapper);
-		this._bookViewer = this._apiWrapper.createTreeView(this.viewId, { showCollapseAll: true, treeDataProvider: this });
-
 	}
 
 	private async initialize(workspaceFolders: vscode.WorkspaceFolder[]): Promise<void> {
@@ -64,11 +62,6 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				// no-op, not all workspace folders are going to be valid books
 			}
 		}));
-		this._bookViewer.onDidChangeVisibility(e => {
-			if (e.visible) {
-				this.revealActiveDocumentInViewlet();
-			}
-		});
 		this._initializeDeferred.resolve();
 	}
 
@@ -183,6 +176,14 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		this.books.push(book);
 		if (!this.currentBook) {
 			this.currentBook = book;
+		}
+		if (!this._bookViewer) {
+			this._bookViewer = this._apiWrapper.createTreeView(this.viewId, { showCollapseAll: true, treeDataProvider: this });
+			this._bookViewer.onDidChangeVisibility(e => {
+				if (e.visible) {
+					this.revealActiveDocumentInViewlet();
+				}
+			});
 		}
 	}
 

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -177,14 +177,12 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		if (!this.currentBook) {
 			this.currentBook = book;
 		}
-		if (!this._bookViewer) {
-			this._bookViewer = this._apiWrapper.createTreeView(this.viewId, { showCollapseAll: true, treeDataProvider: this });
-			this._bookViewer.onDidChangeVisibility(e => {
-				if (e.visible) {
-					this.revealActiveDocumentInViewlet();
-				}
-			});
-		}
+		this._bookViewer = this._apiWrapper.createTreeView(this.viewId, { showCollapseAll: true, treeDataProvider: this });
+		this._bookViewer.onDidChangeVisibility(e => {
+			if (e.visible) {
+				this.revealActiveDocumentInViewlet();
+			}
+		});
 	}
 
 	async showPreviewFile(urlToOpen?: string): Promise<void> {

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -51,6 +51,8 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		this.viewId = view;
 		this.prompter = new CodeAdapter();
 		this._bookTrustManager = new BookTrustManager(this.books, _apiWrapper);
+		this._bookViewer = this._apiWrapper.createTreeView(this.viewId, { showCollapseAll: true, treeDataProvider: this });
+
 	}
 
 	private async initialize(workspaceFolders: vscode.WorkspaceFolder[]): Promise<void> {
@@ -62,6 +64,11 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				// no-op, not all workspace folders are going to be valid books
 			}
 		}));
+		this._bookViewer.onDidChangeVisibility(e => {
+			if (e.visible) {
+				this.revealActiveDocumentInViewlet();
+			}
+		});
 		this._initializeDeferred.resolve();
 	}
 
@@ -177,7 +184,6 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		if (!this.currentBook) {
 			this.currentBook = book;
 		}
-		this._bookViewer = this._apiWrapper.createTreeView(this.viewId, { showCollapseAll: true, treeDataProvider: this });
 	}
 
 	async showPreviewFile(urlToOpen?: string): Promise<void> {

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -129,6 +129,14 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	const providedBookTreeViewProvider = new BookTreeViewProvider(appContext.apiWrapper, [], extensionContext, true, PROVIDED_BOOKS_VIEWID);
 	await providedBookTreeViewProvider.initialized;
 
+	azdata.nb.onDidChangeActiveNotebookEditor(e => {
+		if (e.document.uri.scheme === 'untitled') {
+			providedBookTreeViewProvider.revealActiveDocumentInViewlet(e.document.uri, true);
+		} else {
+			bookTreeViewProvider.revealActiveDocumentInViewlet(e.document.uri, true);
+		}
+
+	});
 
 	extensionContext.subscriptions.push(vscode.window.registerTreeDataProvider(BOOKS_VIEWID, bookTreeViewProvider));
 	extensionContext.subscriptions.push(vscode.window.registerTreeDataProvider(PROVIDED_BOOKS_VIEWID, providedBookTreeViewProvider));

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -131,9 +131,9 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 
 	azdata.nb.onDidChangeActiveNotebookEditor(e => {
 		if (e.document.uri.scheme === 'untitled') {
-			providedBookTreeViewProvider.revealActiveDocumentInViewlet(e.document.uri, true);
+			providedBookTreeViewProvider.revealActiveDocumentInViewlet(e.document.uri, false);
 		} else {
-			bookTreeViewProvider.revealActiveDocumentInViewlet(e.document.uri, true);
+			bookTreeViewProvider.revealActiveDocumentInViewlet(e.document.uri, false);
 		}
 
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

PR to address the following in June milestone #10780 

Ported just the highlight fix part from #10523 : Previously we're trying to find the notebook to highlight in the current book which can be different when using the navigation links. (Current book is the book that's opened last on the viewlet.) Fix is to get the correct book first and then highlight the notebook in it. 


