### PR TITLE
spell error in Severity column name

### DIFF
--- a/src/sql/workbench/contrib/assessment/browser/asmtResultsView.component.ts
+++ b/src/sql/workbench/contrib/assessment/browser/asmtResultsView.component.ts
@@ -91,7 +91,7 @@ export class AsmtResultsViewComponent extends TabChild implements IAssessmentCom
 			width: 80,
 			id: 'target'
 		},
-		{ name: nls.localize('asmt.column.severity', "Serverity"), field: 'severity', maxWidth: 90, id: 'severity' },
+		{ name: nls.localize('asmt.column.severity', "Severity"), field: 'severity', maxWidth: 90, id: 'severity' },
 		{
 			name: nls.localize('asmt.column.message', "Message"),
 			field: 'message',


### PR DESCRIPTION
Fixing spelling error in sql-assessment extension's table column name
