### PR TITLE
Stop hardcoding python3 for python version in spark kernels

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -329,11 +329,6 @@ export class JupyterSession implements nb.ISession {
 				code: doNotCallChangeEndpointParams
 			}, true);
 			await future.done;
-
-			future = this.sessionImpl.kernel.requestExecute({
-				code: `%%configure -f${EOL}{"conf": {"spark.pyspark.python": "python3"}}`
-			}, true);
-			await future.done;
 		}
 	}
 


### PR DESCRIPTION
Got feedback that some customers are running into issues with how we've been hardcoding "python3" for spark kernels in ADS.

"python3" is the default on the cluster-side, and if it's overridden by customers, then we should be honoring that.