### PR TITLE
Remove add database reference from command palette

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -169,6 +169,10 @@
         },
         {
           "command": "sqlDatabaseProjects.importDatabase"
+        },
+        {
+          "command": "sqlDatabaseProjects.addDatabaseReference",
+          "when": "false"
         }
       ],
       "view/item/context": [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #10972. Add database reference should only be launched from the Database Reference node in a project, not from command palette.
