### PR TITLE
Fix tree view icons

### DIFF
--- a/src/sql/workbench/contrib/views/browser/treeView.ts
+++ b/src/sql/workbench/contrib/views/browser/treeView.ts
@@ -812,7 +812,9 @@ class TreeRenderer extends Disposable implements ITreeRenderer<ITreeItem, FuzzyS
 
 		if (iconUrl || sqlIcon) {
 			templateData.icon.className = 'custom-view-tree-node-item-icon';
-			DOM.toggleClass(templateData.icon, sqlIcon ?? '', !!sqlIcon);  // tracked change
+			if (sqlIcon) {
+				DOM.toggleClass(templateData.icon, sqlIcon, !!sqlIcon);  // tracked change
+			}
 			DOM.toggleClass(templateData.icon, 'icon', !!sqlIcon);
 			templateData.icon.style.backgroundImage = iconUrl ? DOM.asCSSUrl(iconUrl) : '';
 		} else {


### PR DESCRIPTION
Broken by https://github.com/microsoft/azuredatastudio/pull/12044 - DOM.toggleClass throws an error if you pass in an empty string for the className which was causing our custom tree views to break.

```
  ERR Failed to execute 'toggle' on 'DOMTokenList': The token provided must not be empty.: Error: Failed to execute 'toggle' on 'DOMTokenList': The token provided must not be empty.
```
Before 
![image](https://user-images.githubusercontent.com/28519865/92057509-d035cd00-ed43-11ea-985c-db4cc64878d3.png)

After 
![image](https://user-images.githubusercontent.com/28519865/92057627-d9269e80-ed43-11ea-824f-d33e7b209fc6.png)

