### PR TITLE
Fix Notebook toolbar contributed actions

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterController.ts
+++ b/extensions/notebook/src/jupyter/jupyterController.ts
@@ -201,9 +201,9 @@ export class JupyterController implements vscode.Disposable {
 		});
 	}
 
-	public async doManagePackages(options?: ManagePackageDialogOptions): Promise<void> {
+	public async doManagePackages(options?: ManagePackageDialogOptions | vscode.Uri): Promise<void> {
 		try {
-			if (!options) {
+			if (!options || options instanceof vscode.Uri) {
 				options = {
 					defaultLocation: constants.localhostName,
 					defaultProviderId: LocalPipPackageManageProvider.ProviderId

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
@@ -56,12 +56,12 @@ export class CellToolbarComponent {
 		this._actionBar = new Taskbar(taskbar);
 		this._actionBar.context = context;
 
-		let addCellsButton = new AddCellAction('notebook.AddCodeCell', localize('codeCellsPreview', "Add cell"), 'notebook-button masked-pseudo code');
+		let addCellsButton = this.instantiationService.createInstance(AddCellAction, 'notebook.AddCodeCell', localize('codeCellsPreview', "Add cell"), 'notebook-button masked-pseudo code');
 
-		let addCodeCellButton = new AddCellAction('notebook.AddCodeCell', localize('codePreview', "Code cell"), 'notebook-button masked-pseudo code');
+		let addCodeCellButton = this.instantiationService.createInstance(AddCellAction, 'notebook.AddCodeCell', localize('codePreview', "Code cell"), 'notebook-button masked-pseudo code');
 		addCodeCellButton.cellType = CellTypes.Code;
 
-		let addTextCellButton = new AddCellAction('notebook.AddTextCell', localize('textPreview', "Text cell"), 'notebook-button masked-pseudo markdown');
+		let addTextCellButton = this.instantiationService.createInstance(AddCellAction, 'notebook.AddTextCell', localize('textPreview', "Text cell"), 'notebook-button masked-pseudo markdown');
 		addTextCellButton.cellType = CellTypes.Markdown;
 
 		let deleteButton = this.instantiationService.createInstance(DeleteCellAction, 'delete', 'codicon masked-icon delete', localize('delete', "Delete"));

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -322,7 +322,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		this._model = this._register(model);
 		await this._model.loadContents(trusted);
 		this.setLoading(false);
-		this.updateToolbarComponents(this._model.trustedMode);
+		this.updateToolbarComponents();
 		this.detectChanges();
 	}
 
@@ -348,11 +348,10 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		}
 	}
 
-	// Updates toolbar components
-	private updateToolbarComponents(isTrusted: boolean) {
-		if (this._trustedAction) {
+	private updateToolbarComponents() {
+		if (this.model.trustedMode) {
 			this._trustedAction.enabled = true;
-			this._trustedAction.trusted = isTrusted;
+			this._trustedAction.trusted = true;
 		}
 	}
 
@@ -417,26 +416,26 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			let spacerElement = document.createElement('li');
 			spacerElement.style.marginLeft = 'auto';
 
-			let addCellsButton = new AddCellAction('notebook.AddCodeCell', localize('codeCellsPreview', "Add cell"), 'notebook-button masked-pseudo code');
+			let addCellsButton = this.instantiationService.createInstance(AddCellAction, 'notebook.AddCodeCell', localize('codeCellsPreview', "Add cell"), 'notebook-button masked-pseudo code');
 
-			let addCodeCellButton = new AddCellAction('notebook.AddCodeCell', localize('codePreview', "Code cell"), 'notebook-button masked-pseudo code');
+			let addCodeCellButton = this.instantiationService.createInstance(AddCellAction, 'notebook.AddCodeCell', localize('codePreview', "Code cell"), 'notebook-button masked-pseudo code');
 			addCodeCellButton.cellType = CellTypes.Code;
 
-			let addTextCellButton = new AddCellAction('notebook.AddTextCell', localize('textPreview', "Text cell"), 'notebook-button masked-pseudo markdown');
+			let addTextCellButton = this.instantiationService.createInstance(AddCellAction, 'notebook.AddTextCell', localize('textPreview', "Text cell"), 'notebook-button masked-pseudo markdown');
 			addTextCellButton.cellType = CellTypes.Markdown;
 
 			this._runAllCellsAction = this.instantiationService.createInstance(RunAllCellsAction, 'notebook.runAllCells', localize('runAllPreview', "Run all"), 'notebook-button masked-pseudo start-outline');
 
 			let collapseCellsAction = this.instantiationService.createInstance(CollapseCellsAction, 'notebook.collapseCells', true);
 
-			let clearResultsButton = new ClearAllOutputsAction('notebook.ClearAllOutputs', true);
+			let clearResultsButton = this.instantiationService.createInstance(ClearAllOutputsAction, 'notebook.ClearAllOutputs', true);
 
 			this._trustedAction = this.instantiationService.createInstance(TrustedAction, 'notebook.Trusted', true);
 			this._trustedAction.enabled = false;
 
 			let taskbar = <HTMLElement>this.toolbar.nativeElement;
 			this._actionBar = new Taskbar(taskbar, { actionViewItemProvider: action => this.actionItemProvider(action as Action) });
-			this._actionBar.context = this;
+			this._actionBar.context = this._notebookParams.notebookUri;
 			taskbar.classList.add('in-preview');
 
 			let buttonDropdownContainer = DOM.$('li.action-item');
@@ -453,7 +452,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 				undefined
 			);
 			dropdownMenuActionViewItem.render(buttonDropdownContainer);
-			dropdownMenuActionViewItem.setActionContext(this);
+			dropdownMenuActionViewItem.setActionContext(this._notebookParams.notebookUri);
 
 			this._actionBar.setContent([
 				{ element: buttonDropdownContainer },
@@ -478,15 +477,15 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			attachToDropdown.render(attachToContainer);
 			attachSelectBoxStyler(attachToDropdown, this.themeService);
 
-			let addCodeCellButton = new AddCellAction('notebook.AddCodeCell', localize('code', "Code"), 'notebook-button icon-add');
+			let addCodeCellButton = this.instantiationService.createInstance(AddCellAction, 'notebook.AddCodeCell', localize('code', "Code"), 'notebook-button icon-add');
 			addCodeCellButton.cellType = CellTypes.Code;
 
-			let addTextCellButton = new AddCellAction('notebook.AddTextCell', localize('text', "Text"), 'notebook-button icon-add');
+			let addTextCellButton = this.instantiationService.createInstance(AddCellAction, 'notebook.AddTextCell', localize('text', "Text"), 'notebook-button icon-add');
 			addTextCellButton.cellType = CellTypes.Markdown;
 
 			this._runAllCellsAction = this.instantiationService.createInstance(RunAllCellsAction, 'notebook.runAllCells', localize('runAll', "Run Cells"), 'notebook-button icon-run-cells');
 
-			let clearResultsButton = new ClearAllOutputsAction('notebook.ClearAllOutputs', false);
+			let clearResultsButton = this.instantiationService.createInstance(ClearAllOutputsAction, 'notebook.ClearAllOutputs', false);
 
 			this._trustedAction = this.instantiationService.createInstance(TrustedAction, 'notebook.Trusted', false);
 			this._trustedAction.enabled = false;
@@ -495,7 +494,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 
 			let taskbar = <HTMLElement>this.toolbar.nativeElement;
 			this._actionBar = new Taskbar(taskbar, { actionViewItemProvider: action => this.actionItemProvider(action as Action) });
-			this._actionBar.context = this;
+			this._actionBar.context = this._notebookParams.notebookUri;
 
 			this._actionBar.setContent([
 				{ action: addCodeCellButton },

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -5,7 +5,7 @@
 
 import * as azdata from 'azdata';
 
-import { Action, ActionRunner, IAction } from 'vs/base/common/actions';
+import { Action } from 'vs/base/common/actions';
 import { localize } from 'vs/nls';
 import { IContextViewProvider } from 'vs/base/browser/ui/contextview/contextview';
 import { INotificationService, Severity, INotificationActions } from 'vs/platform/notification/common/notification';
@@ -25,7 +25,7 @@ import { INotebookModel } from 'sql/workbench/services/notebook/browser/models/m
 import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
 import { TreeUpdateUtils } from 'sql/workbench/services/objectExplorer/browser/treeUpdateUtils';
 import { find, firstIndex } from 'vs/base/common/arrays';
-import { INotebookEditor, INotebookService } from 'sql/workbench/services/notebook/browser/notebookService';
+import { INotebookService } from 'sql/workbench/services/notebook/browser/notebookService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { CellContext } from 'sql/workbench/contrib/notebook/browser/cellViews/codeActions';
 import { URI } from 'vs/base/common/uri';

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -5,7 +5,7 @@
 
 import * as azdata from 'azdata';
 
-import { Action } from 'vs/base/common/actions';
+import { Action, ActionRunner, IAction } from 'vs/base/common/actions';
 import { localize } from 'vs/nls';
 import { IContextViewProvider } from 'vs/base/browser/ui/contextview/contextview';
 import { INotificationService, Severity, INotificationActions } from 'vs/platform/notification/common/notification';
@@ -25,10 +25,10 @@ import { INotebookModel } from 'sql/workbench/services/notebook/browser/models/m
 import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
 import { TreeUpdateUtils } from 'sql/workbench/services/objectExplorer/browser/treeUpdateUtils';
 import { find, firstIndex } from 'vs/base/common/arrays';
-import { INotebookEditor } from 'sql/workbench/services/notebook/browser/notebookService';
-import { NotebookComponent } from 'sql/workbench/contrib/notebook/browser/notebook.component';
+import { INotebookEditor, INotebookService } from 'sql/workbench/services/notebook/browser/notebookService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { CellContext } from 'sql/workbench/contrib/notebook/browser/cellViews/codeActions';
+import { URI } from 'vs/base/common/uri';
 
 const msgLoading = localize('loading', "Loading kernels...");
 export const msgChanging = localize('changing', "Changing kernel...");
@@ -46,11 +46,12 @@ export class AddCellAction extends Action {
 	public cellType: CellType;
 
 	constructor(
-		id: string, label: string, cssClass: string
+		id: string, label: string, cssClass: string,
+		@INotebookService private _notebookService: INotebookService
 	) {
 		super(id, label, cssClass);
 	}
-	public async run(context: INotebookEditor | CellContext): Promise<void> {
+	public async run(context: URI | CellContext): Promise<void> {
 		let index = 0;
 		if (context instanceof CellContext) {
 			if (context?.model?.cells) {
@@ -64,14 +65,9 @@ export class AddCellAction extends Action {
 			}
 		} else {
 			//Add Cell after current selected cell.
-			if (context?.cells) {
-				let notebookcomponent = context as NotebookComponent;
-				let id = notebookcomponent.activeCellId;
-				if (id) {
-					index = context.cells.findIndex(cell => cell.id === id) + 1;
-				}
-			}
-			context.addCell(this.cellType, index);
+			const editor = this._notebookService.findNotebookEditor(context);
+			const index = editor.cells?.findIndex(cell => cell.active) ?? 0;
+			editor.addCell(this.cellType, index);
 		}
 	}
 }
@@ -110,7 +106,8 @@ export class ClearAllOutputsAction extends TooltipFromLabelAction {
 	private static readonly iconClass = 'icon-clear-results';
 	private static readonly maskedIconClass = 'masked-icon';
 
-	constructor(id: string, toggleTooltip: boolean) {
+	constructor(id: string, toggleTooltip: boolean,
+		@INotebookService private _notebookService: INotebookService) {
 		super(id, {
 			label: ClearAllOutputsAction.label,
 			baseClass: ClearAllOutputsAction.baseClass,
@@ -120,8 +117,9 @@ export class ClearAllOutputsAction extends TooltipFromLabelAction {
 		});
 	}
 
-	public run(context: INotebookEditor): Promise<boolean> {
-		return context.clearAllOutputs();
+	public run(context: URI): Promise<boolean> {
+		const editor = this._notebookService.findNotebookEditor(context);
+		return editor.clearAllOutputs();
 	}
 }
 
@@ -181,7 +179,8 @@ export class TrustedAction extends ToggleableAction {
 	private static readonly maskedIconClass = 'masked-icon';
 
 	constructor(
-		id: string, toggleTooltip: boolean
+		id: string, toggleTooltip: boolean,
+		@INotebookService private _notebookService: INotebookService
 	) {
 		super(id, {
 			baseClass: TrustedAction.baseClass,
@@ -202,17 +201,11 @@ export class TrustedAction extends ToggleableAction {
 		this.toggle(value);
 	}
 
-	public run(context: INotebookEditor): Promise<boolean> {
-		let self = this;
-		return new Promise<boolean>((resolve, reject) => {
-			try {
-				self.trusted = !self.trusted;
-				context.model.trustedMode = self.trusted;
-				resolve(true);
-			} catch (e) {
-				reject(e);
-			}
-		});
+	public async run(context: URI): Promise<boolean> {
+		const editor = this._notebookService.findNotebookEditor(context);
+		this.trusted = !this.trusted;
+		editor.model.trustedMode = this.trusted;
+		return true;
 	}
 }
 
@@ -220,13 +213,15 @@ export class TrustedAction extends ToggleableAction {
 export class RunAllCellsAction extends Action {
 	constructor(
 		id: string, label: string, cssClass: string,
-		@INotificationService private notificationService: INotificationService
+		@INotificationService private notificationService: INotificationService,
+		@INotebookService private _notebookService: INotebookService
 	) {
 		super(id, label, cssClass);
 	}
-	public async run(context: INotebookEditor): Promise<boolean> {
+	public async run(context: URI): Promise<boolean> {
 		try {
-			await context.runAllCells();
+			const editor = this._notebookService.findNotebookEditor(context);
+			await editor.runAllCells();
 			return true;
 		} catch (e) {
 			this.notificationService.error(getErrorMessage(e));
@@ -245,7 +240,8 @@ export class CollapseCellsAction extends ToggleableAction {
 	private static readonly expandCssClass = 'icon-show-cells';
 	private static readonly maskedIconClass = 'masked-icon';
 
-	constructor(id: string, toggleTooltip: boolean) {
+	constructor(id: string, toggleTooltip: boolean,
+		@INotebookService private _notebookService: INotebookService) {
 		super(id, {
 			baseClass: CollapseCellsAction.baseClass,
 			toggleOnLabel: CollapseCellsAction.expandCells,
@@ -265,19 +261,13 @@ export class CollapseCellsAction extends ToggleableAction {
 		this.toggle(value);
 	}
 
-	public run(context: INotebookEditor): Promise<boolean> {
-		let self = this;
-		return new Promise<boolean>((resolve, reject) => {
-			try {
-				self.setCollapsed(!self.isCollapsed);
-				context.cells.forEach(cell => {
-					cell.isCollapsed = self.isCollapsed;
-				});
-				resolve(true);
-			} catch (e) {
-				reject(e);
-			}
+	public async run(context: URI): Promise<boolean> {
+		const editor = this._notebookService.findNotebookEditor(context);
+		this.setCollapsed(!this.isCollapsed);
+		editor.cells.forEach(cell => {
+			cell.isCollapsed = this.isCollapsed;
 		});
+		return true;
 	}
 }
 

--- a/src/sql/workbench/contrib/notebook/test/testCommon.ts
+++ b/src/sql/workbench/contrib/notebook/test/testCommon.ts
@@ -5,7 +5,7 @@
 
 import { QueryTextEditor } from 'sql/workbench/browser/modelComponents/queryTextEditor';
 import * as stubs from 'sql/workbench/contrib/notebook/test/stubs';
-import { INotebookModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
+import { INotebookModel, ICellModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { INotebookParams } from 'sql/workbench/services/notebook/browser/notebookService';
 import * as dom from 'vs/base/browser/dom';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -19,6 +19,7 @@ import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServic
 export class NotebookEditorStub extends stubs.NotebookEditorStub {
 	cellEditors: CellEditorProviderStub[];
 	model: INotebookModel | undefined;
+	cells?: ICellModel[] = [];
 
 	get id(): string {
 		return this.notebookParams?.notebookUri?.toString();


### PR DESCRIPTION
Pass URI instead of the entire NotebookComponent for toolbar commands. Verified that the extension side gets the URI as well, which while currently isn't being used could be useful for contributed commands to interact with the editor. 

Fixes https://github.com/microsoft/azuredatastudio/issues/11563