### PR TITLE
Creates Kusto Kernel through Notebook Kernel Alias

### DIFF
--- a/extensions/kusto/package.json
+++ b/extensions/kusto/package.json
@@ -160,7 +160,6 @@
     "connectionProvider": {
       "providerId": "KUSTO",
       "displayName": "%kusto.provider.displayName%",
-      "notebookKernelAlias": "Kusto",
       "iconPath": [
         {
           "id": "kusto:cloud",

--- a/extensions/kusto/package.json
+++ b/extensions/kusto/package.json
@@ -160,6 +160,7 @@
     "connectionProvider": {
       "providerId": "KUSTO",
       "displayName": "%kusto.provider.displayName%",
+      "notebookKernelAlias": "Kusto",
       "iconPath": [
         {
           "id": "kusto:cloud",

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -5062,6 +5062,7 @@ declare module 'azdata' {
 		export interface IKernelChangedArgs {
 			oldValue: IKernel | null;
 			newValue: IKernel | null;
+			nbkernelAlias?: string
 		}
 
 		/// -------- JSON objects, and objects primarily intended not to have methods -----------

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -5062,7 +5062,6 @@ declare module 'azdata' {
 		export interface IKernelChangedArgs {
 			oldValue: IKernel | null;
 			newValue: IKernel | null;
-			nbkernelAlias?: string
 		}
 
 		/// -------- JSON objects, and objects primarily intended not to have methods -----------

--- a/src/sql/platform/capabilities/common/capabilitiesService.ts
+++ b/src/sql/platform/capabilities/common/capabilitiesService.ts
@@ -21,6 +21,7 @@ export const clientCapabilities = {
 export interface ConnectionProviderProperties {
 	providerId: string;
 	displayName: string;
+	notebookKernelAlias?: string;
 	azureResource?: string;
 	connectionOptions: azdata.ConnectionOption[];
 }

--- a/src/sql/platform/capabilities/common/capabilitiesService.ts
+++ b/src/sql/platform/capabilities/common/capabilitiesService.ts
@@ -21,7 +21,6 @@ export const clientCapabilities = {
 export interface ConnectionProviderProperties {
 	providerId: string;
 	displayName: string;
-	notebookKernelAlias?: string;
 	azureResource?: string;
 	connectionOptions: azdata.ConnectionOption[];
 }

--- a/src/sql/workbench/contrib/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/contrib/connection/common/connectionProviderExtension.ts
@@ -26,6 +26,10 @@ const ConnectionProviderContrib: IJSONSchema = {
 			type: 'string',
 			description: localize('schema.displayName', "Display Name for the provider")
 		},
+		notebookKernelAlias: {
+			type: 'string',
+			description: localize('schema.notebookKernelAlias', "Display Kernel Alias for the provider")
+		},
 		iconPath: {
 			description: localize('schema.iconPath', "Icon path for the server type"),
 			oneOf: [

--- a/src/sql/workbench/contrib/connection/common/connectionProviderExtension.ts
+++ b/src/sql/workbench/contrib/connection/common/connectionProviderExtension.ts
@@ -26,10 +26,6 @@ const ConnectionProviderContrib: IJSONSchema = {
 			type: 'string',
 			description: localize('schema.displayName', "Display Name for the provider")
 		},
-		notebookKernelAlias: {
-			type: 'string',
-			description: localize('schema.notebookKernelAlias', "Display Kernel Alias for the provider")
-		},
 		iconPath: {
 			description: localize('schema.iconPath', "Icon path for the server type"),
 			oneOf: [

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -410,7 +410,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 
 			let attachToContainer = document.createElement('li');
 			let attachToDropdown = new AttachToDropdown(attachToContainer, this.contextViewService, this.modelReady,
-				this.connectionManagementService, this.connectionDialogService, this.notificationService, this.capabilitiesService);
+				this.connectionManagementService, this.connectionDialogService, this.notificationService, this.capabilitiesService, this._configurationService);
 			attachToDropdown.render(attachToContainer);
 			attachSelectBoxStyler(attachToDropdown, this.themeService);
 
@@ -474,7 +474,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 
 			let attachToContainer = document.createElement('div');
 			let attachToDropdown = new AttachToDropdown(attachToContainer, this.contextViewService, this.modelReady,
-				this.connectionManagementService, this.connectionDialogService, this.notificationService, this.capabilitiesService);
+				this.connectionManagementService, this.connectionDialogService, this.notificationService, this.capabilitiesService, this._configurationService);
 			attachToDropdown.render(attachToContainer);
 			attachSelectBoxStyler(attachToDropdown, this.themeService);
 

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -28,7 +28,11 @@ import { find, firstIndex } from 'vs/base/common/arrays';
 import { INotebookService } from 'sql/workbench/services/notebook/browser/notebookService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { CellContext } from 'sql/workbench/contrib/notebook/browser/cellViews/codeActions';
+<<<<<<< HEAD
 import { URI } from 'vs/base/common/uri';
+=======
+
+>>>>>>> Get Kernel Alias through Capability Services
 
 const msgLoading = localize('loading', "Loading kernels...");
 export const msgChanging = localize('changing', "Changing kernel...");
@@ -271,15 +275,34 @@ export class CollapseCellsAction extends ToggleableAction {
 	}
 }
 
+<<<<<<< HEAD
 const showAllKernelsConfigName = 'notebook.showAllKernels';
 const workbenchPreviewConfigName = 'workbench.enablePreviewFeatures';
 export const noKernelName = localize('noKernel', "No Kernel");
+=======
+const ShowAllKernelsConfigName = 'notebook.showAllKernels';
+const WorkbenchPreviewConfigName = 'workbench.enablePreviewFeatures';
+
+>>>>>>> Get Kernel Alias through Capability Services
 export class KernelsDropdown extends SelectBox {
 	private model: NotebookModel;
 	private _showAllKernels: boolean = false;
-	constructor(container: HTMLElement, contextViewProvider: IContextViewProvider, modelReady: Promise<INotebookModel>, @IConfigurationService private _configurationService: IConfigurationService) {
+	constructor(container: HTMLElement, contextViewProvider: IContextViewProvider, modelReady: Promise<INotebookModel>, @IConfigurationService private _configurationService: IConfigurationService, @ICapabilitiesService private _capabilitiesService: ICapabilitiesService) {
 		super([msgLoading], msgLoading, contextViewProvider, container, { labelText: kernelLabel, labelOnTop: false, ariaLabel: kernelLabel } as ISelectBoxOptionsWithLabel);
 
+<<<<<<< HEAD
+=======
+		const providers = _capabilitiesService.providers;
+		let kernelAlias = [];
+		if (providers) {
+			for (const server in providers) {
+				if (providers[server].connection.notebookKernelAlias) {
+					kernelAlias.push(providers[server].connection.notebookKernelAlias);
+				}
+			}
+		}
+
+>>>>>>> Get Kernel Alias through Capability Services
 		if (modelReady) {
 			modelReady
 				.then((model) => this.updateModel(model))

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -282,6 +282,7 @@ export const noKernelName = localize('noKernel', "No Kernel");
 =======
 const ShowAllKernelsConfigName = 'notebook.showAllKernels';
 const WorkbenchPreviewConfigName = 'workbench.enablePreviewFeatures';
+let kernelAlias = [];
 
 >>>>>>> Get Kernel Alias through Capability Services
 export class KernelsDropdown extends SelectBox {
@@ -293,10 +294,11 @@ export class KernelsDropdown extends SelectBox {
 <<<<<<< HEAD
 =======
 		const providers = _capabilitiesService.providers;
-		let kernelAlias = [];
+
 		if (providers) {
 			for (const server in providers) {
-				if (providers[server].connection.notebookKernelAlias) {
+				let alias = providers[server].connection.notebookKernelAlias;
+				if (alias && kernelAlias.indexOf(alias) === -1) {
 					kernelAlias.push(providers[server].connection.notebookKernelAlias);
 				}
 			}
@@ -339,6 +341,11 @@ export class KernelsDropdown extends SelectBox {
 				let index;
 				if (standardKernel) {
 					index = firstIndex(kernels, kernel => kernel === standardKernel.displayName);
+					if (kernelAlias !== undefined || kernelAlias.length !== 0) {
+						for (let x in kernelAlias) {
+							kernels.splice(1, 0, kernelAlias[x]);
+						}
+					}
 				} else {
 					let kernelSpec = this.model.specs.kernels.find(k => k.name === kernel.name);
 					index = firstIndex(kernels, k => k === kernelSpec?.display_name);
@@ -368,6 +375,7 @@ export class KernelsDropdown extends SelectBox {
 
 export class AttachToDropdown extends SelectBox {
 	private model: NotebookModel;
+	private kernels: KernelsDropdown;
 
 	constructor(
 		container: HTMLElement, contextViewProvider: IContextViewProvider, modelReady: Promise<INotebookModel>,

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -271,18 +271,29 @@ export class CollapseCellsAction extends ToggleableAction {
 	}
 }
 
+<<<<<<< HEAD
 const showAllKernelsConfigName = 'notebook.showAllKernels';
 const workbenchPreviewConfigName = 'workbench.enablePreviewFeatures';
 export const noKernelName = localize('noKernel', "No Kernel");
+<<<<<<< HEAD
+=======
+const ShowAllKernelsConfigName = 'notebook.showAllKernels';
+const WorkbenchPreviewConfigName = 'workbench.enablePreviewFeatures';
 let kernelAlias = [];
 
+>>>>>>> Get Kernel Alias through Capability Services
+=======
+>>>>>>> Revert "Merge branch 'vabhog/kernel-alias-feature' into feature-AzureDataExplorer"
 export class KernelsDropdown extends SelectBox {
 	private model: NotebookModel;
 	private _showAllKernels: boolean = false;
-	constructor(container: HTMLElement, contextViewProvider: IContextViewProvider, modelReady: Promise<INotebookModel>, @IConfigurationService private _configurationService: IConfigurationService, @ICapabilitiesService private _capabilitiesService: ICapabilitiesService) {
+	constructor(container: HTMLElement, contextViewProvider: IContextViewProvider, modelReady: Promise<INotebookModel>, @IConfigurationService private _configurationService: IConfigurationService) {
 		super([msgLoading], msgLoading, contextViewProvider, container, { labelText: kernelLabel, labelOnTop: false, ariaLabel: kernelLabel } as ISelectBoxOptionsWithLabel);
 
-		const providers = this._capabilitiesService.providers;
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+		const providers = _capabilitiesService.providers;
 
 		if (providers) {
 			for (const server in providers) {
@@ -293,6 +304,9 @@ export class KernelsDropdown extends SelectBox {
 			}
 		}
 
+>>>>>>> Get Kernel Alias through Capability Services
+=======
+>>>>>>> Revert "Merge branch 'vabhog/kernel-alias-feature' into feature-AzureDataExplorer"
 		if (modelReady) {
 			modelReady
 				.then((model) => this.updateModel(model))
@@ -313,21 +327,16 @@ export class KernelsDropdown extends SelectBox {
 	updateModel(model: INotebookModel): void {
 		this.model = model as NotebookModel;
 		this._register(this.model.kernelChanged((changedArgs: azdata.nb.IKernelChangedArgs) => {
-			this.updateKernel(changedArgs.newValue, changedArgs.nbkernelAlias);
+			this.updateKernel(changedArgs.newValue);
 		}));
 		let kernel = this.model.clientSession && this.model.clientSession.kernel;
 		this.updateKernel(kernel);
 	}
 
 	// Update SelectBox values
-	public updateKernel(kernel: azdata.nb.IKernel, nbkernelAlias?: string) {
+	public updateKernel(kernel: azdata.nb.IKernel) {
 		let kernels: string[] = this._showAllKernels ? [...new Set(this.model.specs.kernels.map(a => a.display_name).concat(this.model.standardKernelsDisplayName()))]
 			: this.model.standardKernelsDisplayName();
-		if (kernelAlias !== undefined && kernelAlias.length !== 0) {
-			for (let x in kernelAlias) {
-				kernels.splice(1, 0, kernelAlias[x]);
-			}
-		}
 		if (kernel && kernel.isReady) {
 			let standardKernel = this.model.getStandardKernelFromName(kernel.name);
 			if (kernels) {
@@ -337,9 +346,6 @@ export class KernelsDropdown extends SelectBox {
 				} else {
 					let kernelSpec = this.model.specs.kernels.find(k => k.name === kernel.name);
 					index = firstIndex(kernels, k => k === kernelSpec?.display_name);
-				}
-				if (nbkernelAlias) {
-					index = kernels.indexOf(nbkernelAlias);
 				}
 				// This is an error case that should never happen
 				// Just in case, setting index to 0
@@ -356,7 +362,7 @@ export class KernelsDropdown extends SelectBox {
 
 	public doChangeKernel(displayName: string): void {
 		this.setOptions([msgChanging], 0);
-		this.model.changeKernel(displayName, undefined, kernelAlias);
+		this.model.changeKernel(displayName);
 	}
 
 	private getAllKernelConfigValue(): void {

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -325,14 +325,14 @@ export class KernelsDropdown extends SelectBox {
 	updateModel(model: INotebookModel): void {
 		this.model = model as NotebookModel;
 		this._register(this.model.kernelChanged((changedArgs: azdata.nb.IKernelChangedArgs) => {
-			this.updateKernel(changedArgs.newValue);
+			this.updateKernel(changedArgs.newValue, changedArgs.nbkernelAlias);
 		}));
 		let kernel = this.model.clientSession && this.model.clientSession.kernel;
 		this.updateKernel(kernel);
 	}
 
 	// Update SelectBox values
-	public updateKernel(kernel: azdata.nb.IKernel) {
+	public updateKernel(kernel: azdata.nb.IKernel, nbkernelAlias?: string) {
 		let kernels: string[] = this._showAllKernels ? [...new Set(this.model.specs.kernels.map(a => a.display_name).concat(this.model.standardKernelsDisplayName()))]
 			: this.model.standardKernelsDisplayName();
 		if (kernelAlias !== undefined && kernelAlias.length !== 0) {
@@ -349,6 +349,9 @@ export class KernelsDropdown extends SelectBox {
 				} else {
 					let kernelSpec = this.model.specs.kernels.find(k => k.name === kernel.name);
 					index = firstIndex(kernels, k => k === kernelSpec?.display_name);
+				}
+				if (nbkernelAlias) {
+					index = kernels.indexOf(nbkernelAlias);
 				}
 				// This is an error case that should never happen
 				// Just in case, setting index to 0

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -335,17 +335,17 @@ export class KernelsDropdown extends SelectBox {
 	public updateKernel(kernel: azdata.nb.IKernel) {
 		let kernels: string[] = this._showAllKernels ? [...new Set(this.model.specs.kernels.map(a => a.display_name).concat(this.model.standardKernelsDisplayName()))]
 			: this.model.standardKernelsDisplayName();
+		if (kernelAlias !== undefined && kernelAlias.length !== 0) {
+			for (let x in kernelAlias) {
+				kernels.splice(1, 0, kernelAlias[x]);
+			}
+		}
 		if (kernel && kernel.isReady) {
 			let standardKernel = this.model.getStandardKernelFromName(kernel.name);
 			if (kernels) {
 				let index;
 				if (standardKernel) {
 					index = firstIndex(kernels, kernel => kernel === standardKernel.displayName);
-					if (kernelAlias !== undefined || kernelAlias.length !== 0) {
-						for (let x in kernelAlias) {
-							kernels.splice(1, 0, kernelAlias[x]);
-						}
-					}
 				} else {
 					let kernelSpec = this.model.specs.kernels.find(k => k.name === kernel.name);
 					index = firstIndex(kernels, k => k === kernelSpec?.display_name);
@@ -365,7 +365,7 @@ export class KernelsDropdown extends SelectBox {
 
 	public doChangeKernel(displayName: string): void {
 		this.setOptions([msgChanging], 0);
-		this.model.changeKernel(displayName);
+		this.model.changeKernel(displayName, undefined, kernelAlias);
 	}
 
 	private getAllKernelConfigValue(): void {

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -28,11 +28,7 @@ import { find, firstIndex } from 'vs/base/common/arrays';
 import { INotebookService } from 'sql/workbench/services/notebook/browser/notebookService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { CellContext } from 'sql/workbench/contrib/notebook/browser/cellViews/codeActions';
-<<<<<<< HEAD
 import { URI } from 'vs/base/common/uri';
-=======
-
->>>>>>> Get Kernel Alias through Capability Services
 
 const msgLoading = localize('loading', "Loading kernels...");
 export const msgChanging = localize('changing', "Changing kernel...");
@@ -279,18 +275,22 @@ export class CollapseCellsAction extends ToggleableAction {
 const showAllKernelsConfigName = 'notebook.showAllKernels';
 const workbenchPreviewConfigName = 'workbench.enablePreviewFeatures';
 export const noKernelName = localize('noKernel', "No Kernel");
+<<<<<<< HEAD
 =======
 const ShowAllKernelsConfigName = 'notebook.showAllKernels';
 const WorkbenchPreviewConfigName = 'workbench.enablePreviewFeatures';
 let kernelAlias = [];
 
 >>>>>>> Get Kernel Alias through Capability Services
+=======
+>>>>>>> Revert "Merge branch 'vabhog/kernel-alias-feature' into feature-AzureDataExplorer"
 export class KernelsDropdown extends SelectBox {
 	private model: NotebookModel;
 	private _showAllKernels: boolean = false;
-	constructor(container: HTMLElement, contextViewProvider: IContextViewProvider, modelReady: Promise<INotebookModel>, @IConfigurationService private _configurationService: IConfigurationService, @ICapabilitiesService private _capabilitiesService: ICapabilitiesService) {
+	constructor(container: HTMLElement, contextViewProvider: IContextViewProvider, modelReady: Promise<INotebookModel>, @IConfigurationService private _configurationService: IConfigurationService) {
 		super([msgLoading], msgLoading, contextViewProvider, container, { labelText: kernelLabel, labelOnTop: false, ariaLabel: kernelLabel } as ISelectBoxOptionsWithLabel);
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 =======
 		const providers = _capabilitiesService.providers;
@@ -305,6 +305,8 @@ export class KernelsDropdown extends SelectBox {
 		}
 
 >>>>>>> Get Kernel Alias through Capability Services
+=======
+>>>>>>> Revert "Merge branch 'vabhog/kernel-alias-feature' into feature-AzureDataExplorer"
 		if (modelReady) {
 			modelReady
 				.then((model) => this.updateModel(model))
@@ -325,21 +327,16 @@ export class KernelsDropdown extends SelectBox {
 	updateModel(model: INotebookModel): void {
 		this.model = model as NotebookModel;
 		this._register(this.model.kernelChanged((changedArgs: azdata.nb.IKernelChangedArgs) => {
-			this.updateKernel(changedArgs.newValue, changedArgs.nbkernelAlias);
+			this.updateKernel(changedArgs.newValue);
 		}));
 		let kernel = this.model.clientSession && this.model.clientSession.kernel;
 		this.updateKernel(kernel);
 	}
 
 	// Update SelectBox values
-	public updateKernel(kernel: azdata.nb.IKernel, nbkernelAlias?: string) {
+	public updateKernel(kernel: azdata.nb.IKernel) {
 		let kernels: string[] = this._showAllKernels ? [...new Set(this.model.specs.kernels.map(a => a.display_name).concat(this.model.standardKernelsDisplayName()))]
 			: this.model.standardKernelsDisplayName();
-		if (kernelAlias !== undefined && kernelAlias.length !== 0) {
-			for (let x in kernelAlias) {
-				kernels.splice(1, 0, kernelAlias[x]);
-			}
-		}
 		if (kernel && kernel.isReady) {
 			let standardKernel = this.model.getStandardKernelFromName(kernel.name);
 			if (kernels) {
@@ -349,9 +346,6 @@ export class KernelsDropdown extends SelectBox {
 				} else {
 					let kernelSpec = this.model.specs.kernels.find(k => k.name === kernel.name);
 					index = firstIndex(kernels, k => k === kernelSpec?.display_name);
-				}
-				if (nbkernelAlias) {
-					index = kernels.indexOf(nbkernelAlias);
 				}
 				// This is an error case that should never happen
 				// Just in case, setting index to 0
@@ -368,7 +362,7 @@ export class KernelsDropdown extends SelectBox {
 
 	public doChangeKernel(displayName: string): void {
 		this.setOptions([msgChanging], 0);
-		this.model.changeKernel(displayName, undefined, kernelAlias);
+		this.model.changeKernel(displayName);
 	}
 
 	private getAllKernelConfigValue(): void {
@@ -378,7 +372,6 @@ export class KernelsDropdown extends SelectBox {
 
 export class AttachToDropdown extends SelectBox {
 	private model: NotebookModel;
-	private kernels: KernelsDropdown;
 
 	constructor(
 		container: HTMLElement, contextViewProvider: IContextViewProvider, modelReady: Promise<INotebookModel>,

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookActions.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookActions.test.ts
@@ -24,6 +24,7 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 import { workbenchInstantiationService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { URI } from 'vs/base/common/uri';
+import { TestCapabilitiesService } from 'sql/platform/capabilities/test/common/testCapabilitiesService';
 
 class TestClientSession extends ClientSessionStub {
 	private _errorState: boolean = false;
@@ -263,6 +264,7 @@ suite('Notebook Actions', function (): void {
 		let container: HTMLElement;
 		let notebookModel: TestNotebookModel;
 		let configurationService: TestConfigurationService;
+		let capabilitiesService: TestCapabilitiesService;
 		let notebookEditor: NotebookEditorStub;
 		let sandbox: sinon.SinonSandbox;
 		let setOptionsSpy: sinon.SinonSpy;
@@ -277,7 +279,7 @@ suite('Notebook Actions', function (): void {
 			notebookModel = new TestNotebookModel();
 			notebookEditor = new NotebookEditorStub({ model: notebookModel });
 			await notebookEditor.modelReady;
-			kernelsDropdown = new KernelsDropdown(container, contextViewProvider, notebookEditor.modelReady, configurationService);
+			kernelsDropdown = new KernelsDropdown(container, contextViewProvider, notebookEditor.modelReady, configurationService, capabilitiesService);
 			setOptionsSpy = sandbox.spy(kernelsDropdown, 'setOptions');
 		});
 

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -514,7 +514,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		this._onErrorEmitter.fire({ message: error, severity: Severity.Error });
 	}
 
-	public async startSession(manager: INotebookManager, displayName?: string, setErrorStateOnFail?: boolean, kernelAlias?: string): Promise<void> {
+	public async startSession(manager: INotebookManager, displayName?: string, setErrorStateOnFail?: boolean): Promise<void> {
 		if (displayName && this._standardKernels) {
 			let standardKernel = find(this._standardKernels, kernel => kernel.displayName === displayName);
 			if (standardKernel) {
@@ -552,7 +552,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			await clientSession.ready;
 			if (clientSession.kernel) {
 				await clientSession.kernel.ready;
-				await this.updateKernelInfoOnKernelChange(clientSession.kernel, kernelAlias);
+				await this.updateKernelInfoOnKernelChange(clientSession.kernel);
 			}
 			if (clientSession.isInErrorState) {
 				if (setErrorStateOnFail) {
@@ -688,26 +688,21 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		this._language = language.toLowerCase();
 	}
 
-	public changeKernel(displayName: string, oldKernel?: nb.IKernel, kernelAlias?: string[]): void {
+	public changeKernel(displayName: string): void {
 		this._contextsLoadingEmitter.fire();
-		this.doChangeKernel(displayName, kernelAlias, true).catch(e => this.logService.error(e));
+		this.doChangeKernel(displayName, true).catch(e => this.logService.error(e));
 	}
 
-	private async doChangeKernel(displayName: string, kernelAlias?: string[], mustSetProvider: boolean = true, restoreOnFail: boolean = true): Promise<void> {
+	private async doChangeKernel(displayName: string, mustSetProvider: boolean = true, restoreOnFail: boolean = true): Promise<void> {
 		if (!displayName) {
 			// Can't change to an undefined kernel
 			return;
 		}
 		let oldDisplayName = this._activeClientSession && this._activeClientSession.kernel ? this._activeClientSession.kernel.name : undefined;
-		let nbKernelAlias: string;
-		if (kernelAlias[0] === displayName) {
-			displayName = 'SQL';
-			nbKernelAlias = 'Kusto';
-		}
 		try {
 			let changeKernelNeeded = true;
 			if (mustSetProvider) {
-				let providerChanged = await this.tryStartSessionByChangingProviders(displayName, nbKernelAlias);
+				let providerChanged = await this.tryStartSessionByChangingProviders(displayName);
 				// If provider was changed, a new session with new kernel is already created. We can skip calling changeKernel.
 				changeKernelNeeded = !providerChanged;
 			}
@@ -717,7 +712,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					let kernel = await this._activeClientSession.changeKernel(spec, this._oldKernel);
 					try {
 						await kernel.ready;
-						await this.updateKernelInfoOnKernelChange(kernel, nbKernelAlias);
+						await this.updateKernelInfoOnKernelChange(kernel);
 					} catch (err2) {
 						// TODO should we handle this in any way?
 						this.logService.error(`doChangeKernel: ignoring error ${getErrorMessage(err2)}`);
@@ -735,7 +730,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					// we would never reset the providers
 					this._oldKernel = undefined;
 				}
-				return this.doChangeKernel(oldDisplayName, kernelAlias, mustSetProvider, false);
+				return this.doChangeKernel(oldDisplayName, mustSetProvider, false);
 			} else {
 				this.notifyError(localize('changeKernelFailed', "Failed to change kernel due to error: {0}", getErrorMessage(err)));
 				this._kernelChangedEmitter.fire({
@@ -747,15 +742,14 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		// Else no need to do anything
 	}
 
-	private async updateKernelInfoOnKernelChange(kernel: nb.IKernel, kernelAlias?: string) {
+	private async updateKernelInfoOnKernelChange(kernel: nb.IKernel) {
 		await this.updateKernelInfo(kernel);
 		if (kernel.info) {
 			this.updateLanguageInfo(kernel.info.language_info);
 		}
 		this._kernelChangedEmitter.fire({
 			newValue: kernel,
-			oldValue: undefined,
-			nbkernelAlias: kernelAlias
+			oldValue: undefined
 		});
 	}
 
@@ -934,7 +928,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	 * Set _providerId and start session if it is new provider
 	 * @param displayName Kernel dispay name
 	 */
-	private async tryStartSessionByChangingProviders(displayName: string, kernelAlias?: string): Promise<boolean> {
+	private async tryStartSessionByChangingProviders(displayName: string): Promise<boolean> {
 		if (displayName) {
 			if (this._activeClientSession && this._activeClientSession.isReady) {
 				this._oldKernel = this._activeClientSession.kernel;
@@ -948,7 +942,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				await this.shutdownActiveSession();
 				let manager = this.getNotebookManager(providerId);
 				if (manager) {
-					await this.startSession(manager, displayName, false, kernelAlias);
+					await this.startSession(manager, displayName, false);
 				} else {
 					throw new Error(localize('ProviderNoManager', "Can't find notebook manager for provider {0}", providerId));
 				}

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -514,7 +514,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		this._onErrorEmitter.fire({ message: error, severity: Severity.Error });
 	}
 
-	public async startSession(manager: INotebookManager, displayName?: string, setErrorStateOnFail?: boolean): Promise<void> {
+	public async startSession(manager: INotebookManager, displayName?: string, setErrorStateOnFail?: boolean, kernelAlias?: string): Promise<void> {
 		if (displayName && this._standardKernels) {
 			let standardKernel = find(this._standardKernels, kernel => kernel.displayName === displayName);
 			if (standardKernel) {
@@ -552,7 +552,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			await clientSession.ready;
 			if (clientSession.kernel) {
 				await clientSession.kernel.ready;
-				await this.updateKernelInfoOnKernelChange(clientSession.kernel);
+				await this.updateKernelInfoOnKernelChange(clientSession.kernel, kernelAlias);
 			}
 			if (clientSession.isInErrorState) {
 				if (setErrorStateOnFail) {
@@ -688,21 +688,26 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		this._language = language.toLowerCase();
 	}
 
-	public changeKernel(displayName: string): void {
+	public changeKernel(displayName: string, oldKernel?: nb.IKernel, kernelAlias?: string[]): void {
 		this._contextsLoadingEmitter.fire();
-		this.doChangeKernel(displayName, true).catch(e => this.logService.error(e));
+		this.doChangeKernel(displayName, kernelAlias, true).catch(e => this.logService.error(e));
 	}
 
-	private async doChangeKernel(displayName: string, mustSetProvider: boolean = true, restoreOnFail: boolean = true): Promise<void> {
+	private async doChangeKernel(displayName: string, kernelAlias?: string[], mustSetProvider: boolean = true, restoreOnFail: boolean = true): Promise<void> {
 		if (!displayName) {
 			// Can't change to an undefined kernel
 			return;
 		}
 		let oldDisplayName = this._activeClientSession && this._activeClientSession.kernel ? this._activeClientSession.kernel.name : undefined;
+		let nbKernelAlias: string;
+		if (kernelAlias[0] === displayName) {
+			displayName = 'SQL';
+			nbKernelAlias = 'Kusto';
+		}
 		try {
 			let changeKernelNeeded = true;
 			if (mustSetProvider) {
-				let providerChanged = await this.tryStartSessionByChangingProviders(displayName);
+				let providerChanged = await this.tryStartSessionByChangingProviders(displayName, nbKernelAlias);
 				// If provider was changed, a new session with new kernel is already created. We can skip calling changeKernel.
 				changeKernelNeeded = !providerChanged;
 			}
@@ -712,7 +717,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					let kernel = await this._activeClientSession.changeKernel(spec, this._oldKernel);
 					try {
 						await kernel.ready;
-						await this.updateKernelInfoOnKernelChange(kernel);
+						await this.updateKernelInfoOnKernelChange(kernel, nbKernelAlias);
 					} catch (err2) {
 						// TODO should we handle this in any way?
 						this.logService.error(`doChangeKernel: ignoring error ${getErrorMessage(err2)}`);
@@ -730,7 +735,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					// we would never reset the providers
 					this._oldKernel = undefined;
 				}
-				return this.doChangeKernel(oldDisplayName, mustSetProvider, false);
+				return this.doChangeKernel(oldDisplayName, kernelAlias, mustSetProvider, false);
 			} else {
 				this.notifyError(localize('changeKernelFailed', "Failed to change kernel due to error: {0}", getErrorMessage(err)));
 				this._kernelChangedEmitter.fire({
@@ -742,14 +747,15 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		// Else no need to do anything
 	}
 
-	private async updateKernelInfoOnKernelChange(kernel: nb.IKernel) {
+	private async updateKernelInfoOnKernelChange(kernel: nb.IKernel, kernelAlias?: string) {
 		await this.updateKernelInfo(kernel);
 		if (kernel.info) {
 			this.updateLanguageInfo(kernel.info.language_info);
 		}
 		this._kernelChangedEmitter.fire({
 			newValue: kernel,
-			oldValue: undefined
+			oldValue: undefined,
+			nbkernelAlias: kernelAlias
 		});
 	}
 
@@ -928,7 +934,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	 * Set _providerId and start session if it is new provider
 	 * @param displayName Kernel dispay name
 	 */
-	private async tryStartSessionByChangingProviders(displayName: string): Promise<boolean> {
+	private async tryStartSessionByChangingProviders(displayName: string, kernelAlias?: string): Promise<boolean> {
 		if (displayName) {
 			if (this._activeClientSession && this._activeClientSession.isReady) {
 				this._oldKernel = this._activeClientSession.kernel;
@@ -942,7 +948,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				await this.shutdownActiveSession();
 				let manager = this.getNotebookManager(providerId);
 				if (manager) {
-					await this.startSession(manager, displayName, false);
+					await this.startSession(manager, displayName, false, kernelAlias);
 				} else {
 					throw new Error(localize('ProviderNoManager', "Can't find notebook manager for provider {0}", providerId));
 				}

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -700,7 +700,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		}
 		let oldDisplayName = this._activeClientSession && this._activeClientSession.kernel ? this._activeClientSession.kernel.name : undefined;
 		let nbKernelAlias: string;
-		if (kernelAlias[0] === displayName) {
+		if (kernelAlias.includes(displayName)) {
 			displayName = 'SQL';
 			nbKernelAlias = 'Kusto';
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR creates a new experience for the Kusto kernel.

- The Kusto kernel will be displayed in the dropdown menu when the Kusto extension is installed. 
- The user will be able to switch from any kernel to Kusto and vice versa. 
- When the user uses the "Attach To" in Notebooks to connect to a Kusto connection the kernel will be changed to Kusto and when they switch to any other connection (MSSQL for example) it will switch back to SQL.

