### PR TITLE
Notebook cells - adjusted keyboard navigation and revised edit mode styles.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/codeCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/codeCell.component.ts
@@ -32,11 +32,11 @@ export class CodeCellComponent extends CellView implements OnInit, OnChanges {
 		this._activeCellId = value;
 	}
 
-	@HostListener('document:keydown.escape', ['$event'])
-	handleKeyboardEvent() {
-		this.cellModel.active = false;
-		this._model.updateActiveCell(undefined);
-	}
+	// @HostListener('document:keydown.escape', ['$event'])
+	// handleKeyboardEvent() {
+	// 	this.cellModel.active = false;
+	// 	this._model.updateActiveCell(undefined);
+	// }
 
 	private _model: NotebookModel;
 	private _activeCellId: string;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -49,13 +49,22 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		this._activeCellId = value;
 	}
 
-	@HostListener('document:keydown.escape', ['$event'])
-	handleKeyboardEvent() {
-		if (this.isEditMode) {
-			this.toggleEditMode(false);
+	@HostListener('document:keydown', ['$event'])
+	handleKeyboardEvent(event) {
+		switch (event.key) {
+			case 'Escape':
+				if (this.isEditMode) {
+					this.toggleEditMode(false);
+				}
+				break;
+			case 'Enter':
+				if (!this.isEditMode) {
+					this.toggleEditMode(true);
+				}
+				break;
+			default:
+				break;
 		}
-		this.cellModel.active = false;
-		this._model.updateActiveCell(undefined);
 	}
 
 	@HostListener('document:keydown.meta.a', ['$event'])

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.html
@@ -7,10 +7,10 @@
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div #toolbar class="editor-toolbar actionbar-container" style="flex: 0 0 auto; display: flex; flex-flow: row; width: 100%; align-items: center;">
 	</div>
-	<div #container class="scrollable" style="flex: 1 1 auto; position: relative; outline: none" (click)="unselectActiveCell()" (scroll)="scrollHandler($event)">
+	<div #container class="scrollable" style="flex: 1 1 auto; position: relative; outline: none" (click)="selectTopCell()" (scroll)="scrollHandler($event)">
 		<loading-spinner [loading]="isLoading"></loading-spinner>
 		<div *ngFor="let cell of cells">
-			<div class="notebook-cell" (click)="selectCell(cell, $event)" [class.active]="cell.active">
+			<div class="notebook-cell" (click)="selectCell(cell, $event)" [class.active]="cell.active" (keydown)="onKeyDown($event)">
 				<cell-toolbar-component *ngIf="cell.active" [cellModel]="cell" [model]="model"></cell-toolbar-component>
 				<code-cell-component *ngIf="cell.cellType === 'code'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">
 				</code-cell-component>

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -198,8 +198,8 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		this._scrollTop = (<HTMLElement>event.srcElement).scrollTop;
 	}
 
-	public unselectActiveCell() {
-		this.model.updateActiveCell(undefined);
+	public selectTopCell() {
+		this.model.updateActiveCell(this._model.cells[0]);
 		this.detectChanges();
 	}
 
@@ -212,6 +212,9 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	}
 
 	public onKeyDown(event) {
+		if (!this.model.activeCell) {
+			this.selectTopCell();
+		}
 		switch (event.key) {
 			case 'ArrowDown':
 			case 'ArrowRight':


### PR DESCRIPTION
TextCell - revised keyboard events to handle Esc and Enter. CodeCell - removed keyboard events to prevent cell from becoming unfocussed. Notebook - modified click event on template so that user click anywhere inside the parent container for all cells will cause first cell to receive focus.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses 10798
