### PR TITLE
Arc - Fix sqlmiaa initial load

### DIFF
--- a/extensions/arc/src/models/controllerModel.ts
+++ b/extensions/arc/src/models/controllerModel.ts
@@ -6,11 +6,12 @@
 import * as vscode from 'vscode';
 import { Authentication, BasicAuth } from '../controller/auth';
 import { EndpointsRouterApi, EndpointModel, RegistrationRouterApi, RegistrationResponse, TokenRouterApi, SqlInstanceRouterApi } from '../controller/generated/v1/api';
-import { parseEndpoint, parseInstanceName } from '../common/utils';
+import { getAzurecoreApi, parseEndpoint, parseInstanceName } from '../common/utils';
 import { ResourceType } from '../constants';
 import { ConnectToControllerDialog } from '../ui/dialogs/connectControllerDialog';
 import { AzureArcTreeDataProvider } from '../ui/tree/azureArcTreeDataProvider';
 import * as loc from '../localizedConstants';
+
 
 export type ControllerInfo = {
 	url: string,
@@ -29,6 +30,7 @@ export type ResourceInfo = {
 export interface Registration extends RegistrationResponse {
 	externalIp?: string;
 	externalPort?: string;
+	region?: string
 }
 
 export class ControllerModel {
@@ -101,7 +103,9 @@ export class ControllerModel {
 			}),
 			this._tokenRouter.apiV1TokenPost().then(async response => {
 				this._namespace = response.body.namespace!;
-				this._registrations = (await this._registrationRouter.apiV1RegistrationListResourcesNsGet(this._namespace)).body.map(mapRegistrationResponse);
+				const registrationResponse = await this._registrationRouter.apiV1RegistrationListResourcesNsGet(this._namespace);
+				this._registrations = await Promise.all(registrationResponse.body.map(mapRegistrationResponse));
+
 				this._controllerRegistration = this._registrations.find(r => r.instanceType === ResourceType.dataControllers);
 				this.registrationsLastUpdated = new Date();
 				this._onRegistrationsUpdated.fire(this._registrations);
@@ -183,7 +187,12 @@ export class ControllerModel {
  * Maps a RegistrationResponse to a Registration,
  * @param response The RegistrationResponse to map
  */
-function mapRegistrationResponse(response: RegistrationResponse): Registration {
+async function mapRegistrationResponse(response: RegistrationResponse): Promise<Registration> {
 	const parsedEndpoint = parseEndpoint(response.externalEndpoint);
-	return { ...response, externalIp: parsedEndpoint.ip, externalPort: parsedEndpoint.port };
+	return {
+		...response,
+		externalIp: parsedEndpoint.ip,
+		externalPort: parsedEndpoint.port,
+		region: (await getAzurecoreApi()).getRegionDisplayName(response.location)
+	};
 }

--- a/extensions/arc/src/models/controllerModel.ts
+++ b/extensions/arc/src/models/controllerModel.ts
@@ -12,7 +12,6 @@ import { ConnectToControllerDialog } from '../ui/dialogs/connectControllerDialog
 import { AzureArcTreeDataProvider } from '../ui/tree/azureArcTreeDataProvider';
 import * as loc from '../localizedConstants';
 
-
 export type ControllerInfo = {
 	url: string,
 	username: string,

--- a/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
@@ -29,9 +29,6 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 		instanceNamespace: '-',
 	};
 
-	private _endpointsRetrieved = false;
-	private _registrationsRetrieved = false;
-
 	constructor(modelView: azdata.ModelView, private _controllerModel: ControllerModel) {
 		super(modelView);
 
@@ -196,7 +193,6 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 		this.controllerProperties.subscriptionId = reg?.subscriptionId || this.controllerProperties.subscriptionId;
 		this.controllerProperties.connectionMode = getConnectionModeDisplayText(reg?.connectionMode) || this.controllerProperties.connectionMode;
 		this.controllerProperties.instanceNamespace = reg?.instanceNamespace || this.controllerProperties.instanceNamespace;
-		this._registrationsRetrieved = true;
 		this.refreshDisplayedProperties();
 
 		this._arcResourcesTable.data = this._controllerModel.registrations
@@ -221,55 +217,51 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 				});
 				return [imageComponent, nameLink, resourceTypeToDisplayName(r.instanceType), loc.numVCores(r.vCores)];
 			});
-		this._arcResourcesLoadingComponent.loading = false;
+		this._arcResourcesLoadingComponent.loading = !this._controllerModel.registrationsLastUpdated;
 	}
 
 	private handleEndpointsUpdated(): void {
 		const controllerEndpoint = this._controllerModel.getEndpoint(Endpoints.controller);
 		this.controllerProperties.controllerEndpoint = controllerEndpoint?.endpoint || this.controllerProperties.controllerEndpoint;
-		this._endpointsRetrieved = true;
 		this.refreshDisplayedProperties();
 	}
 
 	private refreshDisplayedProperties(): void {
-		// Only update once we've retrieved all the necessary properties
-		if (this._endpointsRetrieved && this._registrationsRetrieved) {
-			this._propertiesContainer.propertyItems = [
-				{
-					displayName: loc.name,
-					value: this.controllerProperties.instanceName
-				},
-				{
-					displayName: loc.resourceGroup,
-					value: this.controllerProperties.resourceGroupName
-				},
-				{
-					displayName: loc.region,
-					value: this.controllerProperties.location
-				},
-				{
-					displayName: loc.subscriptionId,
-					value: this.controllerProperties.subscriptionId
-				},
-				{
-					displayName: loc.type,
-					value: loc.dataControllersType
-				},
-				{
-					displayName: loc.controllerEndpoint,
-					value: this.controllerProperties.controllerEndpoint
-				},
-				{
-					displayName: loc.connectionMode,
-					value: this.controllerProperties.connectionMode
-				},
-				{
-					displayName: loc.namespace,
-					value: this.controllerProperties.instanceNamespace
-				}
-			];
-			this._propertiesLoadingComponent.loading = false;
-		}
+		this._propertiesContainer.propertyItems = [
+			{
+				displayName: loc.name,
+				value: this.controllerProperties.instanceName
+			},
+			{
+				displayName: loc.resourceGroup,
+				value: this.controllerProperties.resourceGroupName
+			},
+			{
+				displayName: loc.region,
+				value: this.controllerProperties.location
+			},
+			{
+				displayName: loc.subscriptionId,
+				value: this.controllerProperties.subscriptionId
+			},
+			{
+				displayName: loc.type,
+				value: loc.dataControllersType
+			},
+			{
+				displayName: loc.controllerEndpoint,
+				value: this.controllerProperties.controllerEndpoint
+			},
+			{
+				displayName: loc.connectionMode,
+				value: this.controllerProperties.connectionMode
+			},
+			{
+				displayName: loc.namespace,
+				value: this.controllerProperties.instanceNamespace
+			}
+		];
 
+		this._propertiesLoadingComponent.loading = !this._controllerModel.registrationsLastUpdated && !this._controllerModel.endpointsLastUpdated;
 	}
 }

--- a/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
@@ -9,9 +9,7 @@ import * as loc from '../../../localizedConstants';
 import { DashboardPage } from '../../components/dashboardPage';
 import { IconPathHelper, cssStyles, iconSize, ResourceType, Endpoints } from '../../../constants';
 import { ControllerModel } from '../../../models/controllerModel';
-import { resourceTypeToDisplayName, getAzurecoreApi, getResourceTypeIcon, getConnectionModeDisplayText, parseInstanceName } from '../../../common/utils';
-import { RegistrationResponse } from '../../../controller/generated/v1/model/registrationResponse';
-import { EndpointModel } from '../../../controller/generated/v1/api';
+import { resourceTypeToDisplayName, getResourceTypeIcon, getConnectionModeDisplayText, parseInstanceName } from '../../../common/utils';
 
 export class ControllerDashboardOverviewPage extends DashboardPage {
 
@@ -36,19 +34,10 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 
 	constructor(modelView: azdata.ModelView, private _controllerModel: ControllerModel) {
 		super(modelView);
-		this._controllerModel.onRegistrationsUpdated((_: RegistrationResponse[]) => {
-			this.eventuallyRunOnInitialized(() => {
-				this.handleRegistrationsUpdated().catch(e => console.log(e));
-			});
-		});
-		this._controllerModel.onEndpointsUpdated(endpoints => {
-			this.eventuallyRunOnInitialized(() => {
-				this.handleEndpointsUpdated(endpoints);
-			});
-		});
-		this.refresh().catch(e => {
-			console.log(e);
-		});
+
+		this.disposables.push(
+			this._controllerModel.onRegistrationsUpdated(() => this.eventuallyRunOnInitialized(() => this.handleRegistrationsUpdated())),
+			this._controllerModel.onEndpointsUpdated(() => this.eventuallyRunOnInitialized(() => this.handleEndpointsUpdated())));
 	}
 
 	public get title(): string {
@@ -68,27 +57,11 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 	}
 
 	public get container(): azdata.Component {
-
-		const rootContainer = this.modelView.modelBuilder.flexContainer()
-			.withLayout({ flexFlow: 'column' })
-			.component();
-
-		const contentContainer = this.modelView.modelBuilder.divContainer().component();
-		rootContainer.addItem(contentContainer, { CSSStyles: { 'margin': '10px 20px 0px 20px' } });
-
+		// Create loaded components
 		this._propertiesContainer = this.modelView.modelBuilder.propertiesContainer().component();
-		this._propertiesLoadingComponent = this.modelView.modelBuilder.loadingComponent().withItem(this._propertiesContainer).component();
+		this._propertiesLoadingComponent = this.modelView.modelBuilder.loadingComponent().component();
 
-		contentContainer.addItem(this._propertiesLoadingComponent);
-
-		const arcResourcesTitle = this.modelView.modelBuilder.text()
-			.withProperties<azdata.TextComponentProperties>({ value: loc.arcResources })
-			.component();
-
-		contentContainer.addItem(arcResourcesTitle, {
-			CSSStyles: cssStyles.title
-		});
-
+		this._arcResourcesLoadingComponent = this.modelView.modelBuilder.loadingComponent().component();
 		this._arcResourcesTable = this.modelView.modelBuilder.declarativeTable().withProperties<azdata.DeclarativeTableProperties>({
 			data: [],
 			columns: [
@@ -127,11 +100,33 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 			ariaLabel: loc.arcResources
 		}).component();
 
-		const arcResourcesTableContainer = this.modelView.modelBuilder.divContainer()
-			.withItems([this._arcResourcesTable])
+		// Update loaded components with data
+		this.handleRegistrationsUpdated();
+		this.handleEndpointsUpdated();
+
+		// Assign the loading component after it has data
+		this._propertiesLoadingComponent.component = this._propertiesContainer;
+		this._arcResourcesLoadingComponent.component = this._arcResourcesTable;
+
+		// Assemble the container
+		const rootContainer = this.modelView.modelBuilder.flexContainer()
+			.withLayout({ flexFlow: 'column' })
 			.component();
 
-		this._arcResourcesLoadingComponent = this.modelView.modelBuilder.loadingComponent().withItem(arcResourcesTableContainer).component();
+		const contentContainer = this.modelView.modelBuilder.divContainer().component();
+		rootContainer.addItem(contentContainer, { CSSStyles: { 'margin': '10px 20px 0px 20px' } });
+
+		// Properties
+		contentContainer.addItem(this._propertiesLoadingComponent);
+
+		// Resources
+		const arcResourcesTitle = this.modelView.modelBuilder.text()
+			.withProperties<azdata.TextComponentProperties>({ value: loc.arcResources })
+			.component();
+
+		contentContainer.addItem(arcResourcesTitle, {
+			CSSStyles: cssStyles.title
+		});
 
 		contentContainer.addItem(this._arcResourcesLoadingComponent);
 		this.initialized = true;
@@ -193,11 +188,11 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 		).component();
 	}
 
-	private async handleRegistrationsUpdated(): Promise<void> {
+	private handleRegistrationsUpdated(): void {
 		const reg = this._controllerModel.controllerRegistration;
 		this.controllerProperties.instanceName = reg?.instanceName || this.controllerProperties.instanceName;
 		this.controllerProperties.resourceGroupName = reg?.resourceGroupName || this.controllerProperties.resourceGroupName;
-		this.controllerProperties.location = (await getAzurecoreApi()).getRegionDisplayName(reg?.location) || this.controllerProperties.location;
+		this.controllerProperties.location = reg?.region || this.controllerProperties.location;
 		this.controllerProperties.subscriptionId = reg?.subscriptionId || this.controllerProperties.subscriptionId;
 		this.controllerProperties.connectionMode = getConnectionModeDisplayText(reg?.connectionMode) || this.controllerProperties.connectionMode;
 		this.controllerProperties.instanceNamespace = reg?.instanceNamespace || this.controllerProperties.instanceNamespace;
@@ -205,7 +200,7 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 		this.refreshDisplayedProperties();
 
 		this._arcResourcesTable.data = this._controllerModel.registrations
-			.filter(r => r.instanceType !== ResourceType.dataControllers)
+			.filter(r => r.instanceType !== ResourceType.dataControllers && !r.isDeleted)
 			.map(r => {
 				const iconPath = getResourceTypeIcon(r.instanceType ?? '');
 				const imageComponent = this.modelView.modelBuilder.image()
@@ -229,8 +224,8 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 		this._arcResourcesLoadingComponent.loading = false;
 	}
 
-	private handleEndpointsUpdated(endpoints: EndpointModel[]): void {
-		const controllerEndpoint = endpoints.find(endpoint => endpoint.name === Endpoints.controller);
+	private handleEndpointsUpdated(): void {
+		const controllerEndpoint = this._controllerModel.getEndpoint(Endpoints.controller);
 		this.controllerProperties.controllerEndpoint = controllerEndpoint?.endpoint || this.controllerProperties.controllerEndpoint;
 		this._endpointsRetrieved = true;
 		this.refreshDisplayedProperties();

--- a/extensions/arc/src/ui/dashboards/miaa/miaaConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaConnectionStringsPage.ts
@@ -8,20 +8,17 @@ import * as loc from '../../../localizedConstants';
 import { IconPathHelper, cssStyles, ResourceType } from '../../../constants';
 import { KeyValueContainer, KeyValue, InputKeyValue, MultilineInputKeyValue } from '../../components/keyValueContainer';
 import { DashboardPage } from '../../components/dashboardPage';
-import { ControllerModel, Registration } from '../../../models/controllerModel';
+import { ControllerModel } from '../../../models/controllerModel';
 import { MiaaModel } from '../../../models/miaaModel';
 
 export class MiaaConnectionStringsPage extends DashboardPage {
 
 	private _keyValueContainer!: KeyValueContainer;
-	private _instanceRegistration: Registration | undefined;
 
 	constructor(modelView: azdata.ModelView, private _controllerModel: ControllerModel, private _miaaModel: MiaaModel) {
 		super(modelView);
-		this.disposables.push(this._controllerModel.onRegistrationsUpdated(_ => {
-			this._instanceRegistration = this._controllerModel.getRegistration(ResourceType.sqlManagedInstances, this._miaaModel.info.namespace, this._miaaModel.info.name);
-			this.eventuallyRunOnInitialized(() => this.updateConnectionStrings());
-		}));
+		this.disposables.push(this._controllerModel.onRegistrationsUpdated(_ =>
+			this.eventuallyRunOnInitialized(() => this.updateConnectionStrings())));
 	}
 
 	protected get title(): string {
@@ -55,11 +52,9 @@ export class MiaaConnectionStringsPage extends DashboardPage {
 			this.modelView.modelBuilder.flexContainer().withItems([info]).withLayout({ flexWrap: 'wrap' }).component(),
 			{ CSSStyles: { display: 'inline-flex', 'margin-bottom': '25px' } });
 
-		this._keyValueContainer = new KeyValueContainer(this.modelView.modelBuilder, []);
+		this._keyValueContainer = new KeyValueContainer(this.modelView.modelBuilder, this.getConnectionStrings());
 		this.disposables.push(this._keyValueContainer);
 		content.addItem(this._keyValueContainer.container);
-
-		this.updateConnectionStrings();
 		this.initialized = true;
 		return root;
 	}
@@ -68,16 +63,17 @@ export class MiaaConnectionStringsPage extends DashboardPage {
 		return this.modelView.modelBuilder.toolbarContainer().component();
 	}
 
-	private updateConnectionStrings(): void {
-		if (!this._instanceRegistration) {
-			return;
+	private getConnectionStrings(): KeyValue[] {
+		const instanceRegistration = this._controllerModel.getRegistration(ResourceType.sqlManagedInstances, this._miaaModel.info.namespace, this._miaaModel.info.name);
+		if (!instanceRegistration) {
+			return [];
 		}
 
-		const ip = this._instanceRegistration.externalIp;
-		const port = this._instanceRegistration.externalPort;
+		const ip = instanceRegistration.externalIp;
+		const port = instanceRegistration.externalPort;
 		const username = this._miaaModel.username;
 
-		const pairs: KeyValue[] = [
+		return [
 			new InputKeyValue(this.modelView.modelBuilder, 'ADO.NET', `Server=tcp:${ip},${port};Persist Security Info=False;User ID=${username};Password={your_password_here};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;`),
 			new InputKeyValue(this.modelView.modelBuilder, 'C++ (libpq)', `host=${ip} port=${port} user=${username} password={your_password_here} sslmode=require`),
 			new InputKeyValue(this.modelView.modelBuilder, 'JDBC', `jdbc:sqlserver://${ip}:${port};user=${username};password={your_password_here};encrypt=true;trustServerCertificate=false;loginTimeout=30;`),
@@ -91,6 +87,9 @@ $conn = sqlsrv_connect($serverName, $connectionInfo);`),
 			new InputKeyValue(this.modelView.modelBuilder, 'Ruby', `host=${ip}; user=${username} password={your_password_here} port=${port} sslmode=require`),
 			new InputKeyValue(this.modelView.modelBuilder, 'Web App', `Database=master; Data Source=${ip}; User Id=${username}; Password={your_password_here}`)
 		];
-		this._keyValueContainer.refresh(pairs);
+	}
+
+	private updateConnectionStrings(): void {
+		this._keyValueContainer.refresh(this.getConnectionStrings());
 	}
 }

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -7,7 +7,7 @@ import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import * as loc from '../../../localizedConstants';
 import { DashboardPage } from '../../components/dashboardPage';
-import { IconPathHelper, cssStyles, ResourceType } from '../../../constants';
+import { IconPathHelper, cssStyles, ResourceType, Endpoints } from '../../../constants';
 import { ControllerModel } from '../../../models/controllerModel';
 import { promptForResourceDeletion, getDatabaseStateDisplayText } from '../../../common/utils';
 import { MiaaModel } from '../../../models/miaaModel';
@@ -63,7 +63,7 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 	}
 
 	public get container(): azdata.Component {
-		// Loaded components
+		// Create loaded components
 		this._propertiesContainer = this.modelView.modelBuilder.propertiesContainer().component();
 		this._propertiesLoading = this.modelView.modelBuilder.loadingComponent().component();
 
@@ -97,7 +97,7 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 			data: []
 		}).component();
 
-		// Update loaded components with data from the model
+		// Update loaded components with data
 		this.handleRegistrationsUpdated();
 		this.handleMiaaStatusUpdated();
 		this.handleEndpointsUpdated();
@@ -109,6 +109,7 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 		this._grafanaLoading.component = this._grafanaLink;
 		this._databasesTableLoading.component = this._databasesTable;
 
+		// Assemble the container
 		const rootContainer = this.modelView.modelBuilder.flexContainer()
 			.withLayout({ flexFlow: 'column' })
 			.withProperties({ CSSStyles: { 'margin': '18px' } })
@@ -258,11 +259,11 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 
 	private handleEndpointsUpdated(): void {
 		const kibanaQuery = `kubernetes_namespace:"${this._miaaModel.info.namespace}" and instance_name :"${this._miaaModel.info.name}"`;
-		const kibanaUrl = `${this._controllerModel.getEndpoint('logsui')?.endpoint}/app/kibana#/discover?_a=(query:(language:kuery,query:'${kibanaQuery}'))`;
+		const kibanaUrl = `${this._controllerModel.getEndpoint(Endpoints.logsui)?.endpoint}/app/kibana#/discover?_a=(query:(language:kuery,query:'${kibanaQuery}'))`;
 		this._kibanaLink.label = kibanaUrl;
 		this._kibanaLink.url = kibanaUrl;
 
-		const grafanaUrl = `${this._controllerModel.getEndpoint('metricsui')?.endpoint}/d/wZx3OUdmz/azure-sql-db-managed-instance-metrics?var-hostname=${this._miaaModel.info.name}-0`;
+		const grafanaUrl = `${this._controllerModel.getEndpoint(Endpoints.metricsui)?.endpoint}/d/wZx3OUdmz/azure-sql-db-managed-instance-metrics?var-hostname=${this._miaaModel.info.name}-0`;
 		this._grafanaLink.label = grafanaUrl;
 		this._grafanaLink.url = grafanaUrl;
 

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -258,12 +258,15 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 	}
 
 	private handleEndpointsUpdated(): void {
+		const kibanaEndpoint = this._controllerModel.getEndpoint(Endpoints.logsui);
 		const kibanaQuery = `kubernetes_namespace:"${this._miaaModel.info.namespace}" and instance_name :"${this._miaaModel.info.name}"`;
-		const kibanaUrl = `${this._controllerModel.getEndpoint(Endpoints.logsui)?.endpoint}/app/kibana#/discover?_a=(query:(language:kuery,query:'${kibanaQuery}'))`;
+		const kibanaUrl = kibanaEndpoint ? `${kibanaEndpoint.endpoint}/app/kibana#/discover?_a=(query:(language:kuery,query:'${kibanaQuery}'))` : '';
 		this._kibanaLink.label = kibanaUrl;
 		this._kibanaLink.url = kibanaUrl;
 
-		const grafanaUrl = `${this._controllerModel.getEndpoint(Endpoints.metricsui)?.endpoint}/d/wZx3OUdmz/azure-sql-db-managed-instance-metrics?var-hostname=${this._miaaModel.info.name}-0`;
+		const grafanaEndpoint = this._controllerModel.getEndpoint(Endpoints.metricsui);
+		const grafanaQuery = `var-hostname=${this._miaaModel.info.name}-0`;
+		const grafanaUrl = grafanaEndpoint ? `${grafanaEndpoint.endpoint}/d/wZx3OUdmz/azure-sql-db-managed-instance-metrics?${grafanaQuery}` : '';
 		this._grafanaLink.label = grafanaUrl;
 		this._grafanaLink.url = grafanaUrl;
 

--- a/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as loc from '../../../localizedConstants';
-import { IconPathHelper, cssStyles, ResourceType } from '../../../constants';
+import { IconPathHelper, cssStyles, ResourceType, Endpoints } from '../../../constants';
 import { V1Pod, DuskyObjectModelsDatabaseServiceArcPayload } from '../../../controller/generated/dusky/api';
 import { DashboardPage } from '../../components/dashboardPage';
 import { ControllerModel } from '../../../models/controllerModel';
@@ -311,13 +311,13 @@ export class PostgresOverviewPage extends DashboardPage {
 
 	private getKibanaLink(): string {
 		const kibanaQuery = `kubernetes_namespace:"${this._postgresModel.namespace}" and cluster_name:"${this._postgresModel.name}"`;
-		return `${this._controllerModel.getEndpoint('logsui')?.endpoint}/app/kibana#/discover?_a=(query:(language:kuery,query:'${kibanaQuery}'))`;
+		return `${this._controllerModel.getEndpoint(Endpoints.logsui)?.endpoint}/app/kibana#/discover?_a=(query:(language:kuery,query:'${kibanaQuery}'))`;
 
 	}
 
 	private getGrafanaLink(): string {
 		const grafanaQuery = `var-Namespace=${this._postgresModel.namespace}&var-Name=${this._postgresModel.name}`;
-		return `${this._controllerModel.getEndpoint('metricsui')?.endpoint}/d/postgres-metrics?${grafanaQuery}`;
+		return `${this._controllerModel.getEndpoint(Endpoints.metricsui)?.endpoint}/d/postgres-metrics?${grafanaQuery}`;
 	}
 
 	private getNodes(): string[][] {

--- a/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
@@ -349,25 +349,22 @@ export class PostgresOverviewPage extends DashboardPage {
 	}
 
 	private handleRegistrationsUpdated() {
-		this.refreshProperties();
-	}
-
-	private hadleServiceUpdated() {
-		this.refreshProperties();
-		this.refreshNodes();
-	}
-
-	private handlePodsUpdated() {
-		this.refreshProperties();
-		this.refreshNodes();
-	}
-
-	private refreshProperties() {
 		this.properties!.propertyItems = this.getProperties();
 		this.propertiesLoading!.loading = false;
 	}
 
-	private refreshNodes() {
+	private hadleServiceUpdated() {
+		this.properties!.propertyItems = this.getProperties();
+		this.propertiesLoading!.loading = false;
+
+		this.nodesTable!.data = this.getNodes();
+		this.nodesTableLoading!.loading = false;
+	}
+
+	private handlePodsUpdated() {
+		this.properties!.propertyItems = this.getProperties();
+		this.propertiesLoading!.loading = false;
+
 		this.nodesTable!.data = this.getNodes();
 		this.nodesTableLoading!.loading = false;
 	}

--- a/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
@@ -349,22 +349,25 @@ export class PostgresOverviewPage extends DashboardPage {
 	}
 
 	private handleRegistrationsUpdated() {
-		this.properties!.propertyItems = this.getProperties();
-		this.propertiesLoading!.loading = false;
+		this.refreshProperties();
 	}
 
 	private hadleServiceUpdated() {
-		this.properties!.propertyItems = this.getProperties();
-		this.propertiesLoading!.loading = false;
-
-		this.nodesTable!.data = this.getNodes();
-		this.nodesTableLoading!.loading = false;
+		this.refreshProperties();
+		this.refreshNodes();
 	}
 
 	private handlePodsUpdated() {
+		this.refreshProperties();
+		this.refreshNodes();
+	}
+
+	private refreshProperties() {
 		this.properties!.propertyItems = this.getProperties();
 		this.propertiesLoading!.loading = false;
+	}
 
+	private refreshNodes() {
 		this.nodesTable!.data = this.getNodes();
 		this.nodesTableLoading!.loading = false;
 	}


### PR DESCRIPTION
Fixes this bug where the sqlmiaa pages do not load until you click refresh.  Reproduces every time in my environment.

![427d9b5](https://user-images.githubusercontent.com/3500406/85908281-51fbfe00-b7c9-11ea-83ff-4559d0e52f04.gif)

Cause: The models finish refreshing before the UI pages subscribe to model changes.

The code looks something like this:

```
dashboard = azdata.window.createModelViewDashboard(...)
dashboard.registerTabs(() => // create UI pages);
await dashboard.open();

// Kick these off without waiting for them to finish
controllerModel.refresh()
miaaModel.refresh()
```

The models finish refreshing before the registerTabs callback is executed.  When the models fire their updated events, the UI pages have not yet been created and therefore miss the events.

The pages were designed to initialize the UI with empty data, and rely on the model update events to initialize the data.

There are 2 ways to fix it.

1. Move the model refresh to inside the registerTabs callback.  This way the UI pages are created before we initiate the model refreshes.

2. Initialize the UI with data from the model instead of empty data.

I think (2) is the way to go based on a similar but different bug I saw in the Postgres pages.  In that bug, the models finished refreshing after the UI page was constructed, but before it finished initalizing.  eventuallyRunOnInitialized would do its job to delay the refresh until the page was initialized.  But the UI would still show empty data sometimes.  There's some race here I don't fully understand.  But the fix was (2) so applying same idea to sqlmiaa.

