### PR TITLE
Don't propagate click when clicking on header filter

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -14,10 +14,16 @@ interface IExtendedColumn<T> extends Slick.Column<T> {
 	filterValues?: Array<string>;
 }
 
+export interface CommandEventArgs<T extends Slick.SlickData> {
+		grid: Slick.Grid<T>,
+		column: Slick.Column<T>,
+		command: string
+}
+
 export class HeaderFilter<T extends Slick.SlickData> {
 
 	public onFilterApplied = new Slick.Event();
-	public onCommand = new Slick.Event();
+	public onCommand = new Slick.Event<CommandEventArgs<T>>();
 
 	private grid!: Slick.Grid<T>;
 	private handler = new Slick.EventHandler();
@@ -82,10 +88,16 @@ export class HeaderFilter<T extends Slick.SlickData> {
 			.addClass('slick-header-menubutton')
 			.data('column', column);
 
-		$el.bind('click', (e: KeyboardEvent) => this.showFilter(e)).appendTo(args.node);
+		$el.bind('click', (e: KeyboardEvent) => {
+			this.showFilter(e);
+			e.preventDefault();
+			e.stopPropagation();
+		}).appendTo(args.node);
 		$el.bind('keydown', (e: KeyboardEvent) => {
 			if (e.key === 'Enter' || e.keyCode === 13) {
 				this.showFilter(e);
+				e.preventDefault();
+				e.stopPropagation();
 			}
 		}).appendTo(args.node);
 	}
@@ -377,9 +389,9 @@ export class HeaderFilter<T extends Slick.SlickData> {
 		this.hideMenu();
 
 		this.onCommand.notify({
-			'grid': this.grid,
-			'column': columnDef,
-			'command': command
+			grid: this.grid,
+			column: columnDef,
+			command: command
 		}, e, self);
 
 		e.preventDefault();


### PR DESCRIPTION
Without this clicking on the header filter icon would propagate to the header and thus cause it to sort the column as well.

Also added typing to the onCommand event