### PR TITLE
Update required azdata version for ML extension

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3184,7 +3184,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.18.0"
+									"value": ">=1.21.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",


### PR DESCRIPTION
Missed doing this - requires latest ADS version with the azurecore changes