### PR TITLE
Re-enable previously commented out configure python wizard tests

### DIFF
--- a/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
@@ -122,7 +122,7 @@ export class ConfigurePythonWizard {
 
 		this._wizard.generateScriptButton.hidden = true;
 		this._wizard.pages = [page0, page1];
-		this._wizard.open();
+		await this._wizard.open();
 	}
 
 	public async close(): Promise<void> {

--- a/extensions/notebook/src/test/python/configurePython.test.ts
+++ b/extensions/notebook/src/test/python/configurePython.test.ts
@@ -42,36 +42,36 @@ describe('Configure Python Wizard', function () {
 
 	// These wizard tests are disabled due to errors with disposable objects
 	//
-	// it('Start wizard test', async () => {
-	// 	let wizard = new ConfigurePythonWizard(testInstallation);
-	// 	await wizard.start();
-	// 	await wizard.close();
-	// 	await should(wizard.setupComplete).be.resolved();
-	// });
+	it('Start wizard test', async () => {
+		let wizard = new ConfigurePythonWizard(testInstallation);
+		await wizard.start();
+		await wizard.close();
+		await should(wizard.setupComplete).be.resolved();
+	});
 
-	// it('Reject setup on cancel test', async () => {
-	// 	let wizard = new ConfigurePythonWizard(testInstallation);
-	// 	await wizard.start(undefined, true);
-	// 	await wizard.close();
-	// 	await should(wizard.setupComplete).be.rejected();
-	// });
+	it('Reject setup on cancel test', async () => {
+		let wizard = new ConfigurePythonWizard(testInstallation);
+		await wizard.start(undefined, true);
+		await wizard.close();
+		await should(wizard.setupComplete).be.rejected();
+	});
 
-	// it('Error message test', async () => {
-	// 	let wizard = new ConfigurePythonWizard(testInstallation);
-	// 	await wizard.start();
+	it('Error message test', async () => {
+		let wizard = new ConfigurePythonWizard(testInstallation);
+		await wizard.start();
 
-	// 	should(wizard.wizard.message).be.undefined();
+		should(wizard.wizard.message).be.undefined();
 
-	// 	let testMsg = 'Test message';
-	// 	wizard.showErrorMessage(testMsg);
-	// 	should(wizard.wizard.message.text).be.equal(testMsg);
-	// 	should(wizard.wizard.message.level).be.equal(azdata.window.MessageLevel.Error);
+		let testMsg = 'Test message';
+		wizard.showErrorMessage(testMsg);
+		should(wizard.wizard.message.text).be.equal(testMsg);
+		should(wizard.wizard.message.level).be.equal(azdata.window.MessageLevel.Error);
 
-	// 	wizard.clearStatusMessage();
-	// 	should(wizard.wizard.message).be.undefined();
+		wizard.clearStatusMessage();
+		should(wizard.wizard.message).be.undefined();
 
-	// 	await wizard.close();
-	// });
+		await wizard.close();
+	});
 
 	it('Configure Path Page test', async () => {
 		let testPythonLocation = '/not/a/real/path';

--- a/extensions/notebook/src/test/python/configurePython.test.ts
+++ b/extensions/notebook/src/test/python/configurePython.test.ts
@@ -40,8 +40,6 @@ describe('Configure Python Wizard', function () {
 		viewContext = createViewContext();
 	});
 
-	// These wizard tests are disabled due to errors with disposable objects
-	//
 	it('Start wizard test', async () => {
 		let wizard = new ConfigurePythonWizard(testInstallation);
 		await wizard.start();

--- a/src/sql/workbench/browser/modelComponents/viewBase.ts
+++ b/src/sql/workbench/browser/modelComponents/viewBase.ts
@@ -44,7 +44,9 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 		this.rootDescriptor = descriptor;
 		this.modelStore.registerValidationCallback(validationCallback);
 		// Kick off the build by detecting changes to the model
-		this.changeRef.detectChanges();
+		if (!(this.changeRef['destroyed'])) {
+			this.changeRef.detectChanges();
+		}
 	}
 
 	private defineComponent(component: IComponentShape): IComponentDescriptor {


### PR DESCRIPTION
A couple of problems:

- We weren't awaiting `wizard.open()`
- We were calling `changeRef.detectChanges()` without checking whether the `changeRef` was already `destroyed` in src/sql/workbench/browser/modelComponents/viewBase.ts.

Once I fixed these issues, the tests in question passed without any weird disposableStore exceptions being thrown.