### PR TITLE
fix the issue that error dialog is not showing

### DIFF
--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -75,9 +75,11 @@ export class ErrorMessageDialog extends Modal {
 
 	private createCopyButton() {
 		let copyButtonLabel = localize('copyDetails', "Copy details");
-		if (this._messageDetails) {
-			this._copyButton = this.addFooterButton(copyButtonLabel, () => this._clipboardService.writeText(this._messageDetails!).catch(err => onUnexpectedError(err)), 'left');
-		}
+		this._copyButton = this.addFooterButton(copyButtonLabel, () => {
+			if (this._messageDetails) {
+				this._clipboardService.writeText(this._messageDetails!).catch(err => onUnexpectedError(err));
+			}
+		}, 'left');
 		this._copyButton!.icon = 'codicon scriptToClipboard';
 		this._copyButton!.element.title = copyButtonLabel;
 		this._register(attachButtonStyler(this._copyButton!, this._themeService, { buttonBackground: SIDE_BAR_BACKGROUND, buttonHoverBackground: SIDE_BAR_BACKGROUND, buttonForeground: SIDE_BAR_FOREGROUND }));


### PR DESCRIPTION
this PR fixes https://github.com/microsoft/azuredatastudio/issues/12060
introduced by this PR: https://github.com/microsoft/azuredatastudio/commit/adfdd569075e7a83c8a8c2c71a1b897648634cd0#diff-a4aa25990fc5fc205ac53f5b4769e960R78

the connection error dialog is not showing up with the following error message in the console:
![image](https://user-images.githubusercontent.com/13777222/91892467-8ff12480-ec47-11ea-8852-44d826d31e02.png)


root cause, the copybutton is not initialized due to the newly added if check statement.