### PR TITLE
Refresh fix for Edit Data

### DIFF
--- a/src/sql/workbench/browser/editData/editDataInput.ts
+++ b/src/sql/workbench/browser/editData/editDataInput.ts
@@ -84,9 +84,12 @@ export class EditDataInput extends EditorInput implements IConnectableInput {
 			);
 
 			this._register(
+
 				this._queryModelService.onEditSessionReady((result) => {
-					if (self.uri === result.ownerUri) {
-						self.initEditEnd(result);
+					if (this.uri === result.ownerUri) {
+						this._results.editDataGridPanel.onRefreshComplete.then(() => {
+							this.initEditEnd(result);
+						});
 					}
 				})
 			);

--- a/src/sql/workbench/browser/editData/editDataInput.ts
+++ b/src/sql/workbench/browser/editData/editDataInput.ts
@@ -84,7 +84,6 @@ export class EditDataInput extends EditorInput implements IConnectableInput {
 			);
 
 			this._register(
-
 				this._queryModelService.onEditSessionReady((result) => {
 					if (this.uri === result.ownerUri) {
 						this._results.editDataGridPanel.onRefreshComplete.then(() => {

--- a/src/sql/workbench/browser/editData/editDataResultsInput.ts
+++ b/src/sql/workbench/browser/editData/editDataResultsInput.ts
@@ -6,6 +6,7 @@
 import { EditorInput } from 'vs/workbench/common/editor';
 import { Emitter } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
+import { EditDataGridPanel } from 'sql/workbench/contrib/editData/browser/editDataGridPanel';
 
 /**
  * Input for the EditDataResultsEditor. This input helps with logic for the viewing and editing of
@@ -25,11 +26,20 @@ export class EditDataResultsInput extends EditorInput {
 
 	public readonly onRestoreViewStateEmitter = new Emitter<void>();
 	public readonly onSaveViewStateEmitter = new Emitter<void>();
+	private _editDataGridPanel: EditDataGridPanel;
 
 	constructor(private _uri: string) {
 		super();
 		this._visible = false;
 		this._hasBootstrapped = false;
+	}
+
+	get editDataGridPanel(): EditDataGridPanel {
+		return this._editDataGridPanel;
+	}
+
+	set editDataGridPanel(gridPanel: EditDataGridPanel) {
+		this._editDataGridPanel = gridPanel;
 	}
 
 	getTypeId(): string {

--- a/src/sql/workbench/browser/editData/editDataResultsInput.ts
+++ b/src/sql/workbench/browser/editData/editDataResultsInput.ts
@@ -6,7 +6,10 @@
 import { EditorInput } from 'vs/workbench/common/editor';
 import { Emitter } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
-import { EditDataGridPanel } from 'sql/workbench/contrib/editData/browser/editDataGridPanel';
+
+export interface IGridPanel {
+	readonly onRefreshComplete: Promise<void>;
+}
 
 /**
  * Input for the EditDataResultsEditor. This input helps with logic for the viewing and editing of
@@ -26,7 +29,7 @@ export class EditDataResultsInput extends EditorInput {
 
 	public readonly onRestoreViewStateEmitter = new Emitter<void>();
 	public readonly onSaveViewStateEmitter = new Emitter<void>();
-	private _editDataGridPanel: EditDataGridPanel;
+	private _editDataGridPanel: IGridPanel;
 
 	constructor(private _uri: string) {
 		super();
@@ -34,11 +37,11 @@ export class EditDataResultsInput extends EditorInput {
 		this._hasBootstrapped = false;
 	}
 
-	get editDataGridPanel(): EditDataGridPanel {
+	get editDataGridPanel(): IGridPanel {
 		return this._editDataGridPanel;
 	}
 
-	set editDataGridPanel(gridPanel: EditDataGridPanel) {
+	set editDataGridPanel(gridPanel: IGridPanel) {
 		this._editDataGridPanel = gridPanel;
 	}
 

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -413,13 +413,13 @@ export class EditDataGridPanel extends GridParentComponent {
 		if (self.placeHolderDataSets[0]) {
 			this.refreshDatasets();
 		}
-		await self.refreshGrid();
-
-		// Setup the state of the selected cell
-		this.resetCurrentCell();
-		this.removingNewRow = false;
-		this.newRowVisible = false;
-		this.dirtyCells = [];
+		await self.refreshGrid().then(() => {
+			// Setup the state of the selected cell
+			this.resetCurrentCell();
+			this.removingNewRow = false;
+			this.newRowVisible = false;
+			this.dirtyCells = [];
+		});
 	}
 
 	/**

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -382,7 +382,7 @@ export class EditDataGridPanel extends GridParentComponent {
 				self.windowSize,
 				index => { return {}; },
 				resultSet.rowCount,
-				this.loadDataFunction,
+				await this.loadDataFunction,
 			),
 			columnDefinitions: [rowNumberColumn.getColumnDefinition()].concat(resultSet.columnInfo.map((c, i) => {
 				let columnIndex = (i + 1).toString();

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -472,7 +472,7 @@ export class EditDataGridPanel extends GridParentComponent {
 					this.dirtyCells = [];
 				}
 				//allow for the grid to render fully before returning.
-				setTimeout(() => resolve(), 300);
+				setTimeout(() => resolve(), 500);
 			}, this.refreshGridTimeoutInMs);
 		});
 	}

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -78,6 +78,7 @@ export class EditDataGridPanel extends GridParentComponent {
 	public loadDataFunction: (offset: number, count: number) => Promise<{}[]>;
 	public onBeforeAppendCell: (row: number, column: number) => string;
 	public onGridRendered: (event: Slick.OnRenderedEventArgs<any>) => void;
+	public onRefreshComplete: Promise<void>;
 
 	private savedViewState: {
 		gridSelections: Slick.Range[];
@@ -132,7 +133,7 @@ export class EditDataGridPanel extends GridParentComponent {
 					self.handleMessage(self, event);
 					break;
 				case 'resultSet':
-					self.handleResultSet(self, event);
+					this.onRefreshComplete = self.handleResultSet(self, event);
 					break;
 				case 'editSessionReady':
 					self.handleEditSessionReady(self, event);
@@ -358,7 +359,9 @@ export class EditDataGridPanel extends GridParentComponent {
 		}
 	}
 
-	handleResultSet(self: EditDataGridPanel, event: any): void {
+
+
+	async handleResultSet(self: EditDataGridPanel, event: any): Promise<void> {
 		// Clone the data before altering it to avoid impacting other subscribers
 		let resultSet = assign({}, event.data);
 		if (!resultSet.complete) {
@@ -410,14 +413,13 @@ export class EditDataGridPanel extends GridParentComponent {
 		if (self.placeHolderDataSets[0]) {
 			this.refreshDatasets();
 		}
-		self.refreshGrid();
+		await self.refreshGrid();
 
 		// Setup the state of the selected cell
 		this.resetCurrentCell();
 		this.removingNewRow = false;
 		this.newRowVisible = false;
 		this.dirtyCells = [];
-
 	}
 
 	/**

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -435,6 +435,10 @@ export class EditDataGridPanel extends GridParentComponent {
 		return inputStr.replace(/(\r\n|\n|\r)/g, '\u0000');
 	}
 
+	/**
+	 * Code that handles the refresh of the grid.
+	 * @param isManual flag used when called by handleResultSet, for required additional processing.
+	 */
 	private refreshGrid(isManual?: boolean): Thenable<void> {
 		return new Promise<void>(async (resolve, reject) => {
 

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -37,12 +37,6 @@ import * as DOM from 'vs/base/browser/dom';
 import { onUnexpectedError } from 'vs/base/common/errors';
 
 export class EditDataGridPanel extends GridParentComponent {
-	// The time(in milliseconds) we wait before refreshing the grid.
-	// We use clearTimeout and setTimeout pair to avoid unnecessary refreshes.
-	private refreshGridTimeoutInMs = 200;
-
-	// The timeout handle for the refresh grid task
-	private refreshGridTimeoutHandle: any;
 
 	// Optimized for the edit top 200 rows scenario, only need to retrieve the data once
 	// to make the scroll experience smoother
@@ -444,32 +438,27 @@ export class EditDataGridPanel extends GridParentComponent {
 
 	private refreshGrid(): Thenable<void> {
 		return new Promise<void>(async (resolve, reject) => {
-
-			clearTimeout(this.refreshGridTimeoutHandle);
-
-			this.refreshGridTimeoutHandle = setTimeout(() => {
-				try {
-					if (this.dataSet) {
-						this.placeHolderDataSets[0].dataRows = this.dataSet.dataRows;
-						this.onResize();
-					}
-
-
-					if (this.placeHolderDataSets[0].dataRows && this.oldDataRows !== this.placeHolderDataSets[0].dataRows) {
-						this.detectChange();
-						this.oldDataRows = this.placeHolderDataSets[0].dataRows;
-					}
-				}
-				catch {
-					this.logService.error('data set is empty, refresh cancelled.');
-					reject();
+			try {
+				if (this.dataSet) {
+					this.placeHolderDataSets[0].dataRows = this.dataSet.dataRows;
+					this.onResize();
 				}
 
-				if (this.firstRender) {
-					setTimeout(() => this.setActive());
+
+				if (this.placeHolderDataSets[0].dataRows && this.oldDataRows !== this.placeHolderDataSets[0].dataRows) {
+					this.detectChange();
+					this.oldDataRows = this.placeHolderDataSets[0].dataRows;
 				}
-				resolve();
-			}, this.refreshGridTimeoutInMs);
+			}
+			catch {
+				this.logService.error('data set is empty, refresh cancelled.');
+				reject();
+			}
+
+			if (this.firstRender) {
+				setTimeout(() => this.setActive());
+			}
+			resolve();
 		});
 	}
 

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -37,7 +37,6 @@ import * as DOM from 'vs/base/browser/dom';
 import { onUnexpectedError } from 'vs/base/common/errors';
 
 export class EditDataGridPanel extends GridParentComponent {
-
 	// The time(in milliseconds) we wait before refreshing the grid.
 	// We use clearTimeout and setTimeout pair to avoid unnecessary refreshes.
 	// Timeout is set to allow the grid to refresh fully before allowing a manual refresh.
@@ -360,8 +359,6 @@ export class EditDataGridPanel extends GridParentComponent {
 			});
 		}
 	}
-
-
 
 	async handleResultSet(self: EditDataGridPanel, event: any): Promise<void> {
 		// Clone the data before altering it to avoid impacting other subscribers

--- a/src/sql/workbench/contrib/editData/browser/editDataResultsEditor.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataResultsEditor.ts
@@ -105,6 +105,7 @@ export class EditDataResultsEditor extends BaseEditor {
 		// to events from the backing data service
 		this._applySettings();
 		let editGridPanel = this._register(this._instantiationService.createInstance(EditDataGridPanel, dataService, input.onSaveViewStateEmitter.event, input.onRestoreViewStateEmitter.event));
+		input.editDataGridPanel = editGridPanel;
 		editGridPanel.render(this.getContainer());
 	}
 }


### PR DESCRIPTION
Refreshing the grid now uses a promise listener relationship between editDataInput and editDataGridPanel that waits for the refresh to complete fully before returning.

RefreshGrid has been modified to ensure that all steps are completed before returning.

This PR fixes #11259
