### PR TITLE
Fix Notebooks Word Wrapping Logic

### DIFF
--- a/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
@@ -154,8 +154,7 @@ export class QueryTextEditor extends BaseTextEditor {
 			this._editorWorkspaceConfig = this.workspaceConfigurationService.getValue('editor');
 			this._lineHeight = editorWidget.getOption(EditorOption.lineHeight) || 18;
 		}
-		let wordWrapEnabled: boolean = this._editorWorkspaceConfig && this._editorWorkspaceConfig['wordWrap'] && this._editorWorkspaceConfig['wordWrap'] === 'on' ? true : false;
-		if (wordWrapEnabled) {
+		if (layoutInfo.isViewportWrapping) {
 			for (let line = 1; line <= lineCount; line++) {
 				// 2 columns is equivalent to the viewport column width and the edge of the editor
 				if (editorWidgetModel.getLineMaxColumn(line) >= layoutInfo.viewportColumn + 2) {

--- a/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
@@ -20,7 +20,6 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/untitledTextEditorInput';
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
 
@@ -35,7 +34,6 @@ export class QueryTextEditor extends BaseTextEditor {
 	private _maxHeight: number = 4000;
 	private _selected: boolean;
 	private _hideLineNumbers: boolean;
-	private _editorWorkspaceConfig;
 	private _scrollbarHeight: number;
 	private _lineHeight: number;
 
@@ -46,9 +44,7 @@ export class QueryTextEditor extends BaseTextEditor {
 		@ITextResourceConfigurationService configurationService: ITextResourceConfigurationService,
 		@IThemeService themeService: IThemeService,
 		@IEditorGroupsService editorGroupService: IEditorGroupsService,
-		@IEditorService protected editorService: IEditorService,
-		@IConfigurationService private workspaceConfigurationService: IConfigurationService
-
+		@IEditorService protected editorService: IEditorService
 	) {
 		super(
 			QueryTextEditor.ID, telemetryService, instantiationService, storageService,
@@ -150,8 +146,7 @@ export class QueryTextEditor extends BaseTextEditor {
 		// that the viewportColumn will always be greater than any character's column in an editor.
 		let numberWrappedLines = 0;
 		let shouldAddHorizontalScrollbarHeight = false;
-		if (!this._editorWorkspaceConfig || configChanged) {
-			this._editorWorkspaceConfig = this.workspaceConfigurationService.getValue('editor');
+		if (!this._lineHeight || configChanged) {
 			this._lineHeight = editorWidget.getOption(EditorOption.lineHeight) || 18;
 		}
 		if (layoutInfo.isViewportWrapping) {

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
@@ -32,7 +32,6 @@ import { IOverlayWidget, IOverlayWidgetPosition } from 'vs/editor/browser/editor
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfigurationService';
 import { FindReplaceStateChangedEvent, INewFindReplaceState } from 'vs/editor/contrib/find/findState';
 import { getRandomString } from 'vs/editor/test/common/model/linesTextBuffer/textBufferAutoTestUtils';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ContextViewService } from 'vs/platform/contextview/browser/contextViewService';
 import { DidInstallExtensionEvent, DidUninstallExtensionEvent, IExtensionManagementService, InstallExtensionEvent } from 'vs/platform/extensionManagement/common/extensionManagement';
@@ -713,8 +712,7 @@ function setupServices(arg: { workbenchThemeService?: WorkbenchThemeService, ins
 		instantiationService.get(ITextResourceConfigurationService),
 		instantiationService.get(IThemeService),
 		instantiationService.get(IEditorGroupsService),
-		instantiationService.get(IEditorService),
-		instantiationService.get(IConfigurationService)
+		instantiationService.get(IEditorService)
 	);
 	const notebookEditorStub = new NotebookEditorStub({ cellGuid: cellTextEditorGuid, editor: queryTextEditor, model: new NotebookModelStub(), notebookParams: <INotebookParams>{ notebookUri: untitledNotebookInput.notebookUri } });
 	notebookService.addNotebookEditor(notebookEditorStub);

--- a/src/sql/workbench/contrib/notebook/test/testCommon.ts
+++ b/src/sql/workbench/contrib/notebook/test/testCommon.ts
@@ -8,7 +8,6 @@ import * as stubs from 'sql/workbench/contrib/notebook/test/stubs';
 import { INotebookModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { INotebookParams } from 'sql/workbench/services/notebook/browser/notebookService';
 import * as dom from 'vs/base/browser/dom';
-import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
 import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
@@ -55,8 +54,7 @@ class CellEditorProviderStub extends stubs.CellEditorProviderStub {
 				new TestTextResourceConfigurationService(),
 				new TestThemeService(),
 				new TestEditorGroupsService(),
-				new TestEditorService(),
-				new TestConfigurationService()
+				new TestEditorService()
 			);
 		}
 		if (this._editor) {


### PR DESCRIPTION
This addresses #11389.

The markdown language actually has editor overrides and always turns on word wrapping, so us relying on the global setting didn't work for this case. We can access whether the editor is wrapping through layoutInfo here.