### PR TITLE
fixes open button copy not showing #11598

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -367,6 +367,7 @@ class WelcomePage extends Disposable {
 			<li role="none"><a role="menuitem" tabIndex="-1" class="move" href="command:azdata.resource.deploy">${(localize('welcomePage.deployServer', "Deploy a Server"))}</a></li>
 			<li role="none" id="dropdown-mac-only"><a role="menuitem" tabIndex="-1" class="move mac-only" href="command:workbench.action.files.openLocalFileFolder">${openFileCopy}</a></li>
 			<li role="none" id="dropdown-windows-linux-only"><a role="menuitem" tabIndex="-1" class="move windows-only linux-only" href="command:workbench.action.files.openFile">${openFileCopy}</a></li`;
+
 		const getDropdownBtn = container.querySelector('#dropdown-btn-container .monaco-button') as HTMLElement;
 		getDropdownBtn.id = 'dropdown-btn';
 		getDropdownBtn.setAttribute('role', 'navigation');
@@ -380,7 +381,7 @@ class WelcomePage extends Disposable {
 		nav.appendChild(dropdownUl);
 		dropdownButtonContainer.appendChild(nav);
 		const fileBtnWindowsClasses = ['windows-only', 'linux-only', 'btn-secondary'];
-		const fileBtnMacClasses = ['mac-only'];
+		const fileBtnMacClasses = ['mac-only', 'btn-secondary'];
 
 		const fileBtnContainer = container.querySelector('#open-file-btn-container') as HTMLElement;
 		const openFileText = openFileCopy;


### PR DESCRIPTION
This PR fixes the issue of the open button text not showing. It does this by adding the appropriate class to the button that applies the color styling.

Before:
![image](https://user-images.githubusercontent.com/60623315/89483003-ee61da80-d74f-11ea-9501-e6dd17c03a19.png)

After:
![image](https://user-images.githubusercontent.com/60623315/89482954-d5592980-d74f-11ea-8fcb-64922f5c9334.png)


This PR fixes #11598

