### PR TITLE
Disable target connection input box in publish dialog

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/deployDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/deployDatabaseDialog.ts
@@ -282,10 +282,10 @@ export class DeployDatabaseDialog {
 	}
 
 	private createTargetConnectionComponent(view: azdata.ModelView): azdata.FormComponent {
-		// TODO: make this not editable
 		this.targetConnectionTextBox = view.modelBuilder.inputBox().withProperties({
 			value: '',
-			ariaLabel: constants.targetConnectionLabel
+			ariaLabel: constants.targetConnectionLabel,
+			enabled: false
 		}).component();
 
 		this.targetConnectionTextBox.onTextChanged(() => {


### PR DESCRIPTION
Disabling the target connection input box for now because it the value there wasn't actually being used for the connection (the connection is getting saved when it's selected in the connection dialog, not read from the input box). SSDT also has this field disabled. Partially addresses #10984

before selecting a connection:
<img width="399" alt="Screen Shot 2020-06-19 at 10 58 14 AM" src="https://user-images.githubusercontent.com/31145923/85166218-d4118300-b21b-11ea-9d58-324d7e0b4bcf.png">

after selecting a connection:
![image](https://user-images.githubusercontent.com/31145923/85179809-b3a2f200-b236-11ea-8d7b-9ccb799a26e9.png)

