### PR TITLE
Make markdown editing toolbar visible at all times

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.css
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 cell-toolbar-component {
+	z-index: 2;
 	border-width: 1px;
 	border-style: solid;
 	position: absolute;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.html
@@ -4,7 +4,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 -->
-<div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column" (mouseover)="hover=true" (mouseleave)="hover=false">
+<div style="width: 100%; height: 100%; display: flex; flex-flow: column" (mouseover)="hover=true" (mouseleave)="hover=false">
 	<markdown-toolbar-component #markdownToolbar *ngIf="previewFeaturesEnabled === true && isEditMode" [cellModel]="cellModel"></markdown-toolbar-component>
 	<div class="notebook-text" [class.edit-mode]="isEditMode" [class.show-preview]="showPreview">
 		<code-component *ngIf="isEditMode" [cellModel]="cellModel" (onContentChanged)="handleContentChanged()" [model]="model" [activeCellId]="activeCellId">

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
@@ -19,6 +19,7 @@ text-cell-component .notebook-preview {
 	user-select: none;
 	padding-left: 8px;
 	padding-right: 8px;
+	overflow: hidden;
 }
 text-cell-component .edit-mode code-component {
 	display: block;

--- a/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
@@ -183,7 +183,12 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean, conf
 		// Markdown editor toolbar
 		const toolbarBackgroundColor = theme.getColor(toolbarBackground);
 		if (toolbarBackgroundColor) {
-			collector.addRule(`markdown-toolbar-component { background: ${toolbarBackgroundColor};}`);
+			collector.addRule(`markdown-toolbar-component {
+				background: ${toolbarBackgroundColor};
+				position: sticky;
+				top: -16px;
+				z-index: 1;
+			}`);
 		}
 		const toolbarIconColor = theme.getColor(toolbarIcon);
 		if (toolbarIconColor) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #11847 - makes the markdown editing toolbar sticky with a longer text cell. 

Before - toolbar is only visible at the very top of the cell: 
![](https://user-images.githubusercontent.com/39676345/90827803-c0ed6300-e2f1-11ea-82b1-9d5fcf385aab.png)

After - toolbar is visible after scroll: 
![](https://user-images.githubusercontent.com/39676345/90827859-da8eaa80-e2f1-11ea-9cf7-c48f11241701.png)



