### PR TITLE
Adding required 'star' to loading component in forms

### DIFF
--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -372,6 +372,10 @@ class FormContainerBuilder extends GenericContainerBuilder<azdata.FormContainer,
 			componentWrapper.ariaLabel = formComponent.title;
 			if (componentWrapper instanceof LoadingComponentWrapper) {
 				componentWrapper.component.ariaLabel = formComponent.title;
+				let containedComponent = componentWrapper.component as any;
+				if (containedComponent.required) {
+					componentWrapper.required = containedComponent.required;
+				}
 			}
 		}
 		let actions: string[] = undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #10655 

So basically the loading component wasn't getting the child property of required and wasn't showing the required star in its title.

Need some feedback regarding this. Should I create a new interface that extends component and has a  'required' field? 


