### PR TITLE
Use home_oid, over oid, over unique_name, over sub

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -666,7 +666,7 @@ export interface TokenClaims { // https://docs.microsoft.com/en-us/azure/active-
 	idp: string,
 	nbf: number;
 	exp: number;
-	home_oid: string;
+	home_oid?: string;
 	c_hash: string;
 	at_hash: string;
 	aio: string;

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -262,7 +262,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 
 		const tokenClaims: TokenClaims = this.getTokenClaims(accessTokenString);
 
-		const userKey = tokenClaims.sub ?? tokenClaims.oid;
+		const userKey = tokenClaims.home_oid ?? tokenClaims.oid ?? tokenClaims.sub ?? tokenClaims.unique_name;
 
 		if (!userKey) {
 			const msg = localize('azure.noUniqueIdentifier', "The user had no unique identifier within AAD");
@@ -666,6 +666,7 @@ export interface TokenClaims { // https://docs.microsoft.com/en-us/azure/active-
 	idp: string,
 	nbf: number;
 	exp: number;
+	home_oid: string;
 	c_hash: string;
 	at_hash: string;
 	aio: string;

--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -262,7 +262,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 
 		const tokenClaims: TokenClaims = this.getTokenClaims(accessTokenString);
 
-		const userKey = tokenClaims.home_oid ?? tokenClaims.oid ?? tokenClaims.sub ?? tokenClaims.unique_name;
+		const userKey = tokenClaims.home_oid ?? tokenClaims.oid ?? tokenClaims.unique_name ?? tokenClaims.sub;
 
 		if (!userKey) {
 			const msg = localize('azure.noUniqueIdentifier', "The user had no unique identifier within AAD");


### PR DESCRIPTION
oid values aren't present for personal accounts, sub values are different per tenant. This code should get us supporting most all types of accounts. I can't think of any that this would fail on.