### PR TITLE
Move account management icon to action bar

### DIFF
--- a/src/sql/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/sql/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from 'vs/base/browser/dom';
+import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { EventType as TouchEventType, GestureEvent } from 'vs/base/browser/touch';
+import { KeyCode } from 'vs/base/common/keyCodes';
+import { IMenuService } from 'vs/platform/actions/common/actions';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { IColorTheme, IThemeService } from 'vs/platform/theme/common/themeService';
+import { ActivityAction, ActivityActionViewItem, ICompositeBarColors } from 'vs/workbench/browser/parts/compositeBarActions';
+import { IAccountManagementService } from 'sql/platform/accounts/common/interfaces';
+
+export class AccountsActionViewItem extends ActivityActionViewItem {
+	constructor(
+		action: ActivityAction,
+		colors: (theme: IColorTheme) => ICompositeBarColors,
+		@IThemeService themeService: IThemeService,
+		@IContextMenuService protected contextMenuService: IContextMenuService,
+		@IMenuService protected menuService: IMenuService,
+		@IAccountManagementService private readonly accountManagementService: IAccountManagementService
+	) {
+		super(action, { draggable: false, colors, icon: true }, themeService);
+	}
+
+	render(container: HTMLElement): void {
+		super.render(container);
+
+		// Context menus are triggered on mouse down so that an item can be picked
+		// and executed with releasing the mouse over it
+
+		this._register(DOM.addDisposableListener(this.container, DOM.EventType.MOUSE_DOWN, (e: MouseEvent) => {
+			DOM.EventHelper.stop(e, true);
+			this.accountManagementService.openAccountListDialog();
+		}));
+
+		this._register(DOM.addDisposableListener(this.container, DOM.EventType.KEY_UP, (e: KeyboardEvent) => {
+			let event = new StandardKeyboardEvent(e);
+			if (event.equals(KeyCode.Enter) || event.equals(KeyCode.Space)) {
+				DOM.EventHelper.stop(e, true);
+				this.accountManagementService.openAccountListDialog();
+			}
+		}));
+
+		this._register(DOM.addDisposableListener(this.container, TouchEventType.Tap, (e: GestureEvent) => {
+			DOM.EventHelper.stop(e, true);
+			this.accountManagementService.openAccountListDialog();
+		}));
+	}
+}

--- a/src/sql/workbench/contrib/accounts/browser/accounts.contribution.ts
+++ b/src/sql/workbench/contrib/accounts/browser/accounts.contribution.ts
@@ -3,39 +3,11 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Registry } from 'vs/platform/registry/common/platform';
-import { Disposable } from 'vs/base/common/lifecycle';
-import { IWorkbenchContribution, IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
-import { IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/common/statusbar';
-import { localize } from 'vs/nls';
-import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { IAccountManagementService } from 'sql/platform/accounts/common/interfaces';
-
-const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 
 CommandsRegistry.registerCommand('workbench.actions.modal.linkedAccount', accessor => {
 	const accountManagementService = accessor.get(IAccountManagementService);
 	accountManagementService.openAccountListDialog();
 });
 
-class AccountsStatusBarContributions extends Disposable implements IWorkbenchContribution {
-
-	constructor(
-		@IStatusbarService private readonly statusbarService: IStatusbarService
-	) {
-		super();
-		this._register(
-			this.statusbarService.addEntry({
-				command: 'workbench.actions.modal.linkedAccount',
-				text: '$(person-filled)',
-				ariaLabel: 'Accounts'
-			},
-				'status.accountList',
-				localize('status.problems', "Problems"),
-				StatusbarAlignment.LEFT, 15000 /* Highest Priority */)
-		);
-	}
-}
-
-workbenchRegistry.registerWorkbenchContribution(AccountsStatusBarContributions, LifecyclePhase.Restored);

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -8,7 +8,8 @@ import * as nls from 'vs/nls';
 import { ActionsOrientation, ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { GLOBAL_ACTIVITY_ID, IActivity, ACCOUNTS_ACTIIVTY_ID } from 'vs/workbench/common/activity';
 import { Part } from 'vs/workbench/browser/part';
-import { GlobalActivityActionViewItem, ViewContainerActivityAction, PlaceHolderToggleCompositePinnedAction, PlaceHolderViewContainerActivityAction, AccountsActionViewItem, HomeAction, HomeActionViewItem, DeprecatedHomeAction } from 'vs/workbench/browser/parts/activitybar/activitybarActions';
+import { GlobalActivityActionViewItem, ViewContainerActivityAction, PlaceHolderToggleCompositePinnedAction, PlaceHolderViewContainerActivityAction, HomeAction, HomeActionViewItem, DeprecatedHomeAction } from 'vs/workbench/browser/parts/activitybar/activitybarActions';
+import { AccountsActionViewItem } from 'sql/workbench/browser/parts/activitybar/activitybarActions'; // {{ SQL CARBON EDIT }} - use the ADS account management action
 import { IBadge, NumberBadge } from 'vs/workbench/services/activity/common/activity';
 import { IWorkbenchLayoutService, Parts } from 'vs/workbench/services/layout/browser/layoutService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #11166

The lower left corner now looks like below.  The account button behaves the same as the previous status bar button, showing the accounts dialog.

<img width="104" alt="Screen Shot 2020-07-01 at 2 20 43 PM" src="https://user-images.githubusercontent.com/599935/86292731-1cc72580-bba6-11ea-84c8-7f898c7e9101.png">


