### PR TITLE
bump vscodeVersion

### DIFF
--- a/product.json
+++ b/product.json
@@ -36,7 +36,7 @@
 	"gettingStartedUrl": "https://go.microsoft.com/fwlink/?linkid=862039",
 	"releaseNotesUrl": "https://go.microsoft.com/fwlink/?linkid=875578",
 	"documentationUrl": "https://go.microsoft.com/fwlink/?linkid=862277",
-	"vscodeVersion": "1.46.0",
+	"vscodeVersion": "1.47.0",
 	"commit": "9ca6200018fc206d67a47229f991901a8a453781",
 	"date": "2017-12-15T12:00:00.000Z",
 	"recommendedExtensions": [


### PR DESCRIPTION
release/1.20 branch is in sync with vscode 1.47, I will update the main branch (1.48.0) after the release.