### PR TITLE
Add word wrap feature in notebook markdown cells

### DIFF
--- a/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
+++ b/src/sql/workbench/browser/modelComponents/queryTextEditor.ts
@@ -58,7 +58,7 @@ export class QueryTextEditor extends BaseTextEditor {
 	protected getConfigurationOverrides(): IEditorOptions {
 		const options = super.getConfigurationOverrides();
 		if (this.input) {
-			options.inDiffEditor = true;
+			options.inDiffEditor = false;
 			options.scrollBeyondLastLine = false;
 			options.folding = false;
 			options.renderIndentGuides = false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #11860 - change the diffEditor variable to enable word wrap in text cells for notebooks.
