### PR TITLE
findAzdata test fix

### DIFF
--- a/extensions/azdata/src/test/azdata.test.ts
+++ b/extensions/azdata/src/test/azdata.test.ts
@@ -26,15 +26,14 @@ describe('azdata', function () {
 	});
 
 	describe('findAzdata', function () {
+		sinon.stub(utils, 'searchForCmd').returns(Promise.resolve('C:\\path\\to\\azdata.cmd'));
 		// Mock call to --version to simulate azdata being installed
 		it('successful', async function (): Promise<void> {
 			sinon.stub(childProcess, 'executeCommand').returns(Promise.resolve({ stdout: 'v1.0.0', stderr: '' }));
-			sinon.stub(utils, 'searchForCmd').returns(Promise.resolve('C:\\path\\to\\azdata.cmd'));
 			await should(azdata.findAzdata(outputChannelMock.object)).not.be.rejected();
 		});
 		it('unsuccessful', async function (): Promise<void> {
 			sinon.stub(childProcess, 'executeCommand').returns(Promise.reject({ stdout: '', stderr: 'command not found: azdata' }));
-			sinon.stub(utils, 'searchForCmd').returns(Promise.reject(new Error('Could not find azdata')));
 			await should(azdata.findAzdata(outputChannelMock.object)).be.rejected();
 		});
 	});

--- a/extensions/azdata/src/test/azdata.test.ts
+++ b/extensions/azdata/src/test/azdata.test.ts
@@ -27,12 +27,13 @@ describe('azdata', function () {
 
 	describe('findAzdata', function () {
 		// Mock call to --version to simulate azdata being installed
-		sinon.stub(childProcess, 'executeCommand').returns(Promise.resolve({ stdout: 'v1.0.0', stderr: '' }));
 		it('successful', async function (): Promise<void> {
+			sinon.stub(childProcess, 'executeCommand').returns(Promise.resolve({ stdout: 'v1.0.0', stderr: '' }));
 			sinon.stub(utils, 'searchForCmd').returns(Promise.resolve('C:\\path\\to\\azdata.cmd'));
 			await should(azdata.findAzdata(outputChannelMock.object)).not.be.rejected();
 		});
 		it('unsuccessful', async function (): Promise<void> {
+			sinon.stub(childProcess, 'executeCommand').returns(Promise.reject({ stdout: '', stderr: 'command not found: azdata' }));
 			sinon.stub(utils, 'searchForCmd').returns(Promise.reject(new Error('Could not find azdata')));
 			await should(azdata.findAzdata(outputChannelMock.object)).be.rejected();
 		});

--- a/extensions/azdata/src/test/azdata.test.ts
+++ b/extensions/azdata/src/test/azdata.test.ts
@@ -26,14 +26,23 @@ describe('azdata', function () {
 	});
 
 	describe('findAzdata', function () {
-		sinon.stub(utils, 'searchForCmd').returns(Promise.resolve('C:\\path\\to\\azdata.cmd'));
-		// Mock call to --version to simulate azdata being installed
 		it('successful', async function (): Promise<void> {
+			if (process.platform === 'win32') {
+				// Mock searchForCmd to return a path to azdata.cmd
+				sinon.stub(utils, 'searchForCmd').returns(Promise.resolve('C:\\path\\to\\azdata.cmd'));
+			}
+			// Mock call to --version to simulate azdata being installed
 			sinon.stub(childProcess, 'executeCommand').returns(Promise.resolve({ stdout: 'v1.0.0', stderr: '' }));
 			await should(azdata.findAzdata(outputChannelMock.object)).not.be.rejected();
 		});
 		it('unsuccessful', async function (): Promise<void> {
-			sinon.stub(childProcess, 'executeCommand').returns(Promise.reject({ stdout: '', stderr: 'command not found: azdata' }));
+			if (process.platform === 'win32') {
+				// Mock searchForCmd to return a failure to find azdata.cmd
+				sinon.stub(utils, 'searchForCmd').returns(Promise.reject(new Error('Could not find azdata')));
+			} else {
+				// Mock call to executeCommand to simulate azdata --version returning error
+				sinon.stub(childProcess, 'executeCommand').returns(Promise.reject({ stdout: '', stderr: 'command not found: azdata' }));
+			}
 			await should(azdata.findAzdata(outputChannelMock.object)).be.rejected();
 		});
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This a quick fix for findAzdata tests. Previously for unsuccessful test case of findAzdata we were only stubbing the response form searcForCmd function call but since that function is not invoked on mac/linux the test was not working as expected.

With this fix we stub the executeCommand to resolve and reject for sucessful and unsucessful test cases respectively which works on all platforms. We still stub searchForCmd so that will give out an arbitrary path when the test is run so that invocation of that function returns success on windows platform.