### PR TITLE
Add test coverage for dacpac wizard import flow

### DIFF
--- a/extensions/dacpac/src/test/configPages.test.ts
+++ b/extensions/dacpac/src/test/configPages.test.ts
@@ -7,6 +7,9 @@ import 'mocha';
 import * as should from 'should';
 import * as sinon from 'sinon';
 import * as azdata from 'azdata';
+import * as vscode from 'vscode';
+import * as os from 'os';
+import * as path from 'path';
 import { DataTierApplicationWizard, PageName } from '../wizard/dataTierApplicationWizard';
 import { DacFxDataModel } from '../wizard/api/models';
 import { TestContext, createContext } from './testContext';
@@ -82,16 +85,24 @@ describe('Dacfx Wizard Pages', function (): void {
 	});
 
 	it('Should open and edit import config page correctly', async () => {
+		const dacpacPath = path.join(os.tmpdir(), 'myDatabase.dacpac');
+
 		testContext = createContext();
 		wizard.setPages();
+
 		sinon.stub(azdata.connection, 'getConnections').resolves([mockConnectionProfile]);
 		sinon.stub(azdata.connection, 'listDatabases').resolves(['fakeDatabaseName']);
+		sinon.stub(vscode.window, 'showOpenDialog').resolves([vscode.Uri.file(dacpacPath)]);
 
-		let importConfigPage = new TestImportConfigPage(wizard, wizard.pages.get(PageName.deployConfig).wizardPage, wizard.model, testContext.viewContext.view);
+		let importConfigPage = new TestImportConfigPage(wizard, wizard.pages.get(PageName.importConfig).wizardPage, wizard.model, testContext.viewContext.view);
 		await importConfigPage.start();
 
-		let result = await importConfigPage.onPageEnter();
-		should(result).equal(true, 'onPageEnter() should successfullly load connection profiles');
+		//let result = await importConfigPage.onPageEnter();
+		//should(result).equal(true, 'onPageEnter() should successfullly load connection profiles');
+
+		testContext.viewContext.fileButtonOnClick.fire(undefined);
+		should(importConfigPage.Model.filePath).equal(dacpacPath);
+		should(importConfigPage.Model.database).equal('myDatabase');
 	});
 });
 

--- a/extensions/dacpac/src/test/configPages.test.ts
+++ b/extensions/dacpac/src/test/configPages.test.ts
@@ -10,10 +10,12 @@ import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import * as os from 'os';
 import * as path from 'path';
+
 import { DataTierApplicationWizard, PageName } from '../wizard/dataTierApplicationWizard';
 import { DacFxDataModel } from '../wizard/api/models';
 import { TestContext, createContext } from './testContext';
-import { TestDeployConfigPage, TestExtractConfigPage, TestImportConfigPage} from './testDacFxConfigPages';
+import { TestDeployConfigPage, TestExtractConfigPage, TestImportConfigPage } from './testDacFxConfigPages';
+import { mockConnectionProfile } from './testUtils';
 
 let wizard: DataTierApplicationWizard;
 let testContext: TestContext;
@@ -97,8 +99,8 @@ describe('Dacfx Wizard Pages', function (): void {
 		let importConfigPage = new TestImportConfigPage(wizard, wizard.pages.get(PageName.importConfig).wizardPage, wizard.model, testContext.viewContext.view);
 		await importConfigPage.start();
 
-		//let result = await importConfigPage.onPageEnter();
-		//should(result).equal(true, 'onPageEnter() should successfullly load connection profiles');
+		let result = await importConfigPage.onPageEnter();
+		should(result).equal(true, 'onPageEnter() should successfullly load connection profiles');
 
 		testContext.viewContext.fileButtonOnClick.fire(undefined);
 		await importConfigPage.selectionPromise;
@@ -107,18 +109,4 @@ describe('Dacfx Wizard Pages', function (): void {
 	});
 });
 
-const mockConnectionProfile: azdata.connection.ConnectionProfile = {
-	providerId: 'MSSQL',
-	connectionId: 'My Connection ID',
-	connectionName: 'My Connection',
-	serverName: 'My Server',
-	databaseName: 'My Database',
-	userName: 'My User',
-	password: 'My Pwd',
-	authenticationType: 'SqlLogin',
-	savePassword: false,
-	groupFullName: 'My groupName',
-	groupId: 'My GroupId',
-	saveProfile: true,
-	options: {}
-};
+

--- a/extensions/dacpac/src/test/configPages.test.ts
+++ b/extensions/dacpac/src/test/configPages.test.ts
@@ -85,7 +85,7 @@ describe('Dacfx Wizard Pages', function (): void {
 	});
 
 	it('Should open and edit import config page correctly', async () => {
-		const dacpacPath = path.join(os.tmpdir(), 'myDatabase.dacpac');
+		const dacpacPath = vscode.Uri.file(path.join(os.tmpdir(), 'myDatabase.dacpac')).fsPath;
 
 		testContext = createContext();
 		wizard.setPages();
@@ -101,6 +101,7 @@ describe('Dacfx Wizard Pages', function (): void {
 		//should(result).equal(true, 'onPageEnter() should successfullly load connection profiles');
 
 		testContext.viewContext.fileButtonOnClick.fire(undefined);
+		await importConfigPage.selectionPromise;
 		should(importConfigPage.Model.filePath).equal(dacpacPath);
 		should(importConfigPage.Model.database).equal('myDatabase');
 	});

--- a/extensions/dacpac/src/test/testContext.ts
+++ b/extensions/dacpac/src/test/testContext.ts
@@ -51,6 +51,7 @@ export interface ViewTestContext {
 	extractOnClick: vscode.EventEmitter<any>,
 	exportOnClick: vscode.EventEmitter<any>,
 	importOnClick: vscode.EventEmitter<any>,
+	fileButtonOnClick: vscode.EventEmitter<any>;
 }
 
 export function createViewContext(): ViewTestContext {
@@ -63,6 +64,7 @@ export function createViewContext(): ViewTestContext {
 	let extractOnClick: vscode.EventEmitter<any> = new vscode.EventEmitter<any>();
 	let exportOnClick: vscode.EventEmitter<any> = new vscode.EventEmitter<any>();
 	let importOnClick: vscode.EventEmitter<any> = new vscode.EventEmitter<any>();
+	let fileButtonOnClick: vscode.EventEmitter<any> = new vscode.EventEmitter<any>();
 
 	let componentBase: azdata.Component = {
 		id: '',
@@ -110,7 +112,13 @@ export function createViewContext(): ViewTestContext {
 
 	let buttonBuilder: azdata.ComponentBuilder<azdata.ButtonComponent> = {
 		component: () => button,
-		withProperties: () => buttonBuilder,
+		withProperties: (properties) => {
+			if ((properties as any).label === '•••') {
+				button.label = '•••';
+				button.onDidClick = fileButtonOnClick.event;
+			}
+			return buttonBuilder;
+		},
 		withValidation: () => buttonBuilder
 	};
 
@@ -295,5 +303,6 @@ export function createViewContext(): ViewTestContext {
 		extractOnClick: extractOnClick,
 		exportOnClick: exportOnClick,
 		importOnClick: importOnClick,
+		fileButtonOnClick: fileButtonOnClick
 	};
 }

--- a/extensions/dacpac/src/test/testDacFxConfigPages.ts
+++ b/extensions/dacpac/src/test/testDacFxConfigPages.ts
@@ -9,9 +9,9 @@ import { DeployConfigPage } from '../wizard/pages/deployConfigPage';
 import { ExtractConfigPage } from '../wizard/pages/extractConfigPage';
 import { DataTierApplicationWizard } from '../wizard/dataTierApplicationWizard';
 import { SelectOperationPage } from '../wizard/pages/selectOperationpage';
+import { ImportConfigPage } from '../wizard/pages/importConfigPage';
 
 export class TestDeployConfigPage extends DeployConfigPage {
-
 	constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
 		super(instance, wizardPage, model, view);
 	}
@@ -30,7 +30,6 @@ export class TestDeployConfigPage extends DeployConfigPage {
 }
 
 export class TestExtractConfigPage extends ExtractConfigPage {
-
 	constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
 		super(instance, wizardPage, model, view);
 	}
@@ -41,12 +40,21 @@ export class TestExtractConfigPage extends ExtractConfigPage {
 }
 
 export class TestSelectOperationPage extends SelectOperationPage {
-
 	constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
 		super(instance, wizardPage, model, view);
 	}
 
 	get WizardState(): DataTierApplicationWizard {
 		return this.instance;
+	}
+}
+
+export class TestImportConfigPage extends ImportConfigPage {
+	constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
+		super(instance, wizardPage, model, view);
+	}
+
+	get Model(): DacFxDataModel {
+		return this.model;
 	}
 }

--- a/extensions/dacpac/src/test/testDacFxConfigPages.ts
+++ b/extensions/dacpac/src/test/testDacFxConfigPages.ts
@@ -55,9 +55,6 @@ export class TestImportConfigPage extends ImportConfigPage {
 	}
 
 	get Model(): DacFxDataModel {
-		console.log('=== Test page A: ' + this.model);
-		console.log('=== Test page B: ' + this.model.database);
-		console.log('=== Test page C: ' + this.model.filePath);
 		return this.model;
 	}
 }

--- a/extensions/dacpac/src/test/testDacFxConfigPages.ts
+++ b/extensions/dacpac/src/test/testDacFxConfigPages.ts
@@ -55,6 +55,9 @@ export class TestImportConfigPage extends ImportConfigPage {
 	}
 
 	get Model(): DacFxDataModel {
+		console.log('=== Test page A: ' + this.model);
+		console.log('=== Test page B: ' + this.model.database);
+		console.log('=== Test page C: ' + this.model.filePath);
 		return this.model;
 	}
 }

--- a/extensions/dacpac/src/test/testUtils.ts
+++ b/extensions/dacpac/src/test/testUtils.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from 'azdata';
+
+export const mockConnectionProfile: azdata.connection.ConnectionProfile = {
+	providerId: 'MSSQL',
+	connectionId: 'My Connection ID',
+	connectionName: 'My Connection',
+	serverName: 'My Server',
+	databaseName: 'My Database',
+	userName: 'My User',
+	password: 'My Pwd',
+	authenticationType: 'SqlLogin',
+	savePassword: false,
+	groupFullName: 'My groupName',
+	groupId: 'My GroupId',
+	saveProfile: true,
+	options: {}
+};

--- a/extensions/dacpac/src/wizard/api/basePage.ts
+++ b/extensions/dacpac/src/wizard/api/basePage.ts
@@ -123,6 +123,8 @@ export abstract class BasePage {
 			return db;
 		});
 
+		console.log('===2: ' + this.databaseValues);
+
 		if (idx >= 0) {
 			let tmp = this.databaseValues[0];
 			this.databaseValues[0] = this.databaseValues[idx];

--- a/extensions/dacpac/src/wizard/api/basePage.ts
+++ b/extensions/dacpac/src/wizard/api/basePage.ts
@@ -6,13 +6,21 @@
 import * as azdata from 'azdata';
 import * as loc from '../../localizedConstants';
 import { DacFxDataModel } from './models';
+import { DataTierApplicationWizard } from '../dataTierApplicationWizard';
 
 export abstract class BasePage {
-
+	protected readonly instance: DataTierApplicationWizard;
 	protected readonly wizardPage: azdata.window.WizardPage;
 	protected readonly model: DacFxDataModel;
 	protected readonly view: azdata.ModelView;
 	public databaseValues: string[];
+
+	protected constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
+		this.instance = instance;
+		this.wizardPage = wizardPage;
+		this.model = model;
+		this.view = view;
+	}
 
 	/**
 	 * This method constructs all the elements of the page.
@@ -122,8 +130,6 @@ export abstract class BasePage {
 
 			return db;
 		});
-
-		console.log('===2: ' + this.databaseValues);
 
 		if (idx >= 0) {
 			let tmp = this.databaseValues[0];

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -67,6 +67,7 @@ export abstract class DacFxConfigPage extends BasePage {
 
 	protected async populateServerDropdown(): Promise<boolean> {
 		let values = await this.getServerValues();
+
 		if (values === undefined) {
 			return false;
 		}

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -14,11 +14,6 @@ import { BasePage } from './basePage';
 import { sanitizeStringForFilename, isValidBasename, isValidBasenameErrorMessage } from './utils';
 
 export abstract class DacFxConfigPage extends BasePage {
-
-	protected readonly wizardPage: azdata.window.WizardPage;
-	protected readonly instance: DataTierApplicationWizard;
-	protected readonly model: DacFxDataModel;
-	protected readonly view: azdata.ModelView;
 	protected serverDropdown: azdata.DropDownComponent;
 	protected databaseTextBox: azdata.InputBoxComponent;
 	protected databaseDropdown: azdata.DropDownComponent;
@@ -28,11 +23,7 @@ export abstract class DacFxConfigPage extends BasePage {
 	protected fileExtension: string;
 
 	protected constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
-		super();
-		this.instance = instance;
-		this.wizardPage = wizardPage;
-		this.model = model;
-		this.view = view;
+		super(instance, wizardPage, model, view);
 	}
 
 	public setupNavigationValidator(): void {

--- a/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
@@ -10,22 +10,12 @@ import { DataTierApplicationWizard, Operation } from '../dataTierApplicationWiza
 import { BasePage } from '../api/basePage';
 
 export class DacFxSummaryPage extends BasePage {
-
-	protected readonly wizardPage: azdata.window.WizardPage;
-	protected readonly instance: DataTierApplicationWizard;
-	protected readonly model: DacFxDataModel;
-	protected readonly view: azdata.ModelView;
-
 	private form: azdata.FormContainer;
 	private table: azdata.TableComponent;
 	private loader: azdata.LoadingComponent;
 
 	public constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
-		super();
-		this.instance = instance;
-		this.wizardPage = wizardPage;
-		this.model = model;
-		this.view = view;
+		super(instance, wizardPage, model, view);
 	}
 
 	async start(): Promise<boolean> {

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -12,11 +12,6 @@ import { DacFxConfigPage } from '../api/dacFxConfigPage';
 import { generateDatabaseName } from '../api/utils';
 
 export class DeployConfigPage extends DacFxConfigPage {
-
-	protected readonly wizardPage: azdata.window.WizardPage;
-	protected readonly instance: DataTierApplicationWizard;
-	protected readonly model: DacFxDataModel;
-	protected readonly view: azdata.ModelView;
 	private databaseDropdownComponent: azdata.FormComponent;
 	private databaseComponent: azdata.FormComponent;
 	private formBuilder: azdata.FormBuilder;

--- a/extensions/dacpac/src/wizard/pages/deployPlanPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployPlanPage.ts
@@ -34,10 +34,6 @@ class DeployPlanResult {
 }
 
 export class DeployPlanPage extends DacFxConfigPage {
-	protected readonly wizardPage: azdata.window.WizardPage;
-	protected readonly instance: DataTierApplicationWizard;
-	protected readonly model: DacFxDataModel;
-	protected readonly view: azdata.ModelView;
 	private formBuilder: azdata.FormBuilder;
 	private form: azdata.FormContainer;
 	private table: azdata.TableComponent;

--- a/extensions/dacpac/src/wizard/pages/exportConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/exportConfigPage.ts
@@ -11,12 +11,6 @@ import { DataTierApplicationWizard } from '../dataTierApplicationWizard';
 import { DacFxConfigPage } from '../api/dacFxConfigPage';
 
 export class ExportConfigPage extends DacFxConfigPage {
-
-	protected readonly wizardPage: azdata.window.WizardPage;
-	protected readonly instance: DataTierApplicationWizard;
-	protected readonly model: DacFxDataModel;
-	protected readonly view: azdata.ModelView;
-
 	private form: azdata.FormContainer;
 
 	public constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {

--- a/extensions/dacpac/src/wizard/pages/extractConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/extractConfigPage.ts
@@ -11,12 +11,6 @@ import { DataTierApplicationWizard } from '../dataTierApplicationWizard';
 import { DacFxConfigPage } from '../api/dacFxConfigPage';
 
 export class ExtractConfigPage extends DacFxConfigPage {
-
-	protected readonly wizardPage: azdata.window.WizardPage;
-	protected readonly instance: DataTierApplicationWizard;
-	protected readonly model: DacFxDataModel;
-	protected readonly view: azdata.ModelView;
-
 	private form: azdata.FormContainer;
 	private versionTextBox: azdata.InputBoxComponent;
 

--- a/extensions/dacpac/src/wizard/pages/importConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/importConfigPage.ts
@@ -12,12 +12,6 @@ import { DacFxConfigPage } from '../api/dacFxConfigPage';
 import { generateDatabaseName } from '../api/utils';
 
 export class ImportConfigPage extends DacFxConfigPage {
-
-	protected readonly wizardPage: azdata.window.WizardPage;
-	protected readonly instance: DataTierApplicationWizard;
-	protected readonly model: DacFxDataModel;
-	protected readonly view: azdata.ModelView;
-
 	private form: azdata.FormContainer;
 
 	public constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
@@ -77,6 +71,9 @@ export class ImportConfigPage extends DacFxConfigPage {
 			this.model.filePath = fileUri.fsPath;
 			this.model.database = generateDatabaseName(this.model.filePath);
 			this.databaseTextBox.value = this.model.database;
+
+			console.log('=== In click A: ' + this.model.filePath);
+			console.log('=== In click B: ' + this.model.database);
 		});
 
 		this.fileTextBox.onTextChanged(async () => {

--- a/extensions/dacpac/src/wizard/pages/importConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/importConfigPage.ts
@@ -13,6 +13,7 @@ import { generateDatabaseName } from '../api/utils';
 
 export class ImportConfigPage extends DacFxConfigPage {
 	private form: azdata.FormContainer;
+	public selectionPromise: Promise<void>;
 
 	public constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
 		super(instance, wizardPage, model, view);
@@ -48,33 +49,7 @@ export class ImportConfigPage extends DacFxConfigPage {
 	private async createFileBrowser(): Promise<azdata.FormComponent> {
 		this.createFileBrowserParts();
 
-		this.fileButton.onDidClick(async (click) => {
-			let fileUris = await vscode.window.showOpenDialog(
-				{
-					canSelectFiles: true,
-					canSelectFolders: false,
-					canSelectMany: false,
-					defaultUri: vscode.Uri.file(this.getRootPath()),
-					openLabel: loc.open,
-					filters: {
-						'bacpac Files': ['bacpac'],
-					}
-				}
-			);
-
-			if (!fileUris || fileUris.length === 0) {
-				return;
-			}
-
-			let fileUri = fileUris[0];
-			this.fileTextBox.value = fileUri.fsPath;
-			this.model.filePath = fileUri.fsPath;
-			this.model.database = generateDatabaseName(this.model.filePath);
-			this.databaseTextBox.value = this.model.database;
-
-			console.log('=== In click A: ' + this.model.filePath);
-			console.log('=== In click B: ' + this.model.database);
-		});
+		this.fileButton.onDidClick(async (click) => { this.selectionPromise = this.handleFileSelection(); });
 
 		this.fileTextBox.onTextChanged(async () => {
 			this.model.filePath = this.fileTextBox.value;
@@ -87,5 +62,30 @@ export class ImportConfigPage extends DacFxConfigPage {
 			title: loc.fileLocation,
 			actions: [this.fileButton]
 		};
+	}
+
+	private async handleFileSelection(): Promise<void> {
+		let fileUris = await vscode.window.showOpenDialog(
+			{
+				canSelectFiles: true,
+				canSelectFolders: false,
+				canSelectMany: false,
+				defaultUri: vscode.Uri.file(this.getRootPath()),
+				openLabel: loc.open,
+				filters: {
+					'bacpac Files': ['bacpac'],
+				}
+			}
+		);
+
+		if (!fileUris || fileUris.length === 0) {
+			return;
+		}
+
+		let fileUri = fileUris[0];
+		this.fileTextBox.value = fileUri.fsPath;
+		this.model.filePath = fileUri.fsPath;
+		this.model.database = generateDatabaseName(this.model.filePath);
+		this.databaseTextBox.value = this.model.database;
 	}
 }

--- a/extensions/dacpac/src/wizard/pages/selectOperationpage.ts
+++ b/extensions/dacpac/src/wizard/pages/selectOperationpage.ts
@@ -10,12 +10,6 @@ import { DataTierApplicationWizard, Operation, DeployOperationPath, ExtractOpera
 import { BasePage } from '../api/basePage';
 
 export class SelectOperationPage extends BasePage {
-
-	protected readonly wizardPage: azdata.window.WizardPage;
-	protected readonly instance: DataTierApplicationWizard;
-	protected readonly model: DacFxDataModel;
-	protected readonly view: azdata.ModelView;
-
 	private deployRadioButton: azdata.RadioButtonComponent;
 	private extractRadioButton: azdata.RadioButtonComponent;
 	private importRadioButton: azdata.RadioButtonComponent;
@@ -23,11 +17,7 @@ export class SelectOperationPage extends BasePage {
 	private form: azdata.FormContainer;
 
 	public constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
-		super();
-		this.instance = instance;
-		this.wizardPage = wizardPage;
-		this.model = model;
-		this.view = view;
+		super(instance, wizardPage, model, view);
 	}
 
 	async start(): Promise<boolean> {


### PR DESCRIPTION
Also removes redundant variable definitions in dacfx wizard page classes.

Accidentally pushed a large replay on the other branch (https://github.com/microsoft/azuredatastudio/pull/11417), so I just cherry-picked my commits across to here.