### PR TITLE
Skip adding python user package directory to PATH on SAW devices.

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -321,7 +321,8 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 			}
 		}
 
-		if (await utils.exists(this._pythonExecutable)) {
+		// Skip adding user package directory on SAWs, since packages will already be included with ADS
+		if (!this._runningOnSAW && await utils.exists(this._pythonExecutable)) {
 			let pythonUserDir = await this.getPythonUserDir(this._pythonExecutable);
 			if (pythonUserDir) {
 				this.pythonEnvVarPath = pythonUserDir + delimiter + this.pythonEnvVarPath;


### PR DESCRIPTION
Python packages are included with ADS when installed on a SAW device, so adding the user package directory to the PATH is unnecessary.