### PR TITLE
Fix overflow issues with notebook cells

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.html
@@ -5,9 +5,9 @@
  *--------------------------------------------------------------------------------------------*/
 -->
 <div style="width: 100%; height: 100%; display: flex; flex-flow: row" (mouseover)="hover=true" (mouseleave)="hover=false">
-	<div style="flex: 1 1 auto; flex-flow: column;">
+	<div #toolbar class="toolbar"></div>
+	<div style="flex: 1 1 auto; flex-flow: column; overflow: hidden;">
 		<div style="display: flex; flex-flow: row">
-			<div #toolbar class="toolbar"></div>
 			<div style="flex: 1 1 auto; overflow: hidden;">
 				<div #editor class="editor"></div>
 			</div>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #11988 - run code cell is still sticky and there is no more overflow on long lines for code cells. \
Before:

![](https://user-images.githubusercontent.com/39676345/91748817-6cf64000-eb75-11ea-9a74-195acd9ac922.png)
After:
![](https://user-images.githubusercontent.com/39676345/91748810-6a93e600-eb75-11ea-815e-fd1b3eb7df38.png)



