### PR TITLE
Fix for reading "options" property from backend in manage dashboard

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/properties/propertiesWidget.component.ts
@@ -132,10 +132,11 @@ export class PropertiesWidgetComponent extends DashboardWidget implements IDashb
 		});
 	}
 
-	private getValueOrDefault<T>(infoObject: ServerInfo | {}, propertyValue: string, defaultVal?: any): T {
+	private getValueOrDefault<T>(infoObject: ServerInfo | {}, propertyName: string, defaultVal?: any): T {
 		let val: T = undefined;
-		if (infoObject) {
-			val = infoObject[propertyValue];
+		let obj = propertyName in infoObject ? infoObject : ('options' in infoObject && propertyName in infoObject.options ? infoObject.options : undefined);
+		if (obj) {
+			val = obj[propertyName];
 		}
 		if (types.isUndefinedOrNull(val)) {
 			val = defaultVal;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
Fix for reading "options" property from backend when translating to show Cluster/DB properties on manage dashboard in ADS
