### PR TITLE
Stop Running %cd and %set_env for PowerShell Kernel

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -382,7 +382,8 @@ export class JupyterSession implements nb.ISession {
 	}
 
 	private async setEnvironmentVars(skip: boolean = false): Promise<void> {
-		if (!skip && this.sessionImpl) {
+		// The PowerShell kernel doesn't define the %cd and %set_env magics; no need to run those here then
+		if (!skip && this.sessionImpl?.kernel?.name !== 'powershell') {
 			let allCode: string = '';
 			// Ensure cwd matches notebook path (this follows Jupyter behavior)
 			if (this.path && path.dirname(this.path)) {


### PR DESCRIPTION
Fixes #10690.

We've been running the `setEnvironmentVars()` method in JupyterSessionManager for every Jupyter kernel. This is great for the Python (and spark) kernels, but neglects the fact that we ship another kernel (PowerShell) that doesn't actually implement the change directory (`%cd`) or set environment variable (`%set_env`) magics. Therefore, we take a perf hit, and end up sending a bunch of messages to a kernel that we know doesn't support the functionality.

I tried ~20 notebooks, and didn't get into a state where, upon switching to the PowerShell kernel, the results weren't being displayed as expected. Not going to declare victory there yet, but this is a good first step.