### PR TITLE
Fix error when clicking on empty dropdown

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -704,8 +704,8 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 		let elementWidth = 0;
 
 		if (container) {
-			let longest = 0;
-			let longestLength = 0;
+			let longest = -1;
+			let longestLength = -1;
 
 			this.options.forEach((option, index) => {
 				const len = option.text.length + (!!option.decoratorRight ? option.decoratorRight.length : 0);
@@ -715,8 +715,10 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 				}
 			});
 
+			if (longest >= 0) {
+				container.innerHTML = this.options[longest].text + (!!this.options[longest].decoratorRight ? (this.options[longest].decoratorRight + ' ') : '');
+			}
 
-			container.innerHTML = this.options[longest].text + (!!this.options[longest].decoratorRight ? (this.options[longest].decoratorRight + ' ') : '');
 			elementWidth = dom.getTotalWidth(container);
 		}
 


### PR DESCRIPTION
Fixes an error that happens when clicking on a dropdown without any options in it. Didn't appear to have any noticeable impact - this is just cleaning it up. 