### PR TITLE
handle invalid character in kubectl version output

### DIFF
--- a/extensions/resource-deployment/src/services/tools/kubeCtlTool.ts
+++ b/extensions/resource-deployment/src/services/tools/kubeCtlTool.ts
@@ -14,6 +14,13 @@ const localize = nls.loadMessageBundle();
 const defaultInstallationRoot = '/usr/local/bin';
 export const KubeCtlToolName = 'kubectl';
 
+interface KubeCtlVersion {
+	clientVersion: {
+		major: string;
+		minor: string;
+	};
+}
+
 export class KubeCtlTool extends ToolBase {
 	constructor(platformService: IPlatformService) {
 		super(platformService);
@@ -42,8 +49,9 @@ export class KubeCtlTool extends ToolBase {
 	protected getVersionFromOutput(output: string): SemVer | undefined {
 		let version: SemVer | undefined = undefined;
 		if (output) {
-			const versionJson = JSON.parse(output);
-			version = new SemVer(`${versionJson.clientVersion.major}.${versionJson.clientVersion.minor}.0`);
+			const versionJson: KubeCtlVersion = JSON.parse(output);
+			// kubectl version output might contain '+' character in the minor version, e.g. 16+, we have to remove it to make it a valid semantic version string.
+			version = new SemVer(`${versionJson.clientVersion.major}.${versionJson.clientVersion.minor.replace(/\+/g, '')}.0`);
 		}
 		return version;
 	}


### PR DESCRIPTION
this is the output i am getting on windows with latest kubectl. update our code to handle this scenario.

C:\Users\alanren>kubectl version --client -o json
{
  "clientVersion": {
    "major": "1",
    "minor": "16+",
    "gitVersion": "v1.16.6-beta.0",
    "gitCommit": "e7f962ba86f4ce7033828210ca3556393c377bcc",
    "gitTreeState": "clean",
    "buildDate": "2020-01-15T08:26:26Z",
    "goVersion": "go1.13.5",
    "compiler": "gc",
    "platform": "windows/amd64"
  }
}