### PR TITLE
Use a regex to detect notebook started message.

### DIFF
--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -341,7 +341,7 @@ export class PerFolderServerInstance implements IServerInstance {
 		if (urlMatch) {
 			// Legacy case: manually parse token info if no token/port were passed
 			return [vscode.Uri.parse(urlMatch[1]), urlMatch[2]];
-		} else if (this._uri && dataString.match(/jupyter notebook [.0-9]*\s?is running at:/im)) {
+		} else if (this._uri && dataString.match(/jupyter notebook .*is running at:/im)) {
 			// Default case: detect the notebook started message, indicating our preferred port and token were used
 			//
 			// Newer versions of the notebook package include a version number (e.g. 1.2.3) as part of the "notebook running"

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -21,7 +21,6 @@ import * as ports from '../common/ports';
 const NotebookConfigFilename = 'jupyter_notebook_config.py';
 const CustomJsFilename = 'custom.js';
 const defaultPort = 8888;
-const JupyterStartedMessage = 'The Jupyter Notebook is running';
 
 type MessageListener = (data: string | Buffer) => void;
 type ErrorListener = (err: any) => void;
@@ -339,12 +338,14 @@ export class PerFolderServerInstance implements IServerInstance {
 		//                http://localhost:8888/?token=f5ee846e9bd61c3a8d835ecd9b965591511a331417b997b7
 		let dataString = data.toString();
 		let urlMatch = dataString.match(/\[C[\s\S]+ {8}(.+:(\d+)\/.*)$/m);
-
 		if (urlMatch) {
 			// Legacy case: manually parse token info if no token/port were passed
 			return [vscode.Uri.parse(urlMatch[1]), urlMatch[2]];
-		} else if (this._uri && dataString.indexOf(JupyterStartedMessage) > -1) {
+		} else if (this._uri && dataString.match(/jupyter notebook [.0-9]*\s?is running at:/im)) {
 			// Default case: detect the notebook started message, indicating our preferred port and token were used
+			//
+			// Newer versions of the notebook package include a version number (e.g. 1.2.3) as part of the "notebook running"
+			// message, thus the regex above.
 			return [this._uri, this._port];
 		}
 		return [undefined, undefined];


### PR DESCRIPTION
The **notebook** pip package was recently updated, and the newer version uses a different "notebook started" message. We parse the jupyter output in order to detect the the server has started, so this message change broke our string parsing. The newer message format includes the notebook package version, so my fix here is to add a regex to detect that version snippet.

New message format:
"[I 14:28:37.225 NotebookApp] Jupyter Notebook 6.1.1 is running at:"

Old message format:
"[I 14:41:05.133 NotebookApp] The Jupyter Notebook is running at:"

I verified that this works with **notebook** 6.0.3 and 6.1.1.

Addresses https://github.com/microsoft/azuredatastudio/issues/11607
