### PR TITLE
fixes button height discrepancy on welcome page

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -379,7 +379,7 @@ class WelcomePage extends Disposable {
 		getDropdownBtn.appendChild(i);
 		nav.appendChild(dropdownUl);
 		dropdownButtonContainer.appendChild(nav);
-		const fileBtnWindowsClasses = ['windows-only', 'linux-only', 'btn-secondary'];
+		const fileBtnWindowsClasses = ['windows-only', 'linux-only'];
 		const fileBtnMacClasses = ['mac-only'];
 
 		const fileBtnContainer = container.querySelector('#open-file-btn-container') as HTMLElement;


### PR DESCRIPTION
This PR fixes a button height discrepancy between two buttons on the welcome page. It removes a duplication of a CSS class.

This PR fixes #11466