### PR TITLE
Add back toolbar icon for importing db project

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -120,8 +120,8 @@
         "title": "%sqlDatabaseProjects.importDatabase%",
         "category": "%sqlDatabaseProjects.displayName%",
           "icon": {
-            "dark": "images/extension.png",
-            "light": "images/extension.png"
+            "dark": "images/dark/databaseProject.svg",
+            "light": "images/light/databaseProject.svg"
           }
       },
       {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #11509. Just using this icon temporarily while we wait for the toolbar icon from UX. 
![image](https://user-images.githubusercontent.com/31145923/88431874-07fa3e00-cdb0-11ea-83d7-76a45c191179.png)

![image](https://user-images.githubusercontent.com/31145923/88431857-029cf380-cdb0-11ea-841a-3c386bd6c8a0.png)

