### PR TITLE
radio card change

### DIFF
--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -83,7 +83,7 @@ export class ResourceTypePickerDialog extends DialogBase {
 				ariaLabel: localize('deploymentDialog.deploymentOptions', "Deployment options"),
 				width: '1100px'
 			}).component();
-			this._toDispose.push(this._cardGroup.onSelectionChanged((cardId: string) => {
+			this._toDispose.push(this._cardGroup.onSelectionChanged(({ cardId }) => {
 				const resourceType = resourceTypes.find(rt => { return rt.name === cardId; });
 				if (resourceType) {
 					this.selectResourceType(resourceType);

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -174,7 +174,7 @@ declare module 'azdata' {
 	}
 
 	export interface RadioCardGroupComponent extends Component, RadioCardGroupComponentProperties {
-		onSelectionChanged: vscode.Event<any>;
+		onSelectionChanged: vscode.Event<{ cardId: string; card?: RadioCard }>;
 	}
 
 	export interface SeparatorComponent extends Component {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -174,6 +174,9 @@ declare module 'azdata' {
 	}
 
 	export interface RadioCardGroupComponent extends Component, RadioCardGroupComponentProperties {
+		/**
+		 * The card object returned from this function is a clone of the internal representation - changes will not impact the original object
+		 */
 		onSelectionChanged: vscode.Event<{ cardId: string; card?: RadioCard }>;
 	}
 

--- a/src/sql/workbench/browser/modelComponents/radioCardGroup.component.ts
+++ b/src/sql/workbench/browser/modelComponents/radioCardGroup.component.ts
@@ -11,6 +11,7 @@ import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import 'vs/css!./media/card';
 import { IComponent, IComponentDescriptor, IModelStore, ComponentEventType } from 'sql/platform/dashboard/browser/interfaces';
+import { deepClone } from 'vs/base/common/objects';
 
 @Component({
 	templateUrl: decodeURI(require.toUrl('./radioCardGroup.component.html'))
@@ -143,7 +144,7 @@ export default class RadioCardGroup extends ComponentBase implements IComponent,
 			eventType: ComponentEventType.onDidChange,
 			args: {
 				cardId,
-				card: Object.assign({}, this.getCardById(cardId))
+				card: deepClone(this.getCardById(cardId))
 			}
 		});
 	}

--- a/src/sql/workbench/browser/modelComponents/radioCardGroup.component.ts
+++ b/src/sql/workbench/browser/modelComponents/radioCardGroup.component.ts
@@ -141,7 +141,10 @@ export default class RadioCardGroup extends ComponentBase implements IComponent,
 		this._changeRef.detectChanges();
 		this.fireEvent({
 			eventType: ComponentEventType.onDidChange,
-			args: cardId
+			args: {
+				cardId,
+				card: this.getCardById(cardId)
+			}
 		});
 	}
 

--- a/src/sql/workbench/browser/modelComponents/radioCardGroup.component.ts
+++ b/src/sql/workbench/browser/modelComponents/radioCardGroup.component.ts
@@ -143,7 +143,7 @@ export default class RadioCardGroup extends ComponentBase implements IComponent,
 			eventType: ComponentEventType.onDidChange,
 			args: {
 				cardId,
-				card: this.getCardById(cardId)
+				card: Object.assign({}, this.getCardById(cardId))
 			}
 		});
 	}


### PR DESCRIPTION
We have the RadioCard object, let's return that to the user. This way the user can put extra metadata on top of the RadioCard and get it back - reducing the need for a lookup table.

The API was in proposed so I don't feel too bad for breaking it. Let's make sure we do this for future components, lookup by ID is so 2019 :D