### PR TITLE
MIAA Dashboard Updates

### DIFF
--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -100,7 +100,7 @@ export function clickTheTroubleshootButton(resourceType: string): string { retur
 export function numVCores(vCores: string): string {
 	const numCores = +vCores;
 	if (numCores && numCores > 0) {
-		return numCores > 1 ? localize('arc.numVCores', "{0} vCores", numCores) : localize('arc.vCore', "{0} vCore", numCores);
+		return localize('arc.numVCores', "{0} vCores", numCores);
 	} else {
 		return '-';
 	}

--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -21,6 +21,7 @@ export const properties = localize('arc.properties', "Properties");
 export const settings = localize('arc.settings', "Settings");
 export const security = localize('arc.security', "Security");
 export const computeAndStorage = localize('arc.computeAndStorage', "Compute + Storage");
+export const compute = localize('arc.compute', "Compute");
 export const backup = localize('arc.backup', "Backup");
 export const newSupportRequest = localize('arc.newSupportRequest', "New support request");
 export const diagnoseAndSolveProblems = localize('arc.diagnoseAndSolveProblems', "Diagnose and solve problems");
@@ -96,7 +97,14 @@ export function copiedToClipboard(name: string): string { return localize('arc.c
 export function refreshFailed(error: any): string { return localize('arc.refreshFailed', "Refresh failed. {0}", (error instanceof Error ? error.message : error)); }
 export function failedToManagePostgres(name: string, error: any): string { return localize('arc.failedToManagePostgres', "Failed to manage Postgres {0}. {1}", name, (error instanceof Error ? error.message : error)); }
 export function clickTheTroubleshootButton(resourceType: string): string { return localize('arc.clickTheTroubleshootButton', "Click the troubleshoot button to open the Azure Arc {0} troubleshooting notebook.", resourceType); }
-
+export function numVCores(vCores: string): string {
+	const numCores = +vCores;
+	if (numCores && numCores > 0) {
+		return numCores > 1 ? localize('arc.numVCores', "{0} vCores", numCores) : localize('arc.vCore', "{0} vCore", numCores);
+	} else {
+		return '-';
+	}
+}
 export const couldNotFindControllerResource = localize('arc.couldNotFindControllerResource', "Could not find Azure resource for Azure Arc Data Controller", name);
 
 export const arcResources = localize('arc.arcResources', "Azure Arc Resources");

--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -105,6 +105,6 @@ export function numVCores(vCores: string): string {
 		return '-';
 	}
 }
-export const couldNotFindControllerResource = localize('arc.couldNotFindControllerResource', "Could not find Azure resource for Azure Arc Data Controller", name);
+export function couldNotFindRegistration(namespace: string, name: string) { return localize('arc.couldNotFindRegistration', "Could not find controller registration for {0} ({1})", name, namespace); }
 
 export const arcResources = localize('arc.arcResources', "Azure Arc Resources");

--- a/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
@@ -160,7 +160,7 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 				vscode.env.openExternal(vscode.Uri.parse(
 					`https://portal.azure.com/#resource/subscriptions/${r.subscriptionId}/resourceGroups/${r.resourceGroupName}/providers/Microsoft.AzureData/${ResourceType.dataControllers}/${r.instanceName}`));
 			} else {
-				vscode.window.showErrorMessage(loc.couldNotFindControllerResource);
+				vscode.window.showErrorMessage(loc.couldNotFindRegistration(this._controllerModel.namespace, 'controller'));
 			}
 		});
 

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -33,7 +33,7 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 		subscriptionId: '-',
 		miaaAdmin: '-',
 		host: '-',
-		computeAndStorage: '-'
+		vCores: '-'
 	};
 
 	constructor(modelView: azdata.ModelView, private _controllerModel: ControllerModel, private _miaaModel: MiaaModel) {
@@ -157,7 +157,6 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 		}).component();
 
 		this._databasesTableLoading = this.modelView.modelBuilder.loadingComponent().withItem(this._databasesTable).component();
-		this._databasesTableLoading.loading = false;
 		rootContainer.addItem(this._databasesTableLoading, { CSSStyles: { 'margin-bottom': '20px' } });
 
 		this.initialized = true;
@@ -203,7 +202,7 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 			this._instanceProperties.dataController = this._controllerModel.controllerRegistration?.instanceName || '-';
 			this._instanceProperties.region = (await getAzurecoreApi()).getRegionDisplayName(reg.location);
 			this._instanceProperties.subscriptionId = reg.subscriptionId || '-';
-			this._instanceProperties.computeAndStorage = reg.vCores || '-';
+			this._instanceProperties.vCores = reg.vCores || '-';
 			this._instanceProperties.host = reg.externalEndpoint || '-';
 			this.refreshDisplayedProperties();
 		}
@@ -264,8 +263,8 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 				value: this._instanceProperties.host
 			},
 			{
-				displayName: loc.computeAndStorage,
-				value: this._instanceProperties.computeAndStorage
+				displayName: loc.compute,
+				value: loc.numVCores(this._instanceProperties.vCores)
 			}
 		];
 

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
+import * as vscode from 'vscode';
 import * as loc from '../../../localizedConstants';
 import { DashboardPage } from '../../components/dashboardPage';
 import { IconPathHelper, cssStyles, ResourceType } from '../../../constants';
@@ -165,8 +166,8 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 
 	public get toolbarContainer(): azdata.ToolbarContainer {
 
-		const createNewButton = this.modelView.modelBuilder.button().withProperties<azdata.ButtonProperties>({
-			label: loc.createNew,
+		const createDatabaseButton = this.modelView.modelBuilder.button().withProperties<azdata.ButtonProperties>({
+			label: loc.newDatabase,
 			iconPath: IconPathHelper.add
 		}).component();
 
@@ -185,9 +186,19 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 			iconPath: IconPathHelper.openInTab
 		}).component();
 
+		openInAzurePortalButton.onDidClick(async () => {
+			const r = this._controllerModel.getRegistration(ResourceType.sqlManagedInstances, this._miaaModel.namespace, this._miaaModel.name);
+			if (r) {
+				vscode.env.openExternal(vscode.Uri.parse(
+					`https://portal.azure.com/#resource/subscriptions/${r.subscriptionId}/resourceGroups/${r.resourceGroupName}/providers/Microsoft.AzureData/${ResourceType.sqlManagedInstances}/${r.instanceName}`));
+			} else {
+				vscode.window.showErrorMessage(loc.couldNotFindRegistration(this._miaaModel.namespace, this._miaaModel.name));
+			}
+		});
+
 		return this.modelView.modelBuilder.toolbarContainer().withToolbarItems(
 			[
-				{ component: createNewButton },
+				{ component: createDatabaseButton },
 				{ component: deleteButton },
 				{ component: resetPasswordButton, toolbarSeparatorAfter: true },
 				{ component: openInAzurePortalButton }

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -1305,7 +1305,7 @@ declare module 'azdata' {
 
 	// Admin Services interfaces  -----------------------------------------------------------------------
 	export interface DatabaseInfo {
-		options: {};
+		options: { [key: string]: any };
 	}
 
 	export interface LoginInfo {


### PR DESCRIPTION
1. Adds support for fetching actual database info for MIAA instances
1. Updates `Compute + Storage` property - currently we only get the compute (vCores) so just displaying that for now
1. Hooks up `Open in Azure Portal` button
1. Update a few strings

![image](https://user-images.githubusercontent.com/28519865/84929374-97f7ea00-b084-11ea-8408-ec5a701dac9a.png)
