### PR TITLE
Switch Kusto Icon to one that has transparent background

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3675,7 +3675,7 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/extensions/kusto/resources/images/azure_data_explorer_query_124x124.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/extensions/kusto/resources/images/ADX.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",


### PR DESCRIPTION
Current icon has white background and does not look well in dark mode. Switching icon to one that has transparent icon. 