### PR TITLE
Revert to previous behavior for tree data providers getChildren

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -220,7 +220,7 @@ export class TreeViewDataProvider implements ITreeViewDataProvider {
 	}
 
 	protected async postGetChildren(elements: ITreeItem[]): Promise<ITreeItem[]> { // {{SQL CARBON EDIT}} For use by Component Tree View
-		const result: ITreeItem[] = [];
+		const result: ITreeItem[] = []; //{{SQL CARBON EDIT}}
 		const hasResolve = await this.hasResolve;
 		if (elements) {
 			for (const element of elements) {

--- a/src/vs/workbench/api/browser/mainThreadTreeViews.ts
+++ b/src/vs/workbench/api/browser/mainThreadTreeViews.ts
@@ -219,16 +219,23 @@ export class TreeViewDataProvider implements ITreeViewDataProvider {
 		return this.itemsMap.size === 0;
 	}
 
-	protected async postGetChildren(elements: ITreeItem[]): Promise<ResolvableTreeItem[]> { // {{SQL CARBON EDIT}} For use by Component Tree View
-		const result: ResolvableTreeItem[] = [];
+	protected async postGetChildren(elements: ITreeItem[]): Promise<ITreeItem[]> { // {{SQL CARBON EDIT}} For use by Component Tree View
+		const result: ITreeItem[] = [];
 		const hasResolve = await this.hasResolve;
 		if (elements) {
 			for (const element of elements) {
-				const resolvable = new ResolvableTreeItem(element, hasResolve ? () => {
-					return this._proxy.$resolve(this.treeViewId, element.handle);
-				} : undefined);
-				this.itemsMap.set(element.handle, resolvable);
-				result.push(resolvable);
+				// {{SQL CARBON EDIT}} We rely on custom properties on the tree items in a number of places so creating a new item here was
+				// {{SQL CARBON EDIT}} clearing those. Revert to old behavior if the provider doesn't support a resolve (our normal case)
+				if (hasResolve) {
+					const resolvable = new ResolvableTreeItem(element, hasResolve ? () => {
+						return this._proxy.$resolve(this.treeViewId, element.handle);
+					} : undefined);
+					this.itemsMap.set(element.handle, resolvable);
+					result.push(resolvable);
+				} else {
+					this.itemsMap.set(element.handle, element);
+					result.push(element);
+				}
 			}
 		}
 		return result;


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/11297

Another thing broken by https://github.com/microsoft/vscode/commit/39a406daa381ddeb57323088f920d88f8bc8f40b

We couldn't fix it like https://github.com/microsoft/azuredatastudio/pull/11239 since the TreeDataProvider in this case is contributed by the extension and so goes through the vs code side of things. 

I don't like this as a long term fix - I want to talk to the VS Code people and see if they're willing to come up with a solution that will fit both scenarios. In the meantime though this should be safe as a temporary fix (and will also benefit in that if there are any other tree views we have that are broken because of this change they won't be anymore) since we don't register any tree views with a resolve function currently. 