### PR TITLE
Only copy coverage if tests were ran

### DIFF
--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -209,6 +209,7 @@ steps:
       mkdir -p $(Build.ArtifactStagingDirectory)/test-results/coverage
       cp --parents -r $(Build.SourcesDirectory)/extensions/*/coverage/** $(Build.ArtifactStagingDirectory)/test-results/coverage
     displayName: Copy Coverage
+    condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results test-results.xml'


### PR DESCRIPTION
Was getting build failures if the tests weren't ran https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=75407&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=113d799d-a361-55ff-50d8-9c14ded0c900