### PR TITLE
Fix extension gallery query to use correct version

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -850,14 +850,14 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 			// {{SQL CARBON EDIT}}
 			const vsCodeEngine = getEngine(version);
 			const azDataEngine = getAzureDataStudioEngine(version);
-			// We always require an azdata engine version, the VS Code version is optional
-			if (!azDataEngine) {
+			// Require at least one engine version
+			if (!vsCodeEngine && !azDataEngine) {
 				return null;
 			}
-			if (isEngineValid(azDataEngine, this.productService.version)) {
-				if (vsCodeEngine && isEngineValid(vsCodeEngine, this.productService.vscodeVersion)) {
-					return Promise.resolve(version);
-				}
+			const vsCodeEngineValid = !vsCodeEngine || (vsCodeEngine && isEngineValid(vsCodeEngine, this.productService.vscodeVersion));
+			const azDataEngineValid = !azDataEngine || (azDataEngine && isEngineValid(azDataEngine, this.productService.version));
+			if (vsCodeEngineValid && azDataEngineValid) {
+				return Promise.resolve(version);
 			}
 		}
 		return null;

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -847,12 +847,17 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 
 	private getLastValidExtensionVersionFromProperties(extension: IRawGalleryExtension, versions: IRawGalleryExtensionVersion[]): Promise<IRawGalleryExtensionVersion> | null {
 		for (const version of versions) {
-			const engine = getEngine(version);
-			if (!engine) {
+			// {{SQL CARBON EDIT}}
+			const vsCodeEngine = getEngine(version);
+			const azDataEngine = getAzureDataStudioEngine(version);
+			// We always require an azdata engine version, the VS Code version is optional
+			if (!azDataEngine) {
 				return null;
 			}
-			if (isEngineValid(engine, this.productService.version)) {
-				return Promise.resolve(version);
+			if (isEngineValid(azDataEngine, this.productService.version)) {
+				if (vsCodeEngine && isEngineValid(vsCodeEngine, this.productService.vscodeVersion)) {
+					return Promise.resolve(version);
+				}
 			}
 		}
 		return null;


### PR DESCRIPTION
The check was being done using the VS Code engine but against the ADS version so normally would fail (since VS Code engine is much higher). 

Logic here is that we require at least one engine version specified but it can be of either type (so we can support native VS Code extensions that may not have an azdata engine specified). 