### PR TITLE
removes more link from list element into div

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -107,13 +107,11 @@ export default () => `
 									<!-- Filled programmatically -->
 								</ul>
 								<p class="none detail">No recent folders</p>
-								<ul class="moreRecent-list">
-									<li class="moreRecent">
-										<a class="ads-welcome-page-link" href="command:workbench.action.openRecent">${escape(localize('welcomePage.moreRecent', "Show more"))}
-											<i class="icon-arrow-down-dark"></i>
-										</a>
-									</li>
-								</ul>
+								<div class="moreRecent">
+									<a class="ads-welcome-page-link" href="command:workbench.action.openRecent">${escape(localize('welcomePage.moreRecent', "Show more"))}
+									<i class="icon-arrow-down-dark"></i>
+								</a>
+							</div>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
This PR removes the show more button on the welcome page from a list element to a div for accessibility alignment.

This PR fixes #10622
