### PR TITLE
Fix contributed Notebook Action bar actions

### DIFF
--- a/src/sql/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/sql/platform/actions/browser/menuEntryActionViewItem.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MenuItemAction } from 'vs/platform/actions/common/actions';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { LabeledMenuItemActionItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+
+export class NoContextLabeledMenuItemActionItem extends LabeledMenuItemActionItem {
+
+	constructor(
+		action: MenuItemAction,
+		@IKeybindingService labeledkeybindingService: IKeybindingService,
+		@IContextMenuService labeledcontextMenuService: IContextMenuService,
+		@INotificationService notificationService: INotificationService,
+		defaultCSSClassToAdd: string = ''
+	) {
+		super(action, labeledkeybindingService, labeledcontextMenuService, notificationService, defaultCSSClassToAdd);
+		super.setActionContext(undefined);
+	}
+
+	public setActionContext(context: any): void {
+		// No-op
+	}
+}

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -57,6 +57,7 @@ import { NotebookInput } from 'sql/workbench/contrib/notebook/browser/models/not
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { NoContextLabeledMenuItemActionItem } from 'sql/platform/actions/browser/menuEntryActionViewItem';
 
 export const NOTEBOOK_SELECTOR: string = 'notebook-component';
 
@@ -556,6 +557,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			if (action.item.id.includes('jupyter.cmd') && this.previewFeaturesEnabled) {
 				action.tooltip = action.label;
 				action.label = '';
+				return new NoContextLabeledMenuItemActionItem(action, this.keybindingService, this.contextMenuService, this.notificationService, 'notebook-button fixed-width');
 			}
 			return new LabeledMenuItemActionItem(action, this.keybindingService, this.contextMenuService, this.notificationService, 'notebook-button fixed-width');
 		}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/11563

So first off - I'm not really pleased with this solution. I feel like there has to be a better way and I'm going to do some more digging. One thing I wanted to look at is overriding the action runner instead. But this does fix the issue and is scoped down so if we need to for the release this is probably an acceptable short term fix.

edit : Nevermind the below. Chris pointed out this was working until a recent VS Code merge which rewrote a lot of this actionbar stuff. So while the end result is the same (we're trying to send over the entire NotebookComponent which fails) the cause is because of this rewrite. 



The root of the problem was introduced in 
 https://github.com/microsoft/azuredatastudio/commit/47687ff6b2000fc28768113e9cef800226c7fec5. New actions were added for doing things on the Notebook. These need the Notebook context in order to run their actions and so the context for the Taskbar was set to the NotebookComponent here : https://github.com/microsoft/azuredatastudio/blob/main/src/sql/workbench/contrib/notebook/browser/notebook.component.ts#L498

This works fine for all the core actions - but we get in trouble with the contributed actions since those are sent across the RPC boundary to the extension host. And so we fail at trying to serialize the NotebookComponent. 