### PR TITLE
Fix ModelView tree components to keep custom state

### DIFF
--- a/src/sql/workbench/browser/modelComponents/treeViewDataProvider.ts
+++ b/src/sql/workbench/browser/modelComponents/treeViewDataProvider.ts
@@ -50,17 +50,12 @@ export class TreeViewDataProvider extends vsTreeView.TreeViewDataProvider implem
 	refresh(itemsToRefreshByHandle: { [treeItemHandle: string]: ITreeComponentItem }) {
 	}
 
-	getChildren(treeItem?: ITreeComponentItem): Promise<ITreeComponentItem[]> {
-		return Promise.resolve(this._proxy.$getChildren(this.treeViewId, treeItem ? treeItem.handle : undefined)
-			.then(
-				children => this.treeComponentPostGetChildren(children),
-				err => {
-					this.notificationService.error(err);
-					return [];
-				}));
-	}
-
-	private async treeComponentPostGetChildren(elements: ITreeComponentItem[]): Promise<ResolvableTreeComponentItem[]> {
+	/**
+	 * Returns the set of mapped ResolvableTreeComponentItems
+	 * @override
+	 * @param elements The elements to map
+	 */
+	protected async postGetChildren(elements: ITreeComponentItem[]): Promise<ResolvableTreeComponentItem[]> {
 		const result: ResolvableTreeComponentItem[] = [];
 		const hasResolve = await this.hasResolve;
 		if (elements) {

--- a/src/sql/workbench/browser/modelComponents/treeViewDataProvider.ts
+++ b/src/sql/workbench/browser/modelComponents/treeViewDataProvider.ts
@@ -12,6 +12,7 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 // eslint-disable-next-line code-import-patterns
 import * as vsTreeView from 'vs/workbench/api/browser/mainThreadTreeViews';
 import { ResolvableTreeItem } from 'vs/workbench/common/views';
+import { deepClone } from 'vs/base/common/objects';
 
 export class ResolvableTreeComponentItem extends ResolvableTreeItem implements ITreeComponentItem {
 
@@ -25,7 +26,7 @@ export class ResolvableTreeComponentItem extends ResolvableTreeItem implements I
 		this.checked = treeItem.checked;
 		this.enabled = treeItem.enabled;
 		this.onCheckedChanged = treeItem.onCheckedChanged;
-		this.children = treeItem.children;
+		this.children = deepClone(treeItem.children);
 	}
 }
 

--- a/src/sql/workbench/browser/modelComponents/treeViewDataProvider.ts
+++ b/src/sql/workbench/browser/modelComponents/treeViewDataProvider.ts
@@ -11,6 +11,23 @@ import { IModelViewTreeViewDataProvider, ITreeComponentItem } from 'sql/workbenc
 import { INotificationService } from 'vs/platform/notification/common/notification';
 // eslint-disable-next-line code-import-patterns
 import * as vsTreeView from 'vs/workbench/api/browser/mainThreadTreeViews';
+import { ResolvableTreeItem } from 'vs/workbench/common/views';
+
+export class ResolvableTreeComponentItem extends ResolvableTreeItem implements ITreeComponentItem {
+
+	checked?: boolean;
+	enabled?: boolean;
+	onCheckedChanged?: (checked: boolean) => void;
+	children?: ITreeComponentItem[];
+
+	constructor(treeItem: ITreeComponentItem, resolve?: (() => Promise<ITreeComponentItem | undefined>)) {
+		super(treeItem, resolve);
+		this.checked = treeItem.checked;
+		this.enabled = treeItem.enabled;
+		this.onCheckedChanged = treeItem.onCheckedChanged;
+		this.children = treeItem.children;
+	}
+}
 
 export class TreeViewDataProvider extends vsTreeView.TreeViewDataProvider implements IModelViewTreeViewDataProvider {
 	constructor(handle: number, treeViewId: string,
@@ -31,5 +48,30 @@ export class TreeViewDataProvider extends vsTreeView.TreeViewDataProvider implem
 	}
 
 	refresh(itemsToRefreshByHandle: { [treeItemHandle: string]: ITreeComponentItem }) {
+	}
+
+	getChildren(treeItem?: ITreeComponentItem): Promise<ITreeComponentItem[]> {
+		return Promise.resolve(this._proxy.$getChildren(this.treeViewId, treeItem ? treeItem.handle : undefined)
+			.then(
+				children => this.treeComponentPostGetChildren(children),
+				err => {
+					this.notificationService.error(err);
+					return [];
+				}));
+	}
+
+	private async treeComponentPostGetChildren(elements: ITreeComponentItem[]): Promise<ResolvableTreeComponentItem[]> {
+		const result: ResolvableTreeComponentItem[] = [];
+		const hasResolve = await this.hasResolve;
+		if (elements) {
+			for (const element of elements) {
+				const resolvable = new ResolvableTreeComponentItem(element, hasResolve ? () => {
+					return this._proxy.$resolve(this.treeViewId, element.handle);
+				} : undefined);
+				this.itemsMap.set(element.handle, resolvable);
+				result.push(resolvable);
+			}
+		}
+		return result;
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -170,7 +170,7 @@ export class TreeViewDataProvider implements ITreeViewDataProvider {
 	// {{SQL CARBON EDIT}}
 	constructor(protected readonly treeViewId: string,
 		protected readonly _proxy: ExtHostTreeViewsShape,
-		protected readonly notificationService: INotificationService // {{SQL CARBON EDIT}} For use by Component Tree View
+		private readonly notificationService: INotificationService
 	) {
 		this.hasResolve = this._proxy.$hasResolve(this.treeViewId);
 	}
@@ -219,7 +219,7 @@ export class TreeViewDataProvider implements ITreeViewDataProvider {
 		return this.itemsMap.size === 0;
 	}
 
-	private async postGetChildren(elements: ITreeItem[]): Promise<ResolvableTreeItem[]> {
+	protected async postGetChildren(elements: ITreeItem[]): Promise<ResolvableTreeItem[]> { // {{SQL CARBON EDIT}} For use by Component Tree View
 		const result: ResolvableTreeItem[] = [];
 		const hasResolve = await this.hasResolve;
 		if (elements) {

--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -164,13 +164,13 @@ export type TreeItemHandle = string;
 // {{SQL CARBON EDIT}}
 export class TreeViewDataProvider implements ITreeViewDataProvider {
 
-	private readonly itemsMap: Map<TreeItemHandle, ITreeItem> = new Map<TreeItemHandle, ITreeItem>();
-	private hasResolve: Promise<boolean>;
+	protected readonly itemsMap: Map<TreeItemHandle, ITreeItem> = new Map<TreeItemHandle, ITreeItem>(); // {{SQL CARBON EDIT}} For use by Component Tree View
+	protected hasResolve: Promise<boolean>; // {{SQL CARBON EDIT}} For use by Component Tree View
 
 	// {{SQL CARBON EDIT}}
 	constructor(protected readonly treeViewId: string,
 		protected readonly _proxy: ExtHostTreeViewsShape,
-		private readonly notificationService: INotificationService
+		protected readonly notificationService: INotificationService // {{SQL CARBON EDIT}} For use by Component Tree View
 	) {
 		this.hasResolve = this._proxy.$hasResolve(this.treeViewId);
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/11170

In https://github.com/microsoft/vscode/commit/39a406daa381ddeb57323088f920d88f8bc8f40b the tree data provider was modified such that the children elements returned by getChildren were changed into ResolvableTreeItems and being recreated each time.

This broke the ModelView tree component since it relied on custom state being added to the tree items that controlled things such as the checkbox state. 

The fix here is to override the getChildren method and provide our own extended version of the ResolvableTreeItem that we use instead. I kept the logic the same as the base class to reduce chance of this breaking other logic that relies on ResolvableTreeItem being there. 

In the end I think that this is something we're probably going to want to redo at some point since this is starting to get a bit too messy and intertwined with the vs implementation - but for a quick fix for this release it should be fine unless anyone else has any other suggestions for a better fix. 

Note that this should not impact anything outside of the ModelView tree (which as far as I can tell only the data virtualization extension is using). 