### PR TITLE
fix for windows path to show in project tree across platforms correctly

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -98,6 +98,16 @@ export function getSafeNonWindowsPath(filePath: string): string {
 }
 
 /**
+ * Get safe relative path for Windows and non-Windows Platform
+ * This is needed to read sqlproj entried created on SSDT and opened in MAC
+ * '/' in tree is recognized all platforms but "\\" only by windows
+ */
+export function getPlatformSafeFileEntryPath(filePath: string): string {
+	const parts = filePath.split('\\');
+	return parts.join('/');
+}
+
+/**
  * Read SQLCMD variables from xmlDoc and return them
  * @param xmlDoc xml doc to read SQLCMD variables from. Format must be the same that sqlproj and publish profiles use
  */

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -85,11 +85,19 @@ export class ProjectsController {
 				// TODO: prompt to create new datasources.json; for now, swallow
 			}
 			else {
+				this.projects = this.projects.filter((e) => { return e !== newProject; });
 				throw err;
 			}
 		}
 
-		this.refreshProjectsTree();
+		try {
+			this.refreshProjectsTree();
+		}
+		catch (err) {
+			// if the project didnt load - remove it from the list of open projects
+			this.projects = this.projects.filter((e) => { return e !== newProject; });
+			throw err;
+		}
 
 		return newProject;
 	}

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -74,7 +74,8 @@ export class Project {
 					throw new Error(constants.invalidDatabaseReference);
 				}
 
-				this.databaseReferences.push(path.parse(filepath).name);
+				const platformSafeFilePath = utils.getPlatformSafeFileEntryPath(filepath);
+				this.databaseReferences.push(path.parse(platformSafeFilePath).name);
 			}
 		}
 	}

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -250,7 +250,8 @@ export class Project {
 	}
 
 	public createProjectEntry(relativePath: string, entryType: EntryType): ProjectEntry {
-		return new ProjectEntry(Uri.file(path.join(this.projectFolderPath, relativePath)), relativePath, entryType);
+		let platformSafeRelativePath = utils.getPlatformSafeFileEntryPath(relativePath);
+		return new ProjectEntry(Uri.file(path.join(this.projectFolderPath, platformSafeRelativePath)), relativePath, entryType);
 	}
 
 	private findOrCreateItemGroup(containedTag?: string): any {

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -79,6 +79,20 @@ describe.skip('ProjectsController: project controller operations', function (): 
 			should(project.dataSources.length).equal(2); // detailed datasources tests in their own test file
 		});
 
+		it('Should not keep failed to load project in project list.', async function (): Promise<void> {
+			const folderPath = await testUtils.generateTestFolderPath();
+			const sqlProjPath = await testUtils.createTestSqlProjFile('empty file with no valid xml', folderPath);
+			const projController = new ProjectsController(testContext.apiWrapper.object, new SqlDatabaseProjectTreeViewProvider());
+
+			try {
+				await projController.openProject(vscode.Uri.file(sqlProjPath));
+				should.fail(null, null, 'The given project not expected to open');
+			}
+			catch {
+				should(projController.projects.length).equal(0, 'The added project should be removed');
+			}
+		});
+
 		it('Should return silently when no SQL object name provided in prompts', async function (): Promise<void> {
 			for (const name of ['', '    ', undefined]) {
 				testContext.apiWrapper.reset();

--- a/extensions/sql-database-projects/src/test/projectTree.test.ts
+++ b/extensions/sql-database-projects/src/test/projectTree.test.ts
@@ -93,4 +93,27 @@ describe.skip('Project Tree tests', function (): void {
 			DatabaseProjectItemType.file,
 			DatabaseProjectItemType.file]);
 	});
+
+	it('Should be able to parse windows relative path as platform safe path', async function (): Promise<void> {
+		const root = os.platform() === 'win32' ? 'Z:\\' : '/';
+		const proj = new Project(vscode.Uri.file(`${root}TestProj.sqlproj`).fsPath);
+
+		// nested entries before explicit top-level folder entry
+		// also, ordering of files/folders at all levels
+		proj.files.push(proj.createProjectEntry('someFolder1\\MyNestedFolder1\\MyFile1.sql', EntryType.File));
+		proj.files.push(proj.createProjectEntry('someFolder1\\MyNestedFolder2', EntryType.Folder));
+		proj.files.push(proj.createProjectEntry('someFolder1\\MyFile2.sql', EntryType.File));
+
+		const tree = new ProjectRootTreeItem(proj);
+		should(tree.children.map(x => x.uri.path)).deepEqual([
+			'/TestProj.sqlproj/Data Sources',
+			'/TestProj.sqlproj/Database References',
+			'/TestProj.sqlproj/someFolder1']);
+
+		// Why are we only matching names - https://github.com/microsoft/azuredatastudio/issues/11026
+		should(tree.children.find(x => x.uri.path === '/TestProj.sqlproj/someFolder1')?.children.map(y => path.basename(y.uri.path))).deepEqual([
+			'MyNestedFolder1',
+			'MyNestedFolder2',
+			'MyFile2.sql']);
+	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR 
Fixes https://github.com/microsoft/azuredatastudio/issues/10986
Converting the relative path to platform safe path before using in uri. 
Opened a separate bug for MAC --> SSDT.

Fixes https://github.com/microsoft/azuredatastudio/issues/11028 
Adding one more change to allow retry on projects that did not load