### PR TITLE
Add Azure DevOps as a resource for authentication

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -126,7 +126,8 @@ export abstract class AzureAuth implements vscode.Disposable {
 			this.metadata.settings.graphResource,
 			this.metadata.settings.ossRdbmsResource,
 			this.metadata.settings.microsoftResource,
-			this.metadata.settings.azureKeyVaultResource
+			this.metadata.settings.azureKeyVaultResource,
+			this.metadata.settings.azureDevOpsResource,
 		];
 
 		this.scopes = [...this.metadata.settings.scopes];

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -126,9 +126,12 @@ export abstract class AzureAuth implements vscode.Disposable {
 			this.metadata.settings.graphResource,
 			this.metadata.settings.ossRdbmsResource,
 			this.metadata.settings.microsoftResource,
-			this.metadata.settings.azureKeyVaultResource,
-			this.metadata.settings.azureDevOpsResource,
+			this.metadata.settings.azureKeyVaultResource
 		];
+
+		if (this.metadata.settings.azureDevOpsResource) {
+			this.resources = this.resources.concat(this.metadata.settings.azureDevOpsResource);
+		}
 
 		this.scopes = [...this.metadata.settings.scopes];
 		this.scopesString = this.scopes.join(' ');

--- a/extensions/azurecore/src/account-provider/interfaces.ts
+++ b/extensions/azurecore/src/account-provider/interfaces.ts
@@ -100,6 +100,11 @@ interface Settings {
 	azureKeyVaultResource?: Resource;
 
 	/**
+	 * Information that describes the Azure Dev Ops resource
+	 */
+	azureDevOpsResource?: Resource;
+
+	/**
 	 * A list of tenant IDs to authenticate against. If defined, then these IDs will be used
 	 * instead of querying the tenants endpoint of the armResource
 	 */

--- a/extensions/azurecore/src/account-provider/providerSettings.ts
+++ b/extensions/azurecore/src/account-provider/providerSettings.ts
@@ -48,6 +48,11 @@ const publicAzureSettings: ProviderSettings = {
 				endpoint: 'https://vault.azure.net',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
+			azureDevOpsResource: {
+				id: 'ado',
+				endpoint: '499b84ac-1321-427f-aa17-267ca6975798',
+				azureResourceId: AzureResource.AzureDevOps,
+			},
 			redirectUri: 'https://vscode-redirect.azurewebsites.net/',
 			scopes: [
 				'openid', 'email', 'profile', 'offline_access',
@@ -97,6 +102,11 @@ const usGovAzureSettings: ProviderSettings = {
 				id: 'vault',
 				endpoint: 'https://vault.usgovcloudapi.net',
 				azureResourceId: AzureResource.AzureKeyVault
+			},
+			azureDevOpsResource: {
+				id: 'ado',
+				endpoint: '499b84ac-1321-427f-aa17-267ca6975798',
+				azureResourceId: AzureResource.AzureDevOps,
 			},
 			redirectUri: 'https://vscode-redirect.azurewebsites.net/',
 			scopes: [

--- a/extensions/azurecore/src/account-provider/providerSettings.ts
+++ b/extensions/azurecore/src/account-provider/providerSettings.ts
@@ -103,11 +103,6 @@ const usGovAzureSettings: ProviderSettings = {
 				endpoint: 'https://vault.usgovcloudapi.net',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
-			azureDevOpsResource: {
-				id: 'ado',
-				endpoint: '499b84ac-1321-427f-aa17-267ca6975798',
-				azureResourceId: AzureResource.AzureDevOps,
-			},
 			redirectUri: 'https://vscode-redirect.azurewebsites.net/',
 			scopes: [
 				'openid', 'email', 'profile', 'offline_access',

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2216,7 +2216,8 @@ declare module 'azdata' {
 		OssRdbms = 2,
 		AzureKeyVault = 3,
 		Graph = 4,
-		MicrosoftResourceManagement = 5
+		MicrosoftResourceManagement = 5,
+		AzureDevOps = 6
 	}
 
 	export interface DidChangeAccountsParams {

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -407,7 +407,8 @@ export enum AzureResource {
 	OssRdbms = 2,
 	AzureKeyVault = 3,
 	Graph = 4,
-	MicrosoftResourceManagement = 5
+	MicrosoftResourceManagement = 5,
+	AzureDevOps = 6
 }
 
 export class TreeItem extends vsExtTypes.TreeItem {


### PR DESCRIPTION
Adds Azure Devops as a resource for retrieving an account. This will be leveraged by an extension to authenticate against the service.

Initially this change was part of another PR, but breaking it up into more manageable pieces. 