### PR TITLE
reset valid status after clear container

### DIFF
--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -333,6 +333,7 @@ export abstract class ContainerBase<T> extends ComponentBase {
 		this.items = [];
 		this.onItemsUpdated();
 		this._changeRef.detectChanges();
+		this.validate();
 	}
 
 	public setProperties(properties: { [key: string]: any; }): void {


### PR DESCRIPTION

This PR fixes #10811 

previously the checkbox is not set as required, when switching cards, the agreement checkbox container's status is not reset after clear items.
