### PR TITLE
Load profile support for sql project deploy

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -64,6 +64,9 @@ export const dataSourceDropdownTitle = localize('dataSourceDropdownTitle', "Data
 export const noDataSourcesText = localize('noDataSourcesText', "No data sources in this project");
 export const loadProfileButtonText = localize('loadProfileButtonText', "Load Profile...");
 export const profileWarningText = localize('profileWarningText', "⚠Warning: Only database name and SQLCMD variables are able to be loaded from a profile at this time");
+export const sqlCmdTableLabel = localize('sqlCmdTableLabel', "SQLCMD Variables");
+export const sqlCmdVariableColumn = localize('sqlCmdVariableColumn', "Variable");
+export const sqlCmdValueColumn = localize('sqlCmdValueColumn', "Value");
 
 // Error messages
 

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -41,6 +41,7 @@ export const databaseReferenceSameDatabase = localize('databaseReferenceSameData
 export const databaseReferenceDifferentDabaseSameServer = localize('databaseReferenceDifferentDabaseSameServer', "Different database, same server");
 export const databaseReferenceDatabaseName = localize('databaseReferenceDatabaseName', "Database name");
 export const dacpacFiles = localize('dacpacFiles', "dacpac Files");
+export const publishSettingsFiles = localize('publishSettingsFiles', "Publish Settings File");
 export const systemDatabase = localize('systemDatabase', "System Database");
 export function newObjectNamePrompt(objectType: string) { return localize('newObjectNamePrompt', 'New {0} name:', objectType); }
 
@@ -61,6 +62,7 @@ export const connectionRadioButtonLabel = localize('connectionRadioButtonLabel',
 export const selectConnectionRadioButtonsTitle = localize('selectconnectionRadioButtonsTitle', "Specify connection from:");
 export const dataSourceDropdownTitle = localize('dataSourceDropdownTitle', "Data source");
 export const noDataSourcesText = localize('noDataSourcesText', "No data sources in this project");
+export const loadProfileButtonText = localize('loadProfileButtonText', "Load Profile...");
 
 // Error messages
 
@@ -144,6 +146,9 @@ export const ProjJsonToClean = '$(BaseIntermediateOutputPath)\\project.assets.js
 export const NETFrameworkAssembly = 'Microsoft.NETFramework.ReferenceAssemblies';
 export const VersionNumber = '1.0.0';
 export const All = 'All';
+
+// Profile XML names
+export const targetDatabaseName = 'TargetDatabaseName';
 
 // SQL connection string components
 export const initialCatalogSetting = 'Initial Catalog';

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -63,7 +63,7 @@ export const selectConnectionRadioButtonsTitle = localize('selectconnectionRadio
 export const dataSourceDropdownTitle = localize('dataSourceDropdownTitle', "Data source");
 export const noDataSourcesText = localize('noDataSourcesText', "No data sources in this project");
 export const loadProfileButtonText = localize('loadProfileButtonText', "Load Profile...");
-export const profileWarningText = localize('profileWarningText', "⚠Warning: Only database name and SQLCMD variables can be loaded from a profile at this time");
+export const profileWarningText = localize('profileWarningText', "⚠Warning: Only database name and SQLCMD variables are able to be loaded from a profile at this time");
 
 // Error messages
 

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -63,6 +63,7 @@ export const selectConnectionRadioButtonsTitle = localize('selectconnectionRadio
 export const dataSourceDropdownTitle = localize('dataSourceDropdownTitle', "Data source");
 export const noDataSourcesText = localize('noDataSourcesText', "No data sources in this project");
 export const loadProfileButtonText = localize('loadProfileButtonText', "Load Profile...");
+export const profileWarningText = localize('profileWarningText', "⚠Warning: Only database name and SQLCMD variables can be loaded from a profile at this time");
 
 // Error messages
 

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as os from 'os';
+import * as constants from '../common/constants';
 import { promises as fs } from 'fs';
 
 /**
@@ -94,4 +95,17 @@ export function getSafeWindowsPath(filePath: string): string {
 export function getSafeNonWindowsPath(filePath: string): string {
 	filePath = filePath.split('\\').join('/').split('"').join('');
 	return '"' + filePath + '"';
+}
+
+export function readSqlCmdVariables(xmlDoc: any): Record<string, string> {
+	let sqlCmdVariables: Record<string, string> = {};
+	for (let i = 0; i < xmlDoc.documentElement.getElementsByTagName(constants.SqlCmdVariable).length; i++) {
+		const sqlCmdVar = xmlDoc.documentElement.getElementsByTagName(constants.SqlCmdVariable)[i];
+		const varName = sqlCmdVar.getAttribute(constants.Include);
+
+		const varValue = sqlCmdVar.getElementsByTagName(constants.DefaultValue)[0].childNodes[0].nodeValue;
+		sqlCmdVariables[varName] = varValue;
+	}
+
+	return sqlCmdVariables;
 }

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -97,6 +97,10 @@ export function getSafeNonWindowsPath(filePath: string): string {
 	return '"' + filePath + '"';
 }
 
+/**
+ * Read SQLCMD variables from xmlDoc and return them
+ * @param xmlDoc xml doc to read SQLCMD variables from. Format must be the same that sqlproj and publish profiles use
+ */
 export function readSqlCmdVariables(xmlDoc: any): Record<string, string> {
 	let sqlCmdVariables: Record<string, string> = {};
 	for (let i = 0; i < xmlDoc.documentElement.getElementsByTagName(constants.SqlCmdVariable).length; i++) {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -230,8 +230,12 @@ export class ProjectsController {
 			targetDbName = profileXmlDoc.documentElement.getElementsByTagName(constants.targetDatabaseName)[targetDatabaseNameCount - 1].textContent;
 		}
 
+		// find all SQLCMD variables to include from the profile
+		let sqlCmdVariables = utils.readSqlCmdVariables(profileXmlDoc);
+
 		return {
-			databaseName: targetDbName
+			databaseName: targetDbName,
+			sqlCmdVariables: sqlCmdVariables
 		};
 	}
 

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import * as utils from '../common/utils';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
 import * as templates from '../templates/templates';
+import * as xmldom from 'xmldom';
 
 import { Uri, QuickPickItem, WorkspaceFolder, extensions, Extension } from 'vscode';
 import { IConnectionProfile, TaskExecutionMode } from 'azdata';
@@ -19,7 +20,7 @@ import { DeployDatabaseDialog } from '../dialogs/deployDatabaseDialog';
 import { Project, DatabaseReferenceLocation, SystemDatabase, TargetPlatform } from '../models/project';
 import { SqlDatabaseProjectTreeViewProvider } from './databaseProjectTreeViewProvider';
 import { FolderNode } from '../models/tree/fileFolderTreeItem';
-import { IDeploymentProfile, IGenerateScriptProfile } from '../models/IDeploymentProfile';
+import { IDeploymentProfile, IGenerateScriptProfile, PublishSettings } from '../models/IDeploymentProfile';
 import { BaseProjectTreeItem } from '../models/tree/baseTreeItem';
 import { ProjectRootTreeItem } from '../models/tree/projectTreeItem';
 import { ImportDataModel } from '../models/api/import';
@@ -193,6 +194,7 @@ export class ProjectsController {
 
 		deployDatabaseDialog.deploy = async (proj, prof) => await this.executionCallback(proj, prof);
 		deployDatabaseDialog.generateScript = async (proj, prof) => await this.executionCallback(proj, prof);
+		deployDatabaseDialog.readPublishProfile = async (profileUri) => await this.readPublishProfile(profileUri);
 
 		deployDatabaseDialog.openDialog();
 
@@ -214,6 +216,23 @@ export class ProjectsController {
 		else {
 			return await dacFxService.generateDeployScript(dacpacPath, profile.databaseName, profile.connectionUri, TaskExecutionMode.script, profile.sqlCmdVariables);
 		}
+	}
+
+	public async readPublishProfile(profileUri: Uri): Promise<PublishSettings> {
+		const profileText = await fs.readFile(profileUri.fsPath);
+		const profileXmlDoc = new xmldom.DOMParser().parseFromString(profileText.toString());
+
+		// read target database name
+		let targetDbName: string = '';
+		let targetDatabaseNameCount = profileXmlDoc.documentElement.getElementsByTagName(constants.targetDatabaseName).length;
+		if (targetDatabaseNameCount > 0) {
+			// if there are more than one TargetDatabaseName nodes, SSDT uses the name in the last one so we'll do the same here
+			targetDbName = profileXmlDoc.documentElement.getElementsByTagName(constants.targetDatabaseName)[targetDatabaseNameCount - 1].textContent;
+		}
+
+		return {
+			databaseName: targetDbName
+		};
 	}
 
 	public async schemaCompare(treeNode: BaseProjectTreeItem): Promise<void> {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -226,11 +226,11 @@ export class ProjectsController {
 		let targetDbName: string = '';
 		let targetDatabaseNameCount = profileXmlDoc.documentElement.getElementsByTagName(constants.targetDatabaseName).length;
 		if (targetDatabaseNameCount > 0) {
-			// if there are more than one TargetDatabaseName nodes, SSDT uses the name in the last one so we'll do the same here
+			// if there is more than one TargetDatabaseName nodes, SSDT uses the name in the last one so we'll do the same here
 			targetDbName = profileXmlDoc.documentElement.getElementsByTagName(constants.targetDatabaseName)[targetDatabaseNameCount - 1].textContent;
 		}
 
-		// find all SQLCMD variables to include from the profile
+		// get all SQLCMD variables to include from the profile
 		let sqlCmdVariables = utils.readSqlCmdVariables(profileXmlDoc);
 
 		return {

--- a/extensions/sql-database-projects/src/dialogs/deployDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/deployDatabaseDialog.ts
@@ -377,7 +377,7 @@ export class DeployDatabaseDialog {
 					canSelectMany: false,
 					defaultUri: vscode.Uri.parse(this.project.projectFolderPath),
 					filters: {
-						[constants.publishSettingsFiles]: ['*.publish.xml']
+						[constants.publishSettingsFiles]: ['publish.xml']
 					}
 				}
 			);

--- a/extensions/sql-database-projects/src/dialogs/deployDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/deployDatabaseDialog.ts
@@ -106,7 +106,7 @@ export class DeployDatabaseDialog {
 								component: this.targetDatabaseTextBox
 							},
 							{
-								title: '',
+								title: constants.profileWarningText,
 								component: <azdata.ButtonComponent>this.loadProfileButton
 							}
 						]

--- a/extensions/sql-database-projects/src/models/IDeploymentProfile.ts
+++ b/extensions/sql-database-projects/src/models/IDeploymentProfile.ts
@@ -15,3 +15,8 @@ export interface IGenerateScriptProfile {
 	connectionUri: string;
 	sqlCmdVariables?: Record<string, string>;
 }
+
+export interface PublishSettings {
+	databaseName: string;
+	sqlCmdVariables?: Record<string, string>;
+}

--- a/extensions/sql-database-projects/src/models/IDeploymentProfile.ts
+++ b/extensions/sql-database-projects/src/models/IDeploymentProfile.ts
@@ -18,5 +18,5 @@ export interface IGenerateScriptProfile {
 
 export interface PublishSettings {
 	databaseName: string;
-	sqlCmdVariables?: Record<string, string>;
+	sqlCmdVariables: Record<string, string>;
 }

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -64,13 +64,7 @@ export class Project {
 		}
 
 		// find all SQLCMD variables to include
-		for (let i = 0; i < this.projFileXmlDoc.documentElement.getElementsByTagName(constants.SqlCmdVariable).length; i++) {
-			const sqlCmdVar = this.projFileXmlDoc.documentElement.getElementsByTagName(constants.SqlCmdVariable)[i];
-			const varName = sqlCmdVar.getAttribute(constants.Include);
-
-			const varValue = sqlCmdVar.getElementsByTagName(constants.DefaultValue)[0].childNodes[0].nodeValue;
-			this.sqlCmdVariables[varName] = varValue;
-		}
+		this.sqlCmdVariables = utils.readSqlCmdVariables(this.projFileXmlDoc);
 
 		// find all database references to include
 		for (let r = 0; r < this.projFileXmlDoc.documentElement.getElementsByTagName(constants.ArtifactReference).length; r++) {

--- a/extensions/sql-database-projects/src/test/baselines/baselines.ts
+++ b/extensions/sql-database-projects/src/test/baselines/baselines.ts
@@ -19,6 +19,7 @@ export let SSDTUpdatedProjectAfterSystemDbUpdateBaselineWindows: string;
 export let SSDTUpdatedProjectAfterSystemDbUpdateBaseline: string;
 export let SSDTProjectBaselineWithCleanTarget: string;
 export let SSDTProjectBaselineWithCleanTargetAfterUpdate: string;
+export let publishProfileBaseline: string;
 
 const baselineFolderPath = __dirname;
 
@@ -35,6 +36,7 @@ export async function loadBaselines() {
 	SSDTUpdatedProjectAfterSystemDbUpdateBaseline = await loadBaseline(baselineFolderPath, 'SSDTUpdatedProjectAfterSystemDbUpdateBaseline.xml');
 	SSDTProjectBaselineWithCleanTarget = await loadBaseline(baselineFolderPath, 'SSDTProjectBaselineWithCleanTarget.xml');
 	SSDTProjectBaselineWithCleanTargetAfterUpdate = await loadBaseline(baselineFolderPath, 'SSDTProjectBaselineWithCleanTargetAfterUpdate.xml');
+	publishProfileBaseline = await loadBaseline(baselineFolderPath, 'publishProfileBaseline.publish.xml');
 }
 
 async function loadBaseline(baselineFolderPath: string, fileName: string): Promise<string> {

--- a/extensions/sql-database-projects/src/test/baselines/publishProfileBaseline.publish.xml
+++ b/extensions/sql-database-projects/src/test/baselines/publishProfileBaseline.publish.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IncludeCompositeObjects>True</IncludeCompositeObjects>
+    <TargetDatabaseName>targetDb</TargetDatabaseName>
+    <DeployScriptFileName>DatabaseProject1.sql</DeployScriptFileName>
+    <ProfileVersionNumber>1</ProfileVersionNumber>
+  </PropertyGroup>
+  <ItemGroup>
+    <SqlCmdVariable Include="ProdDatabaseName">
+      <DefaultValue>prodName</DefaultValue>
+      <Value>$(SqlCmdVar__1)</Value>
+    </SqlCmdVariable>
+  </ItemGroup>
+</Project>

--- a/extensions/sql-database-projects/src/test/baselines/publishProfileBaseline.publish.xml
+++ b/extensions/sql-database-projects/src/test/baselines/publishProfileBaseline.publish.xml
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <SqlCmdVariable Include="ProdDatabaseName">
-      <DefaultValue>prodName</DefaultValue>
+      <DefaultValue>MyProdDatabase</DefaultValue>
       <Value>$(SqlCmdVar__1)</Value>
     </SqlCmdVariable>
   </ItemGroup>

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -117,6 +117,7 @@ describe.skip('ProjectsController: project controller operations', function (): 
 
 			const deployHoller = 'hello from callback for deploy()';
 			const generateHoller = 'hello from callback for generateScript()';
+			const profileHoller = 'hello from callback for readPublishProfile()';
 
 			let holler = 'nothing';
 
@@ -130,6 +131,13 @@ describe.skip('ProjectsController: project controller operations', function (): 
 			projController.setup(x => x.executionCallback(TypeMoq.It.isAny(), TypeMoq.It.is((_): _ is IDeploymentProfile => true))).returns(async () => {
 				holler = deployHoller;
 				return undefined;
+			});
+			projController.setup(x => x.readPublishProfile(TypeMoq.It.isAny())).returns(async () => {
+				holler = profileHoller;
+				return {
+					databaseName: '',
+					sqlCmdVariables: {}
+				};
 			});
 
 			projController.setup(x => x.executionCallback(TypeMoq.It.isAny(), TypeMoq.It.is((_): _ is IGenerateScriptProfile => true))).returns(async () => {
@@ -146,6 +154,20 @@ describe.skip('ProjectsController: project controller operations', function (): 
 			await dialog.generateScriptClick();
 
 			should(holler).equal(generateHoller, 'executionCallback() is supposed to have been setup and called for GenerateScript scenario');
+
+			await projController.object.readPublishProfile(vscode.Uri.parse('test'));
+			should(holler).equal(profileHoller, 'executionCallback() is supposed to have been setup and called for ReadPublishProfile scenario');
+		});
+
+		it('Should read database name and SQLCMD variables from publish profile', async function (): Promise<void> {
+			await baselines.loadBaselines();
+			let profilePath = await testUtils.createTestFile(baselines.publishProfileBaseline, 'publishProfile.publish.xml');
+			const projController = new ProjectsController(testContext.apiWrapper.object, new SqlDatabaseProjectTreeViewProvider());
+
+			let result = await projController.readPublishProfile(vscode.Uri.parse(profilePath));
+			should(result.databaseName).equal('targetDb');
+			should(Object.keys(result.sqlCmdVariables).length).equal(1);
+			should(result.sqlCmdVariables['ProdDatabaseName']).equal('prodName');
 		});
 	});
 });

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -167,7 +167,7 @@ describe.skip('ProjectsController: project controller operations', function (): 
 			let result = await projController.readPublishProfile(vscode.Uri.parse(profilePath));
 			should(result.databaseName).equal('targetDb');
 			should(Object.keys(result.sqlCmdVariables).length).equal(1);
-			should(result.sqlCmdVariables['ProdDatabaseName']).equal('prodName');
+			should(result.sqlCmdVariables['ProdDatabaseName']).equal('MyProdDatabase');
 		});
 	});
 });

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -155,7 +155,9 @@ describe.skip('ProjectsController: project controller operations', function (): 
 
 			should(holler).equal(generateHoller, 'executionCallback() is supposed to have been setup and called for GenerateScript scenario');
 
+			dialog = await projController.object.deployProject(proj);
 			await projController.object.readPublishProfile(vscode.Uri.parse('test'));
+
 			should(holler).equal(profileHoller, 'executionCallback() is supposed to have been setup and called for ReadPublishProfile scenario');
 		});
 

--- a/extensions/sql-database-projects/src/test/testUtils.ts
+++ b/extensions/sql-database-projects/src/test/testUtils.ts
@@ -49,7 +49,7 @@ export async function generateTestFolderPath(): Promise<string> {
 	return folderPath;
 }
 
-async function createTestFile(contents: string, fileName: string, folderPath?: string): Promise<string> {
+export async function createTestFile(contents: string, fileName: string, folderPath?: string): Promise<string> {
 	folderPath = folderPath ?? await generateTestFolderPath();
 	const filePath = path.join(folderPath, fileName);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #10924. This adds support for reading database name and SQLCMD variables from a publish profile. Support for other profile options will be added in later PRs. 
<img width="407" alt="Screen Shot 2020-06-16 at 5 50 27 PM" src="https://user-images.githubusercontent.com/31145923/84842419-ec09bc80-aff9-11ea-8fcc-66f741ba4f3d.png">

Empty state (no profile loaded and no sqlcmdvars in the sqlproj):
<img width="414" alt="Screen Shot 2020-06-17 at 9 57 54 AM" src="https://user-images.githubusercontent.com/31145923/84926996-0cc92500-b081-11ea-8920-eb8c5ac2bbe1.png">

This also fixes #10947 so that the values of SQLCMD variables show and change if the profile has different values for them (support for editing them in the UI will come later).
![loadProfile](https://user-images.githubusercontent.com/31145923/84842717-b5807180-affa-11ea-8724-560f6a3f2f60.gif)


