### PR TITLE
remove the scheduled run info from yml

### DIFF
--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -108,10 +108,3 @@ jobs:
 
 trigger: none
 pr: none
-
-schedules:
-- cron: "0 5 * * Mon-Fri"
-  displayName: Mon-Fri at 5AM UTC
-  branches:
-    include:
-    - main


### PR DESCRIPTION
the schedule is defined for the daily insider build, but since it is in the yml file, all other ADS pipelines are getting the scheduled runs automatically. I think this should be at the pipeline level, once merged, I will update the Product Build pipeline to take care of its own schedule.
