### PR TITLE
open resource only when it's file

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch.ts
@@ -225,7 +225,7 @@ export class NotebookSearchView extends SearchView {
 			this.toggleCollapseStateDelayer.trigger(() => this.toggleExpandAction.onTreeCollapseStateChange())
 		));
 		this.treeSelectionChangeListener = this._register(this.tree.onDidChangeSelection(async (e) => {
-			if (this.tree.getSelection().length) {
+			if (this.tree.getSelection().length && this.tree.getSelection()[0] instanceof FileMatch) {
 				let element = this.tree.getSelection()[0] as Match;
 				const resource = element instanceof Match ? element.parent().resource : (<FileMatch>element).resource;
 				if (resource.fsPath.endsWith('.md')) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #11779 

Issue: On selection change, irrespective if the node is file/folder, am trying to open it in the editor. 
Fix: Check if the selection is a file resource and only then open it in the editor.
