### PR TITLE
Add new ViewContainerLocation for dialogs

### DIFF
--- a/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
@@ -56,7 +56,7 @@ export const ACCOUNT_VIEW_CONTAINER = Registry.as<IViewContainersRegistry>(ViewC
 	name: localize('accountExplorer.name', "Accounts"),
 	ctorDescriptor: new SyncDescriptor(AccountPaneContainer),
 	storageId: `${VIEWLET_ID}.state`
-}, ViewContainerLocation.Panel);
+}, ViewContainerLocation.Dialog);
 
 class AccountPanel extends ViewPane {
 	public index: number;

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -34,7 +34,8 @@ export namespace Extensions {
 
 export enum ViewContainerLocation {
 	Sidebar,
-	Panel
+	Panel,
+	Dialog // {{SQL CARBON EDIT}}
 }
 
 export interface IViewContainerDescriptor {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/11283

It might be worth it to investigate this further. We have other instances of dialog components using ViewPanes although it looks like those might actually be unused or broken : 

Options dialog - unused? https://github.com/microsoft/azuredatastudio/blob/main/src/sql/workbench/browser/modal/optionsDialog.ts#L41

Insights dialog - seems to be broken, possibly related to the view changes that we had to fix for the other views : https://github.com/microsoft/azuredatastudio/blob/main/src/sql/workbench/services/insights/browser/insightsDialogView.ts#L124