### PR TITLE
3491 Kusto Execute Function Support

### DIFF
--- a/src/sql/workbench/contrib/dataExplorer/browser/nodeContextUtils.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/nodeContextUtils.ts
@@ -20,7 +20,7 @@ export class NodeContextUtils extends Disposable {
 	static readonly canCreateOrDelete = new Set([NodeType.AggregateFunction, NodeType.PartitionFunction, NodeType.ScalarValuedFunction,
 	NodeType.Schema, NodeType.StoredProcedure, NodeType.Table, NodeType.TableValuedFunction,
 	NodeType.User, NodeType.UserDefinedTableType, NodeType.View]);
-	static readonly canExecute = new Set([NodeType.StoredProcedure]);
+	static readonly canExecute = new Set([NodeType.StoredProcedure, NodeType.Function]);
 	static readonly canAlter = new Set([NodeType.AggregateFunction, NodeType.PartitionFunction, NodeType.ScalarValuedFunction,
 	NodeType.StoredProcedure, NodeType.TableValuedFunction, NodeType.View]);
 

--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -139,7 +139,8 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		id: commands.OE_SCRIPT_AS_EXECUTE_COMMAND_ID,
 		title: localize('scriptExecute', "Script as Execute")
 	},
-	when: ContextKeyExpr.and(ConnectionContextKey.Provider.isEqualTo('MSSQL'), TreeNodeContextKey.NodeType.isEqualTo('StoredProcedure'))
+	when: ContextKeyExpr.or(ContextKeyExpr.and(ConnectionContextKey.Provider.isEqualTo('MSSQL'), TreeNodeContextKey.NodeType.isEqualTo('StoredProcedure')),
+		ContextKeyExpr.and(ConnectionContextKey.Provider.isEqualTo('KUSTO'), TreeNodeContextKey.NodeType.isEqualTo('Function')))
 });
 
 MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {

--- a/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
@@ -27,6 +27,15 @@ export function supportsFolderNodeNameDrop(nodeId: string, label: string): boole
 	return false;
 }
 
+function getProviderNameFromElement(element: TreeNode): string | undefined {
+
+	if (element.connection) {
+		return element.connection.providerName;
+	}
+
+	return getProviderNameFromElement(element.parent);
+}
+
 function escapeString(input: string | undefined): string | undefined {
 	return input?.replace(/]/g, ']]');
 }
@@ -94,9 +103,9 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 		const data = dragAndDropData.getData();
 		const element = data[0];
 		if (supportsNodeNameDrop(element.nodeTypeId)) {
-			escapedSchema = this.escapeString(element.metadata.schema);
-			escapedName = this.escapeString(element.metadata.name);
-			let providerName = this.getProviderNameFromElement(element);
+			escapedSchema = escapeString(element.metadata.schema);
+			escapedName = escapeString(element.metadata.name);
+			let providerName = getProviderNameFromElement(element);
 			if (providerName === 'KUSTO') {
 				finalString = element.nodeTypeId !== 'Function' && escapedName.indexOf(' ') > 0 ? `[@"${escapedName}"]` : escapedName;
 			} else {

--- a/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/dragAndDropController.ts
@@ -94,9 +94,14 @@ export class ServerTreeDragAndDrop implements IDragAndDrop {
 		const data = dragAndDropData.getData();
 		const element = data[0];
 		if (supportsNodeNameDrop(element.nodeTypeId)) {
-			escapedSchema = escapeString(element.metadata.schema);
-			escapedName = escapeString(element.metadata.name);
-			finalString = escapedSchema ? `[${escapedSchema}].[${escapedName}]` : `[${escapedName}]`;
+			escapedSchema = this.escapeString(element.metadata.schema);
+			escapedName = this.escapeString(element.metadata.name);
+			let providerName = this.getProviderNameFromElement(element);
+			if (providerName === 'KUSTO') {
+				finalString = element.nodeTypeId !== 'Function' && escapedName.indexOf(' ') > 0 ? `[@"${escapedName}"]` : escapedName;
+			} else {
+				finalString = escapedSchema ? `[${escapedSchema}].[${escapedName}]` : `[${escapedName}]`;
+			}
 			originalEvent.dataTransfer.setData(DataTransfers.RESOURCES, JSON.stringify([`${element.nodeTypeId}:${element.id}?${finalString}`]));
 		}
 		if (supportsFolderNodeNameDrop(element.nodeTypeId, element.label)) {

--- a/src/sql/workbench/services/objectExplorer/browser/mssqlNodeContext.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/mssqlNodeContext.ts
@@ -27,7 +27,7 @@ export class MssqlNodeContext extends Disposable {
 	static readonly canCreateOrDelete = new Set([NodeType.AggregateFunction, NodeType.PartitionFunction, NodeType.ScalarValuedFunction,
 	NodeType.Schema, NodeType.StoredProcedure, NodeType.Table, NodeType.TableValuedFunction,
 	NodeType.User, NodeType.UserDefinedTableType, NodeType.View]);
-	static readonly canExecute = new Set([NodeType.StoredProcedure]);
+	static readonly canExecute = new Set([NodeType.StoredProcedure, NodeType.Function]);
 	static readonly canAlter = new Set([NodeType.AggregateFunction, NodeType.PartitionFunction, NodeType.ScalarValuedFunction,
 	NodeType.StoredProcedure, NodeType.TableValuedFunction, NodeType.View]);
 

--- a/src/sql/workbench/services/objectExplorer/common/nodeType.ts
+++ b/src/sql/workbench/services/objectExplorer/common/nodeType.ts
@@ -93,6 +93,7 @@ export class NodeType {
 	public static ExternalTable = 'ExternalTable';
 	public static ColumnMasterKey = 'ColumnMasterKey';
 	public static ColumnEncryptionKey = 'ColumnEncryptionKey';
+	public static Function = 'Function';
 
 	public static readonly SCRIPTABLE_OBJECTS = [NodeType.Table, NodeType.View, NodeType.Schema, NodeType.User, NodeType.UserDefinedTableType,
 	NodeType.StoredProcedure, NodeType.AggregateFunction, NodeType.PartitionFunction, NodeType.ScalarValuedFunction,


### PR DESCRIPTION
Added kusto function to canExecute in MssqlNodeContext. Changed dragAndDropController > onDragStart to have different logic for Kusto. Added 'Script as Execute' menu option to Kusto functions

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
