### PR TITLE
Update singular vcore string on data controller dashboard

### DIFF
--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -124,7 +124,11 @@ export function copiedToClipboard(name: string): string { return localize('arc.c
 export function clickTheTroubleshootButton(resourceType: string): string { return localize('arc.clickTheTroubleshootButton', "Click the troubleshoot button to open the Azure Arc {0} troubleshooting notebook.", resourceType); }
 export function numVCores(vCores: string | undefined): string {
 	if (vCores && +vCores > 0) {
-		return localize('arc.numVCores', "{0} vCores", vCores);
+		if (+vCores === 1) {
+			return localize('arc.numVCore', "{0} vCore", vCores);
+		} else {
+			return localize('arc.numVCores', "{0} vCores", vCores);
+		}
 	} else {
 		return '-';
 	}


### PR DESCRIPTION
On data controller dashboard, if a resource has 1 vCore, we currently list that as "1 vCores". Fixing this logic to account for the singular case as well:

![image](https://user-images.githubusercontent.com/40371649/86164751-2168dc80-bac7-11ea-9f7a-17e0655af029.png)
