### PR TITLE
Remove extra id property from azure subs and add type name helper

### DIFF
--- a/extensions/azurecore/src/azureResource/azure-resource.d.ts
+++ b/extensions/azurecore/src/azureResource/azure-resource.d.ts
@@ -13,10 +13,10 @@ declare module 'azureResource' {
 			sqlServer = 'microsoft.sql/servers',
 			sqlDatabase = 'microsoft.sql/servers/databases',
 			sqlManagedInstance = 'microsoft.sql/managedinstances',
-			sqlManagedInstanceAzureArc = 'microsoft.azuredata/sqlinstances',
+			azureArcSqlManagedInstance = 'microsoft.azuredata/sqlinstances',
 			virtualMachines = 'microsoft.compute/virtualmachines',
 			kustoClusters = 'microsoft.kusto/clusters',
-			postgresServerArc = 'microsoft.azuredata/postgresinstances',
+			azureArcPostgresServer = 'microsoft.azuredata/postgresinstances',
 			postgresServer = 'microsoft.dbforpostgresql/servers',
 			azureArcService = 'microsoft.azuredata/datacontrollers'
 		}

--- a/extensions/azurecore/src/azureResource/azure-resource.d.ts
+++ b/extensions/azurecore/src/azureResource/azure-resource.d.ts
@@ -7,6 +7,20 @@ declare module 'azureResource' {
 	import { TreeDataProvider } from 'vscode';
 	import { DataProvider, Account, TreeItem } from 'azdata';
 	export namespace azureResource {
+
+		export const enum AzureResourceType {
+			resourceGroup = 'microsoft.resources/subscriptions/resourcegroups',
+			sqlServer = 'microsoft.sql/servers',
+			sqlDatabase = 'microsoft.sql/servers/databases',
+			sqlManagedInstance = 'microsoft.sql/managedinstances',
+			sqlManagedInstanceAzureArc = 'microsoft.azuredata/sqlinstances',
+			virtualMachines = 'microsoft.compute/virtualmachines',
+			kustoClusters = 'microsoft.kusto/clusters',
+			postgresServerArc = 'microsoft.azuredata/postgresinstances',
+			postgresServer = 'microsoft.dbforpostgresql/servers',
+			azureArcService = 'microsoft.azuredata/datacontrollers'
+		}
+
 		export interface IAzureResourceProvider extends DataProvider {
 			getTreeDataProvider(): IAzureResourceTreeDataProvider;
 		}
@@ -28,7 +42,7 @@ declare module 'azureResource' {
 			tenant?: string;
 		}
 
-		export interface AzureResourceSubscription extends AzureResource {
+		export interface AzureResourceSubscription extends Omit<AzureResource, 'subscriptionId'> {
 		}
 
 		export interface AzureSqlResource extends AzureResource {

--- a/extensions/azurecore/src/azureResource/providers/database/databaseService.ts
+++ b/extensions/azurecore/src/azureResource/providers/database/databaseService.ts
@@ -21,7 +21,7 @@ export class AzureResourceDatabaseService implements IAzureResourceService<azure
 
 		// Query servers and databases in parallel (start both promises before waiting on the 1st)
 		let serverQueryPromise = queryGraphResources<GraphData>(resourceClient, subscriptions, serversQuery);
-		let dbQueryPromise = queryGraphResources<GraphData>(resourceClient, subscriptions, 'where type == "microsoft.sql/servers/databases"');
+		let dbQueryPromise = queryGraphResources<GraphData>(resourceClient, subscriptions, `where type == "${azureResource.AzureResourceType.sqlDatabase}"`);
 		let servers: DbServerGraphData[] = await serverQueryPromise as DbServerGraphData[];
 		let dbByGraph: DatabaseGraphData[] = await dbQueryPromise as DatabaseGraphData[];
 

--- a/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerService.ts
+++ b/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerService.ts
@@ -15,7 +15,7 @@ export interface DbServerGraphData extends GraphData {
 	};
 }
 
-export const serversQuery = 'where type == "microsoft.sql/servers"';
+export const serversQuery = `where type == "${azureResource.AzureResourceType.sqlServer}"`;
 
 export class AzureResourceDatabaseServerService extends ResourceServiceBase<DbServerGraphData, azureResource.AzureResourceDatabaseServer> {
 

--- a/extensions/azurecore/src/azureResource/providers/kusto/kustoService.ts
+++ b/extensions/azurecore/src/azureResource/providers/kusto/kustoService.ts
@@ -14,7 +14,7 @@ export interface KustoGraphData extends GraphData {
 	};
 }
 
-const instanceQuery = 'where type == "microsoft.kusto/clusters"';
+const instanceQuery = `where type == "${azureResource.AzureResourceType.kustoClusters}"`;
 
 export class KustoResourceService extends ResourceServiceBase<KustoGraphData, azureResource.AzureResourceDatabaseServer> {
 

--- a/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerService.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerService.ts
@@ -12,7 +12,7 @@ export interface PostgresArcServerGraphData extends GraphData {
 	};
 }
 
-export const serversQuery = `where type == "${azureResource.AzureResourceType.postgresServerArc}"`;
+export const serversQuery = `where type == "${azureResource.AzureResourceType.azureArcPostgresServer}"`;
 
 export class PostgresServerArcService extends ResourceServiceBase<PostgresArcServerGraphData, azureResource.AzureResourceDatabaseServer> {
 

--- a/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerService.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerService.ts
@@ -12,7 +12,7 @@ export interface PostgresArcServerGraphData extends GraphData {
 	};
 }
 
-export const serversQuery = 'where type == "microsoft.azuredata/postgresinstances"';
+export const serversQuery = `where type == "${azureResource.AzureResourceType.postgresServerArc}"`;
 
 export class PostgresServerArcService extends ResourceServiceBase<PostgresArcServerGraphData, azureResource.AzureResourceDatabaseServer> {
 

--- a/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerService.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerService.ts
@@ -15,7 +15,7 @@ interface DbServerGraphData extends GraphData {
 	};
 }
 
-const serversQuery = 'where type == "microsoft.dbforpostgresql/servers"';
+const serversQuery = `where type == "${azureResource.AzureResourceType.postgresServer}"`;
 
 export class PostgresServerService extends ResourceServiceBase<DbServerGraphData, azureResource.AzureResourceDatabaseServer> {
 

--- a/extensions/azurecore/src/azureResource/providers/resourceGroup/resourceGroupService.ts
+++ b/extensions/azurecore/src/azureResource/providers/resourceGroup/resourceGroupService.ts
@@ -10,7 +10,7 @@ import { ResourceServiceBase } from '../resourceTreeDataProviderBase';
 export class AzureResourceGroupService extends ResourceServiceBase<DbServerGraphData, azureResource.AzureResourceResourceGroup> {
 
 	protected get query(): string {
-		return 'ResourceContainers | where type=="microsoft.resources/subscriptions/resourcegroups"';
+		return `ResourceContainers | where type=="${azureResource.AzureResourceType.resourceGroup}"`;
 	}
 
 	protected convertResource(resource: DbServerGraphData): azureResource.AzureResourceResourceGroup {

--- a/extensions/azurecore/src/azureResource/providers/sqlinstance/sqlInstanceService.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstance/sqlInstanceService.ts
@@ -13,7 +13,7 @@ interface SqlInstanceGraphData extends GraphData {
 	};
 }
 
-const instanceQuery = 'where type == "microsoft.sql/managedinstances"';
+const instanceQuery = `where type == "${azureResource.AzureResourceType.sqlManagedInstance}"`;
 
 export class SqlInstanceResourceService extends ResourceServiceBase<SqlInstanceGraphData, azureResource.AzureResourceDatabaseServer> {
 

--- a/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcService.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcService.ts
@@ -13,7 +13,7 @@ export interface SqlInstanceArcGraphData extends GraphData {
 	};
 }
 
-const instanceQuery = `where type == "${azureResource.AzureResourceType.sqlManagedInstanceAzureArc}"`;
+const instanceQuery = `where type == "${azureResource.AzureResourceType.azureArcSqlManagedInstance}"`;
 export class SqlInstanceArcResourceService extends ResourceServiceBase<SqlInstanceArcGraphData, azureResource.AzureResourceDatabaseServer> {
 
 	protected get query(): string {

--- a/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcService.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcService.ts
@@ -13,7 +13,7 @@ export interface SqlInstanceArcGraphData extends GraphData {
 	};
 }
 
-const instanceQuery = 'where type == "microsoft.azuredata/sqlinstances"';
+const instanceQuery = `where type == "${azureResource.AzureResourceType.sqlManagedInstanceAzureArc}"`;
 export class SqlInstanceArcResourceService extends ResourceServiceBase<SqlInstanceArcGraphData, azureResource.AzureResourceDatabaseServer> {
 
 	protected get query(): string {

--- a/extensions/azurecore/src/azureResource/services/subscriptionService.ts
+++ b/extensions/azurecore/src/azureResource/services/subscriptionService.ts
@@ -18,7 +18,6 @@ export class AzureResourceSubscriptionService implements IAzureResourceSubscript
 		subs.forEach((sub) => subscriptions.push({
 			id: sub.subscriptionId,
 			name: sub.displayName,
-			subscriptionId: sub.subscriptionId,
 			tenant: tenantId
 		}));
 

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -62,6 +62,6 @@ export const subscription = localize('azurecore.subscription', "Subscription");
 export const sqlServer = localize('azurecore.sqlServer', "SQL server");
 export const sqlDatabase = localize('azurecore.sqlDatabase', "SQL database");
 export const sqlServerArc = localize('azurecore.sqlServerArc', "SQL Server - Azure Arc");
-export const sqlManagedInstance = localize('azurecore.sqlManagedInstance', "SQL Managed Instance");
+export const sqlManagedInstance = localize('azurecore.sqlManagedInstance', "SQL managed instance");
 export const sqlManagedInstanceAzureArc = localize('azurecore.sqlManagedInstanceAzureArc', "SQL managed instance - Azure Arc");
 export const azureArcService = localize('azurecore.azureArcService', "Data Service - Azure Arc");

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -61,7 +61,9 @@ export const subscription = localize('azurecore.subscription', "Subscription");
 // Azure Resource Types
 export const sqlServer = localize('azurecore.sqlServer', "SQL server");
 export const sqlDatabase = localize('azurecore.sqlDatabase', "SQL database");
-export const sqlServerArc = localize('azurecore.sqlServerArc', "SQL Server - Azure Arc");
+export const postgresServer = localize('azurecore.postgresServer', "Azure Database for PostgreSQL server");
 export const sqlManagedInstance = localize('azurecore.sqlManagedInstance', "SQL managed instance");
-export const sqlManagedInstanceAzureArc = localize('azurecore.sqlManagedInstanceAzureArc', "SQL managed instance - Azure Arc");
+export const azureArcsqlManagedInstance = localize('azurecore.azureArcsqlManagedInstance', "SQL managed instance - Azure Arc");
 export const azureArcService = localize('azurecore.azureArcService', "Data Service - Azure Arc");
+export const sqlServerArc = localize('azurecore.sqlServerArc', "SQL Server - Azure Arc");
+export const azureArcPostgresServer = localize('azurecore.azureArcPostgres', "Azure Arc enabled PostgreSQL Hyperscale");

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -51,3 +51,17 @@ export const westEurope = localize('azurecore.westeurope', "West Europe");
 export const westIndia = localize('azurecore.westindia', "West India");
 export const westUS = localize('azurecore.westus', "West US");
 export const westUS2 = localize('azurecore.westus2', "West US 2");
+
+export const name = localize('azurecore.name', "Name");
+export const resourceType = localize('azurecore.resourceType', "Resource type");
+export const resourceGroup = localize('azurecore.resourceGroup', "Resource group");
+export const location = localize('azurecore.location', "Location");
+export const subscription = localize('azurecore.subscription', "Subscription");
+
+// Azure Resource Types
+export const sqlServer = localize('azurecore.sqlServer', "SQL server");
+export const sqlDatabase = localize('azurecore.sqlDatabase', "SQL database");
+export const sqlServerArc = localize('azurecore.sqlServerArc', "SQL Server - Azure Arc");
+export const sqlManagedInstance = localize('azurecore.sqlManagedInstance', "SQL Managed Instance");
+export const sqlManagedInstanceAzureArc = localize('azurecore.sqlManagedInstanceAzureArc', "SQL managed instance - Azure Arc");
+export const azureArcService = localize('azurecore.azureArcService', "Data Service - Azure Arc");

--- a/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
@@ -47,7 +47,6 @@ const mockSubscriptionId = 'mock_subscription';
 const mockSubscription: azureResource.AzureResourceSubscription = {
 	id: mockSubscriptionId,
 	name: 'mock subscription',
-	subscriptionId: mockSubscriptionId,
 	tenant: mockTenantId
 };
 

--- a/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
@@ -46,7 +46,6 @@ const mockSubscriptionId = 'mock_subscription';
 const mockSubscription: azureResource.AzureResourceSubscription = {
 	id: mockSubscriptionId,
 	name: 'mock subscription',
-	subscriptionId: mockSubscriptionId,
 	tenant: mockTenantId
 };
 

--- a/extensions/azurecore/src/test/azureResource/resourceService.test.ts
+++ b/extensions/azurecore/src/test/azureResource/resourceService.test.ts
@@ -39,7 +39,6 @@ const mockSubscriptionId ='mock_subscription';
 const mockSubscription: azureResource.AzureResourceSubscription = {
 	id: mockSubscriptionId,
 	name: 'mock subscription',
-	subscriptionId: mockSubscriptionId,
 	tenant: mockTenantId
 };
 

--- a/extensions/azurecore/src/test/azureResource/resourceTreeNode.test.ts
+++ b/extensions/azurecore/src/test/azureResource/resourceTreeNode.test.ts
@@ -42,7 +42,6 @@ const mockSubscriptionId = 'mock_subscription';
 const mockSubscription: azureResource.AzureResourceSubscription = {
 	id: mockSubscriptionId,
 	name: 'mock subscription',
-	subscriptionId: mockSubscriptionId,
 	tenant: mockTenantId
 };
 

--- a/extensions/azurecore/src/test/azureResource/tree/accountTreeNode.test.ts
+++ b/extensions/azurecore/src/test/azureResource/tree/accountTreeNode.test.ts
@@ -63,7 +63,6 @@ const mock_subscription_id_1 = 'mock_subscription_1';
 const mockSubscription1: azureResource.AzureResourceSubscription = {
 	id: mock_subscription_id_1,
 	name: 'mock subscription 1',
-	subscriptionId: mock_subscription_id_1,
 	tenant: mockTenantId
 };
 
@@ -71,7 +70,6 @@ const mock_subscription_id_2 = 'mock_subscription_2';
 const mockSubscription2: azureResource.AzureResourceSubscription = {
 	id: mock_subscription_id_2,
 	name: 'mock subscription 2',
-	subscriptionId: mock_subscription_id_2,
 	tenant: mockTenantId
 };
 

--- a/extensions/azurecore/src/test/azureResource/tree/subscriptionTreeNode.test.ts
+++ b/extensions/azurecore/src/test/azureResource/tree/subscriptionTreeNode.test.ts
@@ -49,7 +49,6 @@ const mockSubscriptionId: string = 'mock_subscription';
 const mockSubscription: azureResource.AzureResourceSubscription = {
 	id: mockSubscriptionId,
 	name: 'mock subscription',
-	subscriptionId: mockSubscriptionId,
 	tenant: mockTenantId
 };
 

--- a/extensions/azurecore/src/utils.ts
+++ b/extensions/azurecore/src/utils.ts
@@ -108,10 +108,12 @@ export function getResourceTypeDisplayName(type: string): string {
 			return loc.sqlDatabase;
 		case azureResource.AzureResourceType.sqlManagedInstance:
 			return loc.sqlManagedInstance;
-		case azureResource.AzureResourceType.sqlManagedInstanceAzureArc:
-			return loc.sqlManagedInstanceAzureArc;
+		case azureResource.AzureResourceType.azureArcSqlManagedInstance:
+			return loc.azureArcsqlManagedInstance;
 		case azureResource.AzureResourceType.azureArcService:
 			return loc.azureArcService;
+		case azureResource.AzureResourceType.azureArcPostgresServer:
+			return loc.azureArcPostgresServer;
 	}
 	return type;
 }

--- a/extensions/azurecore/src/utils.ts
+++ b/extensions/azurecore/src/utils.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { azureResource } from 'azureResource';
 import * as loc from './localizedConstants';
 import { AzureRegion } from 'azurecore';
 
@@ -97,4 +98,20 @@ export function getRegionDisplayName(region?: string): string {
 	}
 	console.warn(`Unknown Azure region ${region}`);
 	return region;
+}
+
+export function getResourceTypeDisplayName(type: string): string {
+	switch (type) {
+		case azureResource.AzureResourceType.sqlServer:
+			return loc.sqlServer;
+		case azureResource.AzureResourceType.sqlDatabase:
+			return loc.sqlDatabase;
+		case azureResource.AzureResourceType.sqlManagedInstance:
+			return loc.sqlManagedInstance;
+		case azureResource.AzureResourceType.sqlManagedInstanceAzureArc:
+			return loc.sqlManagedInstanceAzureArc;
+		case azureResource.AzureResourceType.azureArcService:
+			return loc.azureArcService;
+	}
+	return type;
 }

--- a/extensions/machine-learning/src/test/modelManagement/azureModelRegistryService.test.ts
+++ b/extensions/machine-learning/src/test/modelManagement/azureModelRegistryService.test.ts
@@ -81,8 +81,7 @@ function createContext(): TestContext {
 		subscriptions: [
 			{
 				name: 's1',
-				id: 's1',
-				subscriptionId: 's1'
+				id: 's1'
 			}
 		],
 		groups: [

--- a/extensions/machine-learning/src/test/views/models/ModelManagementController.test.ts
+++ b/extensions/machine-learning/src/test/views/models/ModelManagementController.test.ts
@@ -35,8 +35,7 @@ const accounts: azdata.Account[] = [
 const subscriptions: azureResource.AzureResourceSubscription[] = [
 	{
 		name: 'subscription',
-		id: '2',
-		subscriptionId: 'subscription'
+		id: '2'
 	}
 ];
 const groups: azureResource.AzureResourceResourceGroup[] = [

--- a/extensions/machine-learning/src/test/views/models/azureModelsComponent.test.ts
+++ b/extensions/machine-learning/src/test/views/models/azureModelsComponent.test.ts
@@ -50,8 +50,7 @@ describe('Azure Models Component', () => {
 		let subscriptions: azureResource.AzureResourceSubscription[] = [
 			{
 				name: 'subscription',
-				id: '2',
-				subscriptionId: 'subscription'
+				id: '2'
 			}
 		];
 		let groups: azureResource.AzureResourceResourceGroup[] = [

--- a/extensions/machine-learning/src/test/views/models/predictWizard.test.ts
+++ b/extensions/machine-learning/src/test/views/models/predictWizard.test.ts
@@ -58,8 +58,7 @@ describe('Predict Wizard', () => {
 		let subscriptions: azureResource.AzureResourceSubscription[] = [
 			{
 				name: 'subscription',
-				id: '2',
-				subscriptionId: 'subscription'
+				id: '2'
 			}
 		];
 		let groups: azureResource.AzureResourceResourceGroup[] = [

--- a/extensions/machine-learning/src/test/views/models/registerModelWizard.test.ts
+++ b/extensions/machine-learning/src/test/views/models/registerModelWizard.test.ts
@@ -34,8 +34,7 @@ let accounts: azdata.Account[] = [
 let subscriptions: azureResource.AzureResourceSubscription[] = [
 	{
 		name: 'subscription',
-		id: '2',
-		subscriptionId: 'subscription'
+		id: '2'
 	}
 ];
 let groups: azureResource.AzureResourceResourceGroup[] = [

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -39,7 +39,7 @@ export type SqlManagedInstance = AzureProduct;
 export async function getAvailableManagedInstanceProducts(account: azdata.Account, subscription: Subscription): Promise<SqlManagedInstance[]> {
 	const api = await getAzureCoreAPI();
 
-	const result = await api.runGraphQuery<SqlManagedInstance>(account, [subscription], false, 'where type == "microsoft.sql/managedinstances"');
+	const result = await api.runGraphQuery<SqlManagedInstance>(account, [subscription], false, `where type == "${azureResource.AzureResourceType.sqlManagedInstance}"`);
 	return result.resources;
 }
 
@@ -47,7 +47,7 @@ export type SqlServer = AzureProduct;
 export async function getAvailableSqlServers(account: azdata.Account, subscription: Subscription): Promise<SqlServer[]> {
 	const api = await getAzureCoreAPI();
 
-	const result = await api.runGraphQuery<SqlServer>(account, [subscription], false, 'where type == "microsoft.sql/servers"');
+	const result = await api.runGraphQuery<SqlServer>(account, [subscription], false, `where type == "${azureResource.AzureResourceType.sqlServer}"`);
 	return result.resources;
 }
 
@@ -55,6 +55,6 @@ export type SqlVMServer = AzureProduct;
 export async function getAvailableSqlVMs(account: azdata.Account, subscription: Subscription): Promise<SqlVMServer[]> {
 	const api = await getAzureCoreAPI();
 
-	const result = await api.runGraphQuery<SqlVMServer>(account, [subscription], false, 'where type == "microsoft.compute/virtualmachines" and properties.storageProfile.imageReference.publisher == "microsoftsqlserver"');
+	const result = await api.runGraphQuery<SqlVMServer>(account, [subscription], false, `where type == "${azureResource.AzureResourceType.virtualMachines}" and properties.storageProfile.imageReference.publisher == "microsoftsqlserver"`);
 	return result.resources;
 }


### PR DESCRIPTION
Subscriptions already had the id property so subscriptionId is redundant. 

Also adding enum for easily getting the resource types and a helper method for the display names of those types (will be used in the resource viewer)