### PR TITLE
Remove system dbs from dacfx wizard dropdowns

### DIFF
--- a/extensions/dacpac/src/test/configPages.test.ts
+++ b/extensions/dacpac/src/test/configPages.test.ts
@@ -107,6 +107,21 @@ describe('Dacfx Wizard Pages', function (): void {
 		should(importConfigPage.Model.filePath).equal(dacpacPath);
 		should(importConfigPage.Model.database).equal('myDatabase');
 	});
+
+	it('Should filter out system dbs', async () => {
+		testContext = createContext();
+		wizard.setPages();
+
+		sinon.stub(azdata.connection, 'getConnections').resolves([mockConnectionProfile]);
+		sinon.stub(azdata.connection, 'listDatabases').resolves(['fakeDatabaseName', 'master', 'msdb', 'tempdb', 'model']);
+
+		let extractConfigPage = new TestExtractConfigPage(wizard, wizard.pages.get(PageName.deployConfig).wizardPage, wizard.model, testContext.viewContext.view);
+		await extractConfigPage.start();
+		await extractConfigPage.onPageEnter();
+
+		should(extractConfigPage.databaseValues.length).equal(1);
+		should(extractConfigPage.databaseValues[0]).equal('fakeDatabaseName');
+	});
 });
 
 

--- a/extensions/dacpac/src/wizard/api/basePage.ts
+++ b/extensions/dacpac/src/wizard/api/basePage.ts
@@ -8,6 +8,8 @@ import * as loc from '../../localizedConstants';
 import { DacFxDataModel } from './models';
 import { DataTierApplicationWizard } from '../dataTierApplicationWizard';
 
+const systemDbs = ['master', 'msdb', 'tempdb', 'model'];
+
 export abstract class BasePage {
 	protected readonly instance: DataTierApplicationWizard;
 	protected readonly wizardPage: azdata.window.WizardPage;
@@ -122,14 +124,17 @@ export abstract class BasePage {
 	protected async getDatabaseValues(): Promise<string[]> {
 		let idx = -1;
 		let count = -1;
-		this.databaseValues = (await azdata.connection.listDatabases(this.model.server.connectionId)).map(db => {
-			count++;
-			if (this.model.database && db === this.model.database) {
-				idx = count;
-			}
+		this.databaseValues = (await azdata.connection.listDatabases(this.model.server.connectionId))
+			// filter out system dbs
+			.filter(db => systemDbs.find(systemdb => db === systemdb) === undefined)
+			.map(db => {
+				count++;
+				if (this.model.database && db === this.model.database) {
+					idx = count;
+				}
 
-			return db;
-		});
+				return db;
+			});
 
 		if (idx >= 0) {
 			let tmp = this.databaseValues[0];


### PR DESCRIPTION
This PR fixes #11226. Removes the system dbs from the dropdowns in the dacfx wizard since deploying to them isn't supported.
