### PR TITLE
fix the issue with explorer widget context menu

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerTable.ts
@@ -117,7 +117,7 @@ export class ExplorerTable extends Disposable {
 			};
 		} else {
 			context = {
-				profile: dataContext,
+				profile: dataContext.toIConnectionProfile(),
 				uri: this.bootStrapService.getUnderlyingUri()
 			};
 		}

--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -296,6 +296,7 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerWidgetContext, {
 		id: commands.ExplorerScriptCreateAction.ID,
 		title: commands.ExplorerScriptCreateAction.LABEL
 	},
+	when: ItemContextKey.ItemType.notEqualsTo('database'),
 	order: 2
 });
 //#endregion


### PR DESCRIPTION
This PR fixes #10765

for new notebook action, we need to return the IConnectionProfile to avoid the circular structure issue
for script as create action, it is never meant to be exposed on database context.
