### PR TITLE
Hides Edit Data , Script as Create and Script as drop for Kusto tables

### DIFF
--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -114,19 +114,21 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		id: commands.OE_SCRIPT_AS_CREATE_COMMAND_ID,
 		title: localize('scriptCreate', "Script as Create")
 	},
-	when: ContextKeyExpr.or(
-		ContextKeyExpr.and(
-			TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
-			ConnectionContextKey.Provider.notEqualsTo('KUSTO')),
-		TreeNodeContextKey.NodeType.isEqualTo('View'),
-		TreeNodeContextKey.NodeType.isEqualTo('Schema'),
-		TreeNodeContextKey.NodeType.isEqualTo('User'),
-		TreeNodeContextKey.NodeType.isEqualTo('UserDefinedTableType'),
-		TreeNodeContextKey.NodeType.isEqualTo('StoredProcedure'),
-		TreeNodeContextKey.NodeType.isEqualTo('AggregateFunction'),
-		TreeNodeContextKey.NodeType.isEqualTo('PartitionFunction'),
-		TreeNodeContextKey.NodeType.isEqualTo('ScalarValuedFunction'),
-		TreeNodeContextKey.NodeType.isEqualTo('TableValuedFunction'))
+	when:
+		ContextKeyExpr.and(ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
+			ContextKeyExpr.or(
+				TreeNodeContextKey.NodeType.isEqualTo('Table'),
+				TreeNodeContextKey.NodeType.isEqualTo('View'),
+				TreeNodeContextKey.NodeType.isEqualTo('Schema'),
+				TreeNodeContextKey.NodeType.isEqualTo('User'),
+				TreeNodeContextKey.NodeType.isEqualTo('UserDefinedTableType'),
+				TreeNodeContextKey.NodeType.isEqualTo('StoredProcedure'),
+				TreeNodeContextKey.NodeType.isEqualTo('AggregateFunction'),
+				TreeNodeContextKey.NodeType.isEqualTo('PartitionFunction'),
+				TreeNodeContextKey.NodeType.isEqualTo('ScalarValuedFunction'),
+				TreeNodeContextKey.NodeType.isEqualTo('TableValuedFunction')
+			)
+		)
 });
 
 MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
@@ -176,19 +178,21 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		id: commands.OE_SCRIPT_AS_DELETE_COMMAND_ID,
 		title: localize('scriptDelete', "Script as Drop")
 	},
-	when: ContextKeyExpr.or(
-		ContextKeyExpr.and(
-			TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
-			ConnectionContextKey.Provider.notEqualsTo('KUSTO')),
-		TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
-		TreeNodeContextKey.NodeType.isEqualTo(NodeType.Schema),
-		TreeNodeContextKey.NodeType.isEqualTo(NodeType.User),
-		TreeNodeContextKey.NodeType.isEqualTo(NodeType.UserDefinedTableType),
-		TreeNodeContextKey.NodeType.isEqualTo(NodeType.StoredProcedure),
-		TreeNodeContextKey.NodeType.isEqualTo(NodeType.AggregateFunction),
-		TreeNodeContextKey.NodeType.isEqualTo(NodeType.PartitionFunction),
-		TreeNodeContextKey.NodeType.isEqualTo(NodeType.ScalarValuedFunction),
-		TreeNodeContextKey.NodeType.isEqualTo(NodeType.TableValuedFunction))
+	when:
+		ContextKeyExpr.and(ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
+			ContextKeyExpr.or(
+				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
+				TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
+				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Schema),
+				TreeNodeContextKey.NodeType.isEqualTo(NodeType.User),
+				TreeNodeContextKey.NodeType.isEqualTo(NodeType.UserDefinedTableType),
+				TreeNodeContextKey.NodeType.isEqualTo(NodeType.StoredProcedure),
+				TreeNodeContextKey.NodeType.isEqualTo(NodeType.AggregateFunction),
+				TreeNodeContextKey.NodeType.isEqualTo(NodeType.PartitionFunction),
+				TreeNodeContextKey.NodeType.isEqualTo(NodeType.ScalarValuedFunction),
+				TreeNodeContextKey.NodeType.isEqualTo(NodeType.TableValuedFunction)
+			)
+		)
 });
 
 MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {

--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -104,7 +104,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		id: commands.OE_EDIT_DATA_COMMAND_ID,
 		title: localize('editData', "Edit Data")
 	},
-	when: ContextKeyExpr.and(TreeNodeContextKey.NodeType.isEqualTo('Table'), MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()))
+	when: ContextKeyExpr.and(TreeNodeContextKey.NodeType.isEqualTo('Table'), ConnectionContextKey.Provider.notEqualsTo('KUSTO'), MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()))
 });
 
 MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
@@ -115,7 +115,9 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		title: localize('scriptCreate', "Script as Create")
 	},
 	when: ContextKeyExpr.or(
-		TreeNodeContextKey.NodeType.isEqualTo('Table'),
+		ContextKeyExpr.and(
+			TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
+			ConnectionContextKey.Provider.notEqualsTo('KUSTO')),
 		TreeNodeContextKey.NodeType.isEqualTo('View'),
 		TreeNodeContextKey.NodeType.isEqualTo('Schema'),
 		TreeNodeContextKey.NodeType.isEqualTo('User'),
@@ -175,7 +177,9 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		title: localize('scriptDelete', "Script as Drop")
 	},
 	when: ContextKeyExpr.or(
-		TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
+		ContextKeyExpr.and(
+			TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
+			ConnectionContextKey.Provider.notEqualsTo('KUSTO')),
 		TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),
 		TreeNodeContextKey.NodeType.isEqualTo(NodeType.Schema),
 		TreeNodeContextKey.NodeType.isEqualTo(NodeType.User),

--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -115,7 +115,8 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		title: localize('scriptCreate', "Script as Create")
 	},
 	when:
-		ContextKeyExpr.and(ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
+		ContextKeyExpr.and(
+			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
 			ContextKeyExpr.or(
 				TreeNodeContextKey.NodeType.isEqualTo('Table'),
 				TreeNodeContextKey.NodeType.isEqualTo('View'),
@@ -179,7 +180,8 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		title: localize('scriptDelete', "Script as Drop")
 	},
 	when:
-		ContextKeyExpr.and(ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
+		ContextKeyExpr.and(
+			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
 			ContextKeyExpr.or(
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.Table),
 				TreeNodeContextKey.NodeType.isEqualTo(NodeType.View),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
Hides Edit Data , Script as Create and Script as drop for Kusto tables. This is short term fix, there is already an issue for proper fix: https://github.com/microsoft/azuredatastudio/issues/11735