### PR TITLE
Fix errors throw when doing validity checks

### DIFF
--- a/src/sql/platform/dashboard/browser/interfaces.ts
+++ b/src/sql/platform/dashboard/browser/interfaces.ts
@@ -60,7 +60,7 @@ export interface IModelStore {
 	getComponentDescriptor(componentId: string): IComponentDescriptor;
 	registerComponent(component: IComponent): void;
 	unregisterComponent(component: IComponent): void;
-	getComponent(componentId: string): IComponent;
+	getComponent(componentId: string): IComponent | undefined;
 	/**
 	 * Runs on a component immediately if the component exists, or runs on
 	 * registration of the component otherwise

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -286,7 +286,7 @@ export abstract class ContainerBase<T> extends ComponentBase {
 		super(_changeRef, _el);
 		this.items = [];
 		this._validations.push(() => this.items.every(item => {
-			return this.modelStore.getComponent(item.descriptor.id).valid;
+			return this.modelStore.getComponent(item.descriptor.id)?.valid || false;
 		}));
 	}
 

--- a/src/sql/workbench/browser/modelComponents/modelStore.ts
+++ b/src/sql/workbench/browser/modelComponents/modelStore.ts
@@ -47,7 +47,7 @@ export class ModelStore implements IModelStore {
 		// TODO notify model for cleanup
 	}
 
-	getComponent(componentId: string): IComponent {
+	getComponent(componentId: string): IComponent | undefined {
 		return this._componentMappings[componentId];
 	}
 


### PR DESCRIPTION
This has been a long-standing issue, when doing the validity checks for container components if their child hasn't finished initializing yet an exception is thrown since the component isn't added to the ModelStore yet.

I tested out a number of dialogs and views that use validation logic and things seem to work as expected still. 