### PR TITLE
fixes tab focus not being visible after deploying a server

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -94,14 +94,15 @@ export default () => `
 				<div class="resources-container">
 					<h2>${escape(localize('welcomePage.resources', "Resources"))}</h2>
 					<div class="tabs">
-						<input class="input" name="tabs" type="radio" id="tab-1" checked="checked" />
-						<span class="label" for="tab-1" tabIndex="0">${escape(localize('welcomePage.history', "History"))}</span>
+					<!-- Checkbox is not accessible to user yet, this feature is still in development -->
+					<input tabindex="-1" class="input" name="tabs" type="radio" id="tab-1" checked="checked" />
+					<span id="historyLabel" class="label" for="tab-1" tabIndex="0">${escape(localize('welcomePage.history', "History"))}</span>
 						<div class="panel">
 							<div class="recent history">
 								<div class="flex list-header-container">
 									<i class="icon-document themed-icon"></i>
-									<span tabindex="0" class="list-header"><b>${escape(localize('welcomePage.name', "Name"))}</b></span>
-									<span tabindex="0" class="list-header-last-opened"><b>${escape(localize('welcomePage.lastOpened', "Last Opened"))}</b></span>
+									<span class="list-header">${escape(localize('welcomePage.name', "Name"))}</span>
+									<span class="list-header-last-opened">${escape(localize('welcomePage.lastOpened', "Last Opened"))}</span>
 								</div>
 								<ul class="list">
 									<!-- Filled programmatically -->
@@ -110,8 +111,8 @@ export default () => `
 								<div class="moreRecent">
 									<a class="ads-welcome-page-link" href="command:workbench.action.openRecent">${escape(localize('welcomePage.moreRecent', "Show more"))}
 									<i class="icon-arrow-down-dark"></i>
-								</a>
-							</div>
+									</a>
+								</div>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
This PR fixes the issue of when a user is using keyboard navigation and presses enter on the "deploy a server" button tile, the next focus-able item was no in focus. It does this by making an invisible element that was being focused instead, no focus-able. The invisible item exists because it is part of a feature still development, and is not needed by the user yet. I have added a comment explaining that as well.

This PR fixes #10621
