### PR TITLE
azdata improvements

### DIFF
--- a/extensions/azdata/package.json
+++ b/extensions/azdata/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "request": "^2.88.2",
     "sudo-prompt": "^9.2.1",
-    "uuid": "^8.2.0",
     "vscode-nls": "^4.1.2",
     "which": "^2.0.2"
   },

--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -5,7 +5,6 @@
 
 import * as os from 'os';
 import * as path from 'path';
-import * as uuid from 'uuid';
 import * as vscode from 'vscode';
 import { HttpClient } from './common/httpClient';
 import * as loc from './localizedConstants';
@@ -32,9 +31,6 @@ export async function findAzdata(outputChannel: vscode.OutputChannel): Promise<I
 	try {
 		let azdata: IAzdata | undefined = undefined;
 		switch (process.platform) {
-			case 'darwin':
-				azdata = await findAzdataDarwin(outputChannel);
-				break;
 			case 'win32':
 				azdata = await findAzdataWin32(outputChannel);
 				break;
@@ -55,6 +51,7 @@ export async function findAzdata(outputChannel: vscode.OutputChannel): Promise<I
  */
 export async function downloadAndInstallAzdata(outputChannel: vscode.OutputChannel): Promise<void> {
 	const statusDisposable = vscode.window.setStatusBarMessage(loc.installingAzdata);
+	outputChannel.show();
 	outputChannel.appendLine(loc.installingAzdata);
 	try {
 		switch (process.platform) {
@@ -62,13 +59,13 @@ export async function downloadAndInstallAzdata(outputChannel: vscode.OutputChann
 				await downloadAndInstallAzdataWin32(outputChannel);
 				break;
 			case 'darwin':
-				await installAzdataDarwin();
+				await installAzdataDarwin(outputChannel);
 				break;
 			case 'linux':
 				await installAzdataLinux(outputChannel);
 				break;
 			default:
-				throw new Error(`Platform ${process.platform} is unsupported`);
+				throw new Error(loc.platformUnsupported(process.platform));
 		}
 	} finally {
 		statusDisposable.dispose();
@@ -80,17 +77,18 @@ export async function downloadAndInstallAzdata(outputChannel: vscode.OutputChann
  * @param outputChannel Channel used to display diagnostic information
  */
 async function downloadAndInstallAzdataWin32(outputChannel: vscode.OutputChannel): Promise<void> {
-	const downloadPath = path.join(os.tmpdir(), `azdata-msi-${uuid.v4()}.msi`);
-	outputChannel.appendLine(loc.downloadingTo('azdata-cli.msi', downloadPath));
-	await HttpClient.download(`${azdataHostname}/${azdataUri}`, downloadPath, outputChannel);
-	await executeCommand('msiexec', ['/i', downloadPath], outputChannel);
+	const downloadPath = path.join(os.tmpdir());
+	const downloadedFile = await HttpClient.download(`${azdataHostname}/${azdataUri}`, downloadPath, outputChannel);
+	await executeCommand('msiexec', ['/qn', '/i', downloadedFile], outputChannel);
 }
 
 /**
  * Runs commands to install azdata on MacOS
  */
-async function installAzdataDarwin(): Promise<void> {
-	throw new Error('Not yet implemented');
+async function installAzdataDarwin(outputChannel: vscode.OutputChannel): Promise<void> {
+	await executeCommand('brew', ['tap', 'microsoft/azdata-cli-release'], outputChannel);
+	await executeCommand('brew', ['update'], outputChannel);
+	await executeCommand('brew', ['install', 'azdata-cli'], outputChannel);
 }
 
 /**
@@ -104,7 +102,7 @@ async function installAzdataLinux(outputChannel: vscode.OutputChannel): Promise<
 	// Download and install the signing key
 	await executeSudoCommand('curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null', outputChannel);
 	// Add the azdata repository information
-	const release = (await executeCommand('lsb_release', ['-rs'], outputChannel)).trim();
+	const release = (await executeCommand('lsb_release', ['-rs'], outputChannel)).stdout.trim();
 	await executeSudoCommand(`add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/${release}/mssql-server-2019.list)"`, outputChannel);
 	// Update repository information and install azdata
 	await executeSudoCommand('apt-get update', outputChannel);
@@ -121,14 +119,6 @@ async function findAzdataWin32(outputChannel: vscode.OutputChannel): Promise<IAz
 }
 
 /**
- * Finds azdata specifically on MacOS
- * @param outputChannel Channel used to display diagnostic information
- */
-async function findAzdataDarwin(_outputChannel: vscode.OutputChannel): Promise<IAzdata> {
-	throw new Error('Not yet implemented');
-}
-
-/**
  * Gets the version using a known azdata path
  * @param path The path to the azdata executable
  * @param outputChannel Channel used to display diagnostic information
@@ -137,7 +127,7 @@ async function findSpecificAzdata(path: string, outputChannel: vscode.OutputChan
 	const versionOutput = await executeCommand(path, ['--version'], outputChannel);
 	return {
 		path: path,
-		version: parseVersion(versionOutput)
+		version: parseVersion(versionOutput.stdout)
 	};
 }
 

--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -77,7 +77,7 @@ export async function downloadAndInstallAzdata(outputChannel: vscode.OutputChann
  * @param outputChannel Channel used to display diagnostic information
  */
 async function downloadAndInstallAzdataWin32(outputChannel: vscode.OutputChannel): Promise<void> {
-	const downloadPath = path.join(os.tmpdir());
+	const downloadPath = os.tmpdir();
 	const downloadedFile = await HttpClient.download(`${azdataHostname}/${azdataUri}`, downloadPath, outputChannel);
 	await executeCommand('msiexec', ['/qn', '/i', downloadedFile], outputChannel);
 }

--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -76,8 +76,8 @@ export async function downloadAndInstallAzdata(outputChannel: vscode.OutputChann
  * @param outputChannel Channel used to display diagnostic information
  */
 async function downloadAndInstallAzdataWin32(outputChannel: vscode.OutputChannel): Promise<void> {
-	const downloadPath = os.tmpdir();
-	const downloadedFile = await HttpClient.download(`${azdataHostname}/${azdataUri}`, downloadPath, outputChannel);
+	const downloadFolder = os.tmpdir();
+	const downloadedFile = await HttpClient.download(`${azdataHostname}/${azdataUri}`, downloadFolder, outputChannel);
 	await executeCommand('msiexec', ['/qn', '/i', downloadedFile], outputChannel);
 }
 

--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as os from 'os';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { HttpClient } from './common/httpClient';
 import * as loc from './localizedConstants';

--- a/extensions/azdata/src/common/childProcess.ts
+++ b/extensions/azdata/src/common/childProcess.ts
@@ -23,9 +23,9 @@ export class ExitCodeError extends Error {
  * @param args Optional args to pass, every arg and arg value must be a separate item in the array
  * @param outputChannel Channel used to display diagnostic information
  */
-export async function executeCommand(command: string, args?: string[], outputChannel?: vscode.OutputChannel): Promise<{ stdout: string, stderr: string }> {
+export async function executeCommand(command: string, args: string[], outputChannel: vscode.OutputChannel): Promise<{ stdout: string, stderr: string }> {
 	return new Promise((resolve, reject) => {
-		outputChannel?.appendLine(loc.executingCommand(command, args ?? []));
+		outputChannel.appendLine(loc.executingCommand(command, args));
 		const stdoutBuffers: Buffer[] = [];
 		const stderrBuffers: Buffer[] = [];
 		const child = cp.spawn(command, args, { shell: true });
@@ -36,14 +36,14 @@ export async function executeCommand(command: string, args?: string[], outputCha
 			const stdout = Buffer.concat(stdoutBuffers).toString('utf8').trim();
 			const stderr = Buffer.concat(stderrBuffers).toString('utf8').trim();
 			if (stdout) {
-				outputChannel?.appendLine(loc.stdoutOutput(stdout));
+				outputChannel.appendLine(loc.stdoutOutput(stdout));
 			}
 			if (stderr) {
-				outputChannel?.appendLine(loc.stdoutOutput(stderr));
+				outputChannel.appendLine(loc.stdoutOutput(stderr));
 			}
 			if (code) {
 				const err = new ExitCodeError(code);
-				outputChannel?.appendLine(err.message);
+				outputChannel.appendLine(err.message);
 				reject(err);
 			} else {
 				resolve({ stdout: stdout, stderr: stderr });
@@ -59,20 +59,20 @@ export async function executeCommand(command: string, args?: string[], outputCha
  * @param args The additional args
  * @param outputChannel Channel used to display diagnostic information
  */
-export async function executeSudoCommand(command: string, outputChannel?: vscode.OutputChannel): Promise<{ stdout: string, stderr: string }> {
+export async function executeSudoCommand(command: string, outputChannel: vscode.OutputChannel): Promise<{ stdout: string, stderr: string }> {
 	return new Promise((resolve, reject) => {
-		outputChannel?.appendLine(loc.executingCommand(`sudo ${command}`, []));
+		outputChannel.appendLine(loc.executingCommand(`sudo ${command}`, []));
 		sudo.exec(command, { name: vscode.env.appName }, (error, stdout, stderr) => {
 			stdout = stdout?.toString() ?? '';
 			stderr = stderr?.toString() ?? '';
 			if (stdout) {
-				outputChannel?.appendLine(loc.stdoutOutput(stdout));
+				outputChannel.appendLine(loc.stdoutOutput(stdout));
 			}
 			if (stderr) {
-				outputChannel?.appendLine(loc.stdoutOutput(stderr));
+				outputChannel.appendLine(loc.stdoutOutput(stderr));
 			}
 			if (error) {
-				outputChannel?.appendLine(loc.unexpectedCommandError(error.message));
+				outputChannel.appendLine(loc.unexpectedCommandError(error.message));
 				reject(error);
 			} else {
 				resolve({ stdout: stdout, stderr: stderr });

--- a/extensions/azdata/src/common/childProcess.ts
+++ b/extensions/azdata/src/common/childProcess.ts
@@ -9,7 +9,7 @@ import * as sudo from 'sudo-prompt';
 import * as loc from '../localizedConstants';
 
 /**
- * Wrapper error for when an unexpected exit code was recieved
+ * Wrapper error for when an unexpected exit code was received
  */
 export class ExitCodeError extends Error {
 	constructor(public code: number) {
@@ -17,13 +17,15 @@ export class ExitCodeError extends Error {
 	}
 }
 
+export type ProcessOutput = { stdout: string, stderr: string };
+
 /**
  * Executes the specified command. Throws an error for a non-0 exit code or if stderr receives output
  * @param command The command to execute
  * @param args Optional args to pass, every arg and arg value must be a separate item in the array
  * @param outputChannel Channel used to display diagnostic information
  */
-export async function executeCommand(command: string, args: string[], outputChannel: vscode.OutputChannel): Promise<{ stdout: string, stderr: string }> {
+export async function executeCommand(command: string, args: string[], outputChannel: vscode.OutputChannel): Promise<ProcessOutput> {
 	return new Promise((resolve, reject) => {
 		outputChannel.appendLine(loc.executingCommand(command, args));
 		const stdoutBuffers: Buffer[] = [];
@@ -59,7 +61,7 @@ export async function executeCommand(command: string, args: string[], outputChan
  * @param args The additional args
  * @param outputChannel Channel used to display diagnostic information
  */
-export async function executeSudoCommand(command: string, outputChannel: vscode.OutputChannel): Promise<{ stdout: string, stderr: string }> {
+export async function executeSudoCommand(command: string, outputChannel: vscode.OutputChannel): Promise<ProcessOutput> {
 	return new Promise((resolve, reject) => {
 		outputChannel.appendLine(loc.executingCommand(`sudo ${command}`, []));
 		sudo.exec(command, { name: vscode.env.appName }, (error, stdout, stderr) => {

--- a/extensions/azdata/src/common/childProcess.ts
+++ b/extensions/azdata/src/common/childProcess.ts
@@ -52,16 +52,14 @@ export async function executeCommand(command: string, args?: string[], outputCha
  * @param args The additional args
  * @param outputChannel Channel used to display diagnostic information
  */
-export async function executeSudoCommand(command: string, outputChannel?: vscode.OutputChannel): Promise<string> {
-	return new Promise<string>((resolve, reject) => {
+export async function executeSudoCommand(command: string, outputChannel?: vscode.OutputChannel): Promise<{ stdout: string, stderr: string }> {
+	return new Promise((resolve, reject) => {
 		outputChannel?.appendLine(loc.executingCommand(`sudo ${command}`, []));
 		sudo.exec(command, { name: vscode.env.appName }, (error, stdout, stderr) => {
 			if (error) {
 				reject(error);
-			} else if (stderr) {
-				reject(stderr.toString());
 			} else {
-				resolve(stdout ? stdout.toString() : '');
+				resolve({ stdout: stdout?.toString() ?? '', stderr: stderr?.toString() ?? '' });
 			}
 		});
 	});

--- a/extensions/azdata/src/common/httpClient.ts
+++ b/extensions/azdata/src/common/httpClient.ts
@@ -18,6 +18,7 @@ export namespace HttpClient {
 	 * @param downloadUrl The URL to download the file from
 	 * @param targetFolder The folder to download the file to
 	 * @param outputChannel Channel used to display diagnostic information
+	 * @returns Full path to the downloaded file
 	 */
 	export function download(downloadUrl: string, targetFolder: string, outputChannel: vscode.OutputChannel): Promise<string> {
 		return new Promise((resolve, reject) => {

--- a/extensions/azdata/src/common/promise.ts
+++ b/extensions/azdata/src/common/promise.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Deferred promise
+ */
+export class Deferred<T> {
+	promise: Promise<T>;
+	resolve!: (value?: T | PromiseLike<T>) => void;
+	reject!: (reason?: any) => void;
+	constructor() {
+		this.promise = new Promise<T>((resolve, reject) => {
+			this.resolve = resolve;
+			this.reject = reject;
+		});
+	}
+
+	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => TResult | Thenable<TResult>): Thenable<TResult>;
+	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => void): Thenable<TResult>;
+	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => TResult | Thenable<TResult>): Thenable<TResult> {
+		return this.promise.then(onfulfilled, onrejected);
+	}
+}

--- a/extensions/azdata/src/extension.ts
+++ b/extensions/azdata/src/extension.ts
@@ -10,9 +10,7 @@ import { ExitCodeError } from './common/childProcess';
 
 export async function activate(): Promise<void> {
 	const outputChannel = vscode.window.createOutputChannel('azdata');
-	if (false) {
-		await checkForAzdata(outputChannel);
-	}
+	await checkForAzdata(outputChannel);
 }
 
 async function checkForAzdata(outputChannel: vscode.OutputChannel): Promise<void> {
@@ -20,16 +18,22 @@ async function checkForAzdata(outputChannel: vscode.OutputChannel): Promise<void
 		const azdata = await findAzdata(outputChannel);
 		vscode.window.showInformationMessage(loc.foundExistingAzdata(azdata.path, azdata.version));
 	} catch (err) {
-		const response = await vscode.window.showErrorMessage(loc.couldNotFindAzdataWithPrompt, loc.install, loc.cancel);
-		if (response === loc.install) {
-			try {
-				await downloadAndInstallAzdata(outputChannel);
-				vscode.window.showInformationMessage(loc.azdataInstalled);
-			} catch (err) {
-				// Windows: 1602 is User Cancelling installation - not unexpected so don't display
-				if (!(err instanceof ExitCodeError) || err.code !== 1602) {
-					vscode.window.showWarningMessage(loc.installError(err));
-				}
+		// Don't block on this since we want the extension to finish activating without needing user input.
+		// Calls will be made to handle azdata not being installed
+		promptToInstallAzdata(outputChannel).catch(e => console.log(`Unexpected error prompting to install azdata ${e}`));
+	}
+}
+
+async function promptToInstallAzdata(outputChannel: vscode.OutputChannel): Promise<void> {
+	const response = await vscode.window.showErrorMessage(loc.couldNotFindAzdataWithPrompt, loc.install, loc.cancel);
+	if (response === loc.install) {
+		try {
+			await downloadAndInstallAzdata(outputChannel);
+			vscode.window.showInformationMessage(loc.azdataInstalled);
+		} catch (err) {
+			// Windows: 1602 is User Cancelling installation - not unexpected so don't display
+			if (!(err instanceof ExitCodeError) || err.code !== 1602) {
+				vscode.window.showWarningMessage(loc.installError(err));
 			}
 		}
 	}

--- a/extensions/azdata/src/localizedConstants.ts
+++ b/extensions/azdata/src/localizedConstants.ts
@@ -15,8 +15,10 @@ export const installingAzdata = localize('azdata.installingAzdata', "Installing 
 export const azdataInstalled = localize('azdata.azdataInstalled', "azdata was successfully installed. Restarting Azure Data Studio is required to complete configuration - features will not be activated until this is done.");
 export const cancel = localize('azdata.cancel', "Cancel");
 export function downloadingTo(name: string, location: string): string { return localize('azdata.downloadingTo', "Downloading {0} to {1}", name, location); }
+export function executingCommand(command: string, args: string[]): string { return localize('azdata.executingCommand', "Executing command \"{0} {1}\"", command, args?.join(' ')); }
+
 export function couldNotFindAzdata(err: any): string { return localize('azdata.couldNotFindAzdata', "Could not find azdata. Error : {0}", err.message ?? err); }
 export const couldNotFindAzdataWithPrompt = localize('azdata.couldNotFindAzdataWithPrompt', "Could not find azdata, install it now? If not then some features will not be able to function.");
 export const downloadError = localize('azdata.downloadError', "Error while downloading");
 export function installError(err: any): string { return localize('azdata.installError', "Error installing azdata : {0}", err.message ?? err); }
-export function executingCommand(command: string, args: string[]): string { return localize('azdata.executingCommand', "Executing command \"{0} {1}\"", command, args?.join(' ')); }
+export function platformUnsupported(platform: string): string { return localize('azdata.platformUnsupported', "Platform '{0}' is currently unsupported", platform); }

--- a/extensions/azdata/src/localizedConstants.ts
+++ b/extensions/azdata/src/localizedConstants.ts
@@ -16,9 +16,13 @@ export const azdataInstalled = localize('azdata.azdataInstalled', "azdata was su
 export const cancel = localize('azdata.cancel', "Cancel");
 export function downloadingTo(name: string, location: string): string { return localize('azdata.downloadingTo', "Downloading {0} to {1}", name, location); }
 export function executingCommand(command: string, args: string[]): string { return localize('azdata.executingCommand', "Executing command \"{0} {1}\"", command, args?.join(' ')); }
+export function stdoutOutput(stdout: string): string { return localize('azdat.stdoutOutput', "stdout : {0}", stdout); }
+export function stderrOutput(stderr: string): string { return localize('azdat.stderrOutput', "stderr : {0}", stderr); }
 
 export function couldNotFindAzdata(err: any): string { return localize('azdata.couldNotFindAzdata', "Could not find azdata. Error : {0}", err.message ?? err); }
 export const couldNotFindAzdataWithPrompt = localize('azdata.couldNotFindAzdataWithPrompt', "Could not find azdata, install it now? If not then some features will not be able to function.");
 export const downloadError = localize('azdata.downloadError', "Error while downloading");
 export function installError(err: any): string { return localize('azdata.installError', "Error installing azdata : {0}", err.message ?? err); }
 export function platformUnsupported(platform: string): string { return localize('azdata.platformUnsupported', "Platform '{0}' is currently unsupported", platform); }
+export function unexpectedCommandError(errMsg: string): string { return localize('azdata.unexpectedCommandError', "Unexpected error executing command : {0}", errMsg); }
+export function unexpectedExitCode(code: number): string { return localize('azdata.unexpectedExitCode', "Unexpected exit code from command : {0}", code); }

--- a/extensions/azdata/src/localizedConstants.ts
+++ b/extensions/azdata/src/localizedConstants.ts
@@ -18,6 +18,8 @@ export function downloadingTo(name: string, location: string): string { return l
 export function executingCommand(command: string, args: string[]): string { return localize('azdata.executingCommand', "Executing command \"{0} {1}\"", command, args?.join(' ')); }
 export function stdoutOutput(stdout: string): string { return localize('azdat.stdoutOutput', "stdout : {0}", stdout); }
 export function stderrOutput(stderr: string): string { return localize('azdat.stderrOutput', "stderr : {0}", stderr); }
+export function gettingFilenameOfUrl(url: string): string { return localize('azdata.gettingFilenameOfUrl', "Getting filename of resource at URL {0}", url); }
+export function gotFilenameOfUrl(url: string, filename: string): string { return localize('azdata.gotFilenameOfUrl', "Got filename {0} from URL {1}", filename, url); }
 
 export function couldNotFindAzdata(err: any): string { return localize('azdata.couldNotFindAzdata', "Could not find azdata. Error : {0}", err.message ?? err); }
 export const couldNotFindAzdataWithPrompt = localize('azdata.couldNotFindAzdataWithPrompt', "Could not find azdata, install it now? If not then some features will not be able to function.");

--- a/extensions/azdata/src/test/azdata.test.ts
+++ b/extensions/azdata/src/test/azdata.test.ts
@@ -27,7 +27,7 @@ describe('azdata', function () {
 
 	describe('findAzdata', function () {
 		// Mock call to --version to simulate azdata being installed
-		sinon.stub(childProcess, 'executeCommand').returns(Promise.resolve('v1.0.0'));
+		sinon.stub(childProcess, 'executeCommand').returns(Promise.resolve({ stdout: 'v1.0.0', stderr: '' }));
 		it('successful', async function (): Promise<void> {
 			sinon.stub(utils, 'searchForCmd').returns(Promise.resolve('C:\\path\\to\\azdata.cmd'));
 			await should(azdata.findAzdata(outputChannelMock.object)).not.be.rejected();

--- a/extensions/azdata/src/test/common/childProcess.test.ts
+++ b/extensions/azdata/src/test/common/childProcess.test.ts
@@ -20,7 +20,7 @@ describe('ChildProcess', function () {
 	it('Gets expected output', async function (): Promise<void> {
 		const echoOutput = 'test';
 		const output = await executeCommand('echo', [echoOutput]);
-		should(output).equal(echoOutput);
+		should(output.stdout).equal(echoOutput);
 	});
 
 	it('Invalid command errors', async function (): Promise<void> {

--- a/extensions/azdata/src/test/common/childProcess.test.ts
+++ b/extensions/azdata/src/test/common/childProcess.test.ts
@@ -25,6 +25,6 @@ describe('ChildProcess', function () {
 	});
 
 	it('Invalid command errors', async function (): Promise<void> {
-		await should(executeCommand('sdfkslkf', [], outputChannelMock.object)).be.rejected();
+		await should(executeCommand('invalid_command', [], outputChannelMock.object)).be.rejected();
 	});
 });

--- a/extensions/azdata/src/test/common/childProcess.test.ts
+++ b/extensions/azdata/src/test/common/childProcess.test.ts
@@ -9,21 +9,22 @@ import * as TypeMoq from 'typemoq';
 import { executeCommand } from '../../common/childProcess';
 
 describe('ChildProcess', function () {
-	[undefined, [], ['test']].forEach(args => {
+	const outputChannelMock = TypeMoq.Mock.ofType<vscode.OutputChannel>();
+
+	[[], ['test']].forEach(args => {
 		it(`Output channel is used with ${JSON.stringify(args)} args`, async function (): Promise<void> {
-			const outputChannelMock = TypeMoq.Mock.ofType<vscode.OutputChannel>();
 			await executeCommand('echo', args, outputChannelMock.object);
-			outputChannelMock.verify(x => x.appendLine(TypeMoq.It.isAny()), TypeMoq.Times.once());
+			outputChannelMock.verify(x => x.appendLine(TypeMoq.It.isAny()), TypeMoq.Times.atLeastOnce());
 		});
 	});
 
 	it('Gets expected output', async function (): Promise<void> {
 		const echoOutput = 'test';
-		const output = await executeCommand('echo', [echoOutput]);
+		const output = await executeCommand('echo', [echoOutput], outputChannelMock.object);
 		should(output.stdout).equal(echoOutput);
 	});
 
 	it('Invalid command errors', async function (): Promise<void> {
-		await should(executeCommand('sdfkslkf')).be.rejected();
+		await should(executeCommand('sdfkslkf', [], outputChannelMock.object)).be.rejected();
 	});
 });

--- a/extensions/azdata/src/test/common/httpClient.test.ts
+++ b/extensions/azdata/src/test/common/httpClient.test.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 import * as should from 'should';
 import * as TypeMoq from 'typemoq';
 import { HttpClient } from '../../common/httpClient';
-import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as nock from 'nock';

--- a/extensions/azdata/src/test/common/httpClient.test.ts
+++ b/extensions/azdata/src/test/common/httpClient.test.ts
@@ -15,7 +15,7 @@ import * as sinon from 'sinon';
 import { PassThrough } from 'stream';
 import { Deferred } from '../../common/promise';
 
-describe('HttpClient', function () {
+describe('HttpClient', function (): void {
 
 	let outputChannelMock: TypeMoq.IMock<vscode.OutputChannel>;
 
@@ -28,52 +28,88 @@ describe('HttpClient', function () {
 		nock.enableNetConnect();
 	});
 
-	it('downloads file successfully', async function (): Promise<void> {
-		const downloadFolder = path.join(os.tmpdir());
-		const downloadPath = await HttpClient.download('https://raw.githubusercontent.com/microsoft/azuredatastudio/main/README.md', downloadFolder, outputChannelMock.object);
-		// Verify file was downloaded correctly
-		await fs.promises.stat(downloadPath);
-	});
-
-	it('errors on response stream error', async function (): Promise<void> {
-		const downloadPath = path.join(os.tmpdir());
-		nock('https://127.0.0.1')
-			.get('/')
-			.replyWithError('Unexpected Error');
-		const downloadPromise = HttpClient.download('https://127.0.0.1', downloadPath, outputChannelMock.object);
-
-		await should(downloadPromise).be.rejected();
-	});
-
-	it('rejects on non-OK status code', async function (): Promise<void> {
-		const downloadPath = path.join(os.tmpdir());
-		nock('https://127.0.0.1')
-			.get('/')
-			.reply(404, '');
-		const downloadPromise = HttpClient.download('https://127.0.0.1', downloadPath, outputChannelMock.object);
-
-		await should(downloadPromise).be.rejected();
-	});
-
-	it('errors on write stream error', async function (): Promise<void> {
-		const downloadPath = path.join(os.tmpdir());
-		const mockWriteStream = new PassThrough();
-		const deferredPromise = new Deferred();
-		sinon.stub(fs, 'createWriteStream').callsFake(() => {
-			deferredPromise.resolve();
-			return <any>mockWriteStream;
+	describe('download', function(): void {
+		it('downloads file successfully', async function (): Promise<void> {
+			nock('https://127.0.0.1')
+				.get('/README.md')
+				.replyWithFile(200, __filename);
+			const downloadFolder = os.tmpdir();
+			const downloadPath = await HttpClient.download('https://127.0.0.1/README.md', downloadFolder, outputChannelMock.object);
+			// Verify file was downloaded correctly
+			await fs.promises.stat(downloadPath);
 		});
-		nock('https://127.0.0.1')
-			.get('/')
-			.reply(200, '');
-		const downloadPromise = HttpClient.download('https://127.0.0.1', downloadPath, outputChannelMock.object);
-		// Wait for the stream to be created before throwing the error or HttpClient will miss the event
-		await deferredPromise;
-		try {
-			// Passthrough streams will throw the error we emit so just no-op and
-			// let the HttpClient handler handle the error
-			mockWriteStream.emit('error', 'Unexpected write error');
-		} catch (err) { }
-		await should(downloadPromise).be.rejected();
+
+		it('errors on response stream error', async function (): Promise<void> {
+			const downloadFolder = os.tmpdir();
+			nock('https://127.0.0.1')
+				.get('/')
+				.replyWithError('Unexpected Error');
+			const downloadPromise = HttpClient.download('https://127.0.0.1', downloadFolder, outputChannelMock.object);
+
+			await should(downloadPromise).be.rejected();
+		});
+
+		it('rejects on non-OK status code', async function (): Promise<void> {
+			const downloadFolder = os.tmpdir();
+			nock('https://127.0.0.1')
+				.get('/')
+				.reply(404, '');
+			const downloadPromise = HttpClient.download('https://127.0.0.1', downloadFolder, outputChannelMock.object);
+
+			await should(downloadPromise).be.rejected();
+		});
+
+		it('errors on write stream error', async function (): Promise<void> {
+			const downloadFolder = os.tmpdir();
+			const mockWriteStream = new PassThrough();
+			const deferredPromise = new Deferred();
+			sinon.stub(fs, 'createWriteStream').callsFake(() => {
+				deferredPromise.resolve();
+				return <any>mockWriteStream;
+			});
+			nock('https://127.0.0.1')
+				.get('/')
+				.reply(200, '');
+			const downloadPromise = HttpClient.download('https://127.0.0.1', downloadFolder, outputChannelMock.object);
+			// Wait for the stream to be created before throwing the error or HttpClient will miss the event
+			await deferredPromise;
+			try {
+				// Passthrough streams will throw the error we emit so just no-op and
+				// let the HttpClient handler handle the error
+				mockWriteStream.emit('error', 'Unexpected write error');
+			} catch (err) { }
+			await should(downloadPromise).be.rejected();
+		});
 	});
+
+	describe('getFilename', function(): void {
+		it('Gets filename correctly', async function (): Promise<void> {
+			const filename = 'azdata-cli-20.0.0.msi';
+			nock('https://127.0.0.1')
+				.get(`/${filename}`)
+				.reply(200);
+			const receivedFilename = await HttpClient.getFilename(`https://127.0.0.1/${filename}`, outputChannelMock.object);
+
+			should(receivedFilename).equal(filename);
+		});
+
+		it('errors on response error', async function (): Promise<void> {
+			nock('https://127.0.0.1')
+				.get('/')
+				.replyWithError('Unexpected Error');
+			const getFilenamePromise = HttpClient.getFilename('https://127.0.0.1', outputChannelMock.object);
+
+			await should(getFilenamePromise).be.rejected();
+		});
+
+		it('rejects on non-OK status code', async function (): Promise<void> {
+			nock('https://127.0.0.1')
+				.get('/')
+				.reply(404, '');
+			const getFilenamePromise = HttpClient.getFilename('https://127.0.0.1', outputChannelMock.object);
+
+			await should(getFilenamePromise).be.rejected();
+		});
+	});
+
 });

--- a/extensions/azdata/src/test/common/promise.test.ts
+++ b/extensions/azdata/src/test/common/promise.test.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as should from 'should';
+import { Deferred } from '../../common/promise';
+
+describe('DeferredPromise', function (): void {
+
+	it('Resolves correctly', async function(): Promise<void> {
+		const deferred = new Deferred();
+		deferred.resolve();
+		await should(deferred.promise).be.resolved();
+	});
+
+	it('Rejects correctly', async function(): Promise<void> {
+		const deferred = new Deferred();
+		deferred.reject();
+		await should(deferred.promise).be.rejected();
+	});
+
+	it('Chains then correctly', function(done): void {
+		const deferred = new Deferred();
+		deferred.then( () => {
+			done();
+		});
+		deferred.resolve();
+	});
+});

--- a/extensions/azdata/yarn.lock
+++ b/extensions/azdata/yarn.lock
@@ -1242,11 +1242,6 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.2.0.tgz#cb10dd6b118e2dada7d0cd9730ba7417c93d920e"
-  integrity sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==
-
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"


### PR DESCRIPTION
1. Downloaded filename is pulled from URI instead of hardcoding. This may not work for all scenarios possible - but for our purposes in this extension it's controlled enough that this is fine (this is also leading into another enhancement I'm working on where we use that filename to determine the version so we know whether we need to download the installer or not in upgrade scenarios)
1. Show output channel when we start the install
1. Add MacOS installation support
1. Don't error commands on stderr (that's often used as a debug stream, not necessarily that the process failed to execute)
1. Don't block extension activation when prompting user to install azdata. This ends up blocking other extensions and test runs and in general extensions should always activate without needing user input. The extension will just be made to handle the scenario where azdata isn't installed and the user declined the install or hasn't accept yet
1. msi installation doesn't show UI
1. Fix tests and add a few new ones