### PR TITLE
Create sticky run code button for notebook code cell

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 -->
 <div style="width: 100%; height: 100%; display: flex; flex-flow: row" (mouseover)="hover=true" (mouseleave)="hover=false">
-	<div style="flex: 1 1 auto; flex-flow: column; overflow: hidden;">
+	<div style="flex: 1 1 auto; flex-flow: column;">
 		<div style="display: flex; flex-flow: row">
 			<div #toolbar class="toolbar"></div>
 			<div style="flex: 1 1 auto; overflow: hidden;">

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
@@ -81,7 +81,6 @@ code-component .monaco-editor .decorationsOverviewRuler {
 code-component .carbon-taskbar .codicon {
 	background-size: 20px;
 	width: 40px;
-	position: sticky;
 }
 
 code-component .carbon-taskbar .codicon.hideIcon {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
@@ -31,7 +31,7 @@ code-component .toolbar.markdown {
 
 code-component .toolbar .carbon-taskbar {
 	position: sticky;
-	top: 0px;
+	top: -16px;
 	margin-top: 5px;
 }
 
@@ -81,6 +81,7 @@ code-component .monaco-editor .decorationsOverviewRuler {
 code-component .carbon-taskbar .codicon {
 	background-size: 20px;
 	width: 40px;
+	position: sticky;
 }
 
 code-component .carbon-taskbar .codicon.hideIcon {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #11902 - the code button now moves with scrolling so you can run the code cell from anywhere. 

Example:
![](https://user-images.githubusercontent.com/39676345/90840622-53e8c600-e30f-11ea-8684-f47e5cc7716c.png)
