### PR TITLE
Update machine-learning to 0.2.2 insiders

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3151,14 +3151,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.2.1",
-							"lastUpdated": "06/03/2020",
+							"version": "0.2.2",
+							"lastUpdated": "08/07/2020",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/machine-learning/machine-learning-0.2.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/machine-learning/machine-learning-0.2.2.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This includes a fix for using the new Azure APIs instead of the deprecated commands (which have been removed)