### PR TITLE
Add DacFx summary page tests

### DIFF
--- a/extensions/dacpac/src/test/dacFxSummaryPage.test.ts
+++ b/extensions/dacpac/src/test/dacFxSummaryPage.test.ts
@@ -71,6 +71,8 @@ describe('DacFx Summary Page Tests', function (): void {
 		const onPageEnter = await summaryPage.onPageEnter();
 		should(onPageStart).equal(true);
 		should(onPageEnter).equal(true);
+		should(summaryPage.data).not.equal(undefined);
+		should(summaryPage.data.length).equal(summaryPage.WizardState.selectedOperation === Operation.extract ? 4 : 3);
 
 		return summaryPage;
 	}

--- a/extensions/dacpac/src/test/dacFxSummaryPage.test.ts
+++ b/extensions/dacpac/src/test/dacFxSummaryPage.test.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import * as should from 'should';
+import { DataTierApplicationWizard, PageName, Operation } from '../wizard/dataTierApplicationWizard';
+import { DacFxDataModel } from '../wizard/api/models';
+import { TestContext, createContext } from './testContext';
+import { TestDacFxSummaryPage } from './testDacFxConfigPages';
+
+let wizard: DataTierApplicationWizard;
+let testContext: TestContext;
+
+describe('DacFx Summary Page Tests', function (): void {
+	beforeEach(async function (): Promise<void> {
+		wizard = new DataTierApplicationWizard();
+		wizard.model = <DacFxDataModel>{};
+		wizard.model.server = undefined;
+		wizard.setPages();
+		wizard.configureButtons();
+		testContext = createContext();
+	});
+
+	it('DacFx Summary Page should start correctly for deploying to an existing database', async () => {
+		wizard.selectedOperation = Operation.deploy;
+		wizard.model.upgradeExisting = true;
+
+		const summaryPage = await validatePageCreation();
+		should(summaryPage.WizardState.wizard.generateScriptButton.hidden).equal(false, 'Generate script button should not be hidden when the operation is deploy and upgrade existing is true');
+		await validateOnPageLeave(summaryPage);
+	});
+
+	it('DacFx Summary Page should start correctly for deploying to a new database', async () => {
+		wizard.selectedOperation = Operation.deploy;
+		wizard.model.upgradeExisting = false;
+
+		const summaryPage = await validatePageCreation();
+		should(summaryPage.WizardState.wizard.generateScriptButton.hidden).equal(true, 'Generate script button should be hidden when deploying to a new database');
+		await validateOnPageLeave(summaryPage);
+	});
+
+	it('DacFx Summary Page should start correctly for extract', async () => {
+		wizard.selectedOperation = Operation.extract;
+
+		const summaryPage = await validatePageCreation();
+		should(summaryPage.WizardState.wizard.generateScriptButton.hidden).equal(true, 'Generate script button should be hidden when extracting');
+		await validateOnPageLeave(summaryPage);
+	});
+
+	it('DacFx Summary Page should start correctly for import', async () => {
+		wizard.selectedOperation = Operation.import;
+
+		const summaryPage = await validatePageCreation();
+		should(summaryPage.WizardState.wizard.generateScriptButton.hidden).equal(true, 'Generate script button should be hidden when importing');
+		await validateOnPageLeave(summaryPage);
+	});
+
+	it('DacFx Summary Page should start correctly for exporting', async () => {
+		wizard.selectedOperation = Operation.export;
+
+		const summaryPage = await validatePageCreation();
+		should(summaryPage.WizardState.wizard.generateScriptButton.hidden).equal(true, 'Generate script button should be hidden when exporting');
+		await validateOnPageLeave(summaryPage);
+	});
+
+	async function validatePageCreation(): Promise<TestDacFxSummaryPage> {
+		const summaryPage: TestDacFxSummaryPage = new TestDacFxSummaryPage(wizard, wizard.pages.get(PageName.selectOperation).wizardPage, wizard.model, testContext.viewContext.view);
+		const onPageStart = await summaryPage.start();
+		const onPageEnter = await summaryPage.onPageEnter();
+		should(onPageStart).equal(true);
+		should(onPageEnter).equal(true);
+
+		return summaryPage;
+	}
+
+	async function validateOnPageLeave(summaryPage: TestDacFxSummaryPage): Promise<void> {
+		const onPageLeave = await summaryPage.onPageLeave();
+		should(onPageLeave).equal(true);
+		should(summaryPage.WizardState.wizard.generateScriptButton.hidden).equal(true, 'Generate Script button should be hidden when leaving the summary page');
+	}
+});

--- a/extensions/dacpac/src/test/testDacFxConfigPages.ts
+++ b/extensions/dacpac/src/test/testDacFxConfigPages.ts
@@ -10,6 +10,7 @@ import { ExtractConfigPage } from '../wizard/pages/extractConfigPage';
 import { DataTierApplicationWizard } from '../wizard/dataTierApplicationWizard';
 import { SelectOperationPage } from '../wizard/pages/selectOperationpage';
 import { ImportConfigPage } from '../wizard/pages/importConfigPage';
+import { DacFxSummaryPage } from '../wizard/pages/dacFxSummaryPage';
 
 export class TestDeployConfigPage extends DeployConfigPage {
 	constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
@@ -56,5 +57,15 @@ export class TestImportConfigPage extends ImportConfigPage {
 
 	get Model(): DacFxDataModel {
 		return this.model;
+	}
+}
+
+export class TestDacFxSummaryPage extends DacFxSummaryPage {
+	constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
+		super(instance, wizardPage, model, view);
+	}
+
+	get WizardState(): DataTierApplicationWizard {
+		return this.instance;
 	}
 }

--- a/extensions/dacpac/src/test/wizard.test.ts
+++ b/extensions/dacpac/src/test/wizard.test.ts
@@ -74,10 +74,6 @@ describe('Dacfx wizard', function (): void {
 		wizard.model.upgradeExisting = true;
 		should.equal(wizard.isSummaryPage(3), true);
 
-		// summary page should be 3 for generate deploy script
-		wizard.selectedOperation = Operation.generateDeployScript;
-		should.equal(wizard.isSummaryPage(3), true);
-
 		// summary page should be 2 for import
 		wizard.selectedOperation = Operation.import;
 		should.equal(wizard.isSummaryPage(2), true);
@@ -94,9 +90,6 @@ describe('Dacfx wizard', function (): void {
 	it('Should set Done button and operation correctly', async () => {
 		wizard.setDoneButton(Operation.deploy);
 		should.equal(wizard.selectedOperation, Operation.deploy);
-
-		wizard.setDoneButton(Operation.generateDeployScript);
-		should.equal(wizard.selectedOperation, Operation.generateDeployScript);
 
 		wizard.setDoneButton(Operation.extract);
 		should.equal(wizard.selectedOperation, Operation.extract);

--- a/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
+++ b/extensions/dacpac/src/wizard/dataTierApplicationWizard.ts
@@ -31,8 +31,7 @@ export enum Operation {
 	deploy,
 	extract,
 	import,
-	export,
-	generateDeployScript
+	export
 }
 
 export enum DeployOperationPath {
@@ -117,10 +116,7 @@ export class DataTierApplicationWizard {
 
 		this.model.serverId = this.connection.connectionId;
 		this.setPages();
-
-		this.wizard.generateScriptButton.hidden = true;
-		this.wizard.generateScriptButton.onClick(async () => await this.generateDeployScript());
-		this.wizard.doneButton.onClick(async () => await this.executeOperation());
+		this.configureButtons();
 
 		this.wizard.open();
 		return true;
@@ -206,6 +202,12 @@ export class DataTierApplicationWizard {
 		this.wizard.pages = [selectOperationWizardPage, deployConfigWizardPage, deployPlanWizardPage, summaryWizardPage];
 	}
 
+	public configureButtons(): void {
+		this.wizard.generateScriptButton.hidden = true;
+		this.wizard.generateScriptButton.onClick(async () => await this.generateDeployScript());
+		this.wizard.doneButton.onClick(async () => await this.executeOperation());
+	}
+
 	public registerNavigationValidator(validator: (pageChangeInfo: azdata.window.WizardPageChangeInfo) => boolean) {
 		this.wizard.registerNavigationValidator(validator);
 	}
@@ -232,14 +234,9 @@ export class DataTierApplicationWizard {
 				this.selectedOperation = Operation.export;
 				break;
 			}
-			case Operation.generateDeployScript: {
-				this.wizard.doneButton.label = loc.generateScript;
-				this.selectedOperation = Operation.generateDeployScript;
-				break;
-			}
 		}
 
-		if (operation !== Operation.deploy && operation !== Operation.generateDeployScript) {
+		if (operation !== Operation.deploy) {
 			this.model.upgradeExisting = false;
 		}
 	}
@@ -257,9 +254,6 @@ export class DataTierApplicationWizard {
 			}
 			case Operation.export: {
 				return await this.export();
-			}
-			case Operation.generateDeployScript: {
-				return await this.generateDeployScript();
 			}
 		}
 	}
@@ -328,7 +322,7 @@ export class DataTierApplicationWizard {
 			}
 		} else if (this.isSummaryPage(idx)) {
 			page = this.pages.get(PageName.summary);
-		} else if ((this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.deployPlan) {
+		} else if ((this.selectedOperation === Operation.deploy) && idx === DeployOperationPath.deployPlan) {
 			page = this.pages.get(PageName.deployPlan);
 		}
 
@@ -340,7 +334,7 @@ export class DataTierApplicationWizard {
 			|| this.selectedOperation === Operation.export && idx === ExportOperationPath.summary
 			|| this.selectedOperation === Operation.extract && idx === ExtractOperationPath.summary
 			|| this.selectedOperation === Operation.deploy && !this.model.upgradeExisting && idx === DeployNewOperationPath.summary
-			|| (this.selectedOperation === Operation.deploy || this.selectedOperation === Operation.generateDeployScript) && idx === DeployOperationPath.summary;
+			|| (this.selectedOperation === Operation.deploy) && idx === DeployOperationPath.summary;
 	}
 
 	public async generateDeployPlan(): Promise<string> {

--- a/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
@@ -13,6 +13,7 @@ export class DacFxSummaryPage extends BasePage {
 	private form: azdata.FormContainer;
 	private table: azdata.TableComponent;
 	private loader: azdata.LoadingComponent;
+	public data: string[][];
 
 	public constructor(instance: DataTierApplicationWizard, wizardPage: azdata.window.WizardPage, model: DacFxDataModel, view: azdata.ModelView) {
 		super(instance, wizardPage, model, view);
@@ -36,7 +37,7 @@ export class DacFxSummaryPage extends BasePage {
 	}
 
 	async onPageEnter(): Promise<boolean> {
-		this.populateTable();
+		await this.populateTable();
 		this.loader.loading = false;
 		if (this.model.upgradeExisting && this.instance.selectedOperation === Operation.deploy) {
 			this.instance.wizard.generateScriptButton.hidden = false;
@@ -61,8 +62,7 @@ export class DacFxSummaryPage extends BasePage {
 		});
 	}
 
-	private populateTable() {
-		let data = [];
+	private async populateTable(): Promise<void> {
 		let targetServer = loc.targetServer;
 		let targetDatabase = loc.targetDatabase;
 		let sourceServer = loc.sourceServer;
@@ -71,14 +71,14 @@ export class DacFxSummaryPage extends BasePage {
 
 		switch (this.instance.selectedOperation) {
 			case Operation.deploy: {
-				data = [
+				this.data = [
 					[targetServer, this.model.serverName],
 					[fileLocation, this.model.filePath],
 					[targetDatabase, this.model.database]];
 				break;
 			}
 			case Operation.extract: {
-				data = [
+				this.data = [
 					[sourceServer, this.model.serverName],
 					[sourceDatabase, this.model.database],
 					[loc.version, this.model.version],
@@ -86,14 +86,14 @@ export class DacFxSummaryPage extends BasePage {
 				break;
 			}
 			case Operation.import: {
-				data = [
+				this.data = [
 					[targetServer, this.model.serverName],
 					[fileLocation, this.model.filePath],
 					[targetDatabase, this.model.database]];
 				break;
 			}
 			case Operation.export: {
-				data = [
+				this.data = [
 					[sourceServer, this.model.serverName],
 					[sourceDatabase, this.model.database],
 					[fileLocation, this.model.filePath]];
@@ -101,8 +101,8 @@ export class DacFxSummaryPage extends BasePage {
 			}
 		}
 
-		this.table.updateProperties({
-			data: data,
+		await this.table.updateProperties({
+			data: this.data,
 			columns: [
 				{
 					value: loc.setting,

--- a/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
+++ b/extensions/dacpac/src/wizard/pages/dacFxSummaryPage.ts
@@ -99,13 +99,6 @@ export class DacFxSummaryPage extends BasePage {
 					[fileLocation, this.model.filePath]];
 				break;
 			}
-			case Operation.generateDeployScript: {
-				data = [
-					[targetServer, this.model.serverName],
-					[fileLocation, this.model.filePath],
-					[targetDatabase, this.model.database]];
-				break;
-			}
 		}
 
 		this.table.updateProperties({


### PR DESCRIPTION
Adding tests for summary page and cleaning up the generateDeployScript operation that didn't get removed when the deploy action page got removed a while ago in #5942.  