### PR TITLE
Replace URL and use vscode.URI on local paths (#11624)

### DIFF
--- a/extensions/notebook/src/book/githubRemoteBook.ts
+++ b/extensions/notebook/src/book/githubRemoteBook.ts
@@ -15,14 +15,14 @@ import { IAsset } from './remoteBookController';
 import * as constants from '../common/constants';
 
 export class GitHubRemoteBook extends RemoteBook {
-	constructor(public remotePath: URL, public outputChannel: vscode.OutputChannel, protected _asset: IAsset) {
+	constructor(public remotePath: vscode.Uri, public outputChannel: vscode.OutputChannel, protected _asset: IAsset) {
 		super(remotePath, outputChannel, _asset);
 	}
 
 	public async createLocalCopy(): Promise<void> {
 		this.outputChannel.show(true);
 		this.setLocalPath();
-		this.outputChannel.appendLine(loc.msgDownloadLocation(this._localPath.href));
+		this.outputChannel.appendLine(loc.msgDownloadLocation(this._localPath.fsPath));
 		this.outputChannel.appendLine(loc.msgRemoteBookDownloadProgress);
 		this.createDirectory();
 		let notebookConfig = vscode.workspace.getConfiguration(constants.notebookConfigKey);
@@ -35,7 +35,7 @@ export class GitHubRemoteBook extends RemoteBook {
 					'timeout': downloadTimeout
 				}
 			};
-			let downloadRequest = request.get(this._asset.browserDownloadUrl.href, options)
+			let downloadRequest = request.get(this._asset.browserDownloadUrl.toString(false), options)
 				.on('error', (error) => {
 					this.outputChannel.appendLine(loc.msgRemoteBookDownloadError);
 					this.outputChannel.appendLine(error.message);
@@ -47,8 +47,8 @@ export class GitHubRemoteBook extends RemoteBook {
 						return reject(new Error(loc.httpRequestError(response.statusCode, response.statusMessage)));
 					}
 				});
-			let remoteBookFullPath = new URL(this._localPath.href.concat('.zip'));
-			downloadRequest.pipe(fs.createWriteStream(remoteBookFullPath.href))
+			let remoteBookFullPath = vscode.Uri.file(this._localPath.fsPath.concat('.', this._asset.format));
+			downloadRequest.pipe(fs.createWriteStream(remoteBookFullPath.fsPath))
 				.on('close', async () => {
 					resolve(this.extractFiles(remoteBookFullPath));
 				})
@@ -62,34 +62,32 @@ export class GitHubRemoteBook extends RemoteBook {
 	}
 	public async createDirectory(): Promise<void> {
 		let fileName = this._asset.book.concat('-').concat(this._asset.version).concat('-').concat(this._asset.language);
-		this._localPath = new URL(path.join(this._localPath.href, fileName));
+		this._localPath = vscode.Uri.file(path.join(this._localPath.fsPath, fileName));
 		try {
-			let exists = await fs.pathExists(this._localPath.href);
+			let exists = await fs.pathExists(this._localPath.fsPath);
 			if (exists) {
-				await fs.remove(this._localPath.href);
+				await fs.remove(this._localPath.fsPath);
 			}
-			await fs.promises.mkdir(this._localPath.href);
+			await fs.promises.mkdir(this._localPath.fsPath);
 		} catch (error) {
 			this.outputChannel.appendLine(loc.msgRemoteBookDirectoryError);
 			this.outputChannel.appendLine(error.message);
 		}
 	}
-	public async extractFiles(remoteBookFullPath: URL): Promise<void> {
+	public async extractFiles(remoteBookFullPath: vscode.Uri): Promise<void> {
 		try {
 			if (utils.getOSPlatform() === utils.Platform.Windows || utils.getOSPlatform() === utils.Platform.Mac) {
-				let zippedFile = new zip(remoteBookFullPath.href);
-				zippedFile.extractAllTo(this._localPath.href);
+				let zippedFile = new zip(remoteBookFullPath.fsPath);
+				zippedFile.extractAllTo(this._localPath.fsPath);
 			} else {
-				tar.extract({ file: remoteBookFullPath.href, cwd: this._localPath.href }).catch(error => {
-					this.outputChannel.appendLine(loc.msgRemoteBookUnpackingError);
-					this.outputChannel.appendLine(error.message);
-				});
+				await tar.extract({ file: remoteBookFullPath.fsPath, cwd: this._localPath.fsPath });
 			}
-			await fs.promises.unlink(remoteBookFullPath.href);
+			await fs.promises.unlink(remoteBookFullPath.fsPath);
 			this.outputChannel.appendLine(loc.msgRemoteBookDownloadComplete);
-			vscode.commands.executeCommand('notebook.command.openNotebookFolder', this._localPath.href, undefined, true);
+			vscode.commands.executeCommand('notebook.command.openNotebookFolder', this._localPath.fsPath, undefined, true);
 		}
 		catch (err) {
+			this.outputChannel.appendLine(loc.msgRemoteBookUnpackingError);
 			this.outputChannel.appendLine(err.message);
 		}
 	}

--- a/extensions/notebook/src/book/remoteBook.ts
+++ b/extensions/notebook/src/book/remoteBook.ts
@@ -8,9 +8,9 @@ import * as utils from '../common/utils';
 import { IAsset } from './remoteBookController';
 
 export abstract class RemoteBook {
-	protected _localPath: URL;
+	protected _localPath: vscode.Uri;
 
-	constructor(public remotePath: URL, public outputChannel: vscode.OutputChannel, protected _asset?: IAsset) {
+	constructor(public remotePath: vscode.Uri, public outputChannel: vscode.OutputChannel, protected _asset?: IAsset) {
 		this.remotePath = remotePath;
 	}
 
@@ -21,10 +21,10 @@ export abstract class RemoteBook {
 		if (vscode.workspace.workspaceFolders !== undefined) {
 			// Get workspace root path
 			let folders = vscode.workspace.workspaceFolders;
-			this._localPath = new URL(folders[0].uri.fsPath);
+			this._localPath = vscode.Uri.file(folders[0].uri.fsPath);
 		} else {
 			//If no workspace folder is opened then path is Users directory
-			this._localPath = new URL(utils.getUserHome());
+			this._localPath = vscode.Uri.file(utils.getUserHome());
 		}
 	}
 }

--- a/extensions/notebook/src/book/remoteBookController.ts
+++ b/extensions/notebook/src/book/remoteBookController.ts
@@ -17,7 +17,7 @@ export class RemoteBookController {
 	constructor(public model: RemoteBookDialogModel, public outputChannel: vscode.OutputChannel) {
 	}
 
-	public async setRemoteBook(url: URL, remoteLocation: string, asset?: IAsset): Promise<void> {
+	public async setRemoteBook(url: vscode.Uri, remoteLocation: string, asset?: IAsset): Promise<void> {
 		if (remoteLocation === 'GitHub') {
 			this.model.remoteBook = new GitHubRemoteBook(url, this.outputChannel, asset);
 		} else {
@@ -26,7 +26,7 @@ export class RemoteBookController {
 		return await this.model.remoteBook.createLocalCopy();
 	}
 
-	public async getReleases(url?: URL): Promise<IRelease[]> {
+	public async getReleases(url?: vscode.Uri): Promise<IRelease[]> {
 		if (url) {
 			this.model.releases = [];
 			let options = {
@@ -35,7 +35,7 @@ export class RemoteBookController {
 				}
 			};
 			return new Promise<IRelease[]>((resolve, reject) => {
-				request.get(url.href, options, (error, response, body) => {
+				request.get(url.toString(false), options, (error, response, body) => {
 					if (error) {
 						return reject(error);
 					}
@@ -50,7 +50,7 @@ export class RemoteBookController {
 						let keys = Object.keys(releases);
 						keys.forEach(key => {
 							try {
-								bookReleases.push({ name: releases[key].name, assetsUrl: new URL(releases[key].assets_url) });
+								bookReleases.push({ name: releases[key].name, assetsUrl: vscode.Uri.parse(releases[key].assets_url) });
 							}
 							catch (error) {
 								return reject(error);
@@ -84,7 +84,7 @@ export class RemoteBookController {
 				}
 			};
 			return new Promise<IAsset[]>((resolve, reject) => {
-				request.get(release.assetsUrl.href, options, (error, response, body) => {
+				request.get(release.assetsUrl.toString(false), options, (error, response, body) => {
 					if (error) {
 						return reject(error);
 					}
@@ -98,9 +98,9 @@ export class RemoteBookController {
 						let keys = Object.keys(assets);
 						keys.forEach(key => {
 							let asset = {} as IAsset;
-							asset.url = new URL(assets[key].url);
+							asset.url = vscode.Uri.parse(assets[key].url);
 							asset.name = assets[key].name;
-							asset.browserDownloadUrl = new URL(assets[key].browser_download_url);
+							asset.browserDownloadUrl = vscode.Uri.parse(assets[key].browser_download_url);
 							let groupsRe = asset.name.match(assetNameRE);
 							if (groupsRe) {
 								asset.book = groupsRe[1];
@@ -128,7 +128,7 @@ export class RemoteBookController {
 
 export interface IRelease {
 	name: string;
-	assetsUrl: URL;
+	assetsUrl: vscode.Uri;
 }
 
 export interface IAsset {
@@ -137,6 +137,6 @@ export interface IAsset {
 	version: string;
 	language: string;
 	format: string;
-	url: URL;
-	browserDownloadUrl: URL;
+	url: vscode.Uri;
+	browserDownloadUrl: vscode.Uri;
 }

--- a/extensions/notebook/src/book/sharedRemoteBook.ts
+++ b/extensions/notebook/src/book/sharedRemoteBook.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 
 
 export class SharedRemoteBook extends RemoteBook {
-	constructor(public remotePath: URL, public outputChannel: vscode.OutputChannel) {
+	constructor(public remotePath: vscode.Uri, public outputChannel: vscode.OutputChannel) {
 		super(remotePath, outputChannel);
 	}
 	public async createLocalCopy(): Promise<void> {

--- a/extensions/notebook/src/dialog/remoteBookDialog.ts
+++ b/extensions/notebook/src/dialog/remoteBookDialog.ts
@@ -7,6 +7,7 @@ import * as azdata from 'azdata';
 import * as loc from '../common/localizedConstants';
 import { RemoteBookController, IAsset } from '../book/remoteBookController';
 import * as utils from '../common/utils';
+import * as vscode from 'vscode';
 
 const tigerToolboxRepo = 'repos/microsoft/tigertoolbox';
 const urlGithubRE = /^(?:https:\/\/(?:github\.com|api\.github\.com\/repos)|(?:\/)?(?:\/)?repos)([\w-.?!=&%*+:@\/]*)/g;
@@ -185,7 +186,7 @@ export class RemoteBookDialog {
 				let groupsRe = url.match(urlGithubRE);
 				if (groupsRe?.length > 0) {
 					url = apiGitHub(groupsRe[0]);
-					let releases = await this.controller.getReleases(new URL(url));
+					let releases = await this.controller.getReleases(vscode.Uri.parse(url));
 					if (releases) {
 						this.releaseDropdown.enabled = true;
 						await this.fillReleasesDropdown();
@@ -232,7 +233,7 @@ export class RemoteBookDialog {
 				await this.controller.setRemoteBook(selected_asset.url, this.remoteLocationValue, selected_asset);
 			} else {
 				let url = utils.getDropdownValue(this.githubRepoDropdown);
-				let newUrl = new URL(url);
+				let newUrl = vscode.Uri.parse(url);
 				await this.controller.setRemoteBook(newUrl, this.remoteLocationValue);
 			}
 			return true;

--- a/extensions/notebook/src/test/book/remoteBookController.test.ts
+++ b/extensions/notebook/src/test/book/remoteBookController.test.ts
@@ -30,7 +30,7 @@ describe('Remote Book Controller', function () {
 
 	it('Verify that errorMessage is thrown, when fetchReleases call returns empty', async function (): Promise<void> {
 		let expectedBody = JSON.stringify([]);
-		let expectedURL = new URL('https://api.github.com/repos/microsoft/test/releases');
+		let expectedURL = vscode.Uri.parse('https://api.github.com/repos/microsoft/test/releases');
 		getStub.yields(null, { statusCode: 200 }, expectedBody);
 
 		try {
@@ -72,7 +72,7 @@ describe('Remote Book Controller', function () {
 				browser_download_url: 'https://api.github.com/repos/microsoft/test/releases/download/1/test-1.1-FR.tgz',
 			}
 		]);
-		let expectedURL = new URL('https://api.github.com/repos/microsoft/test/releases/1/assets');
+		let expectedURL = vscode.Uri.parse('https://api.github.com/repos/microsoft/test/releases/1/assets');
 		let expectedRelease: IRelease = {
 			name: 'Test Release',
 			assetsUrl: expectedURL
@@ -102,7 +102,7 @@ describe('Remote Book Controller', function () {
 				browser_download_url: 'https://api.github.com/repos/microsoft/test/releases/download/1/test-1.2.zip',
 			},
 		]);
-		let expectedURL = new URL('https://api.github.com/repos/microsoft/test/releases/1/assets');
+		let expectedURL = vscode.Uri.parse('https://api.github.com/repos/microsoft/test/releases/1/assets');
 		let expectedRelease: IRelease = {
 			name: 'Test Release',
 			assetsUrl: expectedURL


### PR DESCRIPTION
* Use vscode.URI for local paths

* Use vscode.uri file method to set the name for remotebookfull path compressed file

* Add await on extract tar function

* Replace remote paths too

* Use vscode.uri.file instead of parse for local paths

This PR fixes #11602
