### PR TITLE
Timeout added when clicking refresh in Edit Data Editor

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataActions.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataActions.ts
@@ -66,7 +66,7 @@ export class RefreshTableAction extends EditDataAction {
 	public static ID = 'refreshTableAction';
 	private static clicked = false;
 	//timeout to ensure query has completed fully.
-	private timeoutClicked = 2500;
+	private timeoutClicked = 2000;
 
 
 	constructor(editor: EditDataEditor,

--- a/src/sql/workbench/contrib/editData/browser/editDataActions.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataActions.ts
@@ -81,7 +81,6 @@ export class RefreshTableAction extends EditDataAction {
 	}
 
 	public async run(): Promise<void> {
-		clearTimeout(this.runTimeoutHandle);
 		this.runTimeoutHandle = setTimeout(() => {
 
 			if (this.isConnected(this.editor)) {

--- a/src/sql/workbench/contrib/editData/browser/editDataActions.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataActions.ts
@@ -66,7 +66,7 @@ export class RefreshTableAction extends EditDataAction {
 	public static ID = 'refreshTableAction';
 	private static clicked = false;
 	//timeout to ensure query has completed fully.
-	private timeoutClicked = 3000;
+	private timeoutClicked = 2500;
 
 
 	constructor(editor: EditDataEditor,
@@ -86,6 +86,7 @@ export class RefreshTableAction extends EditDataAction {
 		if (!RefreshTableAction.clicked && this.isConnected(this.editor)) {
 			RefreshTableAction.clicked = true;
 			this.enabled = false;
+			this._notificationService.status(nls.localize('refreshEditDataTable', "Table refresh in progress, please wait for completion."), { hideAfter: this.timeoutClicked });
 			let input = this.editor.editDataInput;
 
 			let rowLimit: number = undefined;

--- a/src/sql/workbench/contrib/editData/browser/editDataEditor.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataEditor.ts
@@ -673,7 +673,9 @@ export class EditDataEditor extends BaseEditor {
 	private _updateTaskbar(owner: EditDataInput): void {
 		// Update the taskbar if the owner of this call is being presented
 		if (owner.matches(this.editDataInput)) {
-			this._refreshTableAction.enabled = owner.refreshButtonEnabled;
+			if (!this._refreshTableAction.isClicked()) {
+				this._refreshTableAction.enabled = owner.refreshButtonEnabled;
+			}
 			this._stopRefreshTableAction.enabled = owner.stopButtonEnabled;
 			this._changeMaxRowsActionItem.setCurrentOptionIndex = owner.rowLimit;
 			this._showQueryPaneAction.queryPaneEnabled = owner.queryPaneEnabled;

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -224,7 +224,7 @@ export class EditDataGridPanel extends GridParentComponent {
 		// Setup a function for generating a promise to lookup result subsets
 		this.loadDataFunction = (offset: number, count: number): Promise<{}[]> => {
 			return self.dataService.getEditRows(offset, count).then(result => {
-				if (result) {
+				if (this.dataSet) {
 					let gridData = result.subset.map(r => {
 						let dataWithSchema = {};
 						// skip the first column since its a number column

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -39,11 +39,10 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 export class EditDataGridPanel extends GridParentComponent {
 	// The time(in milliseconds) we wait before refreshing the grid.
 	// We use clearTimeout and setTimeout pair to avoid unnecessary refreshes.
-	private refreshGridTimeoutInMs = 300;
+	private refreshGridTimeoutInMs = 200;
 
 	// The timeout handle for the refresh grid task
 	private refreshGridTimeoutHandle: any;
-
 
 	// Optimized for the edit top 200 rows scenario, only need to retrieve the data once
 	// to make the scroll experience smoother
@@ -402,14 +401,20 @@ export class EditDataGridPanel extends GridParentComponent {
 		self.gridDataProvider = new AsyncDataProvider(dataSet.dataRows);
 
 		// Create a dataSet to render without rows to reduce DOM size
-		self.recreateDatasets(dataSet);
+		let undefinedDataSet = deepClone(dataSet);
+		undefinedDataSet.columnDefinitions = dataSet.columnDefinitions;
+		undefinedDataSet.dataRows = undefined;
+		this.placeHolderDataSets.push(undefinedDataSet);
+		if (this.placeHolderDataSets[0]) {
+			this.refreshDatasets();
+		}
 		self.refreshGrid();
 
 		// Setup the state of the selected cell
-		self.resetCurrentCell();
-		self.removingNewRow = false;
-		self.newRowVisible = false;
-		self.dirtyCells = [];
+		this.resetCurrentCell();
+		this.removingNewRow = false;
+		this.newRowVisible = false;
+		this.dirtyCells = [];
 
 	}
 
@@ -494,17 +499,6 @@ export class EditDataGridPanel extends GridParentComponent {
 			handled = true;
 		}
 		return handled;
-	}
-
-
-	recreateDatasets(dataSet: IGridDataSet): void {
-		let undefinedDataSet = deepClone(dataSet);
-		undefinedDataSet.columnDefinitions = dataSet.columnDefinitions;
-		undefinedDataSet.dataRows = undefined;
-		this.placeHolderDataSets.push(undefinedDataSet);
-		if (this.placeHolderDataSets[0]) {
-			this.refreshDatasets();
-		}
 	}
 
 	/**

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -35,7 +35,6 @@ import { Event } from 'vs/base/common/event';
 import { equals } from 'vs/base/common/arrays';
 import * as DOM from 'vs/base/browser/dom';
 import { onUnexpectedError } from 'vs/base/common/errors';
-import { localize } from 'vs/nls';
 
 export class EditDataGridPanel extends GridParentComponent {
 	// The time(in milliseconds) we wait before refreshing the grid.
@@ -44,6 +43,7 @@ export class EditDataGridPanel extends GridParentComponent {
 
 	// The timeout handle for the refresh grid task
 	private refreshGridTimeoutHandle: any;
+
 
 	// Optimized for the edit top 200 rows scenario, only need to retrieve the data once
 	// to make the scroll experience smoother
@@ -224,7 +224,7 @@ export class EditDataGridPanel extends GridParentComponent {
 		// Setup a function for generating a promise to lookup result subsets
 		this.loadDataFunction = (offset: number, count: number): Promise<{}[]> => {
 			return self.dataService.getEditRows(offset, count).then(result => {
-				if (this.dataSet) {
+				if (result) {
 					let gridData = result.subset.map(r => {
 						let dataWithSchema = {};
 						// skip the first column since its a number column
@@ -251,14 +251,8 @@ export class EditDataGridPanel extends GridParentComponent {
 						this.oldGridData = assign({}, gridData);
 					}
 					return gridData;
-				} else if (this.oldGridData) {
-					//handle case where there is a good backup available to use instead.
-					this.logService.error('griddata is undefined, using last known good grid data.');
-					return this.oldGridData;
 				} else {
-					//handle case where there is no backup available. Must reject without data returned.
-					this.notificationService.error(localize('gridDataLoadFail', 'Grid data load failure, no backup available, please reload the table'));
-					return Promise.reject();
+					return this.oldGridData;
 				}
 			});
 		};

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -55,8 +55,7 @@ export class EditDataGridPanel extends GridParentComponent {
 	//main dataset to work on.
 	private dataSet: IGridDataSet;
 	private oldDataRows: VirtualizedCollection<any>;
-
-	private currentGridData: {}[];
+	private oldGridData: {}[];
 	private firstRender = true;
 	private firstLoad = true;
 	private enableEditing = true;
@@ -162,7 +161,7 @@ export class EditDataGridPanel extends GridParentComponent {
 	handleStart(self: EditDataGridPanel, event: any): void {
 		self.dataSet = undefined;
 		self.oldDataRows = undefined;
-		self.currentGridData = undefined;
+		self.oldGridData = undefined;
 		self.placeHolderDataSets = [];
 		self.renderedDataSets = self.placeHolderDataSets;
 
@@ -249,13 +248,15 @@ export class EditDataGridPanel extends GridParentComponent {
 						}, {}));
 					}
 					if (gridData && gridData.length !== 0) {
-						this.currentGridData = assign({}, gridData);
+						this.oldGridData = assign({}, gridData);
 					}
 					return gridData;
-				} else if (this.currentGridData) {
+				} else if (this.oldGridData) {
+					//handle case where there is a good backup available to use instead.
 					this.logService.error('griddata is undefined, using last known good grid data.');
-					return this.currentGridData;
+					return this.oldGridData;
 				} else {
+					//handle case where there is no backup available. Must reject without data returned.
 					this.notificationService.error(localize('gridDataLoadFail', 'Grid data load failure, no backup available, please reload the table'));
 					return Promise.reject();
 				}
@@ -452,15 +453,11 @@ export class EditDataGridPanel extends GridParentComponent {
 
 				if (this.placeHolderDataSets.length !== 0 && this.placeHolderDataSets[0].dataRows && this.oldDataRows !== this.placeHolderDataSets[0].dataRows) {
 					this.detectChange();
-					//check done to prevent oldDataRows from being corrupted during constant refresh.
+					//check if placeHolderDataSets has not been corrupted due to constant refresh.
 					if (this.placeHolderDataSets.length !== 0 && this.placeHolderDataSets[0].dataRows) {
 						this.oldDataRows = assign({}, this.placeHolderDataSets[0].dataRows);
 					}
-				} else {
-					this.logService.error('data set is empty, refresh cancelled.');
-					reject();
 				}
-
 
 				if (this.firstRender) {
 					setTimeout(() => this.setActive());

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -40,7 +40,7 @@ import { localize } from 'vs/nls';
 export class EditDataGridPanel extends GridParentComponent {
 	// The time(in milliseconds) we wait before refreshing the grid.
 	// We use clearTimeout and setTimeout pair to avoid unnecessary refreshes.
-	private refreshGridTimeoutInMs = 200;
+	private refreshGridTimeoutInMs = 300;
 
 	// The timeout handle for the refresh grid task
 	private refreshGridTimeoutHandle: any;

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -250,7 +250,8 @@ export class EditDataGridPanel extends GridParentComponent {
 						this.oldGridData = assign({}, gridData);
 					}
 					return gridData;
-				} else {
+				}
+				else {
 					return this.oldGridData;
 				}
 			});
@@ -404,8 +405,8 @@ export class EditDataGridPanel extends GridParentComponent {
 		let undefinedDataSet = deepClone(dataSet);
 		undefinedDataSet.columnDefinitions = dataSet.columnDefinitions;
 		undefinedDataSet.dataRows = undefined;
-		this.placeHolderDataSets.push(undefinedDataSet);
-		if (this.placeHolderDataSets[0]) {
+		self.placeHolderDataSets.push(undefinedDataSet);
+		if (self.placeHolderDataSets[0]) {
 			this.refreshDatasets();
 		}
 		self.refreshGrid();


### PR DESCRIPTION
This commit adds a timeout of two seconds (enough for any processing done in editDataGridPanel to be completed for a few test databases, both large and small) before the user can click the button again. I also improved the checking in refreshGrid to better account for invalid datasets.

The editDataEditor relies on Edit Data Input to determine when it is "okay" for the run button to be enabled. Since it does not take into consideration any processing done in editDataGridPanel from my understanding: a user can refresh the editor before it is actually ready and corrupt the data retrieval/processing as a result. 

There is currently no way to determine when a refresh has finished fully as the code relies on several components that work semi-independently from each other. 

This PR handles #11259
