### PR TITLE
Genericify azdata components

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2610,7 +2610,6 @@ declare module 'azdata' {
 	export interface ComponentBuilder<TComponent extends Component, TPropertyBag extends ComponentProperties> {
 		component(): TComponent;
 		withProperties<U>(properties: U): ComponentBuilder<TComponent, TPropertyBag>;
-		withProps(properties: TPropertyBag): ComponentBuilder<TComponent, TPropertyBag>;
 		withValidation(validation: (component: TComponent) => boolean): ComponentBuilder<TComponent, TPropertyBag>;
 	}
 	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ComponentProperties> extends ComponentBuilder<TComponent, TPropertyBag> {

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2555,37 +2555,37 @@ declare module 'azdata' {
 	 * Supports defining a model that can be instantiated as a view in the UI
 	 */
 	export interface ModelBuilder {
-		navContainer(): ContainerBuilder<NavContainer, any, any>;
+		navContainer(): ContainerBuilder<NavContainer, any, any, ComponentProperties>;
 		divContainer(): DivBuilder;
 		flexContainer(): FlexBuilder;
 		splitViewContainer(): SplitViewBuilder;
-		dom(): ComponentBuilder<DomComponent>;
+		dom(): ComponentBuilder<DomComponent, DomProperties>;
 		/**
 		 * @deprecated please use radioCardGroup component.
 		 */
-		card(): ComponentBuilder<CardComponent>;
-		inputBox(): ComponentBuilder<InputBoxComponent>;
-		checkBox(): ComponentBuilder<CheckBoxComponent>;
-		radioButton(): ComponentBuilder<RadioButtonComponent>;
-		webView(): ComponentBuilder<WebViewComponent>;
-		editor(): ComponentBuilder<EditorComponent>;
-		diffeditor(): ComponentBuilder<DiffEditorComponent>;
-		text(): ComponentBuilder<TextComponent>;
-		image(): ComponentBuilder<ImageComponent>;
-		button(): ComponentBuilder<ButtonComponent>;
-		dropDown(): ComponentBuilder<DropDownComponent>;
-		tree<T>(): ComponentBuilder<TreeComponent<T>>;
-		listBox(): ComponentBuilder<ListBoxComponent>;
-		table(): ComponentBuilder<TableComponent>;
-		declarativeTable(): ComponentBuilder<DeclarativeTableComponent>;
-		dashboardWidget(widgetId: string): ComponentBuilder<DashboardWidgetComponent>;
-		dashboardWebview(webviewId: string): ComponentBuilder<DashboardWebviewComponent>;
+		card(): ComponentBuilder<CardComponent, CardProperties>;
+		inputBox(): ComponentBuilder<InputBoxComponent, InputBoxProperties>;
+		checkBox(): ComponentBuilder<CheckBoxComponent, CheckBoxProperties>;
+		radioButton(): ComponentBuilder<RadioButtonComponent, RadioButtonProperties>;
+		webView(): ComponentBuilder<WebViewComponent, WebViewProperties>;
+		editor(): ComponentBuilder<EditorComponent, EditorProperties>;
+		diffeditor(): ComponentBuilder<DiffEditorComponent, DiffEditorComponent>;
+		text(): ComponentBuilder<TextComponent, TextComponentProperties>;
+		image(): ComponentBuilder<ImageComponent, ImageComponentProperties>;
+		button(): ComponentBuilder<ButtonComponent, ButtonProperties>;
+		dropDown(): ComponentBuilder<DropDownComponent, DropDownProperties>;
+		tree<T>(): ComponentBuilder<TreeComponent<T>, TreeProperties>;
+		listBox(): ComponentBuilder<ListBoxComponent, ListBoxProperties>;
+		table(): ComponentBuilder<TableComponent, TableComponentProperties>;
+		declarativeTable(): ComponentBuilder<DeclarativeTableComponent, DeclarativeTableProperties>;
+		dashboardWidget(widgetId: string): ComponentBuilder<DashboardWidgetComponent, ComponentProperties>;
+		dashboardWebview(webviewId: string): ComponentBuilder<DashboardWebviewComponent, ComponentProperties>;
 		formContainer(): FormBuilder;
 		groupContainer(): GroupBuilder;
 		toolbarContainer(): ToolbarBuilder;
 		loadingComponent(): LoadingComponentBuilder;
-		fileBrowserTree(): ComponentBuilder<FileBrowserTreeComponent>;
-		hyperlink(): ComponentBuilder<HyperlinkComponent>;
+		fileBrowserTree(): ComponentBuilder<FileBrowserTreeComponent, FileBrowserTreeProperties>;
+		hyperlink(): ComponentBuilder<HyperlinkComponent, HyperlinkComponentProperties>;
 	}
 
 	export interface TreeComponentDataProvider<T> extends vscode.TreeDataProvider<T> {
@@ -2607,31 +2607,32 @@ declare module 'azdata' {
 		enabled?: boolean;
 	}
 
-	export interface ComponentBuilder<T extends Component> {
-		component(): T;
-		withProperties<U>(properties: U): ComponentBuilder<T>;
-		withValidation(validation: (component: T) => boolean): ComponentBuilder<T>;
+	export interface ComponentBuilder<TComponent extends Component, TPropertyBag extends ComponentProperties> {
+		component(): TComponent;
+		withProperties<U>(properties: U): ComponentBuilder<TComponent, TPropertyBag>;
+		withProps(properties: TPropertyBag): ComponentBuilder<TComponent, TPropertyBag>;
+		withValidation(validation: (component: TComponent) => boolean): ComponentBuilder<TComponent, TPropertyBag>;
 	}
-	export interface ContainerBuilder<T extends Component, TLayout, TItemLayout> extends ComponentBuilder<T> {
-		withLayout(layout: TLayout): ContainerBuilder<T, TLayout, TItemLayout>;
-		withItems(components: Array<Component>, itemLayout?: TItemLayout): ContainerBuilder<T, TLayout, TItemLayout>;
+	export interface ContainerBuilder<TComponent extends Component, TLayout, TItemLayout, TPropertyBag extends ComponentProperties> extends ComponentBuilder<TComponent, TPropertyBag> {
+		withLayout(layout: TLayout): ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag>;
+		withItems(components: Array<Component>, itemLayout?: TItemLayout): ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag>;
 	}
 
-	export interface FlexBuilder extends ContainerBuilder<FlexContainer, FlexLayout, FlexItemLayout> {
+	export interface FlexBuilder extends ContainerBuilder<FlexContainer, FlexLayout, FlexItemLayout, ComponentProperties> {
 	}
 
 	// Building on top of flex item
-	export interface SplitViewBuilder extends ContainerBuilder<SplitViewContainer, SplitViewLayout, FlexItemLayout> {
+	export interface SplitViewBuilder extends ContainerBuilder<SplitViewContainer, SplitViewLayout, FlexItemLayout, SplitViewContainer> {
 	}
 
-	export interface DivBuilder extends ContainerBuilder<DivContainer, DivLayout, DivItemLayout> {
+	export interface DivBuilder extends ContainerBuilder<DivContainer, DivLayout, DivItemLayout, DivContainerProperties> {
 	}
 
-	export interface GroupBuilder extends ContainerBuilder<GroupContainer, GroupLayout, GroupItemLayout> {
+	export interface GroupBuilder extends ContainerBuilder<GroupContainer, GroupLayout, GroupItemLayout, GroupContainerProperties> {
 	}
 
-	export interface ToolbarBuilder extends ContainerBuilder<ToolbarContainer, ToolbarLayout, any> {
-		withToolbarItems(components: ToolbarComponent[]): ContainerBuilder<ToolbarContainer, ToolbarLayout, any>;
+	export interface ToolbarBuilder extends ContainerBuilder<ToolbarContainer, ToolbarLayout, any, ComponentProperties> {
+		withToolbarItems(components: ToolbarComponent[]): ContainerBuilder<ToolbarContainer, ToolbarLayout, any, ComponentProperties>;
 
 		/**
 		 * Creates a collection of child components and adds them all to this container
@@ -2648,7 +2649,7 @@ declare module 'azdata' {
 		addToolbarItem(toolbarComponent: ToolbarComponent): void;
 	}
 
-	export interface LoadingComponentBuilder extends ComponentBuilder<LoadingComponent> {
+	export interface LoadingComponentBuilder extends ComponentBuilder<LoadingComponent, LoadingComponentProperties> {
 		/**
 		 * Set the component wrapped by the LoadingComponent
 		 * @param component The component to wrap
@@ -2656,7 +2657,7 @@ declare module 'azdata' {
 		withItem(component: Component): LoadingComponentBuilder;
 	}
 
-	export interface FormBuilder extends ContainerBuilder<FormContainer, FormLayout, FormItemLayout> {
+	export interface FormBuilder extends ContainerBuilder<FormContainer, FormLayout, FormItemLayout, ComponentProperties> {
 		withFormItems(components: (FormComponent | FormComponentGroup)[], itemLayout?: FormItemLayout): FormBuilder;
 
 		/**

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -194,10 +194,10 @@ declare module 'azdata' {
 	}
 
 	export interface ModelBuilder {
-		radioCardGroup(): ComponentBuilder<RadioCardGroupComponent>;
+		radioCardGroup(): ComponentBuilder<RadioCardGroupComponent, RadioCardGroupComponentProperties>;
 		tabbedPanel(): TabbedPanelComponentBuilder;
-		separator(): ComponentBuilder<SeparatorComponent>;
-		propertiesContainer(): ComponentBuilder<PropertiesContainerComponent>;
+		separator(): ComponentBuilder<SeparatorComponent, SeparatorComponentProperties>;
+		propertiesContainer(): ComponentBuilder<PropertiesContainerComponent, PropertiesContainerComponentProperties>;
 	}
 
 	export interface RadioCard {
@@ -375,12 +375,12 @@ declare module 'azdata' {
 	/**
 	 * Builder for TabbedPannelComponent
 	 */
-	export interface TabbedPanelComponentBuilder extends ContainerBuilder<TabbedPanelComponent, TabbedPanelLayout, any> {
+	export interface TabbedPanelComponentBuilder extends ContainerBuilder<TabbedPanelComponent, TabbedPanelLayout, any, ComponentProperties> {
 		/**
 		 * Add the tabs to the component
 		 * @param tabs tabs/tab groups to be added
 		 */
-		withTabs(tabs: (Tab | TabGroup)[]): ContainerBuilder<TabbedPanelComponent, TabbedPanelLayout, any>;
+		withTabs(tabs: (Tab | TabGroup)[]): ContainerBuilder<TabbedPanelComponent, TabbedPanelLayout, any, ComponentProperties>;
 	}
 
 	export interface InputBoxProperties extends ComponentProperties {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -200,6 +200,10 @@ declare module 'azdata' {
 		propertiesContainer(): ComponentBuilder<PropertiesContainerComponent, PropertiesContainerComponentProperties>;
 	}
 
+	export interface ComponentBuilder<TComponent extends Component, TPropertyBag extends ComponentProperties> {
+		withProps(properties: TPropertyBag): ComponentBuilder<TComponent, TPropertyBag>;
+	}
+
 	export interface RadioCard {
 		id: string;
 		descriptions: RadioCardDescription[];

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -23,7 +23,7 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 
 class ModelBuilderImpl implements azdata.ModelBuilder {
 	private nextComponentId: number;
-	private readonly _componentBuilders = new Map<string, ComponentBuilderImpl<any>>();
+	private readonly _componentBuilders = new Map<string, ComponentBuilderImpl<any, azdata.ComponentProperties>>();
 
 	constructor(
 		private readonly _proxy: MainThreadModelViewShape,
@@ -35,9 +35,9 @@ class ModelBuilderImpl implements azdata.ModelBuilder {
 		this.nextComponentId = 0;
 	}
 
-	navContainer(): azdata.ContainerBuilder<azdata.NavContainer, any, any> {
+	navContainer(): azdata.ContainerBuilder<azdata.NavContainer, any, any, azdata.ComponentProperties> {
 		let id = this.getNextComponentId();
-		let container: GenericContainerBuilder<azdata.NavContainer, any, any> = new GenericContainerBuilder(this._proxy, this._handle, ModelComponentTypes.NavContainer, id);
+		let container: GenericContainerBuilder<azdata.NavContainer, any, any, azdata.ComponentProperties> = new GenericContainerBuilder(this._proxy, this._handle, ModelComponentTypes.NavContainer, id);
 		this._componentBuilders.set(id, container);
 		return container;
 	}
@@ -51,14 +51,14 @@ class ModelBuilderImpl implements azdata.ModelBuilder {
 
 	flexContainer(): azdata.FlexBuilder {
 		let id = this.getNextComponentId();
-		let container: GenericContainerBuilder<azdata.FlexContainer, any, any> = new GenericContainerBuilder<azdata.FlexContainer, azdata.FlexLayout, azdata.FlexItemLayout>(this._proxy, this._handle, ModelComponentTypes.FlexContainer, id);
+		let container: GenericContainerBuilder<azdata.FlexContainer, any, any, azdata.ComponentProperties> = new GenericContainerBuilder<azdata.FlexContainer, azdata.FlexLayout, azdata.FlexItemLayout, azdata.ComponentProperties>(this._proxy, this._handle, ModelComponentTypes.FlexContainer, id);
 		this._componentBuilders.set(id, container);
 		return container;
 	}
 
 	splitViewContainer(): azdata.SplitViewBuilder {
 		let id = this.getNextComponentId();
-		let container: GenericContainerBuilder<azdata.SplitViewContainer, any, any> = new GenericContainerBuilder<azdata.SplitViewContainer, azdata.SplitViewLayout, azdata.FlexItemLayout>(this._proxy, this._handle, ModelComponentTypes.SplitViewContainer, id);
+		let container: GenericContainerBuilder<azdata.SplitViewContainer, any, any, azdata.SplitViewContainer> = new GenericContainerBuilder<azdata.SplitViewContainer, azdata.SplitViewLayout, azdata.FlexItemLayout, azdata.SplitViewContainer>(this._proxy, this._handle, ModelComponentTypes.SplitViewContainer, id);
 		this._componentBuilders.set(id, container);
 		return container;
 	}
@@ -85,132 +85,132 @@ class ModelBuilderImpl implements azdata.ModelBuilder {
 	}
 
 	private cardDeprecationMessagePrinted = false;
-	card(): azdata.ComponentBuilder<azdata.CardComponent> {
+	card(): azdata.ComponentBuilder<azdata.CardComponent, azdata.CardProperties> {
 		if (!this.cardDeprecationMessagePrinted) {
 			this.logService.warn(`Extension '${this._extension.identifier.value}' is using card component which has been replaced by radioCardGroup. the card component will be removed in a future release.`);
 			this.cardDeprecationMessagePrinted = true;
 		}
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.CardComponent> = this.getComponentBuilder(new CardWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.CardComponent, azdata.CardProperties> = this.getComponentBuilder(new CardWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	tree<T>(): azdata.ComponentBuilder<azdata.TreeComponent<T>> {
+	tree<T>(): azdata.ComponentBuilder<azdata.TreeComponent<T>, azdata.TreeProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.TreeComponent<T>> = this.getComponentBuilder(new TreeComponentWrapper(this._extHostModelViewTree, this._proxy, this._handle, id, this._extension), id);
+		let builder: ComponentBuilderImpl<azdata.TreeComponent<T>, azdata.TreeProperties> = this.getComponentBuilder(new TreeComponentWrapper(this._extHostModelViewTree, this._proxy, this._handle, id, this._extension), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	inputBox(): azdata.ComponentBuilder<azdata.InputBoxComponent> {
+	inputBox(): azdata.ComponentBuilder<azdata.InputBoxComponent, azdata.InputBoxProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.InputBoxComponent> = this.getComponentBuilder(new InputBoxWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.InputBoxComponent, azdata.InputBoxProperties> = this.getComponentBuilder(new InputBoxWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	text(): azdata.ComponentBuilder<azdata.TextComponent> {
+	text(): azdata.ComponentBuilder<azdata.TextComponent, azdata.TextComponentProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.TextComponent> = this.getComponentBuilder(new TextComponentWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.TextComponent, azdata.TextComponentProperties> = this.getComponentBuilder(new TextComponentWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	image(): azdata.ComponentBuilder<azdata.ImageComponent> {
+	image(): azdata.ComponentBuilder<azdata.ImageComponent, azdata.ImageComponentProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.ImageComponent> = this.getComponentBuilder(new ImageComponentWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.ImageComponent, azdata.ImageComponentProperties> = this.getComponentBuilder(new ImageComponentWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	radioButton(): azdata.ComponentBuilder<azdata.RadioButtonComponent> {
+	radioButton(): azdata.ComponentBuilder<azdata.RadioButtonComponent, azdata.RadioButtonProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.RadioButtonComponent> = this.getComponentBuilder(new RadioButtonWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.RadioButtonComponent, azdata.RadioButtonProperties> = this.getComponentBuilder(new RadioButtonWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	checkBox(): azdata.ComponentBuilder<azdata.CheckBoxComponent> {
+	checkBox(): azdata.ComponentBuilder<azdata.CheckBoxComponent, azdata.CheckBoxProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.CheckBoxComponent> = this.getComponentBuilder(new CheckBoxWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.CheckBoxComponent, azdata.CheckBoxProperties> = this.getComponentBuilder(new CheckBoxWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	webView(): azdata.ComponentBuilder<azdata.WebViewComponent> {
+	webView(): azdata.ComponentBuilder<azdata.WebViewComponent, azdata.WebViewProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.WebViewComponent> = this.getComponentBuilder(new WebViewWrapper(this._proxy, this._handle, id, this._extension.extensionLocation), id);
+		let builder: ComponentBuilderImpl<azdata.WebViewComponent, azdata.WebViewProperties> = this.getComponentBuilder(new WebViewWrapper(this._proxy, this._handle, id, this._extension.extensionLocation), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	editor(): azdata.ComponentBuilder<azdata.EditorComponent> {
+	editor(): azdata.ComponentBuilder<azdata.EditorComponent, azdata.EditorProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.EditorComponent> = this.getComponentBuilder(new EditorWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.EditorComponent, azdata.EditorProperties> = this.getComponentBuilder(new EditorWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	diffeditor(): azdata.ComponentBuilder<azdata.DiffEditorComponent> {
+	diffeditor(): azdata.ComponentBuilder<azdata.DiffEditorComponent, azdata.DiffEditorComponent> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.DiffEditorComponent> = this.getComponentBuilder(new DiffEditorWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.DiffEditorComponent, azdata.DiffEditorComponent> = this.getComponentBuilder(new DiffEditorWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	button(): azdata.ComponentBuilder<azdata.ButtonComponent> {
+	button(): azdata.ComponentBuilder<azdata.ButtonComponent, azdata.ButtonProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.ButtonComponent> = this.getComponentBuilder(new ButtonWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.ButtonComponent, azdata.ButtonProperties> = this.getComponentBuilder(new ButtonWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	separator(): azdata.ComponentBuilder<azdata.SeparatorComponent> {
+	separator(): azdata.ComponentBuilder<azdata.SeparatorComponent, azdata.SeparatorComponentProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.SeparatorComponent> = this.getComponentBuilder(new SeparatorWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.SeparatorComponent, azdata.SeparatorComponentProperties> = this.getComponentBuilder(new SeparatorWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	dropDown(): azdata.ComponentBuilder<azdata.DropDownComponent> {
+	dropDown(): azdata.ComponentBuilder<azdata.DropDownComponent, azdata.DropDownProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.DropDownComponent> = this.getComponentBuilder(new DropDownWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.DropDownComponent, azdata.DropDownProperties> = this.getComponentBuilder(new DropDownWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	listBox(): azdata.ComponentBuilder<azdata.ListBoxComponent> {
+	listBox(): azdata.ComponentBuilder<azdata.ListBoxComponent, azdata.ListBoxProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.ListBoxComponent> = this.getComponentBuilder(new ListBoxWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.ListBoxComponent, azdata.ListBoxProperties> = this.getComponentBuilder(new ListBoxWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	table(): azdata.ComponentBuilder<azdata.TableComponent> {
+	table(): azdata.ComponentBuilder<azdata.TableComponent, azdata.TableComponentProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.TableComponent> = this.getComponentBuilder(new TableComponentWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.TableComponent, azdata.TableComponentProperties> = this.getComponentBuilder(new TableComponentWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	declarativeTable(): azdata.ComponentBuilder<azdata.DeclarativeTableComponent> {
+	declarativeTable(): azdata.ComponentBuilder<azdata.DeclarativeTableComponent, azdata.DeclarativeTableProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.DeclarativeTableComponent> = this.getComponentBuilder(new DeclarativeTableWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.DeclarativeTableComponent, azdata.DeclarativeTableProperties> = this.getComponentBuilder(new DeclarativeTableWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	dashboardWidget(widgetId: string): azdata.ComponentBuilder<azdata.DashboardWidgetComponent> {
+	dashboardWidget(widgetId: string): azdata.ComponentBuilder<azdata.DashboardWidgetComponent, azdata.ComponentProperties> {
 		let id = this.getNextComponentId();
-		let builder = this.getComponentBuilder<azdata.DashboardWidgetComponent>(new ComponentWrapper(this._proxy, this._handle, ModelComponentTypes.DashboardWidget, id), id);
+		let builder = this.getComponentBuilder<azdata.DashboardWidgetComponent, azdata.ComponentProperties>(new ComponentWrapper(this._proxy, this._handle, ModelComponentTypes.DashboardWidget, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	dashboardWebview(webviewId: string): azdata.ComponentBuilder<azdata.DashboardWebviewComponent> {
+	dashboardWebview(webviewId: string): azdata.ComponentBuilder<azdata.DashboardWebviewComponent, azdata.ComponentProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.DashboardWebviewComponent> = this.getComponentBuilder(new ComponentWrapper(this._proxy, this._handle, ModelComponentTypes.DashboardWebview, id), id);
+		let builder: ComponentBuilderImpl<azdata.DashboardWebviewComponent, azdata.ComponentProperties> = this.getComponentBuilder(new ComponentWrapper(this._proxy, this._handle, ModelComponentTypes.DashboardWebview, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
@@ -222,30 +222,30 @@ class ModelBuilderImpl implements azdata.ModelBuilder {
 		return builder;
 	}
 
-	fileBrowserTree(): azdata.ComponentBuilder<azdata.FileBrowserTreeComponent> {
+	fileBrowserTree(): azdata.ComponentBuilder<azdata.FileBrowserTreeComponent, azdata.FileBrowserTreeProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.FileBrowserTreeComponent> = this.getComponentBuilder(new FileBrowserTreeComponentWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.FileBrowserTreeComponent, azdata.FileBrowserTreeProperties> = this.getComponentBuilder(new FileBrowserTreeComponentWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	dom(): azdata.ComponentBuilder<azdata.DomComponent> {
+	dom(): azdata.ComponentBuilder<azdata.DomComponent, azdata.DomProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.DomComponent> = this.getComponentBuilder(new DomComponentWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.DomComponent, azdata.DomProperties> = this.getComponentBuilder(new DomComponentWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	hyperlink(): azdata.ComponentBuilder<azdata.HyperlinkComponent> {
+	hyperlink(): azdata.ComponentBuilder<azdata.HyperlinkComponent, azdata.HyperlinkComponentProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.HyperlinkComponent> = this.getComponentBuilder(new HyperlinkComponentWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.HyperlinkComponent, azdata.HyperlinkComponentProperties> = this.getComponentBuilder(new HyperlinkComponentWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	radioCardGroup(): azdata.ComponentBuilder<azdata.RadioCardGroupComponent> {
+	radioCardGroup(): azdata.ComponentBuilder<azdata.RadioCardGroupComponent, azdata.RadioCardGroupComponentProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.RadioCardGroupComponent> = this.getComponentBuilder(new RadioCardGroupComponentWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.RadioCardGroupComponent, azdata.RadioCardGroupComponentProperties> = this.getComponentBuilder(new RadioCardGroupComponentWrapper(this._proxy, this._handle, id), id);
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
@@ -257,16 +257,16 @@ class ModelBuilderImpl implements azdata.ModelBuilder {
 		return builder;
 	}
 
-	propertiesContainer(): azdata.ComponentBuilder<azdata.PropertiesContainerComponent> {
+	propertiesContainer(): azdata.ComponentBuilder<azdata.PropertiesContainerComponent, azdata.PropertiesContainerComponentProperties> {
 		let id = this.getNextComponentId();
-		let builder: ComponentBuilderImpl<azdata.PropertiesContainerComponent> = this.getComponentBuilder(new PropertiesContainerComponentWrapper(this._proxy, this._handle, id), id);
+		let builder: ComponentBuilderImpl<azdata.PropertiesContainerComponent, azdata.PropertiesContainerComponentProperties> = this.getComponentBuilder(new PropertiesContainerComponentWrapper(this._proxy, this._handle, id), id);
 
 		this._componentBuilders.set(id, builder);
 		return builder;
 	}
 
-	getComponentBuilder<T extends azdata.Component>(component: ComponentWrapper, id: string): ComponentBuilderImpl<T> {
-		let componentBuilder: ComponentBuilderImpl<T> = new ComponentBuilderImpl<T>(component);
+	getComponentBuilder<T extends azdata.Component, TPropertyBag extends azdata.ComponentProperties>(component: ComponentWrapper, id: string): ComponentBuilderImpl<T, TPropertyBag> {
+		let componentBuilder: ComponentBuilderImpl<T, TPropertyBag> = new ComponentBuilderImpl<T, TPropertyBag>(component);
 		this._componentBuilders.set(id, componentBuilder);
 		return componentBuilder;
 	}
@@ -292,7 +292,7 @@ interface IWithEventHandler {
 	handleEvent(eventArgs: IComponentEventArgs): void;
 }
 
-class ComponentBuilderImpl<T extends azdata.Component> implements azdata.ComponentBuilder<T>, IWithEventHandler {
+class ComponentBuilderImpl<T extends azdata.Component, TPropertyBag extends azdata.ComponentProperties> implements azdata.ComponentBuilder<T, TPropertyBag>, IWithEventHandler {
 
 	constructor(protected _component: ComponentWrapper) {
 		_component.registerEvent();
@@ -306,13 +306,18 @@ class ComponentBuilderImpl<T extends azdata.Component> implements azdata.Compone
 		return this._component;
 	}
 
-	withProperties<U>(properties: U): azdata.ComponentBuilder<T> {
+	withProperties<U>(properties: U): azdata.ComponentBuilder<T, TPropertyBag> {
 		// Keep any properties that may have been set during initial object construction
 		this._component.properties = assign({}, this._component.properties, properties);
 		return this;
 	}
 
-	withValidation(validation: (component: T) => boolean): azdata.ComponentBuilder<T> {
+	withProps(properties: TPropertyBag): azdata.ComponentBuilder<T, TPropertyBag> {
+		this._component.properties = assign({}, this._component.properties, properties);
+		return this;
+	}
+
+	withValidation(validation: (component: T) => boolean): azdata.ComponentBuilder<T, TPropertyBag> {
 		this._component.customValidations.push(validation);
 		return this;
 	}
@@ -322,17 +327,17 @@ class ComponentBuilderImpl<T extends azdata.Component> implements azdata.Compone
 	}
 }
 
-class ContainerBuilderImpl<T extends azdata.Component, TLayout, TItemLayout> extends ComponentBuilderImpl<T> implements azdata.ContainerBuilder<T, TLayout, TItemLayout> {
+class ContainerBuilderImpl<TComponent extends azdata.Component, TLayout, TItemLayout, TPropertyBag extends azdata.ComponentProperties> extends ComponentBuilderImpl<TComponent, TPropertyBag> implements azdata.ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag> {
 	constructor(componentWrapper: ComponentWrapper) {
 		super(componentWrapper);
 	}
 
-	withLayout(layout: TLayout): azdata.ContainerBuilder<T, TLayout, TItemLayout> {
+	withLayout(layout: TLayout): azdata.ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag> {
 		this._component.layout = layout;
 		return this;
 	}
 
-	withItems(components: azdata.Component[], itemLayout?: TItemLayout): azdata.ContainerBuilder<T, TLayout, TItemLayout> {
+	withItems(components: azdata.Component[], itemLayout?: TItemLayout): azdata.ContainerBuilder<TComponent, TLayout, TItemLayout, TPropertyBag> {
 		this._component.itemConfigs = components.map(item => {
 			let componentWrapper = item as ComponentWrapper;
 			return new InternalItemConfig(componentWrapper, itemLayout);
@@ -341,19 +346,19 @@ class ContainerBuilderImpl<T extends azdata.Component, TLayout, TItemLayout> ext
 	}
 }
 
-class GenericContainerBuilder<T extends azdata.Component, TLayout, TItemLayout> extends ContainerBuilderImpl<T, TLayout, TItemLayout> {
+class GenericContainerBuilder<T extends azdata.Component, TLayout, TItemLayout, TPropertyBag extends azdata.ComponentProperties> extends ContainerBuilderImpl<T, TLayout, TItemLayout, TPropertyBag> {
 	constructor(proxy: MainThreadModelViewShape, handle: number, type: ModelComponentTypes, id: string) {
 		super(new ComponentWrapper(proxy, handle, type, id));
 	}
 }
 
-class DivContainerBuilder extends ContainerBuilderImpl<azdata.DivContainer, azdata.DivLayout, azdata.DivItemLayout> {
+class DivContainerBuilder extends ContainerBuilderImpl<azdata.DivContainer, azdata.DivLayout, azdata.DivItemLayout, azdata.DivContainerProperties> {
 	constructor(proxy: MainThreadModelViewShape, handle: number, type: ModelComponentTypes, id: string) {
 		super(new DivContainerWrapper(proxy, handle, type, id));
 	}
 }
 
-class FormContainerBuilder extends GenericContainerBuilder<azdata.FormContainer, azdata.FormLayout, azdata.FormItemLayout> implements azdata.FormBuilder {
+class FormContainerBuilder extends GenericContainerBuilder<azdata.FormContainer, azdata.FormLayout, azdata.FormItemLayout, azdata.ComponentProperties> implements azdata.FormBuilder {
 	constructor(proxy: MainThreadModelViewShape, handle: number, type: ModelComponentTypes, id: string, private _builder: ModelBuilderImpl) {
 		super(proxy, handle, type, id);
 	}
@@ -471,14 +476,14 @@ class FormContainerBuilder extends GenericContainerBuilder<azdata.FormContainer,
 	}
 }
 
-class GroupContainerBuilder extends ContainerBuilderImpl<azdata.GroupContainer, azdata.GroupLayout, azdata.GroupItemLayout> {
+class GroupContainerBuilder extends ContainerBuilderImpl<azdata.GroupContainer, azdata.GroupLayout, azdata.GroupItemLayout, azdata.GroupContainerProperties> {
 	constructor(proxy: MainThreadModelViewShape, handle: number, type: ModelComponentTypes, id: string) {
 		super(new GroupContainerComponentWrapper(proxy, handle, type, id));
 	}
 }
 
-class ToolbarContainerBuilder extends GenericContainerBuilder<azdata.ToolbarContainer, azdata.ToolbarLayout, any> implements azdata.ToolbarBuilder {
-	withToolbarItems(components: azdata.ToolbarComponent[]): azdata.ContainerBuilder<azdata.ToolbarContainer, any, any> {
+class ToolbarContainerBuilder extends GenericContainerBuilder<azdata.ToolbarContainer, azdata.ToolbarLayout, any, azdata.ComponentProperties> implements azdata.ToolbarBuilder {
+	withToolbarItems(components: azdata.ToolbarComponent[]): azdata.ContainerBuilder<azdata.ToolbarContainer, any, any, azdata.ComponentProperties> {
 		this._component.itemConfigs = components.map(item => {
 			return this.convertToItemConfig(item);
 		});
@@ -506,8 +511,8 @@ class ToolbarContainerBuilder extends GenericContainerBuilder<azdata.ToolbarCont
 	}
 }
 
-class TabbedPanelComponentBuilder extends ContainerBuilderImpl<azdata.TabbedPanelComponent, azdata.TabbedPanelLayout, any> implements azdata.TabbedPanelComponentBuilder {
-	withTabs(items: (azdata.Tab | azdata.TabGroup)[]): azdata.ContainerBuilder<azdata.TabbedPanelComponent, azdata.TabbedPanelLayout, any> {
+class TabbedPanelComponentBuilder extends ContainerBuilderImpl<azdata.TabbedPanelComponent, azdata.TabbedPanelLayout, any, azdata.ComponentProperties> implements azdata.TabbedPanelComponentBuilder {
+	withTabs(items: (azdata.Tab | azdata.TabGroup)[]): azdata.ContainerBuilder<azdata.TabbedPanelComponent, azdata.TabbedPanelLayout, any, azdata.ComponentProperties> {
 		this._component.itemConfigs = createFromTabs(items);
 		return this;
 	}
@@ -537,7 +542,7 @@ function toTabItemConfig(content: azdata.Component, title: string, id?: string, 
 	});
 }
 
-class LoadingComponentBuilder extends ComponentBuilderImpl<azdata.LoadingComponent> implements azdata.LoadingComponentBuilder {
+class LoadingComponentBuilder extends ComponentBuilderImpl<azdata.LoadingComponent, azdata.LoadingComponentProperties> implements azdata.LoadingComponentBuilder {
 	withItem(component: azdata.Component) {
 		this.component().component = component;
 		return this;


### PR DESCRIPTION
This PR is branched off of amir/componentGenerics


https://github.com/microsoft/azuredatastudio/pull/12158

This will allow you to do `modelBuilder.inputBox().withProps(` without having to specify the property type

