### PR TITLE
Only throw if releaseNotesUrl doesn't exist

### DIFF
--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -55,8 +55,9 @@ export class OpenLatestReleaseNotesInBrowserAction extends Action {
 		if (this.productService.releaseNotesUrl) {
 			const uri = URI.parse(this.productService.releaseNotesUrl);
 			await this.openerService.open(uri);
+		} else { //{{SQL CARBON EDIT}}
+			throw new Error(nls.localize('update.noReleaseNotesOnline', "This version of {0} does not have release notes online", this.productService.nameLong));
 		}
-		throw new Error('This version of Visual Studio Code does not have release notes online');
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/11294

PR for VS Code as well : https://github.com/microsoft/vscode/pull/102149