### PR TITLE
Add RegisterResourceDataProvider API

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -6,6 +6,7 @@
 // This is the place for API experiments and proposal.
 
 import * as vscode from 'vscode';
+import { DataProvider } from 'azdata';
 
 declare module 'azdata' {
 	/**
@@ -95,6 +96,43 @@ declare module 'azdata' {
 	export namespace dataprotocol {
 		export function registerSerializationProvider(provider: SerializationProvider): vscode.Disposable;
 		export function registerSqlAssessmentServicesProvider(provider: SqlAssessmentServicesProvider): vscode.Disposable;
+		/**
+		 * Registers a ResourceDataProvider which is used to provide lists of different types of resources
+		 * @param provider The provider implementation
+		 */
+		export function registerResourceDataProvider<T extends Resource>(provider: ResourceDataProvider<T>): vscode.Disposable;
+	}
+
+	export enum DataProviderType {
+		ResourceDataProvider = 'ResourceDataProvider'
+	}
+
+	/**
+	 * A resource
+	 */
+	export interface Resource {
+		/**
+		 * A unique identifier for this resource
+		 */
+		id: string;
+		/**
+		 * An identifier for the type of resource this is
+		 */
+		typeId: string;
+		/**
+		 * A set of properties for this resource
+		 */
+		properties: { [key: string]: string };
+	}
+
+	/**
+	 * A data provider that provides lists of resources
+	 */
+	export interface ResourceDataProvider<T extends Resource> extends DataProvider {
+		/**
+		 * Gets the list of resources for this provider
+		 */
+		getResources(): Thenable<T[]>;
 	}
 
 	export interface HyperlinkComponent {
@@ -532,5 +570,4 @@ declare module 'azdata' {
 		 */
 		delete?: boolean;
 	}
-
 }

--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -25,6 +25,7 @@ export const CancelQuery = 'CancelQuery';
 export const NewQuery = 'NewQuery';
 export const FirewallRuleRequested = 'FirewallRuleCreated';
 export const DashboardNavigated = 'DashboardNavigated';
+export const GetResources = 'GetResources';
 
 // Telemetry Properties
 

--- a/src/sql/workbench/api/browser/mainThreadDataProtocol.ts
+++ b/src/sql/workbench/api/browser/mainThreadDataProtocol.ts
@@ -28,6 +28,7 @@ import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { assign } from 'vs/base/common/objects';
 import { serializableToMap } from 'sql/base/common/map';
 import { IAssessmentService } from 'sql/workbench/services/assessment/common/interfaces';
+import { IResourceDataProviderService } from 'sql/workbench/services/resourceDataProvider/common/resourceDataProviderService';
 
 /**
  * Main thread class for handling data protocol management registration.
@@ -55,7 +56,8 @@ export class MainThreadDataProtocol extends Disposable implements MainThreadData
 		@IProfilerService private _profilerService: IProfilerService,
 		@ISerializationService private _serializationService: ISerializationService,
 		@IFileBrowserService private _fileBrowserService: IFileBrowserService,
-		@IAssessmentService private _assessmentService: IAssessmentService
+		@IAssessmentService private _assessmentService: IAssessmentService,
+		@IResourceDataProviderService private _resourceDataProviderService: IResourceDataProviderService
 	) {
 		super();
 		if (extHostContext) {
@@ -466,6 +468,17 @@ export class MainThreadDataProtocol extends Disposable implements MainThreadData
 
 		return undefined;
 	}
+
+	public $registerResourceDataProvider<T extends azdata.Resource>(providerId: string, handle: number): void {
+		const self = this;
+		this._resourceDataProviderService.registerProvider(providerId, <azdata.ResourceDataProvider<T>>{
+			providerId: providerId,
+			getResources(): Thenable<T[]> {
+				return self._proxy.$getResources(handle);
+			}
+		});
+	}
+
 	public $registerCapabilitiesServiceProvider(providerId: string, handle: number): Promise<any> {
 		const self = this;
 		this._capabilitiesService.registerProvider(<azdata.CapabilitiesProvider>{

--- a/src/sql/workbench/api/common/extHostDataProtocol.ts
+++ b/src/sql/workbench/api/common/extHostDataProtocol.ts
@@ -173,6 +173,11 @@ export class ExtHostDataProtocol extends ExtHostDataProtocolShape {
 		this._proxy.$registerSqlAssessmentServicesProvider(provider.providerId, provider.handle);
 		return rt;
 	}
+	$registerResourceDataProvider<T extends azdata.Resource>(provider: azdata.ResourceDataProvider<T>): vscode.Disposable {
+		let rt = this.registerProvider(provider, DataProviderType.ResourceDataProvider);
+		this._proxy.$registerResourceDataProvider(provider.providerId, provider.handle);
+		return rt;
+	}
 	$registerCapabilitiesServiceProvider(provider: azdata.CapabilitiesProvider): vscode.Disposable {
 		let rt = this.registerProvider(provider, DataProviderType.CapabilitiesProvider);
 		this._proxy.$registerCapabilitiesServiceProvider(provider.providerId, provider.handle);
@@ -855,5 +860,9 @@ export class ExtHostDataProtocol extends ExtHostDataProtocolShape {
 
 	public $generateAssessmentScript(handle: number, items: azdata.SqlAssessmentResultItem[]): Thenable<azdata.ResultStatus> {
 		return this._resolveProvider<azdata.SqlAssessmentServicesProvider>(handle).generateAssessmentScript(items);
+	}
+
+	public $getResources<T extends azdata.Resource>(handle: number): Thenable<T[]> {
+		return this._resolveProvider<azdata.ResourceDataProvider<T>>(handle).getResources();
 	}
 }

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -373,6 +373,10 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				return extHostDataProvider.$registerSqlAssessmentServiceProvider(provider);
 			};
 
+			let registerResourceDataProvider = <T extends azdata.Resource>(provider: azdata.ResourceDataProvider<T>): vscode.Disposable => {
+				return extHostDataProvider.$registerResourceDataProvider(provider);
+			};
+
 			// namespace: dataprotocol
 			const dataprotocol: typeof azdata.dataprotocol = {
 				registerBackupProvider,
@@ -392,6 +396,7 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				registerCapabilitiesServiceProvider,
 				registerSerializationProvider,
 				registerSqlAssessmentServicesProvider,
+				registerResourceDataProvider,
 				onDidChangeLanguageFlavor(listener: (e: azdata.DidChangeLanguageFlavorParams) => any, thisArgs?: any, disposables?: extHostTypes.Disposable[]) {
 					return extHostDataProvider.onDidChangeLanguageFlavor(listener, thisArgs, disposables);
 				},

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -509,6 +509,8 @@ export abstract class ExtHostDataProtocolShape {
 	 * Generate an assessment script based on recent results
 	 */
 	$generateAssessmentScript(handle: number, items: azdata.SqlAssessmentResultItem[]): Thenable<azdata.ResultStatus> { throw ni(); }
+
+	$getResources<T extends azdata.Resource>(handle: number): Thenable<T[]> { throw ni(); }
 }
 
 /**
@@ -573,6 +575,7 @@ export interface MainThreadDataProtocolShape extends IDisposable {
 	$registerAgentServicesProvider(providerId: string, handle: number): Promise<any>;
 	$registerSerializationProvider(providerId: string, handle: number): Promise<any>;
 	$registerSqlAssessmentServicesProvider(providerId: string, handle: number): Promise<any>;
+	$registerResourceDataProvider(providerId: string, handle: number): void;
 	$unregisterProvider(handle: number): Promise<any>;
 	$onConnectionComplete(handle: number, connectionInfoSummary: azdata.ConnectionInfoSummary): void;
 	$onIntelliSenseCacheComplete(handle: number, connectionUri: string): void;

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -354,7 +354,8 @@ export enum DataProviderType {
 	ObjectExplorerNodeProvider = 'ObjectExplorerNodeProvider',
 	SerializationProvider = 'SerializationProvider',
 	IconProvider = 'IconProvider',
-	SqlAssessmentServicesProvider = 'SqlAssessmentServicesProvider'
+	SqlAssessmentServicesProvider = 'SqlAssessmentServicesProvider',
+	ResourceDataProvider = 'ResourceDataProvider'
 }
 
 export enum DeclarativeDataType {

--- a/src/sql/workbench/services/resourceDataProvider/browser/resourceDataProviderService.ts
+++ b/src/sql/workbench/services/resourceDataProvider/browser/resourceDataProviderService.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from 'azdata';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
+import { IResourceDataProviderService } from 'sql/workbench/services/resourceDataProvider/common/resourceDataProviderService';
+import { invalidProvider } from 'sql/base/common/errors';
+import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
+
+export class ResourceDataProviderService implements IResourceDataProviderService {
+
+	public _serviceBrand: undefined;
+	private _providers: { [handle: string]: azdata.ResourceDataProvider<any>; } = Object.create(null);
+
+	constructor(
+		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
+	) {
+	}
+
+	/**
+	 * Register a resource data provider
+	 */
+	public registerProvider<T extends azdata.Resource>(providerId: string, provider: azdata.ResourceDataProvider<T>): void {
+		this._providers[providerId] = provider;
+	}
+
+	public unregisterProvider(providerId: string): void {
+		delete this._providers[providerId];
+	}
+
+	public async getResources<T extends azdata.Resource>(providerId: string): Promise<T[]> {
+		const provider = this._providers[providerId];
+		if (provider) {
+			this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.FirewallRuleRequested)
+				.withAdditionalProperties({
+					provider: providerId
+				}).send();
+			return provider.getResources();
+		} else {
+			throw invalidProvider(providerId);
+		}
+	}
+}

--- a/src/sql/workbench/services/resourceDataProvider/common/resourceDataProviderService.ts
+++ b/src/sql/workbench/services/resourceDataProvider/common/resourceDataProviderService.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from 'azdata';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+
+export const SERVICE_ID = 'resourceDataProviderService';
+export const IResourceDataProviderService = createDecorator<IResourceDataProviderService>(SERVICE_ID);
+
+export interface IResourceDataProviderService {
+	_serviceBrand: undefined;
+
+	/**
+	 * Register a resource data provider
+	 */
+	registerProvider<T extends azdata.Resource>(providerId: string, provider: azdata.ResourceDataProvider<T>): void;
+
+	/**
+	 * Unregister a resource data provider
+	 */
+	unregisterProvider(providerId: string): void;
+
+	/**
+	 * Gets a list of resources from the specified provider
+	 */
+	getResources<T extends azdata.Resource>(providerId: string): Promise<T[]>;
+}

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -198,6 +198,8 @@ import { INotebookService } from 'sql/workbench/services/notebook/browser/notebo
 import { IScriptingService, ScriptingService } from 'sql/platform/scripting/common/scriptingService';
 import { IAssessmentService } from 'sql/workbench/services/assessment/common/interfaces';
 import { AssessmentService } from 'sql/workbench/services/assessment/common/assessmentService';
+import { ResourceDataProviderService } from 'sql/workbench/services/resourceDataProvider/browser/resourceDataProviderService';
+import { IResourceDataProviderService } from 'sql/workbench/services/resourceDataProvider/common/resourceDataProviderService';
 
 registerSingleton(IDashboardService, DashboardService);
 registerSingleton(IDashboardViewService, DashboardViewService);
@@ -236,6 +238,7 @@ registerSingleton(IAdsTelemetryService, AdsTelemetryService);
 registerSingleton(IObjectExplorerService, ObjectExplorerService);
 registerSingleton(IOEShimService, OEShimService);
 registerSingleton(IAssessmentService, AssessmentService);
+registerSingleton(IResourceDataProviderService, ResourceDataProviderService);
 
 //#endregion
 


### PR DESCRIPTION
This is currently going to be used for the Resource Viewer but is made to be generic enough that others could use it as well.

The general usage here is that extensions can register these data providers - and then when a Resource Viewer editor is opened it populates its items from the resources returned by the data providers that are given for it to use. 

On the extension side it'd look like this

```
	azdata.dataprotocol.registerResourceDataProvider({
		providerId: 'arc',
		getResources: async () => {
                        // Insert actual logic to get items here from wherever you want
			return [
				{ id: 'id1', typeId: 'arcItem', properties: { c1: 'v1.1', c2: 'v1.2', c3: 'v1.3'} },
				{ id: 'id2', typeId: 'arcItem', properties: { c1: 'v2.1', c2: 'v2.2', c3: 'v2.3'} },
				{ id: 'id3', typeId: 'arcItem', properties: { c1: 'v3.1', c2: 'v3.2', c3: 'v3.3'} }
			];
		}
	});
```

Then on the main thread side those resources could be queried like this : 

`const resources = await resourceDataProviderService.getResources('arc');`

Would get the list of resources from the data provider registered with the ID `arc`.

The Resource interface is likely to change once I actually get this hooked up to the grid (for example I'll likely want to add a data type field for the properties) but I wanted to get the API implementation out first and then I can revisit the other stuff later once I have a more concrete implementation hooked up. 

(I would have liked to have just called it ResourceProvider but sadly that was taken up https://github.com/microsoft/azuredatastudio/blob/main/src/sql/azdata.d.ts#L2358 for some reason despite seeming to have nothing to do with providing resources of any type...)