### PR TITLE
Fix up data explorer contributed actions on OE nodes

### DIFF
--- a/extensions/admin-tool-ext-win/package.json
+++ b/extensions/admin-tool-ext-win/package.json
@@ -67,6 +67,23 @@
           "when": "isWindows && connectionProvider == MSSQL && serverInfo && nodeType && mssql:engineedition != 11 && nodeType =~ /^(Database|Table|Column|Index|Statistic|View|ServerLevelLogin|ServerLevelServerRole|ServerLevelCredential|ServerLevelServerAudit|ServerLevelServerAuditSpecification|StoredProcedure|ScalarValuedFunction|TableValuedFunction|AggregateFunction|Synonym|Assembly|UserDefinedDataType|UserDefinedType|UserDefinedTableType|Sequence|User|DatabaseRole|ApplicationRole|Schema|SecurityPolicy|ServerLevelLinkedServer)$/",
           "group": "z-AdminToolExt@2"
         }
+      ],
+      "dataExplorer/context": [
+        {
+          "command": "adminToolExtWin.launchSsmsMinGswDialog",
+          "when": "isWindows && connectionProvider == MSSQL && nodeType && nodeType == Database && mssql:engineedition != 11",
+          "group": "z-AdminToolExt@1"
+        },
+        {
+          "command": "adminToolExtWin.launchSsmsMinPropertiesDialog",
+          "when": "isWindows && connectionProvider == MSSQL && !isCloud && nodeType && nodeType == Server && mssql:engineedition != 11",
+          "group": "z-AdminToolExt@2"
+        },
+        {
+          "command": "adminToolExtWin.launchSsmsMinPropertiesDialog",
+          "when": "isWindows && connectionProvider == MSSQL && nodeType && mssql:engineedition != 11 && nodeType =~ /^(Database|Table|Column|Index|Statistic|View|ServerLevelLogin|ServerLevelServerRole|ServerLevelCredential|ServerLevelServerAudit|ServerLevelServerAuditSpecification|StoredProcedure|ScalarValuedFunction|TableValuedFunction|AggregateFunction|Synonym|Assembly|UserDefinedDataType|UserDefinedType|UserDefinedTableType|Sequence|User|DatabaseRole|ApplicationRole|Schema|SecurityPolicy|ServerLevelLinkedServer)$/",
+          "group": "z-AdminToolExt@2"
+        }
       ]
     },
     "outputChannels": [

--- a/src/sql/workbench/api/common/extHostObjectExplorer.ts
+++ b/src/sql/workbench/api/common/extHostObjectExplorer.ts
@@ -7,15 +7,39 @@ import { IMainContext } from 'vs/workbench/api/common/extHost.protocol';
 import { ExtHostObjectExplorerShape, SqlMainContext, MainThreadObjectExplorerShape } from 'sql/workbench/api/common/sqlExtHost.protocol';
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
+import { ExtHostCommands } from 'vs/workbench/api/common/extHostCommands';
+import { TreeViewItemHandleArg } from 'sql/workbench/common/views';
 
 export class ExtHostObjectExplorer implements ExtHostObjectExplorerShape {
 
 	private _proxy: MainThreadObjectExplorerShape;
 
 	constructor(
-		mainContext: IMainContext
+		mainContext: IMainContext,
+		commands: ExtHostCommands
 	) {
 		this._proxy = mainContext.getProxy(SqlMainContext.MainThreadObjectExplorer);
+
+		function isDataExplorerTreeViewItemHandleArg(arg: any): boolean {
+			return arg?.$treeItem?.payload;
+		}
+
+		function convertDataExplorerArgument(arg: TreeViewItemHandleArg): any {
+			return <azdata.ObjectExplorerContext>{
+				connectionProfile: arg.$treeItem.payload,
+				isConnectionNode: arg.$treeItem.type === 'Server',
+				nodeInfo: arg.$treeItem.nodeInfo
+			};
+		}
+
+		commands.registerArgumentProcessor({
+			processArgument: arg => {
+				if (isDataExplorerTreeViewItemHandleArg(arg)) {
+					return convertDataExplorerArgument(arg);
+				}
+				return arg;
+			}
+		});
 	}
 
 	public $getNode(connectionId: string, nodePath?: string): Thenable<azdata.objectexplorer.ObjectExplorerNode> {

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -33,6 +33,7 @@ import { IURITransformerService } from 'vs/workbench/api/common/extHostUriTransf
 import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IExtensionApiFactory as vsIApiFactory, createApiFactoryAndRegisterActors as vsApiFactory } from 'vs/workbench/api/common/extHost.api.impl';
+import { IExtHostCommands } from 'vs/workbench/api/common/extHostCommands';
 
 export interface IAzdataExtensionApiFactory {
 	(extension: IExtensionDescription): typeof azdata;
@@ -71,13 +72,14 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 	const rpcProtocol = accessor.get(IExtHostRpcService);
 	const extHostLogService = accessor.get(ILogService);
 	const logService = accessor.get(ILogService);
+	const commands = accessor.get(IExtHostCommands);
 
 	// Addressable instances
 	const extHostAccountManagement = rpcProtocol.set(SqlExtHostContext.ExtHostAccountManagement, new ExtHostAccountManagement(rpcProtocol));
 	const extHostConnectionManagement = rpcProtocol.set(SqlExtHostContext.ExtHostConnectionManagement, new ExtHostConnectionManagement(rpcProtocol));
 	const extHostCredentialManagement = rpcProtocol.set(SqlExtHostContext.ExtHostCredentialManagement, new ExtHostCredentialManagement(rpcProtocol));
 	const extHostDataProvider = rpcProtocol.set(SqlExtHostContext.ExtHostDataProtocol, new ExtHostDataProtocol(rpcProtocol, uriTransformer));
-	const extHostObjectExplorer = rpcProtocol.set(SqlExtHostContext.ExtHostObjectExplorer, new ExtHostObjectExplorer(rpcProtocol));
+	const extHostObjectExplorer = rpcProtocol.set(SqlExtHostContext.ExtHostObjectExplorer, new ExtHostObjectExplorer(rpcProtocol, commands));
 	const extHostResourceProvider = rpcProtocol.set(SqlExtHostContext.ExtHostResourceProvider, new ExtHostResourceProvider(rpcProtocol));
 	const extHostModalDialogs = rpcProtocol.set(SqlExtHostContext.ExtHostModalDialogs, new ExtHostModalDialogs(rpcProtocol));
 	const extHostTasks = rpcProtocol.set(SqlExtHostContext.ExtHostTasks, new ExtHostTasks(rpcProtocol, extHostLogService));

--- a/src/sql/workbench/common/views.ts
+++ b/src/sql/workbench/common/views.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ITreeViewDataProvider, ITreeItem as vsITreeItem, IViewDescriptor, ITreeView as vsITreeView } from 'vs/workbench/common/views';
-import { IConnectionProfile } from 'azdata';
+import { IConnectionProfile, NodeInfo } from 'azdata';
 
 export enum NodeType {
 	Server = 'Server',
@@ -28,6 +28,7 @@ export interface ITreeItem extends vsITreeItem {
 	payload?: IConnectionProfile; // its possible we will want this to be more generic
 	sqlIcon?: string;
 	type?: NodeType;
+	nodeInfo?: NodeInfo
 }
 
 export interface ITreeView extends vsITreeView {

--- a/src/sql/workbench/contrib/dataExplorer/browser/extensions.contribution.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/extensions.contribution.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
-import { DATA_TIER_WIZARD_COMMAND_ID, PROFILER_COMMAND_ID, IMPORT_COMMAND_ID, SCHEMA_COMPARE_COMMAND_ID, GENERATE_SCRIPTS_COMMAND_ID, PROPERTIES_COMMAND_ID, IMPORT_DATABASE_COMMAND_ID } from 'sql/workbench/contrib/dataExplorer/browser/extensionActions';
-import { ContextKeyExpr, ContextKeyRegexExpr } from 'vs/platform/contextkey/common/contextkey';
+import { DATA_TIER_WIZARD_COMMAND_ID, PROFILER_COMMAND_ID, IMPORT_COMMAND_ID, SCHEMA_COMPARE_COMMAND_ID, IMPORT_DATABASE_COMMAND_ID } from 'sql/workbench/contrib/dataExplorer/browser/extensionActions';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { MssqlNodeContext } from 'sql/workbench/services/objectExplorer/browser/mssqlNodeContext';
 import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { NodeType } from 'sql/workbench/services/objectExplorer/common/nodeType';
@@ -84,42 +84,4 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 	},
 	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
 		MssqlNodeContext.NodeType.isEqualTo(NodeType.Database))
-});
-
-// Generate Scripts Action
-MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
-	group: 'z-AdminToolExt@1',
-	order: 12,
-	command: {
-		id: GENERATE_SCRIPTS_COMMAND_ID,
-		title: localize('generateScripts', "Generate Scripts...")
-	},
-	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
-		MssqlNodeContext.NodeType.isEqualTo(NodeType.Database),
-		MssqlNodeContext.IsWindows, MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()))
-});
-
-// Properties Action
-MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
-	group: 'z-AdminToolExt@2',
-	order: 13,
-	command: {
-		id: PROPERTIES_COMMAND_ID,
-		title: localize('properties', "Properties")
-	},
-	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
-		MssqlNodeContext.NodeType.isEqualTo(NodeType.Server), ContextKeyExpr.not('isCloud'),
-		MssqlNodeContext.IsWindows, MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()))
-});
-
-MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
-	group: 'z-AdminToolExt@2',
-	order: 13,
-	command: {
-		id: PROPERTIES_COMMAND_ID,
-		title: localize('properties', "Properties")
-	},
-	when: ContextKeyExpr.and(MssqlNodeContext.NodeProvider.isEqualTo(mssqlProviderName),
-		MssqlNodeContext.IsWindows, MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()),
-		ContextKeyRegexExpr.create('nodeType', /^(Database|Table|Column|Index|Statistic|View|ServerLevelLogin|ServerLevelServerRole|ServerLevelCredential|ServerLevelServerAudit|ServerLevelServerAuditSpecification|StoredProcedure|ScalarValuedFunction|TableValuedFunction|AggregateFunction|Synonym|Assembly|UserDefinedDataType|UserDefinedType|UserDefinedTableType|Sequence|User|DatabaseRole|ApplicationRole|Schema|SecurityPolicy|ServerLevelLinkedServer)$/))
 });

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerViewTreeShim.ts
@@ -197,7 +197,8 @@ export class OEShimService extends Disposable implements IOEShimService {
 			providerHandle: parentNode.childProvider,
 			payload: node.payload || (databaseChanged ? updatedPayload : parentNode.payload),
 			contextValue: node.nodeTypeId,
-			sqlIcon: icon
+			sqlIcon: icon,
+			nodeInfo: nodeInfo
 		};
 		this.nodeHandleMap.set(generateNodeMapKey(viewId, newTreeItem), nodePath);
 		this.nodeInfoMap.set(newTreeItem, nodeInfo);

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -58,7 +58,7 @@ export class ExtHostTreeViews implements ExtHostTreeViewsShape {
 	) {
 
 		function isTreeViewItemHandleArg(arg: any): boolean {
-			return arg && arg.$treeViewId && arg.$treeItemHandle;
+			return arg && arg.$treeViewId && arg.$treeItemHandle && !arg.$treeItem?.payload;
 		}
 		commands.registerArgumentProcessor({
 			processArgument: arg => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/11641

I may be missing some context here on what was originally broken that necessitated this - but here's the fix I'm doing to try and address this.

- Add OE NodeInfo to the TreeItem created for Data Explorer nodes
- Register handler that will convert the TreeItem input into an ObjectExplorerContext

With these changes I see the nodes show up as expected on DE trees and am able to run and launch them successfully.

Assuming that there aren't any issues found with this approach I plan on doing the same for all the other actions contributed by extensions - since they are currently broken in the same way as the admin-tool-ext-win ones. 