### PR TITLE
Add Arc extension and deprecate old Arc Deployment extension

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3028,7 +3028,7 @@
 				{
 					"extensionId": "63",
 					"extensionName": "arcdeployment",
-					"displayName": "Azure Arc deployment",
+					"displayName": "Azure Arc deployment (deprecated)",
 					"shortDescription": "Provides a notebook-based experience to deploy resources on Azure Arc",
 					"publisher": {
 						"displayName": "Microsoft",
@@ -3037,14 +3037,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.3.1",
+							"version": "0.3.2",
 							"lastUpdated": "6/3/2020",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arcdeployment/arcdeployment-0.3.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arcdeployment/arcdeployment-0.3.2.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -3052,15 +3052,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arcdeployment/content/0.3.1/README.md"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arcdeployment/content/0.3.2/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arcdeployment/content/0.3.1/package.json"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arcdeployment/content/0.3.2/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arcdeployment/content/0.3.1/LICENSE.txt"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arcdeployment/content/0.3.2/LICENSE.txt"
 								}
 							],
 							"properties": [

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3303,6 +3303,63 @@
 					"flags": "preview"
 				},
 				{
+					"extensionId": "68",
+					"extensionName": "arc",
+					"displayName": "Azure Arc",
+					"shortDescription": "Provides deployment and management capabilities for Azure Arc",
+					"publisher": {
+						"displayName": "Microsoft",
+						"publisherId": "Microsoft",
+						"publisherName": "Microsoft"
+					},
+					"versions": [
+						{
+							"version": "0.1.0",
+							"lastUpdated": "06/22/2020",
+							"assetUri": "",
+							"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+								{
+									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-0.1.0.vsix"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/extensions/arc/images/extension.png"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/extensions/arc/README.md"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Code.Manifest",
+									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/extensions/arc/package.json"
+								},
+								{
+									"assetType": "Microsoft.VisualStudio.Services.Content.License",
+									"source": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt"
+								}
+							],
+							"properties": [
+								{
+									"key": "Microsoft.VisualStudio.Code.Engine",
+									"value": ">=1.20.0"
+								},
+								{
+									"key": "Microsoft.AzDataEngine",
+									"value": ">=1.20.0"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/Microsoft/azuredatastudio"
+								}
+							]
+						}
+					],
+					"statistics": [],
+					"flags": "preview"
+				},
+				{
 					"extensionId": "69",
 					"extensionName": "code-settings-sync",
 					"displayName": "Settings Sync",
@@ -3480,7 +3537,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 59
+							"count": 60
 						}
 					]
 				}

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3038,7 +3038,7 @@
 					"versions": [
 						{
 							"version": "0.3.2",
-							"lastUpdated": "6/3/2020",
+							"lastUpdated": "6/29/2020",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
@@ -3315,7 +3315,7 @@
 					"versions": [
 						{
 							"version": "0.1.0",
-							"lastUpdated": "06/22/2020",
+							"lastUpdated": "06/29/2020",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [


### PR DESCRIPTION
Ready to publish to gallery now, replacing old Arc Deployment extension with new Arc extension (deprecating the old deployment extension)