### PR TITLE
Disable VS tests that fail randomly

### DIFF
--- a/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
+++ b/src/vs/platform/files/test/electron-browser/diskFileService.test.ts
@@ -118,7 +118,7 @@ export class TestDiskFileSystemProvider extends DiskFileSystemProvider {
 	}
 }
 
-suite('Disk File Service', function () {
+suite.skip('Disk File Service', function () { // {{SQL CARBON EDIT}} Disable occasionally failing tests
 
 	const parentDir = getRandomTestPath(tmpdir(), 'vsctests', 'diskfileservice');
 	const testSchema = 'test';


### PR DESCRIPTION
These tests fail occasionally. Seems like this was a known issue and they tried to "fix" it by adding a retry but apparently that isn't fully solving the problem : https://github.com/microsoft/vscode/issues/78602

Just disabling them for us since our need for running the core vs tests is low. 