### PR TITLE
Fixes the declarative table issue

### DIFF
--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
@@ -34,8 +34,8 @@ export default class DeclarativeTableComponent extends ContainerBase<any> implem
 	@Input() descriptor: IComponentDescriptor;
 	@Input() modelStore: IModelStore;
 
-	public data: any[][] = [];
-	public columns: azdata.DeclarativeTableColumn[] = [];
+	private data: any[][] = [];
+	private columns: azdata.DeclarativeTableColumn[] = [];
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) changeRef: ChangeDetectorRef,
@@ -132,6 +132,7 @@ export default class DeclarativeTableComponent extends ContainerBase<any> implem
 
 	private onCellDataChanged(newValue: any, rowIdx: number, colIdx: number): void {
 		this.data[rowIdx][colIdx] = newValue;
+		this.setPropertyFromUI<azdata.DeclarativeTableProperties, any[][]>((props, value) => props.data = value, this.data);
 		let newCellData: azdata.TableCell = {
 			row: rowIdx,
 			column: colIdx,


### PR DESCRIPTION
This PR is a fix for #11320 

Before this change, we had a line of code that did 

`this.data = this.data`, this caused the setter for the data value to go and fire an event that changed the properties object in the extHostModelView.ts file.

This fix brings the special call the data setter did to this component.

Thanks to @aasimkhan30  and @alanrenmsft for finding this issue