### PR TITLE
First draft of outputProcessor tests

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/outputProcessor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/outputProcessor.ts
@@ -41,10 +41,10 @@ export function getData(output: nb.ICellOutput): JSONObject {
 	} else if (nbformat.isError(output)) {
 		let traceback = output.traceback ? output.traceback.join('\n') : undefined;
 		bundle['application/vnd.jupyter.stderr'] = undefined;
-		if (traceback && traceback !== '') {
+		if (traceback) {
 			bundle['application/vnd.jupyter.stderr'] = traceback;
 		} else if (output.evalue) {
-			bundle['application/vnd.jupyter.stderr'] = output.ename && output.ename !== '' ? `${output.ename}: ${output.evalue}` : `${output.evalue}`;
+			bundle['application/vnd.jupyter.stderr'] = output.ename ? `${output.ename}: ${output.evalue}` : `${output.evalue}`;
 		}
 	}
 	return convertBundle(bundle);
@@ -78,7 +78,7 @@ export function getBundleOptions(options: IOutputModelOptions): MimeModel.IOptio
  */
 export function extract(value: JSONObject, key: string): {} {
 	let item = value[key];
-	if (isPrimitive(item)) {
+	if (item === undefined || item === null || isPrimitive(item)) {
 		return item;
 	}
 	return JSON.parse(JSON.stringify(item));

--- a/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
@@ -8,7 +8,6 @@ import { nb } from 'azdata';
 import * as op from 'sql/workbench/contrib/notebook/browser/models/outputProcessor';
 import { JSONObject } from 'sql/workbench/services/notebook/common/jsonext';
 import { nbformat as nbformat } from 'sql/workbench/services/notebook/common/nbformat';
-import { getRandomElement } from 'vs/base/common/arrays';
 
 suite('OutputProcessor functions', function (): void {
 	const text = 'An arbitrary text input:!@#$%^&*()_+~`:;,.-_=';
@@ -42,7 +41,7 @@ suite('OutputProcessor functions', function (): void {
 		}
 
 		// error tests
-		for (const traceback of [undefined, [undefined], [], [''], ['tb1:!@#$%^&*()_+~`:;,.-_=', 'tb2:!@#$%^&*()_+~`:;,.-_=']]) {
+		for (const traceback of [undefined, [undefined], [], [''], ['Arbitrary traceback 1:!@#$%^&*()_+~`:;,.-_=', 'Arbitrary traceback 2:!@#$%^&*()_+~`:;,.-_=']]) {
 			for (const evalue of [undefined, '', 'evalue1:!@#$%^&*()_+~`:;,.-_=']) {
 				for (const ename of ['ename1:!@#$%^&*()_+~`:;,.-_=', '', undefined]) {
 					const output = <nbformat.IError>{
@@ -72,7 +71,7 @@ suite('OutputProcessor functions', function (): void {
 	});
 
 	suite('getMetadata', function (): void {
-		for (const outputType of ['execute_result', 'display_data', getRandomElement(['update_display_data', 'stream', 'error'])] as nbformat.OutputType[]) {
+		for (const outputType of ['execute_result', 'display_data', 'update_display_data', 'stream', 'error'] as nbformat.OutputType[]) {
 			const output: nb.ICellOutput = {
 				output_type: outputType
 			};
@@ -90,25 +89,25 @@ suite('OutputProcessor functions', function (): void {
 
 	suite('getBundleOptions', function (): void {
 		for (const trusted of [true, false]) {
-			const outputType = getRandomElement(['execute_result', 'display_data']) as nbformat.OutputType;
-
-			const output: nb.ICellOutput = {
-				output_type: outputType,
-				metadata: arbitraryMetadata
-			};
-			const options: op.IOutputModelOptions = {
-				value: output,
-				trusted: trusted
-			};
-			test(`test for outputType:${outputType}, bundleOptions.trusted:${trusted}`, () => {
-				const result = op.getBundleOptions(options);
-				const expected = {
-					data: op.getData(output),
-					metadata: op.getMetadata(output),
+			for (const outputType of ['execute_result', 'display_data'] as nbformat.OutputType[]) {
+				const output: nb.ICellOutput = {
+					output_type: outputType,
+					metadata: arbitraryMetadata
+				};
+				const options: op.IOutputModelOptions = {
+					value: output,
 					trusted: trusted
 				};
-				assert.deepEqual(result, expected, `getBundleOptions should return an object that has data and metadata fields as returned by getData and getMetadata calls and a trusted field as the value of the 'trusted' field in options passed to it`);
-			});
+				test(`test for outputType:${outputType}, bundleOptions.trusted:${trusted}`, () => {
+					const result = op.getBundleOptions(options);
+					const expected = {
+						data: op.getData(output),
+						metadata: op.getMetadata(output),
+						trusted: trusted
+					};
+					assert.deepEqual(result, expected, `getBundleOptions should return an object that has data and metadata fields as returned by getData and getMetadata calls and a trusted field as the value of the 'trusted' field in options passed to it`);
+				});
+			}
 		}
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
@@ -131,6 +131,6 @@ suite('OutputProcessor functions', function (): void {
 	});
 });
 
-function getRandom<T>(...list: T[]) {
+function getRandom<T>(...list: T[]): T {
 	return list[Math.floor((Math.random() * list.length))];
 }

--- a/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// import * as TypeMoq from 'typemoq';
 import * as assert from 'assert';
 import { nb } from 'azdata';
 import * as op from 'sql/workbench/contrib/notebook/browser/models/outputProcessor';
@@ -14,72 +13,48 @@ import { getRandomString } from 'vs/editor/test/common/model/linesTextBuffer/tex
 
 suite('OutputProcessor functions', function (): void {
 	suite('getData', async function (): Promise<void> {
-		for (const outputType of ['execute_result', 'display_data', 'update_display_data', 'stream', 'error'] as nbformat.OutputType[]) {
-			const text = getRandomString(1, 10);
-			const output: nb.ICellOutput = {
-				output_type: outputType
-			};
-			if (nbformat.isError(output)) {
-				for (const traceback of [undefined, [], [getRandomString(1, 10), getRandomString(1, 10)]]) {
-					for (const evalue of [undefined, getRandomString(1, 10)]) {
-						for (const ename of [text, '']) {
-							test(`test for outputType:${outputType}, ename:'${ename}', evalue:${evalue}, and traceback:${JSON.stringify(traceback)}`, async () => {
-								output.ename = ename;
-								output.evalue = evalue;
-								output.traceback = traceback;
-								const result = op.getData(output);
-								const tracedata = (traceback === undefined || traceback === []) ? undefined : traceback.join('\n');
-								let expectedData: JSONObject = {
-									'application/vnd.jupyter.stderr': undefined
-								};
-								if (tracedata) {
-									expectedData = {
-										'application/vnd.jupyter.stderr': tracedata
-									};
-								} else if (evalue) {
-									if (ename !== '') {
-										expectedData = {
-											'application/vnd.jupyter.stderr': `${output.ename}: ${output.evalue}`
-										};
-									} else {
-										expectedData = {
-											'application/vnd.jupyter.stderr': `${output.evalue}`
-										};
-									}
+		const text = getRandomString(1, 10);
 
-								}
-								assert.deepEqual(result, <JSONObject>expectedData, `getData should return the expectedData:'${JSON.stringify(expectedData)}' object`);
-							});
-						}
-					}
+		// data tests
+		for (const outputType of ['execute_result', 'display_data', 'update_display_data'] as nbformat.OutputType[]) {
+			const output = <nbformat.IExecuteResult>{
+				output_type: outputType,
+				data: <op.IMimeBundle>{
+					result: text  // free form fields of the IMimeBundle. This is just an arbitrarily cooked-up hardcoded example for the test.
 				}
-			} else if (nbformat.isStream(output)) {
-				for (const name of ['stderr', 'stdout'] as nbformat.StreamType[]) {
-					test(`test for outputType:${outputType} and name:${name}`, async () => {
-						output.text = text;
-						output.name = name;
-						const expectedData =
-							name === 'stderr'
-								? {
-									'application/vnd.jupyter.stderr': output.text,
-								}
-								: {
-									'application/vnd.jupyter.stdout': output.text,
-								};
-						const result = op.getData(output);
-						assert.deepEqual(result, expectedData, `getData should return the expectedData:${expectedData} object`);
+			};
+			test(`test for outputType:${output.output_type}`, async () => {
+				verifyGetDataForDataOutput(output);
+			});
+		}
+
+		// error tests
+		for (const traceback of [undefined, [], [''], [getRandomString(0, 10), getRandomString(0, 10)]]) {
+			for (const evalue of [undefined, getRandomString(1, 10)]) {
+				for (const ename of [text, '']) {
+					const output = <nbformat.IError>{
+						output_type: 'error',
+						ename: ename,
+						evalue: evalue,
+						traceback: traceback
+					};
+					test(`test for outputType:'${output.output_type}', ename:'${ename}', evalue:${evalue}, and traceback:${JSON.stringify(traceback)}`, async () => {
+						verifyGetDataForErrorOutput(output);
 					});
 				}
-			} else {
-				test(`test for outputType:${outputType}`, async () => {
-					const expectedData = {
-						data: text
-					};
-					(output as nbformat.IExecuteResult).data = expectedData;
-					const result = op.getData(output);
-					assert.deepEqual(result, expectedData, `getData should return the expectedData:${expectedData} object`);
-				});
 			}
+		}
+
+		// stream tests
+		for (const name of ['stderr', 'stdout'] as nbformat.StreamType[]) {
+			const output = <nbformat.IStream>{
+				output_type: 'stream',
+				text: text,
+				name: name
+			};
+			test(`test for outputType:'${output.output_type} and name:${name}`, async () => {
+				verifyGetDataForStreamOutput(output);
+			});
 		}
 	});
 
@@ -94,9 +69,9 @@ suite('OutputProcessor functions', function (): void {
 				output.metadata = metadata;
 				const result = op.getMetadata(output);
 				if (nbformat.isExecuteResult(output) || nbformat.isDisplayData(output)) {
-					assert.deepEqual(result, metadata, `getData should return the expectedData:'${JSON.stringify(metadata)}' object`);
+					assert.deepEqual(result, metadata, `getData should return the metadata object passed in the output object to the getMetadata() call`);
 				} else {
-					assert.deepEqual(result, {}, `getMetadata should return the expectedData:'${JSON.stringify(metadata)}' object`);
+					assert.deepEqual(result, {}, `getMetadata should return an empty object when output_type is ont IDisplayData or IExecuteResult`);
 				}
 			});
 		}
@@ -125,11 +100,60 @@ suite('OutputProcessor functions', function (): void {
 					metadata: op.getMetadata(output),
 					trusted: trusted
 				};
-				assert.deepEqual(result, expected, `getBundleOptions did not return the expected object:'${JSON.stringify(expected)}'`);
+				assert.deepEqual(result, expected, `getBundleOptions should return an object that has data and metadata fields as returned by getData and getMetadata calls and a trusted field as the value of the 'trusted' field in options passed to it`);
 			});
 		}
 	});
 });
+
+function verifyGetDataForDataOutput(output: nbformat.IExecuteResult | nbformat.IDisplayData | nbformat.IDisplayUpdate) {
+	const result = op.getData(output);
+	// getData just returns the data property object for ExecutionResults/DisplayData/DisplayUpdate Output object sent to it.
+	assert.deepEqual(result, output.data, `getData should return the expectedData:${output.data} object`);
+}
+
+function verifyGetDataForStreamOutput(output: nbformat.IStream): void {
+	//expected return value is an object with a single property of 'application/vnd.jupyter.stderr' or 'application/vnd.jupyter.stdout' corresponding to the stream name
+	const expectedData = output.name === 'stderr'
+		? {
+			'application/vnd.jupyter.stderr': output.text,
+		}
+		: {
+			'application/vnd.jupyter.stdout': output.text,
+		};
+	const result = op.getData(output);
+	assert.deepEqual(result, expectedData, `getData should return the expectedData:${expectedData} object`);
+}
+
+function verifyGetDataForErrorOutput(output: nbformat.IError): void {
+	const result = op.getData(output);
+	const tracedata = (output.traceback === undefined || output.traceback === []) ? undefined : output.traceback.join('\n');
+	// getData returns an object with single property: 'application/vnd.jupyter.stderr'
+	// this property is assigned to a '\n' delimited traceback data when it is present.
+	// when absent ths property gets ename and evalue information information ': ' delimited unless
+	// ename is empty in which case it is just evalue information.
+	let expectedData: JSONObject = {
+		'application/vnd.jupyter.stderr': undefined
+	};
+	if (tracedata) {
+		expectedData = {
+			'application/vnd.jupyter.stderr': tracedata
+		};
+	}
+	else if (output.evalue) {
+		if (output.ename !== '') {
+			expectedData = {
+				'application/vnd.jupyter.stderr': `${output.ename}: ${output.evalue}`
+			};
+		}
+		else {
+			expectedData = {
+				'application/vnd.jupyter.stderr': `${output.evalue}`
+			};
+		}
+	}
+	assert.deepEqual(result, <JSONObject>expectedData, `getData should return the expectedData:'${JSON.stringify(expectedData)}' object`);
+}
 
 function getRandom<T>(...list: T[]): T {
 	return list[Math.floor((Math.random() * list.length))];

--- a/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
@@ -9,11 +9,9 @@ import * as op from 'sql/workbench/contrib/notebook/browser/models/outputProcess
 import { JSONObject } from 'sql/workbench/services/notebook/common/jsonext';
 import { nbformat as nbformat } from 'sql/workbench/services/notebook/common/nbformat';
 import { getRandomElement } from 'vs/base/common/arrays';
-import { getRandomString } from 'vs/editor/test/common/model/linesTextBuffer/textBufferAutoTestUtils';
-
 
 suite('OutputProcessor functions', function (): void {
-	const text = getRandomString(1, 10);
+	const text = 'An arbitrary text input:!@#$%^&*()_+~`:;,.-_=';
 
 	const arbitraryMetadata = {
 		// arbitrarily construction chart options. It is any JSONObject
@@ -29,7 +27,7 @@ suite('OutputProcessor functions', function (): void {
 		}
 	};
 
-	suite('getData', async function (): Promise<void> {
+	suite('getData', function (): void {
 		// data tests
 		for (const outputType of ['execute_result', 'display_data', 'update_display_data'] as nbformat.OutputType[]) {
 			const output = <nbformat.IExecuteResult>{
@@ -38,22 +36,22 @@ suite('OutputProcessor functions', function (): void {
 					result: text  // free form fields of the IMimeBundle. This is just an arbitrarily cooked-up hardcoded example for the test.
 				}
 			};
-			test(`test for outputType:${output.output_type}`, async () => {
+			test(`test for outputType:${output.output_type}`, () => {
 				verifyGetDataForDataOutput(output);
 			});
 		}
 
 		// error tests
-		for (const traceback of [undefined, [undefined], [], [''], [getRandomString(0, 10), getRandomString(0, 10)]]) {
-			for (const evalue of [undefined, getRandomString(1, 10)]) {
-				for (const ename of [text, '']) {
+		for (const traceback of [undefined, [undefined], [], [''], ['tb1:!@#$%^&*()_+~`:;,.-_=', 'tb2:!@#$%^&*()_+~`:;,.-_=']]) {
+			for (const evalue of [undefined, '', 'evalue1:!@#$%^&*()_+~`:;,.-_=']) {
+				for (const ename of ['ename1:!@#$%^&*()_+~`:;,.-_=', '', undefined]) {
 					const output = <nbformat.IError>{
 						output_type: 'error',
 						ename: ename,
 						evalue: evalue,
 						traceback: traceback
 					};
-					test(`test for outputType:'${output.output_type}', ename:'${ename}', evalue:${evalue}, and traceback:${JSON.stringify(traceback)}`, async () => {
+					test(`test for outputType:'${output.output_type}', ename:'${ename}', evalue:${evalue}, and traceback:${JSON.stringify(traceback)}`, () => {
 						verifyGetDataForErrorOutput(output);
 					});
 				}
@@ -67,18 +65,18 @@ suite('OutputProcessor functions', function (): void {
 				text: text,
 				name: name
 			};
-			test(`test for outputType:'${output.output_type} and name:${name}`, async () => {
+			test(`test for outputType:'${output.output_type} and name:${name}`, () => {
 				verifyGetDataForStreamOutput(output);
 			});
 		}
 	});
 
-	suite('getMetadata', async function (): Promise<void> {
+	suite('getMetadata', function (): void {
 		for (const outputType of ['execute_result', 'display_data', getRandomElement(['update_display_data', 'stream', 'error'])] as nbformat.OutputType[]) {
 			const output: nb.ICellOutput = {
 				output_type: outputType
 			};
-			test(`test for outputType:${outputType}`, async () => {
+			test(`test for outputType:${outputType}`, () => {
 				output.metadata = arbitraryMetadata;
 				const result = op.getMetadata(output);
 				if (nbformat.isExecuteResult(output) || nbformat.isDisplayData(output)) {
@@ -90,7 +88,7 @@ suite('OutputProcessor functions', function (): void {
 		}
 	});
 
-	suite('getBundleOptions', async function (): Promise<void> {
+	suite('getBundleOptions', function (): void {
 		for (const trusted of [true, false]) {
 			const outputType = getRandomElement(['execute_result', 'display_data']) as nbformat.OutputType;
 
@@ -102,7 +100,7 @@ suite('OutputProcessor functions', function (): void {
 				value: output,
 				trusted: trusted
 			};
-			test(`test for outputType:${outputType}, bundleOptions.trusted:${trusted}`, async () => {
+			test(`test for outputType:${outputType}, bundleOptions.trusted:${trusted}`, () => {
 				const result = op.getBundleOptions(options);
 				const expected = {
 					data: op.getData(output),
@@ -151,7 +149,7 @@ function verifyGetDataForErrorOutput(output: nbformat.IError): void {
 		};
 	}
 	else if (output.evalue) {
-		if (output.ename !== '') {
+		if (output.ename !== undefined && output.ename !== '') {
 			expectedData = {
 				'application/vnd.jupyter.stderr': `${output.ename}: ${output.evalue}`
 			};

--- a/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/outputProcessor.test.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// import * as TypeMoq from 'typemoq';
+import * as assert from 'assert';
+import { nb } from 'azdata';
+import * as op from 'sql/workbench/contrib/notebook/browser/models/outputProcessor';
+import { JSONObject } from 'sql/workbench/services/notebook/common/jsonext';
+import { nbformat as nbformat } from 'sql/workbench/services/notebook/common/nbformat';
+import { getRandomString } from 'vs/editor/test/common/model/linesTextBuffer/textBufferAutoTestUtils';
+
+
+suite('OutputProcessor functions', function (): void {
+	suite('getData', async function (): Promise<void> {
+		for (const outputType of ['execute_result', 'display_data', 'update_display_data', 'stream', 'error'] as nbformat.OutputType[]) {
+			const text = getRandomString(1, 10);
+			const output: nb.ICellOutput = {
+				output_type: outputType
+			};
+			if (nbformat.isError(output)) {
+				for (const traceback of [undefined, [], [getRandomString(1, 10), getRandomString(1, 10)]]) {
+					for (const evalue of [undefined, getRandomString(1, 10)]) {
+						for (const ename of [text, '']) {
+							test(`test for outputType:${outputType}, ename:'${ename}', evalue:${evalue}, and traceback:${JSON.stringify(traceback)}`, async () => {
+								output.ename = ename;
+								output.evalue = evalue;
+								output.traceback = traceback;
+								const result = op.getData(output);
+								const tracedata = (traceback === undefined || traceback === []) ? undefined : traceback.join('\n');
+								let expectedData: JSONObject = {
+									'application/vnd.jupyter.stderr': undefined
+								};
+								if (tracedata) {
+									expectedData = {
+										'application/vnd.jupyter.stderr': tracedata
+									};
+								} else if (evalue) {
+									if (ename !== '') {
+										expectedData = {
+											'application/vnd.jupyter.stderr': `${output.ename}: ${output.evalue}`
+										};
+									} else {
+										expectedData = {
+											'application/vnd.jupyter.stderr': `${output.evalue}`
+										};
+									}
+
+								}
+								assert.deepEqual(result, <JSONObject>expectedData, `getData should return the expectedData:'${JSON.stringify(expectedData)}' object`);
+							});
+						}
+					}
+				}
+			} else if (nbformat.isStream(output)) {
+				for (const name of ['stderr', 'stdout'] as nbformat.StreamType[]) {
+					test(`test for outputType:${outputType} and name:${name}`, async () => {
+						output.text = text;
+						output.name = name;
+						const expectedData =
+							name === 'stderr'
+								? {
+									'application/vnd.jupyter.stderr': output.text,
+								}
+								: {
+									'application/vnd.jupyter.stdout': output.text,
+								};
+						const result = op.getData(output);
+						assert.deepEqual(result, expectedData, `getData should return the expectedData:${expectedData} object`);
+					});
+				}
+			} else {
+				test(`test for outputType:${outputType}`, async () => {
+					const expectedData = {
+						data: text
+					};
+					(output as nbformat.IExecuteResult).data = expectedData;
+					const result = op.getData(output);
+					assert.deepEqual(result, expectedData, `getData should return the expectedData:${expectedData} object`);
+				});
+			}
+		}
+	});
+
+	suite('getMetadata', async function (): Promise<void> {
+		for (const outputType of ['execute_result', 'display_data', getRandom('update_display_data', 'stream', 'error')] as nbformat.OutputType[]) {
+			const text = getRandomString(1, 10);
+			const output: nb.ICellOutput = {
+				output_type: outputType
+			};
+			test(`test for outputType:${outputType}`, async () => {
+				const metadata: JSONObject = { key: text };
+				output.metadata = metadata;
+				const result = op.getMetadata(output);
+				if (nbformat.isExecuteResult(output) || nbformat.isDisplayData(output)) {
+					assert.deepEqual(result, metadata, `getData should return the expectedData:'${JSON.stringify(metadata)}' object`);
+				} else {
+					assert.deepEqual(result, {}, `getMetadata should return the expectedData:'${JSON.stringify(metadata)}' object`);
+				}
+			});
+		}
+	});
+
+	suite('getBundleOptions', async function (): Promise<void> {
+		for (const trusted of [true, false]) {
+			const outputType = getRandom('execute_result', 'display_data') as nbformat.OutputType;
+			const output: nb.ICellOutput = {
+				output_type: outputType,
+				metadata: {
+					azdata_chartOptions: {
+						scale: true,
+						dataGrid: false
+					}
+				}
+			};
+			const options: op.IOutputModelOptions = {
+				value: output,
+				trusted: trusted
+			};
+			test(`test for outputType:${outputType}, bundleOptions.trusted:${trusted}`, async () => {
+				const result = op.getBundleOptions(options);
+				const expected = {
+					data: op.getData(output),
+					metadata: op.getMetadata(output),
+					trusted: trusted
+				};
+				assert.deepEqual(result, expected, `getBundleOptions did not return the expected object:'${JSON.stringify(expected)}'`);
+			});
+		}
+	});
+});
+
+function getRandom<T>(...list: T[]) {
+	return list[Math.floor((Math.random() * list.length))];
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR adds unit tests for OutputProcessor.ts

This PR also fixes #11355 and removes a couple of redundant checks in conditionals.

Testing: 
1.  Ran all unit test
2. Measured code coverage of the new tests.

Coverage:
[Code coverage report for workbench_contrib_notebook_browser_models_outputProcessor.ts.pdf](https://github.com/microsoft/azuredatastudio/files/4928535/Code.coverage.report.for.workbench_contrib_notebook_browser_models_outputProcessor.ts.pdf)
