### PR TITLE
Fix dnd auto-connecting profiles when dragging

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeDragAndDrop.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeDragAndDrop.ts
@@ -56,7 +56,7 @@ export class AsyncServerTreeDragAndDrop implements ITreeDragAndDrop<ServerTreeEl
 		const canDragOver = this._dragAndDrop.onDragOver(undefined, data, targetElement, <any>originalEvent);
 
 		if (canDragOver.accept) {
-			return TreeDragOverReactions.acceptBubbleDown(true);
+			return TreeDragOverReactions.acceptBubbleDown(canDragOver.autoExpand);
 		} else {
 			return { accept: false };
 		}

--- a/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
@@ -156,14 +156,20 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 			canDragOver = true;
 		}
 
-		if (canDragOver && targetElement instanceof ConnectionProfileGroup) {
-			// Auto-expand the group so that sub-groups can be exposed
+		if (canDragOver) {
+			if (targetElement instanceof ConnectionProfile) {
+				const isConnected = this._connectionManagementService.isProfileConnected(targetElement);
+				// Don't auto-expand disconnected connections - doing so will try to connect the connection
+				// when expanded which is not something we want to support currently
+				return DRAG_OVER_ACCEPT_BUBBLE_DOWN(isConnected);
+			}
+			// Auto-expand other elements (groups, tree nodes) so their children can be
+			// exposed for further dragging
 			return DRAG_OVER_ACCEPT_BUBBLE_DOWN(true);
-		} else if (canDragOver) {
-			// Don't auto-expand connections - doing so will try to connect the connection
-			// when expanded which is not something we want to support currently
-			return DRAG_OVER_ACCEPT_BUBBLE_DOWN(false);
-		} else {
+		} else if (canDragOver && targetElement instanceof ConnectionProfile) {
+
+
+		} else if (canDragOver) { } else {
 			return DRAG_OVER_REJECT;
 		}
 	}

--- a/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
@@ -6,7 +6,7 @@
 import { ConnectionProfileGroup } from 'sql/platform/connection/common/connectionProfileGroup';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
-import { ITree, IDragAndDrop, IDragOverReaction, DRAG_OVER_ACCEPT_BUBBLE_DOWN, DRAG_OVER_REJECT } from 'vs/base/parts/tree/browser/tree';
+import { ITree, IDragAndDrop, IDragOverReaction, DRAG_OVER_ACCEPT_BUBBLE_DOWN, DRAG_OVER_REJECT, DRAG_OVER_ACCEPT } from 'vs/base/parts/tree/browser/tree';
 import { DragMouseEvent } from 'vs/base/browser/mouseEvent';
 import { TreeUpdateUtils } from 'sql/workbench/services/objectExplorer/browser/treeUpdateUtils';
 import { UNSAVED_GROUP_ID } from 'sql/platform/connection/common/constants';
@@ -156,8 +156,13 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 			canDragOver = true;
 		}
 
-		if (canDragOver) {
+		if (canDragOver && targetElement instanceof ConnectionProfileGroup) {
+			// Auto-expand the group so that sub-groups can be exposed
 			return DRAG_OVER_ACCEPT_BUBBLE_DOWN(true);
+		} else if (canDragOver) {
+			// Don't auto-expand connections - doing so will try to connect the connection
+			// when expanded which is not something we want to support currently
+			return DRAG_OVER_ACCEPT_BUBBLE_DOWN(false);
 		} else {
 			return DRAG_OVER_REJECT;
 		}

--- a/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
@@ -6,7 +6,7 @@
 import { ConnectionProfileGroup } from 'sql/platform/connection/common/connectionProfileGroup';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
-import { ITree, IDragAndDrop, IDragOverReaction, DRAG_OVER_ACCEPT_BUBBLE_DOWN, DRAG_OVER_REJECT, DRAG_OVER_ACCEPT } from 'vs/base/parts/tree/browser/tree';
+import { ITree, IDragAndDrop, IDragOverReaction, DRAG_OVER_ACCEPT_BUBBLE_DOWN, DRAG_OVER_REJECT } from 'vs/base/parts/tree/browser/tree';
 import { DragMouseEvent } from 'vs/base/browser/mouseEvent';
 import { TreeUpdateUtils } from 'sql/workbench/services/objectExplorer/browser/treeUpdateUtils';
 import { UNSAVED_GROUP_ID } from 'sql/platform/connection/common/constants';
@@ -166,10 +166,7 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 			// Auto-expand other elements (groups, tree nodes) so their children can be
 			// exposed for further dragging
 			return DRAG_OVER_ACCEPT_BUBBLE_DOWN(true);
-		} else if (canDragOver && targetElement instanceof ConnectionProfile) {
-
-
-		} else if (canDragOver) { } else {
+		} else {
 			return DRAG_OVER_REJECT;
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/11886

This was/is actually not behaving correctly in the normal server tree so I'm fixing it there too - we should only be expanding connection nodes if they're connected. 