### PR TITLE
let semver to parse the version

### DIFF
--- a/extensions/resource-deployment/src/services/tools/kubeCtlTool.ts
+++ b/extensions/resource-deployment/src/services/tools/kubeCtlTool.ts
@@ -49,7 +49,11 @@ export class KubeCtlTool extends ToolBase {
 		let version: SemVer | undefined = undefined;
 		if (output) {
 			const versionJson: KubeCtlVersion = JSON.parse(output);
-			version = new SemVer(versionJson.clientVersion.gitVersion);
+			if (versionJson && versionJson.clientVersion && versionJson.clientVersion.gitVersion) {
+				version = new SemVer(versionJson.clientVersion.gitVersion);
+			} else {
+				throw new Error(localize('resourceDeployment.invalidKubectlVersionOutput', "Unable to parse the kubectl version command output: \"{0}\"", output));
+			}
 		}
 		return version;
 	}

--- a/extensions/resource-deployment/src/services/tools/kubeCtlTool.ts
+++ b/extensions/resource-deployment/src/services/tools/kubeCtlTool.ts
@@ -16,8 +16,7 @@ export const KubeCtlToolName = 'kubectl';
 
 interface KubeCtlVersion {
 	clientVersion: {
-		major: string;
-		minor: string;
+		gitVersion: string;
 	};
 }
 
@@ -50,8 +49,7 @@ export class KubeCtlTool extends ToolBase {
 		let version: SemVer | undefined = undefined;
 		if (output) {
 			const versionJson: KubeCtlVersion = JSON.parse(output);
-			// kubectl version output might contain '+' character in the minor version, e.g. 16+, we have to remove it to make it a valid semantic version string.
-			version = new SemVer(`${versionJson.clientVersion.major}.${versionJson.clientVersion.minor.replace(/\+/g, '')}.0`);
+			version = new SemVer(versionJson.clientVersion.gitVersion);
 		}
 		return version;
 	}


### PR DESCRIPTION
fortunately SemVer is able to handle the gitVersion string,

![image](https://user-images.githubusercontent.com/13777222/88106492-6b8b2e00-cb5a-11ea-9034-f5ed91413dcf.png)

also tested :
    "gitVersion": "v1.18.0",