### PR TITLE
set currentMatch on find changes only

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -346,7 +346,7 @@ export class NotebookEditor extends BaseEditor implements IFindNotebookControlle
 				this._findDecorations.getCount(),
 				this._currentMatch
 			);
-			if (this._finder.getDomNode().style.visibility === 'visible') {
+			if (this._finder.getDomNode().style.visibility === 'visible' && this._previousMatch !== this._currentMatch) {
 				this._setCurrentFindMatch(this._currentMatch);
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Issue: When user tries to edit a cell when Find is active (and have a highlight in different cell), it scrolls the focus to the find result cell.

Fix: On edit of a cell, it triggers updateActiveCell which triggers onCellModeChanged on both the previous active cell and the current cell selected for editing. If the previous active cell has an active highlight, find is trying set the highlight again irrespective of it being already highlighted, which in turn triggers the scroll to that cell. Fixed it by only setting the highlight when it's different.

This PR fixes #11120 
