### PR TITLE
Update to checkout action v2.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       CHILD_CONCURRENCY: "1"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.2.0
     # TODO: rename azure-pipelines/linux/xvfb.init to github-actions
     - run: |
         sudo apt-get update
@@ -72,7 +72,7 @@ jobs:
       CHILD_CONCURRENCY: "1"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.2.0
     - uses: actions/setup-node@v1
       with:
         node-version: 10
@@ -108,7 +108,7 @@ jobs:
       CHILD_CONCURRENCY: "1"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.2.0
     - uses: actions/setup-node@v1
       with:
         node-version: 10
@@ -141,7 +141,7 @@ jobs:
   #     CHILD_CONCURRENCY: "1"
   #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   #   steps:
-  #   - uses: actions/checkout@v1
+  #   - uses: actions/checkout@v2.2.0
   #   # TODO: rename azure-pipelines/linux/xvfb.init to github-actions
   #   - run: |
   #       sudo apt-get update

--- a/.github/workflows/on-issue-open.yml
+++ b/.github/workflows/on-issue-open.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.2.0
         with:
           repository: 'microsoft/azuredatastudio'
           ref: main


### PR DESCRIPTION
This should fix the issue we've been seeing with the coverage upload failing. See https://github.com/coverallsapp/github-action/issues/55 for some more information - but in short v1 of the action was just pulling the latest all the time. v2.2.0 was changed to pull the commit specified by GITHUB_SHA which is what coveralls uses for the upload and so should ensure that the specified commit always exists. 

I updated all the action versions for consistency - we really only need to update the ci ones but it's best to keep things consistent when we can. 