### PR TITLE
Fix dropping async oe tree item onto root

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeDragAndDrop.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeDragAndDrop.ts
@@ -10,15 +10,15 @@ import { TreeUpdateUtils } from 'sql/workbench/services/objectExplorer/browser/t
 import { IDragAndDropData } from 'vs/base/browser/dnd';
 import { ITreeDragAndDrop, ITreeDragOverReaction, TreeDragOverReactions } from 'vs/base/browser/ui/tree/tree';
 import { ServerTreeDragAndDrop } from 'sql/workbench/services/objectExplorer/browser/dragAndDropController';
-import { IDragAndDrop } from 'vs/base/parts/tree/browser/tree';
-import { ServerTreeElement } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
+import { ServerTreeElement, AsyncServerTree } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
 
 /**
  * Implements drag and drop for the server tree
  */
 export class AsyncServerTreeDragAndDrop implements ITreeDragAndDrop<ServerTreeElement> {
 
-	private _dragAndDrop: IDragAndDrop;
+	private _dragAndDrop: ServerTreeDragAndDrop;
+	private _tree: AsyncServerTree | undefined;
 
 	constructor(
 		@IConnectionManagementService connectionManagementService: IConnectionManagementService,
@@ -27,18 +27,25 @@ export class AsyncServerTreeDragAndDrop implements ITreeDragAndDrop<ServerTreeEl
 	}
 
 	/**
+	 * Sets the tree context for this drag and drop controller
+	 */
+	public set tree(value: AsyncServerTree) {
+		this._tree = value;
+	}
+
+	/**
 	 * Returns a uri if the given element should be allowed to drag.
 	 * Returns null, otherwise.
 	 */
 	public getDragURI(element: ServerTreeElement): string {
-		return this._dragAndDrop.getDragURI(undefined, element);
+		return this._dragAndDrop.getDragURI(this._tree, element);
 	}
 
 	/**
 	 * Returns a label(name) to display when dragging the element.
 	 */
 	public getDragLabel(elements: ServerTreeElement[]): string {
-		return this._dragAndDrop.getDragLabel(undefined, elements);
+		return this._dragAndDrop.getDragLabel(this._tree, elements);
 	}
 
 	/**
@@ -47,13 +54,17 @@ export class AsyncServerTreeDragAndDrop implements ITreeDragAndDrop<ServerTreeEl
 	public onDragStart(dragAndDropData: IDragAndDropData, originalEvent: DragEvent): void {
 		// Force the event cast while in preview - we don't use any of the mouse properties on the
 		// implementation so this is fine for now
-		return this._dragAndDrop.onDragStart(undefined, dragAndDropData, <any>originalEvent);
+		return this._dragAndDrop.onDragStart(this._tree, dragAndDropData, <any>originalEvent);
 	}
 
 	public onDragOver(data: IDragAndDropData, targetElement: ServerTreeElement, targetIndex: number, originalEvent: DragEvent): boolean | ITreeDragOverReaction {
+		// Dropping onto an empty space (undefined targetElement) we treat as wanting to move into the root connection group
+		if (!targetElement) {
+			targetElement = this._tree?.getInput();
+		}
 		// Force the event cast while in preview - we don't use any of the mouse properties on the
 		// implementation so this is fine for now
-		const canDragOver = this._dragAndDrop.onDragOver(undefined, data, targetElement, <any>originalEvent);
+		const canDragOver = this._dragAndDrop.onDragOver(this._tree, data, targetElement, <any>originalEvent);
 
 		if (canDragOver.accept) {
 			return TreeDragOverReactions.acceptBubbleDown(true);
@@ -66,11 +77,13 @@ export class AsyncServerTreeDragAndDrop implements ITreeDragAndDrop<ServerTreeEl
 	 * Handle a drop in the server tree.
 	 */
 	public drop(data: IDragAndDropData, targetElement: ServerTreeElement, targetIndex: number, originalEvent: DragEvent): void {
+		// Dropping onto an empty space (undefined targetElement) we treat as wanting to move into the root connection group
+		if (!targetElement) {
+			targetElement = this._tree?.getInput();
+		}
 		// Force the event cast while in preview - we don't use any of the mouse properties on the
 		// implementation so this is fine for now
-
-		// TODO: chgagnon Drop on root node
-		this._dragAndDrop.drop(undefined, data, targetElement, <any>originalEvent);
+		this._dragAndDrop.drop(this._tree, data, targetElement, <any>originalEvent);
 	}
 
 	public onDragEnd(originalEvent: DragEvent): void {

--- a/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
@@ -12,6 +12,7 @@ import { TreeUpdateUtils } from 'sql/workbench/services/objectExplorer/browser/t
 import { UNSAVED_GROUP_ID } from 'sql/platform/connection/common/constants';
 import { DataTransfers, IDragAndDropData } from 'vs/base/browser/dnd';
 import { TreeNode } from 'sql/workbench/services/objectExplorer/common/treeNode';
+import { AsyncServerTree } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
 
 export function supportsNodeNameDrop(nodeId: string): boolean {
 	if (nodeId === 'Table' || nodeId === 'Column' || nodeId === 'View') {
@@ -45,7 +46,7 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 	 * Returns a uri if the given element should be allowed to drag.
 	 * Returns null, otherwise.
 	 */
-	public getDragURI(tree: ITree, element: any): string {
+	public getDragURI(tree: AsyncServerTree | ITree, element: any): string {
 		if (element) {
 			if (element instanceof ConnectionProfile) {
 				return (<ConnectionProfile>element).id;
@@ -67,7 +68,7 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 	/**
 	 * Returns a label(name) to display when dragging the element.
 	 */
-	public getDragLabel(tree: ITree, elements: any[]): string {
+	public getDragLabel(tree: AsyncServerTree | ITree, elements: any[]): string {
 		if (elements) {
 			if (elements[0] instanceof ConnectionProfile) {
 				return (<ConnectionProfile>elements[0]).serverName;
@@ -88,7 +89,7 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 	/**
 	 * Called when the drag operation starts.
 	 */
-	public onDragStart(tree: ITree, dragAndDropData: IDragAndDropData, originalEvent: DragMouseEvent): void {
+	public onDragStart(tree: AsyncServerTree | ITree, dragAndDropData: IDragAndDropData, originalEvent: DragMouseEvent): void {
 		let escapedSchema, escapedName, finalString;
 		TreeUpdateUtils.isInDragAndDrop = true;
 		const data = dragAndDropData.getData();
@@ -136,7 +137,7 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 	 * dropped into target or some parent of the target.
 	 * Returns DRAG_OVER_ACCEPT_BUBBLE_DOWN when element is a connection group or connection
 	 */
-	public onDragOver(tree: ITree, data: IDragAndDropData, targetElement: any, originalEvent: DragMouseEvent): IDragOverReaction {
+	public onDragOver(tree: AsyncServerTree | ITree, data: IDragAndDropData, targetElement: any, originalEvent: DragMouseEvent): IDragOverReaction {
 		let canDragOver: boolean = true;
 
 		if (targetElement instanceof ConnectionProfile || targetElement instanceof ConnectionProfileGroup) {
@@ -166,7 +167,7 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 	/**
 	 * Handle a drop in the server tree.
 	 */
-	public drop(tree: ITree, data: IDragAndDropData, targetElement: any, originalEvent: DragMouseEvent): void {
+	public drop(tree: AsyncServerTree | ITree, data: IDragAndDropData, targetElement: any, originalEvent: DragMouseEvent): void {
 		TreeUpdateUtils.isInDragAndDrop = false;
 
 		let targetConnectionProfileGroup: ConnectionProfileGroup = this.getTargetGroup(targetElement);

--- a/src/sql/workbench/services/objectExplorer/browser/treeCreationUtils.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeCreationUtils.ts
@@ -104,7 +104,7 @@ export class TreeCreationUtils {
 				identityProvider: identityProvider
 			};
 
-			return instantiationService.createInstance(
+			const tree = instantiationService.createInstance(
 				AsyncServerTree,
 				'ServerTreeView',
 				treeContainer,
@@ -117,6 +117,8 @@ export class TreeCreationUtils {
 				dataSource,
 				treeOptions
 			);
+			dnd.tree = tree;
+			return tree;
 		} else {
 			const dataSource = instantiationService.createInstance(ServerTreeDataSource);
 			const actionProvider = instantiationService.createInstance(ServerTreeActionProvider);


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/11874

Set tree context and targetElement so we can use the old logic. 