### PR TITLE
show hidden connection properties

### DIFF
--- a/src/sql/workbench/services/connection/browser/media/connectionDialog.css
+++ b/src/sql/workbench/services/connection/browser/media/connectionDialog.css
@@ -60,7 +60,6 @@
 }
 
 .connection-provider-info {
-	overflow-y: hidden;
 	margin: 15px;
 }
 


### PR DESCRIPTION
remove the overflow-hidden property, the parent dialog already has the overflow-y scroll set, we can rely on it to have a dialog level vertical scrollbar.

This PR fixes #11644

![image](https://user-images.githubusercontent.com/13777222/89355657-ca7b9780-d670-11ea-8561-db0534783924.png)

![image](https://user-images.githubusercontent.com/13777222/89355668-d10a0f00-d670-11ea-9f17-79f8ff89bd93.png)
