### PR TITLE
replace obsolete command

### DIFF
--- a/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-azure.ipynb
+++ b/extensions/asde-deployment/notebooks/edge/deploy-sql-edge-azure.ipynb
@@ -362,7 +362,7 @@
                 "if len(vm_list) == 0:\n",
                 "    vm_image = run_command(f'az vm image list --all --location {azure_location} --offer iot_edge_vm_ubuntu --publisher microsoft_iot_edge --sku ubuntu_1604_edgeruntimeonly', returnObject=True)\n",
                 "    image_urn = vm_image[0]['urn']\n",
-                "    run_command(f'az vm image accept-terms --urn {image_urn}')\n",
+                "    run_command(f'az vm image terms accept --urn {image_urn}')\n",
                 "    vm_password_placeholder = '<admin_password>'\n",
                 "    create_vm_command_template = f'az vm create --name {iot_device_id} --resource-group {azure_resource_group} --admin-username {vm_admin} --admin-password {vm_password_placeholder} --authentication-type password --image {image_urn} --location {azure_location} --nsg {network_security_group} --public-ip-address \\\"{public_ip_address_name}\\\" --public-ip-address-allocation static --public-ip-sku Standard --size {vm_size} --subnet {subnet_name} --subnet-address-prefix \\\"{subnet_address_prefix}\\\" --vnet-name {vnet_name} --vnet-address-prefix \\\"{vnet_address_prefix}\\\"'\n",
                 "    run_command(create_vm_command_template.replace(vm_password_placeholder, vm_password), displayCommand=create_vm_command_template.replace(vm_password_placeholder, '******'))\n",

--- a/extensions/asde-deployment/package.json
+++ b/extensions/asde-deployment/package.json
@@ -383,7 +383,8 @@
             },
             "requiredTools": [
               {
-                "name": "azure-cli"
+                "name": "azure-cli",
+                "version": "2.9.1"
               }
             ],
             "when": "type=azure-create-new"
@@ -469,7 +470,8 @@
             },
             "requiredTools": [
               {
-                "name": "azure-cli"
+                "name": "azure-cli",
+                "version": "2.9.1"
               }
             ],
             "when": "type=azure-single-device"
@@ -558,7 +560,8 @@
             },
             "requiredTools": [
               {
-                "name": "azure-cli"
+                "name": "azure-cli",
+                "version": "2.9.1"
               }
             ],
             "when": "type=azure-multi-device"


### PR DESCRIPTION
the command `az vm image accept-terms --urn` is about to be removed, update it to use the new command and meanwhile update the required az-cli version.