### PR TITLE
check for jupyter-book versions and install 6.4

### DIFF
--- a/extensions/notebook/resources/notebooks/JupyterBooksCreate.ipynb
+++ b/extensions/notebook/resources/notebooks/JupyterBooksCreate.ipynb
@@ -38,13 +38,18 @@
             "source": [
                 "import sys\r\n",
                 "\r\n",
-                "#install jupyter-book\r\n",
+                "#install jupyter-book 0.6.4\r\n",
                 "cmd = f'{sys.executable} -m pip show jupyter-book'\r\n",
                 "cmdOutput = !{cmd}\r\n",
                 "if len(cmdOutput) > 1 and '0.6.4' in cmdOutput[1]:\r\n",
                 "    print('Jupyter-book required version is already installed!')\r\n",
+                "elif len(cmdOutput) > 1:\r\n",
+                "    print('Unsupported version of Jupyter-book installed, Please wait while we uninstall and install the supported version.')\r\n",
+                "    !pip uninstall jupyter-book --yes\r\n",
+                "    !pip install jupyter-book==0.6.4\r\n",
                 "else:\r\n",
-                "    !pip install jupyter-book"
+                "    print('Installing Jupyter-book...')\r\n",
+                "    !pip install jupyter-book==0.6.4"
             ],
             "metadata": {
                 "azdata_cell_guid": "8bd77173-2f63-4bf8-95e8-af2a654fc91e",

--- a/extensions/notebook/resources/notebooks/JupyterBooksCreate.ipynb
+++ b/extensions/notebook/resources/notebooks/JupyterBooksCreate.ipynb
@@ -25,6 +25,7 @@
             "source": [
                 "# Create Jupyter Book\n",
                 "\n",
+                "<strong style=\"color: red; opacity: 0.80;\">Note: Jupyter Books in Azure Data Studio only support jupyter-book versions <= 0.6.4 To create a Jupyter Book, we will be uninstalling versions newer than 0.6.4 and replacing with 0.6.4</strong>\n",
                 "## 1. Installation\n",
                 "\n",
                 "To install the Jupyter Book command-line interface (CLI), use `pip`!"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

jupyter-book released new version 7.1 which is not yet supported by us. Made changes on the create book to install the older version 0.6.4 that's currently supported by us.

I tested the below two scenarios with my changes:
1. Install the latest version of jupyter-book and tried running the book, it uninstalls the 7.1 and installs 6.4.
2. Uninstalled jupyter-book and tried running the book, it installs 6.4 and continues. 

My only current concern is, if the users have the latest version installed for their personal use and us uninstalling it. Should I add a prompt to user, that asks users permission to continue to uninstall the version they have? 

Update: Added a note:
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/12754347/86292739-205aac80-bba6-11ea-8c31-c4217b7b76e9.png)

This PR fixes #11158 
