### PR TITLE
Fix sql proj sqlcmd table showing after loading publish profile when it shouldn't

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -29,6 +29,7 @@ export class PublishDatabaseDialog {
 	private dataSourcesRadioButton: azdata.RadioButtonComponent | undefined;
 	private loadProfileButton: azdata.ButtonComponent | undefined;
 	private sqlCmdVariablesTable: azdata.TableComponent | undefined;
+	private sqlCmdVariablesFormComponent: azdata.FormComponent | undefined;
 	private formBuilder: azdata.FormBuilder | undefined;
 
 	private connectionId: string | undefined;
@@ -105,6 +106,11 @@ export class PublishDatabaseDialog {
 				width: 400,
 				height: 400
 			}).component();
+
+			this.sqlCmdVariablesFormComponent = {
+				title: constants.sqlCmdTableLabel,
+				component: <azdata.TableComponent>this.sqlCmdVariablesTable
+			};
 
 			this.formBuilder = <azdata.FormBuilder>view.modelBuilder.formContainer()
 				.withFormItems([
@@ -418,13 +424,14 @@ export class PublishDatabaseDialog {
 					data: data
 				});
 
-				// add SQLCMD Variables table if it wasn't there before
-				if (Object.keys(this.project.sqlCmdVariables).length === 0) {
-					this.formBuilder?.insertFormItem({
-						title: constants.sqlCmdTableLabel,
-						component: <azdata.TableComponent>this.sqlCmdVariablesTable
-					},
-						6);
+				if (Object.keys(result.sqlCmdVariables).length) {
+					// add SQLCMD Variables table if it wasn't there before
+					if (Object.keys(this.project.sqlCmdVariables).length === 0) {
+						this.formBuilder?.insertFormItem(<azdata.FormComponent>this.sqlCmdVariablesFormComponent, 6);
+					}
+				} else if (Object.keys(this.project.sqlCmdVariables).length === 0) {
+					// remove the table if there are no SQLCMD variables in the project and loaded profile
+					this.formBuilder?.removeFormItem(<azdata.FormComponent>this.sqlCmdVariablesFormComponent);
 				}
 			}
 		});


### PR DESCRIPTION
This PR fixes #11468. This adds a couple checks for if the loaded publish profile didn't have any sqlcmd variables: 
- table should only be added if the profile has sqlcmd variables 
- table should be removed if both the profile and project don't have sqlcmd variables