### PR TITLE
Adds docker build environment to the codebase

### DIFF
--- a/build/sqlbuilder/build.js
+++ b/build/sqlbuilder/build.js
@@ -10,7 +10,6 @@ const args = process.argv.slice(2);
 const adsDir = path.join(process.cwd(), 'azuredatastudio');
 
 
-const copyCmd = `powershell.exe Copy-Item -Path "C:\\ads\\azuredatastudio\\.build" -Destination "C:\\Output" -Recurse`;
 
 execSync(`git checkout ${args[0]}`, {
 	cwd: adsDir,
@@ -32,6 +31,7 @@ execSync(`yarn gulp vscode-win32-x64-archive`, {
 	stdio: 'inherit'
 });
 
+const copyCmd = `powershell.exe Copy-Item -Path "C:\\ads\\azuredatastudio\\.build" -Destination "C:\\Output" -Recurse`;
 execSync(copyCmd, {
 	cwd: adsDir,
 	stdio: 'inherit'

--- a/build/sqlbuilder/build.js
+++ b/build/sqlbuilder/build.js
@@ -32,7 +32,6 @@ execSync(`yarn gulp vscode-win32-x64-archive`, {
 	stdio: 'inherit'
 });
 
-
 execSync(copyCmd, {
 	cwd: adsDir,
 	stdio: 'inherit'

--- a/build/sqlbuilder/build.js
+++ b/build/sqlbuilder/build.js
@@ -9,6 +9,9 @@ const args = process.argv.slice(2);
 
 const adsDir = path.join(process.cwd(), 'azuredatastudio');
 
+
+const copyCmd = `powershell.exe Copy-Item -Path "C:\\ads\\azuredatastudio\\.build" -Destination "C:\\Output" -Recurse`;
+
 execSync(`git checkout ${args[0]}`, {
 	cwd: adsDir,
 	stdio: 'inherit'
@@ -29,7 +32,8 @@ execSync(`yarn gulp vscode-win32-x64-archive`, {
 	stdio: 'inherit'
 });
 
-execSync('Copy-Item -Path "C:\\ads\\azuredatastudio\\.build\\" -Destination "C:\\Output" -Recurse', {
+
+execSync(copyCmd, {
 	cwd: adsDir,
 	stdio: 'inherit'
 });

--- a/build/sqlbuilder/build.js
+++ b/build/sqlbuilder/build.js
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const { execSync } = require('child_process');
+const path = require('path');
+const args = process.argv.slice(2);
+
+const adsDir = path.join(process.cwd(), 'azuredatastudio');
+
+execSync(`git checkout ${args[0]}`, {
+	cwd: adsDir,
+	stdio: 'inherit'
+});
+
+execSync(`yarn install`, {
+	cwd: adsDir,
+	stdio: 'inherit'
+});
+
+execSync(`yarn gulp vscode-win32-x64`, {
+	cwd: adsDir,
+	stdio: 'inherit'
+});
+
+execSync(`yarn gulp vscode-win32-x64-archive`, {
+	cwd: adsDir,
+	stdio: 'inherit'
+});
+
+execSync('Copy-Item -Path "C:\\ads\\azuredatastudio\\.build\\" -Destination "C:\\Output" -Recurse', {
+	cwd: adsDir,
+	stdio: 'inherit'
+});

--- a/build/sqlbuilder/windows.Dockerfile
+++ b/build/sqlbuilder/windows.Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/windows:2004
+
+RUN powershell -Command Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+RUN choco install nodejs --version=12.14.0 --yes
+RUN choco install git --yes
+# RUN choco install python --version=2.7.11 --yes
+
+RUN npm install -g yarn
+RUN npm install -g windows-build-tools --vs2015
+
+WORKDIR "C:/ads"

--- a/build/sqlbuilder/windows.Dockerfile
+++ b/build/sqlbuilder/windows.Dockerfile
@@ -10,3 +10,9 @@ RUN npm install -g yarn
 RUN npm install -g windows-build-tools --vs2015
 
 WORKDIR "C:/ads"
+
+RUN git clone https://github.com/microsoft/azuredatastudio.git
+
+COPY build.js .
+
+ENTRYPOINT [ "node", "build.js" ]

--- a/build/sqlbuilder/windows.Dockerfile
+++ b/build/sqlbuilder/windows.Dockerfile
@@ -13,6 +13,14 @@ WORKDIR "C:/ads"
 
 RUN git clone https://github.com/microsoft/azuredatastudio.git
 
+WORKDIR "C:/ads/azuredatastudio"
+
+RUN yarn install
+
+RUN git clean -fxd
+
+WORKDIR "C:/ads"
+
 COPY build.js .
 
 ENTRYPOINT [ "node", "build.js" ]


### PR DESCRIPTION
Example usage assuming the image is built with the tag of "sqlbuilder"
```
docker run --rm -v "C:\Users\SomeUser\Desktop\AdsBuilds:C:\Output" sqlbuilder 725e1b2ee34fe6d2dd70b4a018091ed34fe3a871
```