### PR TITLE
Add some package management unit tests for JupyterServerInstallation

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -788,11 +788,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		return this._usingConda;
 	}
 
-	public isCondaInstalled(): boolean {
-		if (!this._usingExistingPython) {
-			return false;
-		}
-
+	private isCondaInstalled(): boolean {
 		let condaExePath = this.getCondaExePath();
 		// eslint-disable-next-line no-sync
 		return fs.existsSync(condaExePath);

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -670,11 +670,14 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 
 			let cmd = `"${pythonExePath ?? this.pythonExecutable}" -m pip list --format=json`;
 			let packagesInfo = await this.executeBufferedCommand(cmd);
-			let packagesResult: PythonPkgDetails[] = [];
+			let packages: PythonPkgDetails[] = [];
 			if (packagesInfo) {
-				packagesResult = <PythonPkgDetails[]>JSON.parse(packagesInfo);
+				let parsedResult = <PythonPkgDetails[]>JSON.parse(packagesInfo);
+				if (parsedResult) {
+					packages = parsedResult;
+				}
 			}
-			return packagesResult;
+			return packages;
 		}
 		catch (err) {
 			this.outputChannel.appendLine(msgPackageRetrievalFailed(utils.getErrorMessage(err)));
@@ -716,15 +719,14 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 			let cmd = `"${condaExe}" list --json`;
 			let packagesInfo = await this.executeBufferedCommand(cmd);
 
+			let packages: PythonPkgDetails[] = [];
 			if (packagesInfo) {
-				let packagesResult = JSON.parse(packagesInfo);
-				if (Array.isArray(packagesResult)) {
-					return packagesResult
-						.filter(pkg => pkg && pkg.channel && pkg.channel !== 'pypi')
-						.map(pkg => <PythonPkgDetails>{ name: pkg.name, version: pkg.version });
+				let parsedResult = <PythonPkgDetails[]>JSON.parse(packagesInfo);
+				if (parsedResult) {
+					packages = parsedResult.filter(pkg => pkg && pkg.channel && pkg.channel !== 'pypi');
 				}
 			}
-			return [];
+			return packages;
 		}
 		catch (err) {
 			this.outputChannel.appendLine(msgPackageRetrievalFailed(utils.getErrorMessage(err)));
@@ -786,7 +788,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		return this._usingConda;
 	}
 
-	private isCondaInstalled(): boolean {
+	public isCondaInstalled(): boolean {
 		if (!this._usingExistingPython) {
 			return false;
 		}
@@ -886,6 +888,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 export interface PythonPkgDetails {
 	name: string;
 	version: string;
+	channel?: string;
 }
 
 export interface PipPackageOverview {

--- a/extensions/notebook/src/test/python/configurePython.test.ts
+++ b/extensions/notebook/src/test/python/configurePython.test.ts
@@ -5,13 +5,13 @@
 
 import * as azdata from 'azdata';
 import * as TypeMoq from 'typemoq';
-import { ConfigurePythonWizard, ConfigurePythonModel } from '../dialog/configurePython/configurePythonWizard';
-import { JupyterServerInstallation } from '../jupyter/jupyterServerInstallation';
-import { ConfigurePathPage } from '../dialog/configurePython/configurePathPage';
+import { ConfigurePythonWizard, ConfigurePythonModel } from '../../dialog/configurePython/configurePythonWizard';
+import { JupyterServerInstallation } from '../../jupyter/jupyterServerInstallation';
+import { ConfigurePathPage } from '../../dialog/configurePython/configurePathPage';
 import * as should from 'should';
-import { PickPackagesPage } from '../dialog/configurePython/pickPackagesPage';
-import { python3DisplayName, allKernelsName } from '../common/constants';
-import { TestContext, createViewContext, TestButton } from './common';
+import { PickPackagesPage } from '../../dialog/configurePython/pickPackagesPage';
+import { python3DisplayName, allKernelsName } from '../../common/constants';
+import { TestContext, createViewContext, TestButton } from '../common';
 import { EventEmitter } from 'vscode';
 
 describe('Configure Python Wizard', function () {

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as should from 'should';
+import * as sinon from 'sinon';
+import * as TypeMoq from 'typemoq';
+import { JupyterServerInstallation } from '../../jupyter/jupyterServerInstallation';
+
+describe('Jupyter Server Installation', function () {
+	const outputChannelStub = TypeMoq.Mock.ofType<vscode.OutputChannel>();
+	outputChannelStub.setup(c => c.show(TypeMoq.It.isAny()));
+	outputChannelStub.setup(c => c.appendLine(TypeMoq.It.isAnyString()));
+
+	let installation: JupyterServerInstallation;
+
+	beforeEach(function (): void {
+		installation = new JupyterServerInstallation('', outputChannelStub.object);
+	});
+
+	afterEach(function (): void {
+		sinon.restore();
+	});
+
+	it('Get pip packages', async function() {
+
+	});
+
+	it('Install pip package', async function() {
+
+	});
+
+	it('Get conda packages', async function() {
+
+	});
+
+	it('Install conda package', async function() {
+		should(true);
+	});
+});

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -93,6 +93,22 @@ describe('Jupyter Server Installation', function () {
 		should(commandStr.includes('"TestPkg1>=1.2.3" "TestPkg2>=4.5.6"')).be.true();
 	});
 
+	it('Uninstall pip package', async function() {
+		let commandStub = sinon.stub(installation, 'executeStreamedCommand').resolves();
+
+		let testPackages = [{
+			name: 'jupyter',
+			version: '1.0.0'
+		}, {
+			name: 'TestPkg2',
+			version: '4.5.6'
+		}];
+		await should(installation.uninstallPipPackages(testPackages)).be.resolved();
+		should(commandStub.calledOnce).be.true();
+		let commandStr = commandStub.args[0][0] as string;
+		should(commandStr.includes('"jupyter==1.0.0" "TestPkg2==4.5.6"')).be.true();
+	});
+
 	it('Get conda packages', async function() {
 		// Should return nothing if conda is not installed
 		sinon.stub(installation, 'isCondaInstalled').returns(false);
@@ -159,5 +175,21 @@ describe('Jupyter Server Installation', function () {
 		should(commandStub.calledTwice).be.true();
 		commandStr = commandStub.args[1][0] as string;
 		should(commandStr.includes('"TestPkg1>=1.2.3" "TestPkg2>=4.5.6"')).be.true();
+	});
+
+	it('Uninstall conda package', async function() {
+		let commandStub = sinon.stub(installation, 'executeStreamedCommand').resolves();
+
+		let testPackages = [{
+			name: 'jupyter',
+			version: '1.0.0'
+		}, {
+			name: 'TestPkg2',
+			version: '4.5.6'
+		}];
+		await should(installation.uninstallCondaPackages(testPackages)).be.resolved();
+		should(commandStub.calledOnce).be.true();
+		let commandStr = commandStub.args[0][0] as string;
+		should(commandStr.includes('"jupyter==1.0.0" "TestPkg2==4.5.6"')).be.true();
 	});
 });

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -8,7 +8,7 @@ import * as should from 'should';
 import * as sinon from 'sinon';
 import * as TypeMoq from 'typemoq';
 import { JupyterServerInstallation, PythonPkgDetails } from '../../jupyter/jupyterServerInstallation';
-import uuid = require('uuid');
+import * as uuid from 'uuid';
 
 describe('Jupyter Server Installation', function () {
 	let outputChannelStub: TypeMoq.IMock<vscode.OutputChannel>;
@@ -28,7 +28,7 @@ describe('Jupyter Server Installation', function () {
 
 	it('Get pip packages', async function() {
 		// Should return nothing if passed an invalid python path
-		let fakePath = uuid.v4().replace('-', '');
+		let fakePath = uuid.v4();
 		let pkgResult = await installation.getInstalledPipPackages(fakePath);
 		should(pkgResult).not.be.undefined();
 		should(pkgResult.length).be.equal(0);
@@ -40,6 +40,7 @@ describe('Jupyter Server Installation', function () {
 		should(pkgResult.length).be.equal(0);
 
 		// Should return nothing on error
+		sinon.restore();
 		sinon.stub(JupyterServerInstallation, 'isPythonInstalled').returns(true);
 		sinon.stub(installation, 'executeBufferedCommand').rejects(new Error('Expected test failure.'));
 		pkgResult = await installation.getInstalledPipPackages();
@@ -48,6 +49,7 @@ describe('Jupyter Server Installation', function () {
 		outputChannelStub.verify(c => c.appendLine(TypeMoq.It.isAnyString()), TypeMoq.Times.once());
 
 		// Normal use case
+		sinon.restore();
 		let testPackages: PythonPkgDetails[] = [{
 			name: 'TestPkg1',
 			version: '1.2.3'
@@ -55,6 +57,7 @@ describe('Jupyter Server Installation', function () {
 			name: 'TestPkg2',
 			version: '4.5.6'
 		}];
+		sinon.stub(JupyterServerInstallation, 'isPythonInstalled').returns(true);
 		sinon.stub(installation, 'executeBufferedCommand').returns(Promise.resolve(JSON.stringify(testPackages)));
 		pkgResult = await installation.getInstalledPipPackages();
 		should(pkgResult).be.deepEqual(testPackages);

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -68,7 +68,41 @@ describe('Jupyter Server Installation', function () {
 	});
 
 	it('Get conda packages', async function() {
+		// Should return nothing if conda is not installed
+		sinon.stub(installation, 'isCondaInstalled').returns(false);
+		let pkgResult = await installation.getInstalledCondaPackages();
+		should(pkgResult).not.be.undefined();
+		should(pkgResult.length).be.equal(0);
 
+		// Should return nothing on error
+		sinon.restore();
+		sinon.stub(installation, 'isCondaInstalled').returns(true);
+		sinon.stub(installation, 'executeBufferedCommand').rejects(new Error('Expected test failure.'));
+		pkgResult = await installation.getInstalledCondaPackages();
+		should(pkgResult).not.be.undefined();
+		should(pkgResult.length).be.equal(0);
+		outputChannelStub.verify(c => c.appendLine(TypeMoq.It.isAnyString()), TypeMoq.Times.once());
+
+		// Normal use case
+		sinon.restore();
+		let testPackages: PythonPkgDetails[] = [{
+			name: 'TestPkg1',
+			version: '1.2.3',
+			channel: 'conda'
+		}, {
+			name: 'TestPkg2',
+			version: '4.5.6',
+			channel: 'pypi'
+		}, {
+			name: 'TestPkg3',
+			version: '7.8.9',
+			channel: 'conda'
+		}];
+		sinon.stub(installation, 'isCondaInstalled').returns(true);
+		sinon.stub(installation, 'executeBufferedCommand').returns(Promise.resolve(JSON.stringify(testPackages)));
+		pkgResult = await installation.getInstalledCondaPackages();
+		let filteredPackages = testPackages.filter(pkg => pkg.channel !== 'pypi');
+		should(pkgResult).be.deepEqual(filteredPackages);
 	});
 
 	it('Install conda package', async function() {

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -7,16 +7,18 @@ import * as vscode from 'vscode';
 import * as should from 'should';
 import * as sinon from 'sinon';
 import * as TypeMoq from 'typemoq';
-import { JupyterServerInstallation } from '../../jupyter/jupyterServerInstallation';
+import { JupyterServerInstallation, PythonPkgDetails } from '../../jupyter/jupyterServerInstallation';
+import uuid = require('uuid');
 
 describe('Jupyter Server Installation', function () {
-	const outputChannelStub = TypeMoq.Mock.ofType<vscode.OutputChannel>();
-	outputChannelStub.setup(c => c.show(TypeMoq.It.isAny()));
-	outputChannelStub.setup(c => c.appendLine(TypeMoq.It.isAnyString()));
-
+	let outputChannelStub: TypeMoq.IMock<vscode.OutputChannel>;
 	let installation: JupyterServerInstallation;
 
 	beforeEach(function (): void {
+		outputChannelStub = TypeMoq.Mock.ofType<vscode.OutputChannel>();
+		outputChannelStub.setup(c => c.show(TypeMoq.It.isAny()));
+		outputChannelStub.setup(c => c.appendLine(TypeMoq.It.isAnyString()));
+
 		installation = new JupyterServerInstallation('', outputChannelStub.object);
 	});
 
@@ -25,7 +27,37 @@ describe('Jupyter Server Installation', function () {
 	});
 
 	it('Get pip packages', async function() {
+		// Should return nothing if passed an invalid python path
+		let fakePath = uuid.v4().replace('-', '');
+		let pkgResult = await installation.getInstalledPipPackages(fakePath);
+		should(pkgResult).not.be.undefined();
+		should(pkgResult.length).be.equal(0);
 
+		// Should return nothing if python is not installed
+		sinon.stub(JupyterServerInstallation, 'isPythonInstalled').returns(false);
+		pkgResult = await installation.getInstalledPipPackages();
+		should(pkgResult).not.be.undefined();
+		should(pkgResult.length).be.equal(0);
+
+		// Should return nothing on error
+		sinon.stub(JupyterServerInstallation, 'isPythonInstalled').returns(true);
+		sinon.stub(installation, 'executeBufferedCommand').rejects(new Error('Expected test failure.'));
+		pkgResult = await installation.getInstalledPipPackages();
+		should(pkgResult).not.be.undefined();
+		should(pkgResult.length).be.equal(0);
+		outputChannelStub.verify(c => c.appendLine(TypeMoq.It.isAnyString()), TypeMoq.Times.once());
+
+		// Normal use case
+		let testPackages: PythonPkgDetails[] = [{
+			name: 'TestPkg1',
+			version: '1.2.3'
+		}, {
+			name: 'TestPkg2',
+			version: '4.5.6'
+		}];
+		sinon.stub(installation, 'executeBufferedCommand').returns(Promise.resolve(JSON.stringify(testPackages)));
+		pkgResult = await installation.getInstalledPipPackages();
+		should(pkgResult).be.deepEqual(testPackages);
 	});
 
 	it('Install pip package', async function() {

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -9,6 +9,7 @@ import * as sinon from 'sinon';
 import * as TypeMoq from 'typemoq';
 import { JupyterServerInstallation, PythonPkgDetails } from '../../jupyter/jupyterServerInstallation';
 import * as uuid from 'uuid';
+import { Type } from 'js-yaml';
 
 describe('Jupyter Server Installation', function () {
 	let outputChannelStub: TypeMoq.IMock<vscode.OutputChannel>;
@@ -58,7 +59,7 @@ describe('Jupyter Server Installation', function () {
 			version: '4.5.6'
 		}];
 		sinon.stub(JupyterServerInstallation, 'isPythonInstalled').returns(true);
-		sinon.stub(installation, 'executeBufferedCommand').returns(Promise.resolve(JSON.stringify(testPackages)));
+		sinon.stub(installation, 'executeBufferedCommand').resolves(JSON.stringify(testPackages));
 		pkgResult = await installation.getInstalledPipPackages();
 		should(pkgResult).be.deepEqual(testPackages);
 	});
@@ -99,7 +100,7 @@ describe('Jupyter Server Installation', function () {
 			channel: 'conda'
 		}];
 		sinon.stub(installation, 'isCondaInstalled').returns(true);
-		sinon.stub(installation, 'executeBufferedCommand').returns(Promise.resolve(JSON.stringify(testPackages)));
+		sinon.stub(installation, 'executeBufferedCommand').resolves(JSON.stringify(testPackages));
 		pkgResult = await installation.getInstalledCondaPackages();
 		let filteredPackages = testPackages.filter(pkg => pkg.channel !== 'pypi');
 		should(pkgResult).be.deepEqual(filteredPackages);

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -132,6 +132,32 @@ describe('Jupyter Server Installation', function () {
 	});
 
 	it('Install conda package', async function() {
-		should(true);
+		let commandStub = sinon.stub(installation, 'executeStreamedCommand').resolves();
+
+		// Should not execute any commands when passed an empty package list
+		await should(installation.installCondaPackages(undefined, false)).be.resolved();
+		should(commandStub.called).be.false();
+
+		await should(installation.installCondaPackages([], false)).be.resolved();
+		should(commandStub.called).be.false();
+
+		// Install package using exact version
+		let testPackages = [{
+			name: 'TestPkg1',
+			version: '1.2.3'
+		}, {
+			name: 'TestPkg2',
+			version: '4.5.6'
+		}];
+		await should(installation.installCondaPackages(testPackages, false)).be.resolved();
+		should(commandStub.calledOnce).be.true();
+		let commandStr = commandStub.args[0][0] as string;
+		should(commandStr.includes('"TestPkg1==1.2.3" "TestPkg2==4.5.6"')).be.true();
+
+		// Install package using minimum version
+		await should(installation.installCondaPackages(testPackages, true)).be.resolved();
+		should(commandStub.calledTwice).be.true();
+		commandStr = commandStub.args[1][0] as string;
+		should(commandStr.includes('"TestPkg1>=1.2.3" "TestPkg2>=4.5.6"')).be.true();
 	});
 });

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -8,6 +8,7 @@ import * as should from 'should';
 import * as sinon from 'sinon';
 import * as TypeMoq from 'typemoq';
 import * as uuid from 'uuid';
+import * as fs from 'fs-extra';
 import { JupyterServerInstallation, PythonPkgDetails } from '../../jupyter/jupyterServerInstallation';
 
 describe('Jupyter Server Installation', function () {
@@ -67,10 +68,10 @@ describe('Jupyter Server Installation', function () {
 		let commandStub = sinon.stub(installation, 'executeStreamedCommand').resolves();
 
 		// Should not execute any commands when passed an empty package list
-		await should(installation.installPipPackages(undefined, false)).be.resolved();
+		await installation.installPipPackages(undefined, false);
 		should(commandStub.called).be.false();
 
-		await should(installation.installPipPackages([], false)).be.resolved();
+		await installation.installPipPackages([], false);
 		should(commandStub.called).be.false();
 
 		// Install package using exact version
@@ -81,13 +82,13 @@ describe('Jupyter Server Installation', function () {
 			name: 'TestPkg2',
 			version: '4.5.6'
 		}];
-		await should(installation.installPipPackages(testPackages, false)).be.resolved();
+		await installation.installPipPackages(testPackages, false);
 		should(commandStub.calledOnce).be.true();
 		let commandStr = commandStub.args[0][0] as string;
 		should(commandStr.includes('"TestPkg1==1.2.3" "TestPkg2==4.5.6"')).be.true();
 
 		// Install package using minimum version
-		await should(installation.installPipPackages(testPackages, true)).be.resolved();
+		await installation.installPipPackages(testPackages, true);
 		should(commandStub.calledTwice).be.true();
 		commandStr = commandStub.args[1][0] as string;
 		should(commandStr.includes('"TestPkg1>=1.2.3" "TestPkg2>=4.5.6"')).be.true();
@@ -103,7 +104,7 @@ describe('Jupyter Server Installation', function () {
 			name: 'TestPkg2',
 			version: '4.5.6'
 		}];
-		await should(installation.uninstallPipPackages(testPackages)).be.resolved();
+		await installation.uninstallPipPackages(testPackages);
 		should(commandStub.calledOnce).be.true();
 		let commandStr = commandStub.args[0][0] as string;
 		should(commandStr.includes('"jupyter==1.0.0" "TestPkg2==4.5.6"')).be.true();
@@ -111,14 +112,14 @@ describe('Jupyter Server Installation', function () {
 
 	it('Get conda packages', async function() {
 		// Should return nothing if conda is not installed
-		sinon.stub(installation, 'isCondaInstalled').returns(false);
+		sinon.stub(fs, 'existsSync').returns(false);
 		let pkgResult = await installation.getInstalledCondaPackages();
 		should(pkgResult).not.be.undefined();
 		should(pkgResult.length).be.equal(0);
 
 		// Should return nothing on error
 		sinon.restore();
-		sinon.stub(installation, 'isCondaInstalled').returns(true);
+		sinon.stub(fs, 'existsSync').returns(true);
 		sinon.stub(installation, 'executeBufferedCommand').rejects(new Error('Expected test failure.'));
 		pkgResult = await installation.getInstalledCondaPackages();
 		should(pkgResult).not.be.undefined();
@@ -140,7 +141,7 @@ describe('Jupyter Server Installation', function () {
 			version: '7.8.9',
 			channel: 'conda'
 		}];
-		sinon.stub(installation, 'isCondaInstalled').returns(true);
+		sinon.stub(fs, 'existsSync').returns(true);
 		sinon.stub(installation, 'executeBufferedCommand').resolves(JSON.stringify(testPackages));
 		pkgResult = await installation.getInstalledCondaPackages();
 		let filteredPackages = testPackages.filter(pkg => pkg.channel !== 'pypi');
@@ -151,10 +152,10 @@ describe('Jupyter Server Installation', function () {
 		let commandStub = sinon.stub(installation, 'executeStreamedCommand').resolves();
 
 		// Should not execute any commands when passed an empty package list
-		await should(installation.installCondaPackages(undefined, false)).be.resolved();
+		await installation.installCondaPackages(undefined, false);
 		should(commandStub.called).be.false();
 
-		await should(installation.installCondaPackages([], false)).be.resolved();
+		await installation.installCondaPackages([], false);
 		should(commandStub.called).be.false();
 
 		// Install package using exact version
@@ -165,13 +166,13 @@ describe('Jupyter Server Installation', function () {
 			name: 'TestPkg2',
 			version: '4.5.6'
 		}];
-		await should(installation.installCondaPackages(testPackages, false)).be.resolved();
+		await installation.installCondaPackages(testPackages, false);
 		should(commandStub.calledOnce).be.true();
 		let commandStr = commandStub.args[0][0] as string;
 		should(commandStr.includes('"TestPkg1==1.2.3" "TestPkg2==4.5.6"')).be.true();
 
 		// Install package using minimum version
-		await should(installation.installCondaPackages(testPackages, true)).be.resolved();
+		await installation.installCondaPackages(testPackages, true);
 		should(commandStub.calledTwice).be.true();
 		commandStr = commandStub.args[1][0] as string;
 		should(commandStr.includes('"TestPkg1>=1.2.3" "TestPkg2>=4.5.6"')).be.true();
@@ -187,7 +188,7 @@ describe('Jupyter Server Installation', function () {
 			name: 'TestPkg2',
 			version: '4.5.6'
 		}];
-		await should(installation.uninstallCondaPackages(testPackages)).be.resolved();
+		await installation.uninstallCondaPackages(testPackages);
 		should(commandStub.calledOnce).be.true();
 		let commandStr = commandStub.args[0][0] as string;
 		should(commandStr.includes('"jupyter==1.0.0" "TestPkg2==4.5.6"')).be.true();


### PR DESCRIPTION
There's a lot of code in JupyterServerInstallation, so these tests only increased the code coverage by 10-20%. Unit testing the python installation would require a lot of mocking, so I'll try to tackle that next week.