### PR TITLE
This fixes the weird angular stuff - we need to do this in every othe…

### DIFF
--- a/extensions/import/src/wizard/api/models.ts
+++ b/extensions/import/src/wizard/api/models.ts
@@ -30,3 +30,5 @@ export interface ColumnMetadata {
 	primaryKey: boolean;
 	nullable: boolean;
 }
+
+export type ColumnMetadataArray = (string | number | boolean)[];

--- a/extensions/import/src/wizard/pages/modifyColumnsPage.ts
+++ b/extensions/import/src/wizard/pages/modifyColumnsPage.ts
@@ -5,7 +5,7 @@
 
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
-import { ColumnMetadata, ImportDataModel } from '../api/models';
+import { ColumnMetadata, ImportDataModel, ColumnMetadataArray } from '../api/models';
 import { ImportPage } from '../api/importPage';
 import { FlatFileProvider } from '../../services/contracts';
 import { FlatFileWizard } from '../flatFileWizard';
@@ -59,7 +59,7 @@ export class ModifyColumnsPage extends ImportPage {
 	}
 
 
-	private static convertMetadata(column: ColumnMetadata): any[] {
+	private static convertMetadata(column: ColumnMetadata): ColumnMetadataArray {
 		return [column.columnName, column.dataType, false, column.nullable];
 	}
 
@@ -130,7 +130,7 @@ export class ModifyColumnsPage extends ImportPage {
 	}
 
 	private async populateTable() {
-		let data: any[][] = [];
+		let data: ColumnMetadataArray[] = [];
 
 		this.model.proseColumns.forEach((column) => {
 			data.push(ModifyColumnsPage.convertMetadata(column));

--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.html
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.html
@@ -1,0 +1,26 @@
+<table role=grid #container *ngIf="columns" class="declarative-table" [attr.aria-label]="ariaLabel">
+	<thead>
+		<ng-container *ngFor="let column of columns; let c = index;">
+		<th class="declarative-table-header" aria-sort="none" [style.width]="getColumnWidth(column)" [attr.aria-label]="column.ariaLabel" [ngStyle]="column.headerCssStyles" role="columnheader">
+			{{column.displayName}}
+			<checkbox *ngIf="isCheckBox(c)" [checked]="isHeaderChecked(c)" (onChange)="onHeaderCheckBoxChanged($event,c)" label="" ></checkbox>
+		</th>
+		</ng-container>
+	</thead>
+		<ng-container *ngIf="data">
+			<ng-container *ngFor="let row of data;let r = index;trackBy:trackByFnRows">
+				<tr class="declarative-table-row">
+					<ng-container *ngFor="let cellData of row;let c = index;trackBy:trackByFnCols">
+						<td class="declarative-table-cell" [style.width]="getColumnWidth(c)" [attr.aria-label]="getAriaLabel(r, c)" [ngStyle]="columns[c].rowCssStyles">
+							<checkbox *ngIf="isCheckBox(c)" label="" (onChange)="onCheckBoxChanged($event,r,c)" [enabled]="isControlEnabled(c)" [checked]="isChecked(r,c)"></checkbox>
+							<select-box *ngIf="isSelectBox(c)" [options]="getOptions(c)" (onDidSelect)="onSelectBoxChanged($event,r,c)" [selectedOption]="getSelectedOptionDisplayName(r,c)"></select-box>
+							<editable-select-box *ngIf="isEditableSelectBox(c)" [options]="getOptions(c)" (onDidSelect)="onSelectBoxChanged($event,r,c)" [selectedOption]="getSelectedOptionDisplayName(r,c)"></editable-select-box>
+							<input-box *ngIf="isInputBox(c)" [value]="cellData" (onDidChange)="onInputBoxChanged($event,r,c)"></input-box>
+							<ng-container *ngIf="isLabel(c)" >{{cellData}}</ng-container>
+							<model-component-wrapper *ngIf="isComponent(c)" [descriptor]="getItemDescriptor(cellData)" [modelStore]="modelStore"></model-component-wrapper>
+						</td>
+					</ng-container>
+				</tr>
+			</ng-container>
+		</ng-container>
+	</table>

--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
@@ -28,34 +28,7 @@ export enum DeclarativeDataType {
 
 @Component({
 	selector: 'modelview-declarativeTable',
-	template: `
-	<table role=grid #container *ngIf="columns" class="declarative-table" [attr.aria-label]="ariaLabel">
-	<thead>
-		<ng-container *ngFor="let column of columns; let c = index;">
-		<th class="declarative-table-header" aria-sort="none" [style.width]="getColumnWidth(column)" [attr.aria-label]="column.ariaLabel" [ngStyle]="column.headerCssStyles" role="columnheader">
-			{{column.displayName}}
-			<checkbox *ngIf="isCheckBox(c)" [checked]="isHeaderChecked(c)" (onChange)="onHeaderCheckBoxChanged($event,c)" label="" ></checkbox>
-		</th>
-		</ng-container>
-	</thead>
-		<ng-container *ngIf="data">
-			<ng-container *ngFor="let row of data;let r = index">
-				<tr class="declarative-table-row">
-					<ng-container *ngFor="let cellData of row;let c = index">
-						<td class="declarative-table-cell" [style.width]="getColumnWidth(c)" [attr.aria-label]="getAriaLabel(r, c)" [ngStyle]="columns[c].rowCssStyles">
-							<checkbox *ngIf="isCheckBox(c)" label="" (onChange)="onCheckBoxChanged($event,r,c)" [enabled]="isControlEnabled(c)" [checked]="isChecked(r,c)"></checkbox>
-							<select-box *ngIf="isSelectBox(c)" [options]="getOptions(c)" (onDidSelect)="onSelectBoxChanged($event,r,c)" [selectedOption]="getSelectedOptionDisplayName(r,c)"></select-box>
-							<editable-select-box *ngIf="isEditableSelectBox(c)" [options]="getOptions(c)" (onDidSelect)="onSelectBoxChanged($event,r,c)" [selectedOption]="getSelectedOptionDisplayName(r,c)"></editable-select-box>
-							<input-box *ngIf="isInputBox(c)" [value]="cellData" (onDidChange)="onInputBoxChanged($event,r,c)"></input-box>
-							<ng-container *ngIf="isLabel(c)" >{{cellData}}</ng-container>
-							<model-component-wrapper *ngIf="isComponent(c)" [descriptor]="getItemDescriptor(cellData)" [modelStore]="modelStore"></model-component-wrapper>
-						</td>
-					</ng-container>
-				</tr>
-			</ng-container>
-		</ng-container>
-	</table>
-	`
+	templateUrl: decodeURI(require.toUrl('./declarativeTable.component.html'))
 })
 export default class DeclarativeTableComponent extends ComponentBase implements IComponent, OnDestroy, AfterViewInit {
 	@Input() descriptor: IComponentDescriptor;
@@ -119,12 +92,20 @@ export default class DeclarativeTableComponent extends ComponentBase implements 
 	}
 
 	public onHeaderCheckBoxChanged(e: boolean, colIdx: number): void {
-		this.data.forEach((row, rowidx) => {
-			if (row[rowidx][colIdx] !== e) {
-				this.onCellDataChanged(e, rowidx, colIdx);
+		this.data.forEach((row, rowIdx) => {
+			if (row[colIdx] !== e) {
+				this.onCellDataChanged(e, rowIdx, colIdx);
 			}
 		});
 		this._changeRef.detectChanges();
+	}
+
+	public trackByFnRows(index: number, item: any): any {
+		return index;
+	}
+
+	public trackByFnCols(index: number, item: any): any {
+		return index;
 	}
 
 	public onSelectBoxChanged(e: ISelectData | string, rowIdx: number, colIdx: number): void {
@@ -146,7 +127,6 @@ export default class DeclarativeTableComponent extends ComponentBase implements 
 
 	private onCellDataChanged(newValue: any, rowIdx: number, colIdx: number): void {
 		this.data[rowIdx][colIdx] = newValue;
-		this.data = this.data;
 		let newCellData: azdata.TableCell = {
 			row: rowIdx,
 			column: colIdx,


### PR DESCRIPTION
This might actually solve a TON of performance issue in notebooks as well if we make these changes there.

Specifically: https://github.com/microsoft/azuredatastudio/pull/10857/files#diff-1d9b614e6b182267f591bb2ee0acf3a3R103-R110

I added everyone else as reviewers as an FYI

Essentially without this code, everytime the checkbox that top checkbox of the column was clicked, it reconstructed all the other checkboxes.

So in the import extension, if we had 30 columns, that would be 60 checkbox objects each click - and it also didn't even visually show it right.

Extend this to any other component that has for loops and this completely blows up.