### PR TITLE
Move load profile button to top of publish dialog

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -112,6 +112,10 @@ export class PublishDatabaseDialog {
 					{
 						title: constants.targetDatabaseSettings,
 						components: [
+							{
+								title: constants.profileWarningText,
+								component: <azdata.ButtonComponent>this.loadProfileButton
+							},
 							/* TODO : enable using this when data source creation is enabled
 							{
 								title: constants.selectConnectionRadioButtonsTitle,
@@ -121,10 +125,6 @@ export class PublishDatabaseDialog {
 							{
 								title: constants.databaseNameLabel,
 								component: this.targetDatabaseTextBox
-							},
-							{
-								title: constants.profileWarningText,
-								component: <azdata.ButtonComponent>this.loadProfileButton
 							}
 						]
 					}


### PR DESCRIPTION
Moving the "load profile" button to the top of the dialog as discussed with Raden. 
![image](https://user-images.githubusercontent.com/31145923/86979081-3c75c500-c135-11ea-8497-d8728417500e.png)
