### PR TITLE
3328 Fixed drag and drop for kusto tables with spaces

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
@@ -87,7 +87,7 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 			escapedName = this.escapeString(element.metadata.name);
 			let providerName = this.getProviderNameFromElement(element);
 			if (providerName === 'KUSTO') {
-				finalString = escapedName;
+				finalString = this.getFinalStringForKusto(element.nodeTypeId, escapedName);
 			} else {
 				finalString = escapedSchema ? `[${escapedSchema}].[${escapedName}]` : `[${escapedName}]`;
 			}
@@ -115,6 +115,14 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 		}
 
 		return this.getProviderNameFromElement(element.parent);
+	}
+
+	private getFinalStringForKusto(nodeTypeId: string, escapedName: string) {
+		if (nodeTypeId === 'Table' && escapedName.indexOf(' ') > 0) {
+			return `[@"${escapedName}"]`;
+		}
+
+		return escapedName;
 	}
 
 	private escapeString(input: string | undefined): string | undefined {


### PR DESCRIPTION
Created function getProviderNameForElement. Added logic to add [@" "] around table names with spaces.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
