### PR TITLE
emit better errors for azure access failure

### DIFF
--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -976,8 +976,10 @@ async function showAzureAccessError(selectedAccount: azdata.Account, error: any,
 	switch (await getAccountStatus(selectedAccount)) {
 		case AccountStatus.notFound:
 			vscode.window.showErrorMessage(localize('azure.accounts.accountNotFoundError', "The selected account '{0}' is no longer available. Kindly add it back by signing in.\n Error Details: {1}.", getAccountDisplayString(selectedAccount), getErrorMessage(error)));
+			break;
 		case AccountStatus.isStale:
 			vscode.window.showErrorMessage(localize('azure.accounts.accountStaleError', "The access token for selected account '{0}' is no longer valid. Kindly sign in again to refresh your credentials.\n Error Details: {1}.", getAccountDisplayString(selectedAccount), getErrorMessage(error)));
+			break;
 		case AccountStatus.isNotStale:
 			vscode.window.showErrorMessage(unexpectedErrorMessage);
 	}

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -943,10 +943,9 @@ async function handleSelectedAccountChanged(
 			return;
 		}
 		if (response.errors.length > 0) {
-			// If we got back some subscriptions then don't display the errors to the user - it's normal for users
-			// to not necessarily have access to all subscriptions on an account so displaying the errors
-			// in that case is usually just distracting and causes confusion
 			const accountStatus = await getAccountStatus(selectedAccount);
+			// If accountStatus is not found our stale then user needs to sign in again ignoring the errors received
+			// else bubble up errors received from the response.
 			if (accountStatus === AccountStatus.isStale || accountStatus === AccountStatus.notFound) {
 				const errMsg = await getAzureAccessError(selectedAccount);
 				context.container.message = {
@@ -955,6 +954,9 @@ async function handleSelectedAccountChanged(
 					level: azdata.window.MessageLevel.Error
 				};
 			} else {
+				// If we got back some subscriptions then don't display the errors to the user - it's normal for users
+				// to not necessarily have access to all subscriptions on an account so displaying the errors
+				// in that case is usually just distracting and causes confusion
 				const errMsg = response.errors.join(EOL);
 				if (response.subscriptions.length === 0) {
 					context.container.message = {
@@ -1048,10 +1050,9 @@ async function handleSelectedSubscriptionChanged(context: AzureAccountFieldConte
 			return;
 		}
 		if (response.errors.length > 0) {
-			// If we got back some Resource Groups then don't display the errors to the user - it's normal for users
-			// to not necessarily have access to all Resource Groups on a subscription so displaying the errors
-			// in that case is usually just distracting and causes confusion
 			const accountStatus = await getAccountStatus(selectedAccount);
+			// If accountStatus is not found our stale then user needs to sign in again ignoring the errors received
+			// else bubble up errors received from the response.
 			if (accountStatus === AccountStatus.isStale || accountStatus === AccountStatus.notFound) {
 				const errMsg = await getAzureAccessError(selectedAccount);
 				context.container.message = {
@@ -1060,6 +1061,9 @@ async function handleSelectedSubscriptionChanged(context: AzureAccountFieldConte
 					level: azdata.window.MessageLevel.Error
 				};
 			} else {
+				// If we got back some Resource Groups then don't display the errors to the user - it's normal for users
+				// to not necessarily have access to all Resource Groups on a subscription so displaying the errors
+				// in that case is usually just distracting and causes confusion
 				const errMsg = response.errors.join(EOL);
 				if (response.resourceGroups.length === 0) {
 					context.container.message = {

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -763,7 +763,7 @@ const enum AccountStatus {
 }
 
 async function getAccountStatus(account: azdata.Account): Promise<AccountStatus> {
-	const refreshedAccount = (await azdata.accounts.getAllAccounts()).filter(ac => ac.key.accountId === account.key.accountId).shift();
+	const refreshedAccount = (await azdata.accounts.getAllAccounts()).find(ac => ac.key.accountId === account.key.accountId);
 	return (refreshedAccount === undefined)
 		? AccountStatus.notFound
 		: refreshedAccount.isStale ? AccountStatus.isStale : AccountStatus.isNotStale;

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -980,9 +980,9 @@ async function getAzureAccessError(selectedAccount: azdata.Account, error: any, 
 	}
 	switch (accountStatus) {
 		case AccountStatus.notFound:
-			return localize('azure.accounts.accountNotFoundError', "The selected account '{0}' is no longer available. Kindly add it back by signing in.\n Error Details: {1}.", getAccountDisplayString(selectedAccount), getErrorMessage(error));
+			return localize('azure.accounts.accountNotFoundError', "The selected account '{0}' is no longer available.  Click sign in to add it again or select a different account.\n Error Details: {1}.", getAccountDisplayString(selectedAccount), getErrorMessage(error));
 		case AccountStatus.isStale:
-			return localize('azure.accounts.accountStaleError', "The access token for selected account '{0}' is no longer valid. Kindly sign in again to refresh your credentials.\n Error Details: {1}.", getAccountDisplayString(selectedAccount), getErrorMessage(error));
+			return localize('azure.accounts.accountStaleError', "The access token for selected account '{0}' is no longer valid. Please click the sign in button and refresh the account or select a different account.\n Error Details: {1}.", getAccountDisplayString(selectedAccount), getErrorMessage(error));
 		case AccountStatus.isNotStale:
 			return defaultErrorMessage;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Improves error message shown to the user when there is a failure to fetch the subscription/resource group. Here is what the improved messages look like:
![image](https://user-images.githubusercontent.com/41588310/89451414-05cda300-d711-11ea-9f54-556468cea8e2.png)

The improved messages are emitted when the account is chosen is no longer available or is no longer signed in. Here are the sample messages for each case:

1. The selected account 'Arvind Ranasaria - arvran@microsoft.com (iIBqJnswLig1ZXx3fBnlL0fBT9XNVk1EDi2eVXTMazs)' is no longer available. Please click the 'Sign in' button to add it again or select a different account.
2. The access token for selected account 'Arvind Ranasaria - arvran@microsoft.com (acc41c7a-3409-4ece-bd95-39ad3e31dd05)' is no longer valid. Please click the 'Sign in' button and refresh the account or select a different account.


This PR fixes #11499. 
