### PR TITLE
Fixes button text not showing on open button on welcome

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -45,7 +45,7 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { joinPath } from 'vs/base/common/resources';
-import { addStandardDisposableListener, EventHelper } from 'vs/base/browser/dom';
+import { addStandardDisposableListener, EventHelper, clearNode } from 'vs/base/browser/dom';
 import { GuidedTour } from 'sql/workbench/contrib/welcome/page/browser/gettingStartedTour';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
@@ -308,19 +308,13 @@ class WelcomePage extends Disposable {
 				recent.classList.add('emptyRecent');
 				return;
 			}
-			const ul = container.querySelector('.recent ul');
+			const ul = container.querySelector('.recent ul') as HTMLElement;
 			if (!ul) {
 				return;
 			}
 			const workspacesToShow = workspaces.slice(0, 5);
-			const updateEntries = async () => {
-				while (ul.firstChild) {
-					ul.removeChild(ul.firstChild);
-				}
-				await this.mapListEntries(workspacesToShow, fileService, container);
-			};
-			await updateEntries();
-			this._register(this.labelService.onDidChangeFormatters(updateEntries));
+			clearNode(ul);
+			await this.mapListEntries(workspacesToShow, fileService, container, ul);
 		}).then(undefined, onUnexpectedError);
 		this.addExtensionList(container, '.extension-list');
 		this.addExtensionPack(container, '.extensionPack');
@@ -685,7 +679,7 @@ class WelcomePage extends Disposable {
 		return result;
 	}
 
-	private async mapListEntries(recents: (IRecentWorkspace | IRecentFolder)[], fileService: IFileService, container: HTMLElement): Promise<HTMLElement[]> {
+	private async mapListEntries(recents: (IRecentWorkspace | IRecentFolder)[], fileService: IFileService, container: HTMLElement, ul: HTMLElement): Promise<HTMLElement[]> {
 		const result: HTMLElement[] = [];
 		for (let i = 0; i < recents.length; i++) {
 			const recent = recents[i];
@@ -705,7 +699,6 @@ class WelcomePage extends Disposable {
 		}
 		return result;
 	}
-
 	private addExtensionList(container: HTMLElement, listSelector: string): void {
 		const list = container.querySelector(listSelector);
 		if (list) {


### PR DESCRIPTION
This PR fixes the issue of the "Open" button text not showing on the welcome page on macOS devices. It fixes the issue by adding the appropriate class to the mac only button.

This PR fixes #11366
