### PR TITLE
focus in editor after dropping

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
+++ b/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
@@ -361,6 +361,7 @@ class DropOverlay extends Themable {
 			const editor = this.editorService.activeTextEditorControl as ICodeEditor;
 			if (untitledOrFileResources[0].resource.scheme === 'Column' || untitledOrFileResources[0].resource.scheme === 'Table') {
 				SnippetController2.get(editor).insert(untitledOrFileResources[0].resource.query);
+				editor.focus();
 				return;
 			}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Focus is in editor after dragging and dropping column/table into editor

This PR fixes #11403
