### PR TITLE
minor cleanups to hide extra tree and command pallet items 

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -225,6 +225,10 @@
         {
           "command": "sqlDatabaseProjects.openContainingFolder",
           "when": "false"
+        },
+        {
+          "command": "sqlDatabaseProjects.exclude",
+          "when": "false"
         }
       ],
       "view/item/context": [

--- a/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
@@ -37,7 +37,8 @@ export class ProjectRootTreeItem extends BaseProjectTreeItem {
 
 	public get children(): BaseProjectTreeItem[] {
 		const output: BaseProjectTreeItem[] = [];
-		output.push(this.dataSourceNode);
+		// [8/31/2020] Hiding Data source for Preview since we do not have a way to add or update those.
+		// output.push(this.dataSourceNode);
 		output.push(this.databaseReferencesNode);
 
 		return output.concat(Object.values(this.fileChildren).sort(fileTree.sortFileFolderNodes));


### PR DESCRIPTION
1. Hiding Data source from Tree 
2. Hiding Exclude item command from command pallet



<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
