### PR TITLE
Fix error when calling getParent

### DIFF
--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -29,7 +29,7 @@ export interface BookTreeItemFormat {
 
 export class BookTreeItem extends vscode.TreeItem {
 	private _sections: IJupyterBookSection[];
-	private _uri: string;
+	private _uri: string | undefined;
 	private _previousUri: string;
 	private _nextUri: string;
 	public command: vscode.Command;
@@ -124,7 +124,7 @@ export class BookTreeItem extends vscode.TreeItem {
 		return this.book.title;
 	}
 
-	public get uri(): string {
+	public get uri(): string | undefined {
 		return this._uri;
 	}
 

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -485,7 +485,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	}
 
 	getParent(element?: BookTreeItem): vscode.ProviderResult<BookTreeItem> {
-		if (element) {
+		if (element?.uri) {
 			let parentPath: string;
 			parentPath = path.join(element.root, Content, element.uri.substring(0, element.uri.lastIndexOf(path.posix.sep)));
 			if (parentPath === element.root) {


### PR DESCRIPTION
Root Book items don't have a URI so this was throwing.

It didn't have a functional impact as far as I can tell since those items never had a parent anyways - but we still should make sure we're handling these cases correctly. 