### PR TITLE
expose realm field to the wizard UI

### DIFF
--- a/extensions/resource-deployment/src/localizedConstants.ts
+++ b/extensions/resource-deployment/src/localizedConstants.ts
@@ -19,5 +19,6 @@ export const signIn = localize('azure.signin', "Sign in…");
 export const refresh = localize('azure.refresh', "Refresh");
 export const createNewResourceGroup = localize('azure.resourceGroup.createNewResourceGroup', "Create a new resource group");
 export const NewResourceGroupAriaLabel = localize('azure.resourceGroup.NewResourceGroupAriaLabel', "New resource group name");
+export const realm = localize('deployCluster.Realm', "Realm");
 
 

--- a/extensions/resource-deployment/src/services/bigDataClusterDeploymentProfile.ts
+++ b/extensions/resource-deployment/src/services/bigDataClusterDeploymentProfile.ts
@@ -26,6 +26,7 @@ export interface ActiveDirectorySettings {
 	domainControllerFQDNs: string;
 	dnsIPAddresses: string;
 	domainDNSName: string;
+	realm?: string;
 	clusterUsers: string;
 	clusterAdmins: string;
 	appReaders?: string;
@@ -284,7 +285,7 @@ export class BigDataClusterDeploymentProfile {
 		activeDirectoryObject.domainDnsName = adSettings.domainDNSName;
 		activeDirectoryObject.subdomain = adSettings.subdomain;
 		activeDirectoryObject.accountPrefix = adSettings.accountPrefix;
-		activeDirectoryObject.realm = adSettings.domainDNSName.toUpperCase();
+		activeDirectoryObject.realm = adSettings.realm ?? adSettings.domainDNSName.toUpperCase();
 		activeDirectoryObject.clusterAdmins = this.splitByComma(adSettings.clusterAdmins);
 		activeDirectoryObject.clusterUsers = this.splitByComma(adSettings.clusterUsers);
 		if (adSettings.appReaders) {

--- a/extensions/resource-deployment/src/ui/deployClusterWizard/deployClusterWizardModel.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/deployClusterWizardModel.ts
@@ -128,6 +128,7 @@ export class DeployClusterWizardModel extends Model {
 				organizationalUnit: this.getStringValue(VariableNames.OrganizationalUnitDistinguishedName_VariableName)!,
 				domainControllerFQDNs: this.getStringValue(VariableNames.DomainControllerFQDNs_VariableName)!,
 				domainDNSName: this.getStringValue(VariableNames.DomainDNSName_VariableName)!,
+				realm: this.getStringValue(VariableNames.Realm_VariableName),
 				dnsIPAddresses: this.getStringValue(VariableNames.DomainDNSIPAddresses_VariableName)!,
 				clusterAdmins: this.getStringValue(VariableNames.ClusterAdmins_VariableName)!,
 				clusterUsers: this.getStringValue(VariableNames.ClusterUsers_VariableName)!,

--- a/extensions/resource-deployment/src/ui/deployClusterWizard/pages/clusterSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/pages/clusterSettingsPage.ts
@@ -150,6 +150,12 @@ export class ClusterSettingsPage extends WizardPageBase<DeployClusterWizard> {
 					variableName: VariableNames.DomainDNSName_VariableName
 				}, {
 					type: FieldType.Text,
+					label: localize('deployCluster.Realm', "Realm"),
+					required: false,
+					variableName: VariableNames.Realm_VariableName,
+					description: localize('deployCluster.RealmDescription', "If not provided, the domain DNS name will be used as the default value.")
+				}, {
+					type: FieldType.Text,
 					label: localize('deployCluster.ClusterAdmins', "Cluster admin group"),
 					required: true,
 					variableName: VariableNames.ClusterAdmins_VariableName,

--- a/extensions/resource-deployment/src/ui/deployClusterWizard/pages/clusterSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/pages/clusterSettingsPage.ts
@@ -13,6 +13,7 @@ import { WizardPageBase } from '../../wizardPageBase';
 import * as VariableNames from '../constants';
 import { DeployClusterWizard } from '../deployClusterWizard';
 import { AuthenticationMode } from '../deployClusterWizardModel';
+import * as localizedConstants from '../../../localizedConstants';
 const localize = nls.loadMessageBundle();
 
 const ConfirmPasswordName = 'ConfirmPassword';
@@ -150,7 +151,7 @@ export class ClusterSettingsPage extends WizardPageBase<DeployClusterWizard> {
 					variableName: VariableNames.DomainDNSName_VariableName
 				}, {
 					type: FieldType.Text,
-					label: localize('deployCluster.Realm', "Realm"),
+					label: localizedConstants.realm,
 					required: false,
 					variableName: VariableNames.Realm_VariableName,
 					description: localize('deployCluster.RealmDescription', "If not provided, the domain DNS name will be used as the default value.")

--- a/extensions/resource-deployment/src/ui/deployClusterWizard/pages/summaryPage.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/pages/summaryPage.ts
@@ -152,13 +152,13 @@ export class SummaryPage extends WizardPageBase<DeployClusterWizard> {
 					{
 						type: FieldType.ReadonlyText,
 						label: localize('deployCluster.AppOwners', "App owners"),
-						defaultValue: this.wizard.model.getStringValue(VariableNames.AppOwners_VariableName) ?? '',
+						defaultValue: this.wizard.model.getStringValue(VariableNames.AppOwners_VariableName, ''),
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					},
 					{
 						type: FieldType.ReadonlyText,
 						label: localize('deployCluster.AppReaders', "App readers"),
-						defaultValue: this.wizard.model.getStringValue(VariableNames.AppReaders_VariableName) ?? '',
+						defaultValue: this.wizard.model.getStringValue(VariableNames.AppReaders_VariableName, ''),
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					}]
 			});
@@ -167,13 +167,13 @@ export class SummaryPage extends WizardPageBase<DeployClusterWizard> {
 					{
 						type: FieldType.ReadonlyText,
 						label: localize('deployCluster.Subdomain', "Subdomain"),
-						defaultValue: this.wizard.model.getStringValue(VariableNames.Subdomain_VariableName) ?? '',
+						defaultValue: this.wizard.model.getStringValue(VariableNames.Subdomain_VariableName, ''),
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					},
 					{
 						type: FieldType.ReadonlyText,
 						label: localize('deployCluster.AccountPrefix', "Account prefix"),
-						defaultValue: this.wizard.model.getStringValue(VariableNames.AccountPrefix_VariableName) ?? '',
+						defaultValue: this.wizard.model.getStringValue(VariableNames.AccountPrefix_VariableName, ''),
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					}]
 			});
@@ -187,7 +187,7 @@ export class SummaryPage extends WizardPageBase<DeployClusterWizard> {
 					}, {
 						type: FieldType.ReadonlyText,
 						label: localize('deployCluster.Realm', "Realm"),
-						defaultValue: this.wizard.model.getStringValue(VariableNames.Realm_VariableName) ?? '',
+						defaultValue: this.wizard.model.getStringValue(VariableNames.Realm_VariableName, ''),
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					}]
 			});

--- a/extensions/resource-deployment/src/ui/deployClusterWizard/pages/summaryPage.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/pages/summaryPage.ts
@@ -10,6 +10,7 @@ import { createSection, createGroupContainer, createFlexContainer, createLabel }
 import { WizardPageBase } from '../../wizardPageBase';
 import * as VariableNames from '../constants';
 import { AuthenticationMode } from '../deployClusterWizardModel';
+import * as localizedConstants from '../../../localizedConstants';
 const localize = nls.loadMessageBundle();
 
 export class SummaryPage extends WizardPageBase<DeployClusterWizard> {
@@ -186,7 +187,7 @@ export class SummaryPage extends WizardPageBase<DeployClusterWizard> {
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					}, {
 						type: FieldType.ReadonlyText,
-						label: localize('deployCluster.Realm', "Realm"),
+						label: localizedConstants.realm,
 						defaultValue: this.wizard.model.getStringValue(VariableNames.Realm_VariableName, ''),
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					}]

--- a/extensions/resource-deployment/src/ui/deployClusterWizard/pages/summaryPage.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/pages/summaryPage.ts
@@ -183,6 +183,11 @@ export class SummaryPage extends WizardPageBase<DeployClusterWizard> {
 						label: localize('deployCluster.DomainServiceAccountUserName', "Service account username"),
 						defaultValue: this.wizard.model.getStringValue(VariableNames.DomainServiceAccountUserName_VariableName),
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
+					}, {
+						type: FieldType.ReadonlyText,
+						label: localize('deployCluster.Realm', "Realm"),
+						defaultValue: this.wizard.model.getStringValue(VariableNames.Realm_VariableName),
+						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					}]
 			});
 		}

--- a/extensions/resource-deployment/src/ui/deployClusterWizard/pages/summaryPage.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/pages/summaryPage.ts
@@ -53,6 +53,7 @@ export class SummaryPage extends WizardPageBase<DeployClusterWizard> {
 						{
 							type: FieldType.ReadonlyText,
 							label: localize('deployCluster.ClusterContext', "Cluster context"),
+							defaultValue: this.wizard.model.getStringValue(VariableNames.ClusterContext_VariableName),
 							labelCSSStyles: { fontWeight: FontWeight.Bold }
 						}]
 				}
@@ -151,13 +152,13 @@ export class SummaryPage extends WizardPageBase<DeployClusterWizard> {
 					{
 						type: FieldType.ReadonlyText,
 						label: localize('deployCluster.AppOwners', "App owners"),
-						defaultValue: this.wizard.model.getStringValue(VariableNames.AppOwners_VariableName),
+						defaultValue: this.wizard.model.getStringValue(VariableNames.AppOwners_VariableName) ?? '',
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					},
 					{
 						type: FieldType.ReadonlyText,
 						label: localize('deployCluster.AppReaders', "App readers"),
-						defaultValue: this.wizard.model.getStringValue(VariableNames.AppReaders_VariableName),
+						defaultValue: this.wizard.model.getStringValue(VariableNames.AppReaders_VariableName) ?? '',
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					}]
 			});
@@ -166,13 +167,13 @@ export class SummaryPage extends WizardPageBase<DeployClusterWizard> {
 					{
 						type: FieldType.ReadonlyText,
 						label: localize('deployCluster.Subdomain', "Subdomain"),
-						defaultValue: this.wizard.model.getStringValue(VariableNames.Subdomain_VariableName),
+						defaultValue: this.wizard.model.getStringValue(VariableNames.Subdomain_VariableName) ?? '',
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					},
 					{
 						type: FieldType.ReadonlyText,
 						label: localize('deployCluster.AccountPrefix', "Account prefix"),
-						defaultValue: this.wizard.model.getStringValue(VariableNames.AccountPrefix_VariableName),
+						defaultValue: this.wizard.model.getStringValue(VariableNames.AccountPrefix_VariableName) ?? '',
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					}]
 			});
@@ -186,7 +187,7 @@ export class SummaryPage extends WizardPageBase<DeployClusterWizard> {
 					}, {
 						type: FieldType.ReadonlyText,
 						label: localize('deployCluster.Realm', "Realm"),
-						defaultValue: this.wizard.model.getStringValue(VariableNames.Realm_VariableName),
+						defaultValue: this.wizard.model.getStringValue(VariableNames.Realm_VariableName) ?? '',
 						labelCSSStyles: { fontWeight: FontWeight.Bold }
 					}]
 			});


### PR DESCRIPTION
This PR fixes #10883 

previously we are defaulting the Realm field to the domain name, recently, Akshay from the BDC team reached out to me to saying this field should be exposed now to allow users to specify their own value.

also fixed other issues in the same file I noticed during the testing
1. the cluster context field value was mistakenly removed by Arvind in this commit: https://github.com/microsoft/azuredatastudio/commit/678bbe314283f3e3a9125c8b5a2bddb211954e57#diff-65f92098d2deba3a83e14f6c245ce984L56

2. set default value to empty string for the optional fields, otherwise it will be undefined and a text component won't be created, causing the layout to break. see the app readers, app owners fields in the **Before** screenshot

**Before**
<img width="1200" alt="Screen Shot 2020-07-16 at 5 03 19 PM" src="https://user-images.githubusercontent.com/13777222/87734067-7161c780-c786-11ea-828b-82325ebe6717.png">

**After**
<img width="1189" alt="Screen Shot 2020-07-16 at 5 08 37 PM" src="https://user-images.githubusercontent.com/13777222/87734275-01a00c80-c787-11ea-8113-a5156ecaa15f.png">
