### PR TITLE
Fix Notebook Viewlet Highlighting

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -232,12 +232,10 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		if (!uri) {
 			let openDocument = azdata.nb.activeNotebookEditor;
 			if (openDocument) {
-				let book = this.books.find(b => openDocument.document.uri.fsPath.replace(/\\/g, '/').toLowerCase().indexOf(b.bookPath.toLowerCase()) > -1);
-				bookItem = book?.getNotebook(openDocument.document.uri.fsPath);
+				bookItem = this.currentBook?.getNotebook(openDocument.document.uri.fsPath);
 			}
 		} else if (uri.fsPath) {
-			let book = this.books.find(b => uri.fsPath.replace(/\\/g, '/').toLowerCase().indexOf(b.bookPath.toLowerCase()) > -1);
-			bookItem = book?.getNotebook(uri.fsPath);
+			bookItem = this.currentBook?.getNotebook(uri.fsPath);
 		}
 		if (bookItem) {
 			// Select + focus item in viewlet if books viewlet is already open, or if we pass in variable

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -134,8 +134,6 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 
 	});
 
-	extensionContext.subscriptions.push(vscode.window.registerTreeDataProvider(BOOKS_VIEWID, bookTreeViewProvider));
-	extensionContext.subscriptions.push(vscode.window.registerTreeDataProvider(PROVIDED_BOOKS_VIEWID, providedBookTreeViewProvider));
 	return {
 		getJupyterController() {
 			return controller;


### PR DESCRIPTION
#10780.

Two issues:
- We were registering the tree data provider twice (one explicitly, via calling `vscode.window.registerTreeDataProvider()`, and once when calling `this._bookViewer = this._apiWrapper.createTreeView(this.viewId, { showCollapseAll: true, treeDataProvider: this });`

- The currentBook selection logic was incorrect, and was trying to find notebooks/markdown files as relative paths to the books locations. If there were nested books, this caused issues finding the right book in the viewlet (depending on the order in which they exist when we discover the books + notebooks in a folder). I've reverted this logic to match what we shipped in May.

![notebookviewlethighlight](https://user-images.githubusercontent.com/40371649/84345482-5934d200-ab62-11ea-8560-137d8d54f3db.gif)