### PR TITLE
use default row height and update button column

### DIFF
--- a/src/sql/base/browser/ui/table/media/table.css
+++ b/src/sql/base/browser/ui/table/media/table.css
@@ -165,7 +165,7 @@
 
 .slick-icon-cell-content,
 .slick-button-cell-content {
-	background-position: 7px center !important;
+	background-position: 5px center !important;
 	background-repeat: no-repeat;
 	background-size: 16px !important;
 	width: 100%;
@@ -174,10 +174,6 @@
 	color: inherit !important;
 	display: flex;
 	align-items: center;
-}
-
-.slick-button-cell {
-	padding: 5px !important;
 }
 
 .slick-button-cell-content {

--- a/src/sql/base/browser/ui/table/plugins/buttonColumn.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/buttonColumn.plugin.ts
@@ -14,7 +14,6 @@ export interface ButtonColumnDefinition<T extends Slick.SlickData> extends TextW
 export interface ButtonColumnOptions {
 	iconCssClass?: string;
 	title?: string;
-	width?: number;
 	id?: string;
 }
 
@@ -38,10 +37,9 @@ export class ButtonColumn<T extends Slick.SlickData> implements Slick.Plugin<T> 
 			formatter: (row: number, cell: number, value: any, columnDef: Slick.Column<T>, dataContext: T): string => {
 				return this.formatter(row, cell, value, columnDef, dataContext);
 			},
-			width: options.width,
+			width: 30,
 			selectable: false,
-			iconCssClassField: options.iconCssClass,
-			cssClass: 'slick-button-cell'
+			iconCssClassField: options.iconCssClass
 		};
 	}
 

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable.ts
@@ -66,13 +66,12 @@ export class ExplorerTable extends Disposable {
 		this._view = new TableDataView<Slick.SlickData>(undefined, undefined, undefined, (data: Slick.SlickData[]): Slick.SlickData[] => {
 			return explorerFilter.filter(this._filterStr, data);
 		});
-		this._table = new Table<Slick.SlickData>(parentElement, { dataProvider: this._view }, { forceFitColumns: true, rowHeight: 35 });
+		this._table = new Table<Slick.SlickData>(parentElement, { dataProvider: this._view }, { forceFitColumns: true });
 		this._table.setSelectionModel(new RowSelectionModel());
 		this._actionsColumn = new ButtonColumn<Slick.SlickData>({
 			id: 'actions',
 			iconCssClass: 'toggle-more',
-			title: ShowActionsText,
-			width: 40
+			title: ShowActionsText
 		});
 		this._table.registerPlugin(this._actionsColumn);
 		this._register(this._actionsColumn.onClick((args) => {


### PR DESCRIPTION
This PR fixes #10840 

not sure why did i set the row height to 35 in the first place, it is not necessary and we can simply let slickgrid to handle the height
also, removed the width support for the button column, our css styles doesn't really support that well.

![Screen Shot 2020-06-11 at 2 22 38 PM](https://user-images.githubusercontent.com/13777222/84441712-2259cd00-abf1-11ea-8860-5a5aab084ee3.png)
![Screen Shot 2020-06-11 at 2 11 41 PM](https://user-images.githubusercontent.com/13777222/84441715-238afa00-abf1-11ea-96ff-f8be5ff740ea.png)

