### PR TITLE
Fix markdown cell toolbar focus not being visible

### DIFF
--- a/src/sql/media/icons/common-icons.css
+++ b/src/sql/media/icons/common-icons.css
@@ -345,8 +345,8 @@ Includes non-masked style declarations. */
 }
 
 .codicon.masked-icon.code::before {
-	-webkit-mask-image: url("toolbar-code.svg");
-	mask-image: url("toolbar-code.svg");
+	-webkit-mask-image: url("code.svg");
+	mask-image: url("code.svg");
 }
 
 .codicon.masked-icon.insert-link::before {
@@ -378,10 +378,7 @@ Includes non-masked style declarations. */
 	-webkit-mask-image: url("toolbar-preview-toggle-off.svg");
 	mask-image: url("toolbar-preview-toggle-off.svg");
 }
-.codicon.code {
-	-webkit-mask-image: url("code.svg");
-	mask-image: url("code.svg");
-}
+
 .codicon.markdown {
 	-webkit-mask-image: url("markdown.svg");
 	mask-image: url("markdown.svg");

--- a/src/sql/media/icons/common-icons.css
+++ b/src/sql/media/icons/common-icons.css
@@ -324,47 +324,57 @@ Includes non-masked style declarations. */
 	mask-size: 50% 100%;
 }
 
-.codicon.bold {
+.codicon.masked-icon.bold::before {
 	-webkit-mask-image: url("toolbar-bold.svg");
 	mask-image: url("toolbar-bold.svg");
 }
-.codicon.italic {
+
+.codicon.masked-icon.italic::before {
 	-webkit-mask-image: url("toolbar-italic.svg");
 	mask-image: url("toolbar-italic.svg");
 }
-.codicon.underline {
+
+.codicon.masked-icon.underline::before {
 	-webkit-mask-image: url("toolbar-underline.svg");
 	mask-image: url("toolbar-underline.svg");
 }
-.codicon.highlight {
+
+.codicon.masked-icon.highlight::before {
 	-webkit-mask-image: url("toolbar-highlight.svg");
 	mask-image: url("toolbar-highlight.svg");
 }
-.codicon.code {
+
+.codicon.masked-icon.code::before {
 	-webkit-mask-image: url("toolbar-code.svg");
 	mask-image: url("toolbar-code.svg");
 }
-.codicon.insert-link {
+
+.codicon.masked-icon.insert-link::before {
 	-webkit-mask-image: url("toolbar-link.svg");
 	mask-image: url("toolbar-link.svg");
 }
-.codicon.list {
+
+.codicon.masked-icon.list::before {
 	-webkit-mask-image: url("toolbar-list.svg");
 	mask-image: url("toolbar-list.svg");
 }
-.codicon.ordered-list {
+
+.codicon.masked-icon.ordered-list::before {
 	-webkit-mask-image: url("toolbar-ordered-list.svg");
 	mask-image: url("toolbar-ordered-list.svg");
 }
-.codicon.insert-image {
+
+.codicon.masked-icon.insert-image::before {
 	-webkit-mask-image: url("toolbar-image.svg");
 	mask-image: url("toolbar-image.svg");
 }
-.codicon.split-toggle-on {
+
+.codicon.masked-icon.split-toggle-on::before {
 	-webkit-mask-image: url("toolbar-preview-toggle-on.svg");
 	mask-image: url("toolbar-preview-toggle-on.svg");
 }
-.codicon.split-toggle-off {
+
+.codicon.masked-icon.split-toggle-off::before {
 	-webkit-mask-image: url("toolbar-preview-toggle-off.svg");
 	mask-image: url("toolbar-preview-toggle-off.svg");
 }

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -52,9 +52,9 @@ export class MarkdownToolbarComponent {
 
 	private initActionBar() {
 		let boldButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.boldText', '', 'bold masked-icon', this.buttonBold, this.cellModel, MarkdownButtonType.BOLD);
-		let italicButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.italicText', '', 'italic  masked-icon', this.buttonItalic, this.cellModel, MarkdownButtonType.ITALIC);
-		let underlineButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.underlineText', '', 'underline  masked-icon', this.buttonUnderline, this.cellModel, MarkdownButtonType.UNDERLINE);
-		let highlightButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.highlightText', '', 'highlight  masked-icon', this.buttonHighlight, this.cellModel, MarkdownButtonType.HIGHLIGHT);
+		let italicButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.italicText', '', 'italic masked-icon', this.buttonItalic, this.cellModel, MarkdownButtonType.ITALIC);
+		let underlineButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.underlineText', '', 'underline masked-icon', this.buttonUnderline, this.cellModel, MarkdownButtonType.UNDERLINE);
+		let highlightButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.highlightText', '', 'highlight masked-icon', this.buttonHighlight, this.cellModel, MarkdownButtonType.HIGHLIGHT);
 		let codeButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.codeText', '', 'code masked-icon', this.buttonCode, this.cellModel, MarkdownButtonType.CODE);
 		let linkButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.linkText', '', 'insert-link masked-icon', this.buttonLink, this.cellModel, MarkdownButtonType.LINK);
 		let listButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.listText', '', 'list masked-icon', this.buttonList, this.cellModel, MarkdownButtonType.UNORDERED_LIST);

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -51,16 +51,16 @@ export class MarkdownToolbarComponent {
 	}
 
 	private initActionBar() {
-		let boldButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.boldText', '', 'bold', this.buttonBold, this.cellModel, MarkdownButtonType.BOLD);
-		let italicButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.italicText', '', 'italic', this.buttonItalic, this.cellModel, MarkdownButtonType.ITALIC);
-		let underlineButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.underlineText', '', 'underline', this.buttonUnderline, this.cellModel, MarkdownButtonType.UNDERLINE);
-		let highlightButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.highlightText', '', 'highlight', this.buttonHighlight, this.cellModel, MarkdownButtonType.HIGHLIGHT);
-		let codeButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.codeText', '', 'code', this.buttonCode, this.cellModel, MarkdownButtonType.CODE);
-		let linkButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.linkText', '', 'insert-link', this.buttonLink, this.cellModel, MarkdownButtonType.LINK);
-		let listButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.listText', '', 'list', this.buttonList, this.cellModel, MarkdownButtonType.UNORDERED_LIST);
-		let orderedListButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.orderedText', '', 'ordered-list', this.buttonOrderedList, this.cellModel, MarkdownButtonType.ORDERED_LIST);
-		let imageButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.imageText', '', 'insert-image', this.buttonImage, this.cellModel, MarkdownButtonType.IMAGE);
-		let togglePreviewAction = this._instantiationService.createInstance(TogglePreviewAction, 'notebook.togglePreview', true, this.cellModel.showPreview);
+		let boldButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.boldText', '', 'bold masked-icon', this.buttonBold, this.cellModel, MarkdownButtonType.BOLD);
+		let italicButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.italicText', '', 'italic  masked-icon', this.buttonItalic, this.cellModel, MarkdownButtonType.ITALIC);
+		let underlineButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.underlineText', '', 'underline  masked-icon', this.buttonUnderline, this.cellModel, MarkdownButtonType.UNDERLINE);
+		let highlightButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.highlightText', '', 'highlight  masked-icon', this.buttonHighlight, this.cellModel, MarkdownButtonType.HIGHLIGHT);
+		let codeButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.codeText', '', 'code masked-icon', this.buttonCode, this.cellModel, MarkdownButtonType.CODE);
+		let linkButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.linkText', '', 'insert-link masked-icon', this.buttonLink, this.cellModel, MarkdownButtonType.LINK);
+		let listButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.listText', '', 'list masked-icon', this.buttonList, this.cellModel, MarkdownButtonType.UNORDERED_LIST);
+		let orderedListButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.orderedText', '', 'ordered-list masked-icon', this.buttonOrderedList, this.cellModel, MarkdownButtonType.ORDERED_LIST);
+		let imageButton = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.imageText', '', 'insert-image masked-icon', this.buttonImage, this.cellModel, MarkdownButtonType.IMAGE);
+		let togglePreviewAction = this._instantiationService.createInstance(TogglePreviewAction, 'notebook.togglePreview masked-icon', true, this.cellModel.showPreview);
 
 		let headingDropdown = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.heading', '', 'heading', this.dropdownHeading, this.cellModel, null);
 		let heading1 = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.heading1', this.optionHeading1, 'heading 1', this.optionHeading1, this.cellModel, MarkdownButtonType.HEADING1);

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.css
@@ -52,53 +52,57 @@
 	position: absolute;
 	right: 0;
 }
+
 .markdown-toolbar .carbon-taskbar li a {
 	display: flex;
 	height: 20px;
 	width: 20px;
-	-webkit-mask-position: center;
-	-webkit-mask-repeat: no-repeat;
-	mask-position: center;
-	mask-repeat: no-repeat;
 }
 
-.markdown-toolbar li a.codicon.bold {
+.markdown-toolbar li a.codicon.bold::before {
 	-webkit-mask-size: 50% 100%;
 	mask-size: 50% 100%;
 }
-.markdown-toolbar li a.codicon.italic {
+.markdown-toolbar li a.codicon.italic::before {
 	-webkit-mask-size: 60% 100%;
 	mask-size: 60% 100%;
 }
-.markdown-toolbar li a.codicon.highlight {
+
+.markdown-toolbar li a.codicon.underline::before{
+	-webkit-mask-size: 65% 100%;
+	mask-size: 60% 100%;
+}
+
+.markdown-toolbar li a.codicon.highlight::before {
 	-webkit-mask-size: 65% 100%;
 	mask-size: 65% 100%;
 }
-.markdown-toolbar li a.codicon.code {
+
+.markdown-toolbar li a.codicon.code::before {
 	-webkit-mask-size: 88% 100%;
 	mask-size: 88% 100%;
 }
-.markdown-toolbar li a.codicon.insert-link {
+.markdown-toolbar li a.codicon.insert-link::before {
 	-webkit-mask-size: 80% 100%;
 	mask-size: 80% 100%;
 }
-.markdown-toolbar li a.codicon.list {
+.markdown-toolbar li a.codicon.list::before {
 	-webkit-mask-size: 80% 100%;
 	mask-size: 80% 100%;
 }
-.markdown-toolbar li a.codicon.ordered-list {
+.markdown-toolbar li a.codicon.ordered-list::before {
 	-webkit-mask-size: 86% 100%;
 	mask-size: 86% 100%;
 }
-.markdown-toolbar li a.codicon.insertimage {
+.markdown-toolbar li a.codicon.insertimage::before {
 	-webkit-mask-size: 86% 100%;
 	mask-size: 86% 100%;
 }
-.markdown-toolbar li a.codicon.split-toggle-on {
+.markdown-toolbar li a.codicon.split-toggle-on::before {
 	-webkit-mask-size: 75% 100%;
 	mask-size: 75% 100%;
 }
-.markdown-toolbar li a.codicon.split-toggle-off {
+.markdown-toolbar li a.codicon.split-toggle-off::before {
 	-webkit-mask-size: 75% 100%;
 	mask-size: 75% 100%;
 }

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.css
@@ -59,52 +59,24 @@
 	width: 20px;
 }
 
-.markdown-toolbar li a.codicon.bold::before {
-	-webkit-mask-size: 50% 100%;
-	mask-size: 50% 100%;
-}
-.markdown-toolbar li a.codicon.italic::before {
-	-webkit-mask-size: 60% 100%;
-	mask-size: 60% 100%;
-}
-
-.markdown-toolbar li a.codicon.underline::before{
-	-webkit-mask-size: 65% 100%;
-	mask-size: 60% 100%;
-}
-
-.markdown-toolbar li a.codicon.highlight::before {
-	-webkit-mask-size: 65% 100%;
-	mask-size: 65% 100%;
+.markdown-toolbar li a.codicon.masked-icon::before {
+	-webkit-mask-size: auto;
+	mask-size: auto;
 }
 
 .markdown-toolbar li a.codicon.code::before {
 	-webkit-mask-size: 88% 100%;
 	mask-size: 88% 100%;
 }
+
 .markdown-toolbar li a.codicon.insert-link::before {
 	-webkit-mask-size: 80% 100%;
 	mask-size: 80% 100%;
 }
-.markdown-toolbar li a.codicon.list::before {
-	-webkit-mask-size: 80% 100%;
-	mask-size: 80% 100%;
-}
+
 .markdown-toolbar li a.codicon.ordered-list::before {
 	-webkit-mask-size: 86% 100%;
 	mask-size: 86% 100%;
-}
-.markdown-toolbar li a.codicon.insertimage::before {
-	-webkit-mask-size: 86% 100%;
-	mask-size: 86% 100%;
-}
-.markdown-toolbar li a.codicon.split-toggle-on::before {
-	-webkit-mask-size: 75% 100%;
-	mask-size: 75% 100%;
-}
-.markdown-toolbar li a.codicon.split-toggle-off::before {
-	-webkit-mask-size: 75% 100%;
-	mask-size: 75% 100%;
 }
 
 text-cell-component .offscreen {

--- a/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
@@ -187,7 +187,7 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean, conf
 		}
 		const toolbarIconColor = theme.getColor(toolbarIcon);
 		if (toolbarIconColor) {
-			collector.addRule(`.markdown-toolbar li a { background-color: ${toolbarIconColor};}`);
+			collector.addRule(`.markdown-toolbar li a:before { background-color: ${toolbarIconColor};}`);
 		}
 		const toolbarBottomBorderColor = theme.getColor(toolbarBottomBorder);
 		if (toolbarBottomBorderColor) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #10653 Markdown Cell Toolbar Keyboard Focus.

I utilized the masked-icon styles to use :before pseudo element similar to that of the notebook toolbar and cell toolbar. I made edits to reduce the CSS mask sizes in order to reduce code as well. 

Below are screenshots for the different themes illustrating the focus. 

Light Theme:
![image](https://user-images.githubusercontent.com/23587151/87729986-382c5600-c78c-11ea-9ec7-f581668e9651.png)

Dark Theme:
![image](https://user-images.githubusercontent.com/23587151/87730006-45494500-c78c-11ea-80d6-09546f8c7943.png)

High Contrast Theme:
![image](https://user-images.githubusercontent.com/23587151/87730024-5003da00-c78c-11ea-8979-2218112bef23.png)



