### PR TITLE
Add more arc tests

### DIFF
--- a/extensions/arc/src/common/utils.ts
+++ b/extensions/arc/src/common/utils.ts
@@ -91,7 +91,7 @@ export function getDatabaseStateDisplayText(state: string): string {
 			return loc.restoring;
 		case 'RECOVERING':
 			return loc.recovering;
-		case 'RECOVERY PENDING	':
+		case 'RECOVERY PENDING':
 			return loc.recoveryPending;
 		case 'SUSPECT':
 			return loc.suspect;

--- a/extensions/arc/src/test/common/promise.test.ts
+++ b/extensions/arc/src/test/common/promise.test.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import 'mocha';
+import { Deferred } from '../../common/promise';
+
+describe('Deferred', () => {
+	it('Then should be called upon resolution', function (done): void {
+		const deferred = new Deferred();
+		deferred.then(() => {
+			done();
+		});
+		deferred.resolve();
+	});
+});

--- a/extensions/arc/src/test/common/utils.test.ts
+++ b/extensions/arc/src/test/common/utils.test.ts
@@ -5,16 +5,14 @@
 
 import * as vscode from 'vscode';
 import * as should from 'should';
-import * as TypeMoq from 'typemoq';
 import 'mocha';
 import { resourceTypeToDisplayName, parseEndpoint, parseInstanceName, getAzurecoreApi, getResourceTypeIcon, getConnectionModeDisplayText, getDatabaseStateDisplayText, promptForResourceDeletion } from '../../common/utils';
 
 import * as loc from '../../localizedConstants';
 import { ResourceType, IconPathHelper, Connectionmode as ConnectionMode } from '../../constants';
 import { MockInputBox } from '../stubs';
-import { mock } from 'sinon';
 
-describe('resourceTypeToDisplayName Method Tests', () => {
+describe('resourceTypeToDisplayName Method Tests', function(): void {
 	it('Display Name should be correct for valid ResourceType', function (): void {
 		should(resourceTypeToDisplayName(ResourceType.dataControllers)).equal(loc.dataControllersType);
 		should(resourceTypeToDisplayName(ResourceType.postgresInstances)).equal(loc.pgSqlType);
@@ -34,7 +32,7 @@ describe('resourceTypeToDisplayName Method Tests', () => {
 	});
 });
 
-describe('parseEndpoint Method Tests', () => {
+describe('parseEndpoint Method Tests', function(): void {
 	it('Should parse valid endpoint correctly', function (): void {
 		should(parseEndpoint('127.0.0.1:1337')).deepEqual({ ip: '127.0.0.1', port: '1337' });
 	});
@@ -66,13 +64,13 @@ describe('parseInstanceName Method Tests', () => {
 	});
 });
 
-describe('getAzurecoreApi Method Tests', () => {
+describe('getAzurecoreApi Method Tests', function() {
 	it('Should get azurecore API correctly', function (): void {
 		should(getAzurecoreApi()).not.be.undefined();
 	});
 });
 
-describe('getResourceTypeIcon Method Tests', () => {
+describe('getResourceTypeIcon Method Tests', function() {
 	it('Correct icons should be returned for valid ResourceTypes', function (): void {
 		should(getResourceTypeIcon(ResourceType.sqlManagedInstances)).equal(IconPathHelper.miaa, 'Unexpected MIAA icon');
 		should(getResourceTypeIcon(ResourceType.postgresInstances)).equal(IconPathHelper.postgres, 'Unexpected Postgres icon');
@@ -89,7 +87,7 @@ describe('getResourceTypeIcon Method Tests', () => {
 	});
 });
 
-describe('getConnectionModeDisplayText Method Tests', () => {
+describe('getConnectionModeDisplayText Method Tests', function() {
 	it('Display Name should be correct for valid ResourceType', function (): void {
 		should(getConnectionModeDisplayText(ConnectionMode.connected)).equal(loc.connected);
 		should(getConnectionModeDisplayText(ConnectionMode.disconnected)).equal(loc.disconnected);
@@ -105,6 +103,26 @@ describe('getConnectionModeDisplayText Method Tests', () => {
 
 	it('Display Name should be correct for undefined value', function (): void {
 		should(getConnectionModeDisplayText(undefined)).equal('');
+	});
+});
+
+describe('getDatabaseStateDisplayText Method Tests', function() {
+	it('State should be correct for valid states', function (): void {
+		should(getDatabaseStateDisplayText('ONLINE')).equal(loc.online);
+		should(getDatabaseStateDisplayText('OFFLINE')).equal(loc.offline);
+		should(getDatabaseStateDisplayText('RESTORING')).equal(loc.restoring);
+		should(getDatabaseStateDisplayText('RECOVERING')).equal(loc.recovering);
+		should(getDatabaseStateDisplayText('RECOVERY PENDING')).equal(loc.recoveryPending);
+		should(getDatabaseStateDisplayText('SUSPECT')).equal(loc.suspect);
+		should(getDatabaseStateDisplayText('EMERGENCY')).equal(loc.emergecy);
+	});
+
+	it('State should stay the same for unknown value', function (): void {
+		should(getDatabaseStateDisplayText('UnknownState')).equal('UnknownState');
+	});
+
+	it('State should stay the same for empty value', function (): void {
+		should(getDatabaseStateDisplayText('')).equal('');
 	});
 });
 

--- a/extensions/arc/src/test/stubs.ts
+++ b/extensions/arc/src/test/stubs.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export class MockInputBox implements vscode.InputBox {
+	private _value: string = '';
+	public get value(): string {
+		return this._value;
+	}
+	public set value(newValue: string) {
+		this._value = newValue;
+		if (this._onDidChangeValueCallback) {
+			this._onDidChangeValueCallback(this._value);
+		}
+	}
+	placeholder: string | undefined;
+	password: boolean = false;
+	private _onDidChangeValueCallback: ((e: string) => any) | undefined = undefined;
+	onDidChangeValue: vscode.Event<string> = (listener) => {
+		this._onDidChangeValueCallback = listener;
+		return new vscode.Disposable(() => { });
+	};
+	private _onDidAcceptCallback: ((e: void) => any) | undefined = undefined;
+	public onDidAccept: vscode.Event<void> = (listener) => {
+		this._onDidAcceptCallback = listener;
+		return new vscode.Disposable(() => { });
+	};
+	buttons: readonly vscode.QuickInputButton[] = [];
+	onDidTriggerButton: vscode.Event<vscode.QuickInputButton> = (listener) => { return new vscode.Disposable(() => { }); };
+	prompt: string | undefined;
+	validationMessage: string | undefined;
+	title: string | undefined;
+	step: number | undefined;
+	totalSteps: number | undefined;
+	enabled: boolean = false;
+	busy: boolean = false;
+	ignoreFocusOut: boolean = false;
+	show(): void { }
+
+	hide(): void {
+		if (this._onDidHideCallback) {
+			this._onDidHideCallback();
+		}
+	}
+	private _onDidHideCallback: ((e: void) => any) | undefined = undefined;
+	onDidHide: vscode.Event<void> = (listener) => {
+		this._onDidHideCallback = listener;
+		return new vscode.Disposable(() => { });
+	};
+	dispose(): void { }
+
+	public async triggerAccept(): Promise<any> {
+		if (this._onDidAcceptCallback) {
+			return await this._onDidAcceptCallback();
+		}
+		return undefined;
+	}
+}

--- a/extensions/arc/src/test/stubs.ts
+++ b/extensions/arc/src/test/stubs.ts
@@ -29,7 +29,7 @@ export class MockInputBox implements vscode.InputBox {
 		return new vscode.Disposable(() => { });
 	};
 	buttons: readonly vscode.QuickInputButton[] = [];
-	onDidTriggerButton: vscode.Event<vscode.QuickInputButton> = (listener) => { return new vscode.Disposable(() => { }); };
+	onDidTriggerButton: vscode.Event<vscode.QuickInputButton> = (_) => { return new vscode.Disposable(() => { }); };
 	prompt: string | undefined;
 	validationMessage: string | undefined;
 	title: string | undefined;

--- a/scripts/test-extensions-unit.bat
+++ b/scripts/test-extensions-unit.bat
@@ -19,6 +19,7 @@ if "%INTEGRATION_TEST_ELECTRON_PATH%"=="" (
 	:: Run from a build: need to compile all test extensions
 	call yarn gulp compile-extension:admin-tool-ext-win
 	call yarn gulp compile-extension:agent
+	call yarn gulp compile-extension:arc
 	call yarn gulp compile-extension:azurecore
 	call yarn gulp compile-extension:cms
 	call yarn gulp compile-extension:dacpac


### PR DESCRIPTION
Most of them are pretty standard but the prompt tests are a bit more interesting.

I was getting tired of having to plumb the ApiWrapper through every single thing in an extension and so for this I'm experimenting just overwriting the vscode API directly here for createInputBox.

I chatted with Amir a bit about this and we both agree that while this seems like a good idea it
1. Belongs in a more common place (likely `vscodetestcover` extension)
1. Should be something we can revert back easily after a test is done so it doesn't affect other tests

I'm getting this PR out here as it is as a proof of concept to make sure that the idea itself is usable and to see whether anyone else has any better ideas. Then if we like this I'll start working on a more common solution to this to get in at a later date.