### PR TITLE
Do ModelView initialization actions before others

### DIFF
--- a/src/sql/platform/dashboard/browser/interfaces.ts
+++ b/src/sql/platform/dashboard/browser/interfaces.ts
@@ -67,8 +67,9 @@ export interface IModelStore {
 	 *
 	 * @param componentId unique identifier of the component
 	 * @param action some action to perform
+	 * @param isInitialization whether this is an initialization action that will run before other actions
 	 */
-	eventuallyRunOnComponent<T>(componentId: string, action: (component: IComponent) => T): Promise<T>;
+	eventuallyRunOnComponent<T>(componentId: string, action: (component: IComponent) => T, isInitialization?: boolean): Promise<T>;
 	/**
 	 * Register a callback that will validate components when given a component ID
 	 */

--- a/src/sql/workbench/browser/modelComponents/modelStore.ts
+++ b/src/sql/workbench/browser/modelComponents/modelStore.ts
@@ -19,6 +19,7 @@ export class ModelStore implements IModelStore {
 	private _descriptorMappings: { [x: string]: IComponentDescriptor } = {};
 	private _componentMappings: { [x: string]: IComponent } = {};
 	private _componentActions: { [x: string]: Deferred<IComponent> } = {};
+	private _componentInitializationActions: { [x: string]: Deferred<IComponent> } = {};
 	private _validationCallbacks: ((componentId: string) => Thenable<boolean>)[] = [];
 	constructor() {
 	}
@@ -51,12 +52,12 @@ export class ModelStore implements IModelStore {
 		return this._componentMappings[componentId];
 	}
 
-	eventuallyRunOnComponent<T>(componentId: string, action: (component: IComponent) => T): Promise<T> {
+	eventuallyRunOnComponent<T>(componentId: string, action: (component: IComponent) => T, isInitialization: boolean = false): Promise<T> {
 		let component = this.getComponent(componentId);
 		if (component) {
 			return Promise.resolve(action(component));
 		} else {
-			return this.addPendingAction(componentId, action);
+			return this.addPendingAction(componentId, action, isInitialization);
 		}
 	}
 
@@ -69,13 +70,18 @@ export class ModelStore implements IModelStore {
 		return Promise.all(this._validationCallbacks.map(callback => callback(componentId))).then(validations => validations.every(validation => validation === true));
 	}
 
-	private addPendingAction<T>(componentId: string, action: (component: IComponent) => T): Promise<T> {
+	private addPendingAction<T>(componentId: string, action: (component: IComponent) => T, isInitialization: boolean): Promise<T> {
 		// We create a promise and chain it onto a tracking promise whose resolve method
 		// will only be called once the component is created
-		let deferredPromise = this._componentActions[componentId];
+
+		// If this is an initialization action we want to run it before the other actions that may have come in
+		// after initialization but before the component was finished being created or we hit race conditions with
+		// setting properties
+		const actionsStore = isInitialization ? this._componentInitializationActions : this._componentActions;
+		let deferredPromise = actionsStore[componentId];
 		if (!deferredPromise) {
 			deferredPromise = new Deferred();
-			this._componentActions[componentId] = deferredPromise;
+			actionsStore[componentId] = deferredPromise;
 		}
 		let promise = deferredPromise.promise.then((component) => {
 			return action(component);
@@ -84,9 +90,10 @@ export class ModelStore implements IModelStore {
 	}
 
 	private runPendingActions(componentId: string, component: IComponent) {
-		let promiseTracker = this._componentActions[componentId];
-		if (promiseTracker) {
-			promiseTracker.resolve(component);
-		}
+		// If we have initialization actions to run start those first
+		const initializationActionsPromise = this._componentInitializationActions[componentId];
+		initializationActionsPromise?.resolve(component);
+		const actionsPromise = this._componentActions[componentId];
+		actionsPromise?.resolve(component);
 	}
 }


### PR DESCRIPTION
This is specifically to fix an issue with the Arc dashboards where the loading components are having loading set to false too quickly on first load and so spin forever.

In the end this ties back to the race condition issues we keep seeing pop up with ModelView. The short synopsis of the issue is that when we execute the queued up actions they're all triggered at the same time - and order is not guaranteed. This means that we can sometimes run into issues where the initial calls to setProperties happens AFTER properties are updated by the extension side. This then causes those property values to be overwritten and causes issues such as the one above.

This isn't the perfect fix in my eyes - I'd rather we serialize the actions completely so that we always guarantee the order of execution. Right now we still have some potential for problems since we don't actually wait for the actions to all finish (since they're actually called by the Promise.resolve which just returns immediately)

But in my experimentation with completely serializing the queued actions things broke in some very weird ways so I still need to spend some more time working on that.

In the meantime though this is a simpler fix that seems to resolve the immediate issue we were seeing and is a lot safer. 
