### PR TITLE
Add formatting to true by default when saving XML

### DIFF
--- a/src/sql/workbench/services/query/common/resultSerializer.ts
+++ b/src/sql/workbench/services/query/common/resultSerializer.ts
@@ -246,7 +246,7 @@ export class ResultSerializer {
 
 		// get save results config from vscode config
 		let saveConfig = this._configurationService.getValue<IXmlConfig>('sql.saveAsXml');
-		// if user entered config, set options
+		// if user entered config, set those options
 		if (saveConfig) {
 			if (saveConfig.formatted !== undefined) {
 				saveResultsParams.formatted = saveConfig.formatted;
@@ -254,6 +254,8 @@ export class ResultSerializer {
 			if (saveConfig.encoding !== undefined) {
 				saveResultsParams.encoding = saveConfig.encoding;
 			}
+		} else { // otherwise format and encode by default
+			saveResultsParams.formatted = true;
 		}
 
 		return saveResultsParams;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes # https://github.com/microsoft/azuredatastudio/issues/11315

The issue was most likely caused by this - https://github.com/microsoft/azuredatastudio/blob/main/src/sql/workbench/contrib/configuration/common/configurationUpgrader.ts#L20

Added formatting to true by default when no formatting settings are found in user settings. Don't need to explicitly set encoding to `utf-8` since that is the default.
