### PR TITLE
Notebook URI test fixes

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -593,6 +593,7 @@
     "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.17.0",
     "mocha-multi-reporters": "^1.1.7",
+    "nock": "^13.0.2",
     "should": "^13.2.3",
     "sinon": "^9.0.2",
     "typemoq": "^2.1.0",

--- a/extensions/notebook/src/common/constants.ts
+++ b/extensions/notebook/src/common/constants.ts
@@ -10,6 +10,8 @@ const localize = nls.loadMessageBundle();
 // CONFIG VALUES ///////////////////////////////////////////////////////////
 export const extensionOutputChannelName = 'Notebooks';
 
+export const notebookCommandNew = 'notebook.command.new';
+
 // JUPYTER CONFIG //////////////////////////////////////////////////////////
 export const pythonBundleVersion = '0.0.1';
 export const pythonVersion = '3.6.6';

--- a/extensions/notebook/src/protocol/notebookUriHandler.ts
+++ b/extensions/notebook/src/protocol/notebookUriHandler.ts
@@ -14,6 +14,7 @@ const localize = nls.loadMessageBundle();
 import { IQuestion, confirm } from '../prompts/question';
 import CodeAdapter from '../prompts/adapter';
 import { getErrorMessage, isEditorTitleFree } from '../common/utils';
+import * as constants from '../common/constants';
 
 export class NotebookUriHandler implements vscode.UriHandler {
 	private prompter = new CodeAdapter();
@@ -24,12 +25,11 @@ export class NotebookUriHandler implements vscode.UriHandler {
 	handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
 		switch (uri.path) {
 			case '/new':
-				return vscode.commands.executeCommand('notebook.command.new');
+				return vscode.commands.executeCommand(constants.notebookCommandNew);
 			case '/open':
 				return this.open(uri);
 			default:
-				vscode.window.showErrorMessage(localize('notebook.unsupportedAction', "Action {0} is not supported for this handler", uri?.path));
-				return Promise.reject(`Action ${uri?.path} is not supported for this handler`);
+				vscode.window.showErrorMessage(localize('notebook.unsupportedAction', "Action {0} is not supported for this handler", uri.path));
 		}
 	}
 

--- a/extensions/notebook/src/protocol/notebookUriHandler.ts
+++ b/extensions/notebook/src/protocol/notebookUriHandler.ts
@@ -21,8 +21,8 @@ export class NotebookUriHandler implements vscode.UriHandler {
 	constructor() {
 	}
 
-	handleUri(uri: vscode.Uri): Thenable<void> {
-		switch (uri?.path) {
+	handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
+		switch (uri.path) {
 			case '/new':
 				return vscode.commands.executeCommand('notebook.command.new');
 			case '/open':

--- a/extensions/notebook/src/test/protocol/notebookUriHandler.test.ts
+++ b/extensions/notebook/src/test/protocol/notebookUriHandler.test.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 import * as nock from 'nock';
 import * as loc from '../../common/localizedConstants';
+import * as constants from '../../common/constants';
 
 import { NotebookUriHandler } from '../../protocol/notebookUriHandler';
 
@@ -32,13 +33,15 @@ describe('Notebook URI Handler', function (): void {
 	it('should handle empty string gracefully', async function (): Promise<void> {
 		await notebookUriHandler.handleUri(vscode.Uri.parse(''));
 		sinon.assert.calledOnce(showErrorMessageSpy);
+		const showNotebookDocumentStub = sinon.stub(azdata.nb, 'showNotebookDocument');
 
-		sinon.assert.neverCalledWith(executeCommandSpy, 'notebook.command.new');
+		sinon.assert.neverCalledWith(executeCommandSpy, constants.notebookCommandNew);
+		sinon.assert.notCalled(showNotebookDocumentStub);
 	});
 
 	it('should create new notebook when new passed in', async function (): Promise<void> {
 		await notebookUriHandler.handleUri(vscode.Uri.parse('azuredatastudio://microsoft.notebook/new'));
-		sinon.assert.calledOnce(executeCommandSpy);
+		sinon.assert.calledWith(executeCommandSpy, constants.notebookCommandNew);
 	});
 
 	it('should show error message when no query passed into open', async function (): Promise<void> {

--- a/extensions/notebook/yarn.lock
+++ b/extensions/notebook/yarn.lock
@@ -1113,7 +1113,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -1156,6 +1156,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
 lodash@^4.16.4, lodash@^4.17.13, lodash@^4.17.4:
   version "4.17.19"
@@ -1329,6 +1334,16 @@ nise@^4.0.1:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
+nock@^13.0.2:
+  version "13.0.4"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.4.tgz#9fb74db35d0aa056322e3c45be14b99105cd7510"
+  integrity sha512-alqTV8Qt7TUbc74x1pKRLSENzfjp4nywovcJgi/1aXDiUxXdt7TkruSTF5MDWPP7UoPVgea4F9ghVdmX0xxnSA==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash.set "^4.3.2"
+    propagate "^2.0.0"
+
 node-fetch@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
@@ -1397,6 +1412,11 @@ postinstall-build@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/postinstall-build/-/postinstall-build-5.0.3.tgz#238692f712a481d8f5bc8960e94786036241efc7"
   integrity sha512-vPvPe8TKgp4FLgY3+DfxCE5PIfoXBK2lyLfNCxsRbDsV6vS4oU5RG/IWxrblMn6heagbnMED3MemUQllQ2bQUg==
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 psl@^1.1.24:
   version "1.1.31"


### PR DESCRIPTION
Some notes :

1. Make sure you're awaiting stuff properly
1. Be careful of localized constants - it's unlikely we'll be running these in non-English languages for the time being but there's no reason not to just use the actual string
1. Be careful of generically checking call count for something as common as "executeCommand" - I ran into a few instances where the setContext command was being executed by the extension in the background which was failing the tests. Ideally we shouldn't have to worry about this but for the time being it should be fine to just make sure you're being a bit more specific about what you're checking for. 
1. Use nock for mocking HTTP requests
1. Make sure you're testing all the various paths the code can go through. I added some extra cases like declining installation and HTTP errors but you should walk through the code yourself and ensure all paths are covered appropriately. 

Note that this code isn't fully cleaned up - I just threw this together quick to help get you unblocked. Feel free to move stuff around and pull things out into constants where appropriate to make it easier to read and debug. 