### PR TITLE
Support width for DeclarativeTableComponent

### DIFF
--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
@@ -29,7 +29,7 @@ export enum DeclarativeDataType {
 @Component({
 	selector: 'modelview-declarativeTable',
 	template: `
-	<table role=grid #container *ngIf="columns" class="declarative-table" [style.height]="getHeight()" [attr.aria-label]="ariaLabel">
+	<table role=grid #container *ngIf="columns" class="declarative-table" [style.height]="getHeight()" [style.width]="getWidth()" [attr.aria-label]="ariaLabel">
 	<thead>
 		<ng-container *ngFor="let column of columns;">
 		<th class="declarative-table-header" aria-sort="none" [style.width]="getColumnWidth(column)" [attr.aria-label]="column.ariaLabel" [ngStyle]="column.headerCssStyles">{{column.displayName}}</th>


### PR DESCRIPTION
Updates the DeclarativeTableComponent to support the width property.

I'm not sure this is the correct approach.  I had a DeclarativeTableComponent that I wanted to take up 100% width of the parent, and it did not respect the width property until I made this change.