### PR TITLE
give back the getter for container property

### DIFF
--- a/src/sql/workbench/browser/editor/profiler/dashboardInput.ts
+++ b/src/sql/workbench/browser/editor/profiler/dashboardInput.ts
@@ -127,7 +127,7 @@ export class DashboardInput extends EditorInput {
 		this._parentContainer = container;
 	}
 
-	getContainer(): HTMLElement | undefined {
+	get container(): HTMLElement | undefined {
 		return this._parentContainer;
 	}
 

--- a/src/sql/workbench/browser/editor/profiler/dashboardInput.ts
+++ b/src/sql/workbench/browser/editor/profiler/dashboardInput.ts
@@ -122,7 +122,7 @@ export class DashboardInput extends EditorInput {
 		}
 	}
 
-	set container(container: HTMLElement) {
+	set container(container: HTMLElement | undefined) {
 		this._disposeContainer();
 		this._parentContainer = container;
 	}


### PR DESCRIPTION
This PR fixes #12106 

the getter for the container property of the dashboardInput was changed unexpectedly by https://github.com/microsoft/azuredatastudio/commit/d8dcc9085731df0ff6bb9dc336c0a76e6e1a0dd0#diff-fa11a5cd769e38a19da55711f5836079L131

this is causing the container property to be undefined.
