### PR TITLE
Add grid streaming support for notebooks

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -4750,6 +4750,7 @@ declare module 'azdata' {
 			execution_count: number;
 			batchId?: number;
 			id?: number;
+			conversionComplete?: boolean;
 		}
 		export interface IErrorResult extends ICellOutput {
 			/**

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -4750,7 +4750,7 @@ declare module 'azdata' {
 			execution_count: number;
 			batchId?: number;
 			id?: number;
-			conversionComplete?: boolean;
+			data: any;
 		}
 		export interface IErrorResult extends ICellOutput {
 			/**

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -4748,9 +4748,6 @@ declare module 'azdata' {
 			 * Number of times the cell was executed
 			 */
 			execution_count: number;
-			batchId?: number;
-			id?: number;
-			data: any;
 		}
 		export interface IErrorResult extends ICellOutput {
 			/**

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -4748,6 +4748,8 @@ declare module 'azdata' {
 			 * Number of times the cell was executed
 			 */
 			execution_count: number;
+			batchId?: number;
+			id?: number;
 		}
 		export interface IErrorResult extends ICellOutput {
 			/**

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -44,6 +44,12 @@ declare module 'azdata' {
 		export interface IKernelChangedArgs {
 			nbKernelAlias?: string
 		}
+
+		export interface IExecuteResult {
+			data: any;
+			batchId?: number;
+			id?: number;
+		}
 	}
 
 	export type SqlDbType = 'BigInt' | 'Binary' | 'Bit' | 'Char' | 'DateTime' | 'Decimal'

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
@@ -42,6 +42,8 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 	private _initialized: boolean = false;
 	private _activeCellId: string;
 	private _componentInstance: IMimeComponent;
+	private _batchId?: number;
+	private _id?: number;
 	private _queryRunner?: QueryRunner;
 	public errorText: string;
 
@@ -102,6 +104,14 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 			this.loadComponent();
 		}
 		return this._componentInstance;
+	}
+
+	@Input() set batchId(value: number) {
+		this._batchId = value;
+	}
+
+	@Input() set id(value: number) {
+		this._id = value;
 	}
 
 	@Input() set queryRunner(value: QueryRunner) {
@@ -181,6 +191,8 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 			this._componentInstance.cellOutput = this.cellOutput;
 			this._componentInstance.bundleOptions = options;
 			if (this._queryRunner) {
+				this._componentInstance.batchId = this._batchId;
+				this._componentInstance.id = this._id;
 				this._componentInstance.queryRunner = this._queryRunner;
 			}
 			this._changeref.detectChanges();

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
@@ -21,7 +21,6 @@ import { localize } from 'vs/nls';
 import * as types from 'vs/base/common/types';
 import { getErrorMessage } from 'vs/base/common/errors';
 import { CellView } from 'sql/workbench/contrib/notebook/browser/cellViews/interfaces';
-import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 
 export const OUTPUT_SELECTOR: string = 'output-component';
 const USER_SELECT_CLASS = 'actionselect';
@@ -44,7 +43,7 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 	private _componentInstance: IMimeComponent;
 	private _batchId?: number;
 	private _id?: number;
-	private _queryRunner?: QueryRunner;
+	private _queryRunnerUri?: string;
 	public errorText: string;
 
 	constructor(
@@ -114,8 +113,8 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 		this._id = value;
 	}
 
-	@Input() set queryRunner(value: QueryRunner) {
-		this._queryRunner = value;
+	@Input() set queryRunnerUri(value: string) {
+		this._queryRunnerUri = value;
 	}
 
 	get trustedMode(): boolean {
@@ -190,10 +189,10 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 			this._componentInstance.cellModel = this.cellModel;
 			this._componentInstance.cellOutput = this.cellOutput;
 			this._componentInstance.bundleOptions = options;
-			if (this._queryRunner) {
+			if (this._queryRunnerUri) {
 				this._componentInstance.batchId = this._batchId;
 				this._componentInstance.id = this._id;
-				this._componentInstance.queryRunner = this._queryRunner;
+				this._componentInstance.queryRunnerUri = this._queryRunnerUri;
 			}
 			this._changeref.detectChanges();
 			let el = <HTMLElement>componentRef.location.nativeElement;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
@@ -21,6 +21,7 @@ import { localize } from 'vs/nls';
 import * as types from 'vs/base/common/types';
 import { getErrorMessage } from 'vs/base/common/errors';
 import { CellView } from 'sql/workbench/contrib/notebook/browser/cellViews/interfaces';
+import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 
 export const OUTPUT_SELECTOR: string = 'output-component';
 const USER_SELECT_CLASS = 'actionselect';
@@ -41,6 +42,7 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 	private _initialized: boolean = false;
 	private _activeCellId: string;
 	private _componentInstance: IMimeComponent;
+	private _queryRunner?: QueryRunner;
 	public errorText: string;
 
 	constructor(
@@ -100,6 +102,10 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 			this.loadComponent();
 		}
 		return this._componentInstance;
+	}
+
+	@Input() set queryRunner(value: QueryRunner) {
+		this._queryRunner = value;
 	}
 
 	get trustedMode(): boolean {
@@ -174,6 +180,9 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 			this._componentInstance.cellModel = this.cellModel;
 			this._componentInstance.cellOutput = this.cellOutput;
 			this._componentInstance.bundleOptions = options;
+			if (this._queryRunner) {
+				this._componentInstance.queryRunner = this._queryRunner;
+			}
 			this._changeref.detectChanges();
 			let el = <HTMLElement>componentRef.location.nativeElement;
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.component.html
@@ -6,7 +6,7 @@
 -->
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div #outputarea link-handler [isTrusted]="isTrusted" [notebookUri]="notebookUri" class="notebook-output" style="flex: 0 0 auto;">
-		<output-component *ngFor="let output of cellModel.outputs" [cellOutput]="output" [trustedMode] = "cellModel.trustedMode" [cellModel]="cellModel" [activeCellId]="activeCellId" [batchId]="output.batchId" [id]="output.id" [queryRunner]="output.queryRunner">
+		<output-component *ngFor="let output of cellModel.outputs" [cellOutput]="output" [trustedMode] = "cellModel.trustedMode" [cellModel]="cellModel" [activeCellId]="activeCellId" [batchId]="output.batchId" [id]="output.id" [queryRunnerUri]="output.queryRunnerUri">
 		</output-component>
 	</div>
 </div>

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.component.html
@@ -6,7 +6,7 @@
 -->
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div #outputarea link-handler [isTrusted]="isTrusted" [notebookUri]="notebookUri" class="notebook-output" style="flex: 0 0 auto;">
-		<output-component *ngFor="let output of cellModel.outputs" [cellOutput]="output" [trustedMode] = "cellModel.trustedMode" [cellModel]="cellModel" [activeCellId]="activeCellId">
+		<output-component *ngFor="let output of cellModel.outputs" [cellOutput]="output" [trustedMode] = "cellModel.trustedMode" [cellModel]="cellModel" [activeCellId]="activeCellId" [queryRunner]="output.queryRunner">
 		</output-component>
 	</div>
 </div>

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.component.html
@@ -6,7 +6,7 @@
 -->
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div #outputarea link-handler [isTrusted]="isTrusted" [notebookUri]="notebookUri" class="notebook-output" style="flex: 0 0 auto;">
-		<output-component *ngFor="let output of cellModel.outputs" [cellOutput]="output" [trustedMode] = "cellModel.trustedMode" [cellModel]="cellModel" [activeCellId]="activeCellId" [queryRunner]="output.queryRunner">
+		<output-component *ngFor="let output of cellModel.outputs" [cellOutput]="output" [trustedMode] = "cellModel.trustedMode" [cellModel]="cellModel" [activeCellId]="activeCellId" [batchId]="output.batchId" [id]="output.id" [queryRunner]="output.queryRunner">
 		</output-component>
 	</div>
 </div>

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/outputArea.component.ts
@@ -38,6 +38,7 @@ export class OutputAreaComponent extends AngularDisposable implements OnInit {
 			this._register(this.cellModel.onOutputsChanged(e => {
 				if (!(this._changeRef['destroyed'])) {
 					this._changeRef.detectChanges();
+					this._changeRef.detach();
 					if (e && e.shouldScroll) {
 						this.setFocusAndScroll(this.outputArea.nativeElement);
 					}

--- a/src/sql/workbench/contrib/notebook/browser/models/fileNotebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/fileNotebookInput.ts
@@ -10,6 +10,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { NotebookInput } from 'sql/workbench/contrib/notebook/browser/models/notebookInput';
 import { INotebookService } from 'sql/workbench/services/notebook/browser/notebookService';
+import { INotificationService } from 'vs/platform/notification/common/notification';
 
 export class FileNotebookInput extends NotebookInput {
 	public static ID: string = 'workbench.editorinputs.fileNotebookInput';
@@ -21,9 +22,10 @@ export class FileNotebookInput extends NotebookInput {
 		@ITextModelService textModelService: ITextModelService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@INotebookService notebookService: INotebookService,
-		@IExtensionService extensionService: IExtensionService
+		@IExtensionService extensionService: IExtensionService,
+		@INotificationService notificationService: INotificationService
 	) {
-		super(title, resource, textInput, textModelService, instantiationService, notebookService, extensionService);
+		super(title, resource, textInput, textModelService, instantiationService, notebookService, extensionService, notificationService);
 	}
 
 	public get textInput(): FileEditorInput {

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -298,7 +298,7 @@ export abstract class NotebookInput extends EditorInput {
 			severity: Severity.Info,
 			message: nls.localize('convertingData', "Waiting for table data conversion to complete..."),
 			progress: {
-				infinite: true
+				infinite: true // Keep showing conversion notification until notificationHandle is closed
 			}
 		};
 		const notificationHandle = this.notificationService.notify(conversionNotification);

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -75,7 +75,7 @@ export class NotebookEditorModel extends EditorModel {
 			}));
 		} else {
 			if (this.textEditorModel instanceof TextFileEditorModel) {
-				this._register(this.textEditorModel.onDidSave(async () => {
+				this._register(this.textEditorModel.onDidSave(() => {
 					let dirty = this.textEditorModel instanceof ResourceEditorModel ? false : this.textEditorModel.isDirty();
 					this.setDirty(dirty);
 					this.sendNotebookSerializationStateChange();

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -76,7 +76,6 @@ export class NotebookEditorModel extends EditorModel {
 		} else {
 			if (this.textEditorModel instanceof TextFileEditorModel) {
 				this._register(this.textEditorModel.onDidSave(async () => {
-					await this.getNotebookModel().gridDataConversionComplete;
 					let dirty = this.textEditorModel instanceof ResourceEditorModel ? false : this.textEditorModel.isDirty();
 					this.setDirty(dirty);
 					this.sendNotebookSerializationStateChange();

--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -75,7 +75,8 @@ export class NotebookEditorModel extends EditorModel {
 			}));
 		} else {
 			if (this.textEditorModel instanceof TextFileEditorModel) {
-				this._register(this.textEditorModel.onDidSave(() => {
+				this._register(this.textEditorModel.onDidSave(async () => {
+					await this.getNotebookModel().gridDataConversionComplete;
 					let dirty = this.textEditorModel instanceof ResourceEditorModel ? false : this.textEditorModel.isDirty();
 					this.setDirty(dirty);
 					this.sendNotebookSerializationStateChange();
@@ -290,6 +291,7 @@ export abstract class NotebookInput extends EditorInput {
 	}
 
 	async save(groupId: number, options?: ITextFileSaveOptions): Promise<IEditorInput | undefined> {
+		await this._model.getNotebookModel().gridDataConversionComplete;
 		this.updateModel();
 		let input = await this.textInput.save(groupId, options);
 		await this.setTrustForNewEditor(input);

--- a/src/sql/workbench/contrib/notebook/browser/models/untitledNotebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/untitledNotebookInput.ts
@@ -10,6 +10,7 @@ import { IExtensionService } from 'vs/workbench/services/extensions/common/exten
 import { NotebookInput } from 'sql/workbench/contrib/notebook/browser/models/notebookInput';
 import { INotebookService } from 'sql/workbench/services/notebook/browser/notebookService';
 import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/untitledTextEditorInput';
+import { INotificationService } from 'vs/platform/notification/common/notification';
 
 export class UntitledNotebookInput extends NotebookInput {
 	public static ID: string = 'workbench.editorinputs.untitledNotebookInput';
@@ -21,9 +22,10 @@ export class UntitledNotebookInput extends NotebookInput {
 		@ITextModelService textModelService: ITextModelService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@INotebookService notebookService: INotebookService,
-		@IExtensionService extensionService: IExtensionService
+		@IExtensionService extensionService: IExtensionService,
+		@INotificationService notificationService: INotificationService
 	) {
-		super(title, resource, textInput, textModelService, instantiationService, notebookService, extensionService);
+		super(title, resource, textInput, textModelService, instantiationService, notebookService, extensionService, notificationService);
 	}
 
 	public get textInput(): UntitledTextEditorInput {

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -374,15 +374,14 @@ export class DataResourceDataProvider implements IGridDataProvider {
 	public async convertAllData(result: ResultSetSummary): Promise<void> {
 		// Querying 50 rows at a time. Querying large amount of rows will be slow and
 		// affect table rendering since each time the user scrolls, getRowData is called.
-		let numRows = 50;
-		for (let i = 0; i < result.rowCount; i += 50) {
-			if (i + 50 > result.rowCount) {
+		let numRows = 100;
+		for (let i = 0; i < result.rowCount; i += 100) {
+			if (i + 100 > result.rowCount) {
 				numRows += result.rowCount - i;
 			}
 			let rows = await this._queryRunner.getQueryRows(i, numRows, this._batchId, this._id);
 			this.convertData(rows);
 		}
-
 	}
 
 	private convertData(rows: ResultSetSubset): void {

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -41,7 +41,6 @@ import { IQueryManagementService } from 'sql/workbench/services/query/common/que
 import { values } from 'vs/base/common/collections';
 import { URI } from 'vs/base/common/uri';
 import { assign } from 'vs/base/common/objects';
-import { ILogService } from 'vs/platform/log/common/log';
 
 @Component({
 	selector: GridOutputComponent.SELECTOR,
@@ -318,7 +317,6 @@ export class DataResourceDataProvider implements IGridDataProvider {
 		@ITextResourcePropertiesService private _textResourcePropertiesService: ITextResourcePropertiesService,
 		@ISerializationService private _serializationService: ISerializationService,
 		@IInstantiationService private _instantiationService: IInstantiationService,
-		@ILogService private readonly logService: ILogService,
 	) {
 		this._documentUri = this.cellModel.notebookModel.notebookUri.toString();
 		this._queryRunner = queryRunner;
@@ -376,22 +374,18 @@ export class DataResourceDataProvider implements IGridDataProvider {
 	public async convertAllData(result: ResultSetSummary): Promise<void> {
 		// Querying 50 rows at a time. Querying large amount of rows will be slow and
 		// affect table rendering since each time the user scrolls, getRowData is called.
-		try {
-			let numRows = 50;
-			for (let i = 0; i < result.rowCount; i += 50) {
-				if (i + 50 > result.rowCount) {
-					numRows += result.rowCount - i;
-				}
-				let rows = await this._queryRunner.getQueryRows(i, numRows, this._batchId, this._id);
-				this.convertData(rows);
+		let numRows = 50;
+		for (let i = 0; i < result.rowCount; i += 50) {
+			if (i + 50 > result.rowCount) {
+				numRows += result.rowCount - i;
 			}
-		} catch (err) {
-			this.logService.error(`Error converting rows to mimeType and html: ${err}`);
+			let rows = await this._queryRunner.getQueryRows(i, numRows, this._batchId, this._id);
+			this.convertData(rows);
 		}
 
 	}
 
-	private async convertData(rows: ResultSetSubset): Promise<void> {
+	private convertData(rows: ResultSetSubset): void {
 		let dataResourceRows = this.convertToDataResource(rows);
 		let htmlStringArr = this.convertToHtmlTable(rows);
 		this._data['application/vnd.dataresource+json'].data = this._data['application/vnd.dataresource+json'].data.concat(dataResourceRows);

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -11,7 +11,7 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IDataResource, MaxTableRowsConfigName, NotebookConfigSectionName, IDataResourceSchema, IDataResourceFields } from 'sql/workbench/services/notebook/browser/sql/sqlSessionManager';
+import { IDataResource, MaxTableRowsConfigName, NotebookConfigSectionName, IDataResourceSchema, IDataResourceFields, MAX_ROWS } from 'sql/workbench/services/notebook/browser/sql/sqlSessionManager';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
 import QueryRunner, { getEolString, shouldIncludeHeaders, shouldRemoveNewLines } from 'sql/workbench/services/query/common/queryRunner';
 import { ResultSetSummary, ResultSetSubset, ICellValue, BatchSummary } from 'sql/workbench/services/query/common/query';
@@ -60,7 +60,7 @@ export class GridOutputComponent extends AngularDisposable implements IMimeCompo
 	private _id: number;
 	private _queryRunnerUri: string;
 	private _queryRunner: QueryRunner;
-	private _configuredMaxRows: number;
+	private _configuredMaxRows: number = MAX_ROWS;
 
 	constructor(
 		@Inject(IInstantiationService) private instantiationService: IInstantiationService,

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -291,10 +291,6 @@ class DataResourceTable extends GridTableBase<any> {
 		this.cellModel.sendChangeToNotebook(NotebookChangeType.CellMetadataUpdated);
 	}
 
-	public updateResult(set: ResultSetSummary) {
-		super.updateResult(set);
-	}
-
 	public convertData(set: ResultSetSummary): Promise<void> {
 		return this._gridDataProvider.convertAllData(set);
 	}
@@ -376,6 +372,8 @@ export class DataResourceDataProvider implements IGridDataProvider {
 	}
 
 	public async convertAllData(result: ResultSetSummary): Promise<void> {
+		// Querying 50 rows at a time. Querying large amount of rows will be slow and
+		// affect table rendering since each time the user scrolls, getRowData is called.
 		let numRows = 50;
 		for (let i = 0; i < result.rowCount; i += 50) {
 			if (i + 50 > result.rowCount) {

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -150,7 +150,7 @@ export class GridOutputComponent extends AngularDisposable implements IMimeCompo
 		if (!Array.isArray(resultSet)) {
 			resultsToUpdate = [resultSet];
 		} else {
-			resultsToUpdate = resultSet.splice(0);
+			resultsToUpdate = resultSet?.splice(0);
 		}
 		for (let set of resultsToUpdate) {
 			if (this._batchId === set.batchId && this._id === set.id) {

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -386,8 +386,8 @@ export class DataResourceDataProvider implements IGridDataProvider {
 	}
 
 	private convertData(rows: ResultSetSubset): void {
-		let dataResourceRows = this.convertToDataResource(rows);
-		let htmlStringArr = this.convertToHtmlTable(rows);
+		let dataResourceRows = this.convertRowsToDataResource(rows);
+		let htmlStringArr = this.convertRowsToHtml(rows);
 		this._data['application/vnd.dataresource+json'].data = this._data['application/vnd.dataresource+json'].data.concat(dataResourceRows);
 		this._data['text/html'].splice(this._data['text/html'].length - 1, 0, ...htmlStringArr);
 		this.cellModel.updateOutputData(this._batchId, this._id, this._data);
@@ -518,7 +518,7 @@ export class DataResourceDataProvider implements IGridDataProvider {
 		return (selection && !((selection.fromCell === selection.toCell) && (selection.fromRow === selection.toRow)));
 	}
 
-	private convertToDataResource(subset: ResultSetSubset): any[] {
+	private convertRowsToDataResource(subset: ResultSetSubset): any[] {
 		return subset.rows.map(row => {
 			let rowObject: { [key: string]: any; } = {};
 			row.forEach((val, index) => {
@@ -528,7 +528,7 @@ export class DataResourceDataProvider implements IGridDataProvider {
 		});
 	}
 
-	private convertToHtmlTable(subset: ResultSetSubset): string[] {
+	private convertRowsToHtml(subset: ResultSetSubset): string[] {
 		let htmlStringArr = [];
 		for (const row of subset.rows) {
 			let rowData = '<tr>';

--- a/src/sql/workbench/contrib/notebook/browser/outputs/mimeRegistry.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/mimeRegistry.ts
@@ -24,6 +24,8 @@ export interface IMimeComponent {
 	mimeType: string;
 	cellModel?: ICellModel;
 	cellOutput?: nb.ICellOutput;
+	batchId?: number;
+	id?: number;
 	queryRunner?: QueryRunner;
 	layout(): void;
 }

--- a/src/sql/workbench/contrib/notebook/browser/outputs/mimeRegistry.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/mimeRegistry.ts
@@ -11,6 +11,7 @@ import * as types from 'vs/base/common/types';
 import { ICellModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { values } from 'vs/base/common/collections';
 import { nb } from 'azdata';
+import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 
 export type FactoryIdentifier = string;
 
@@ -23,6 +24,7 @@ export interface IMimeComponent {
 	mimeType: string;
 	cellModel?: ICellModel;
 	cellOutput?: nb.ICellOutput;
+	queryRunner?: QueryRunner;
 	layout(): void;
 }
 

--- a/src/sql/workbench/contrib/notebook/browser/outputs/mimeRegistry.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/mimeRegistry.ts
@@ -11,7 +11,6 @@ import * as types from 'vs/base/common/types';
 import { ICellModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { values } from 'vs/base/common/collections';
 import { nb } from 'azdata';
-import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 
 export type FactoryIdentifier = string;
 
@@ -26,7 +25,7 @@ export interface IMimeComponent {
 	cellOutput?: nb.ICellOutput;
 	batchId?: number;
 	id?: number;
-	queryRunner?: QueryRunner;
+	queryRunnerUri?: string;
 	layout(): void;
 }
 

--- a/src/sql/workbench/contrib/notebook/test/browser/cellToolbarActions.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/cellToolbarActions.test.ts
@@ -177,7 +177,7 @@ suite('CellToolbarActions', function (): void {
 	});
 });
 
-async function createandLoadNotebookModel(codeContent?: nb.INotebookContents): Promise<NotebookModel> {
+export async function createandLoadNotebookModel(codeContent?: nb.INotebookContents): Promise<NotebookModel> {
 	let defaultCodeContent: nb.INotebookContents = {
 		cells: [{
 			cell_type: CellTypes.Code,

--- a/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
@@ -22,6 +22,7 @@ import { SaveFormat, ResultSerializer } from 'sql/workbench/services/query/commo
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { URI } from 'vs/base/common/uri';
 import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
+import { CellModel } from 'sql/workbench/services/notebook/browser/models/cell';
 
 export class TestSerializationProvider implements azdata.SerializationProvider {
 	providerId: string;
@@ -65,8 +66,7 @@ suite('Data Resource Data Provider', function () {
 			id: 0,
 			rowCount: 2
 		};
-
-		let documentUri = 'untitled:Notebook-0';
+		let cellModel = TypeMoq.Mock.ofType(CellModel);
 		tempFolderPath = path.join(os.tmpdir(), `TestDataResourceDataProvider_${uuid.v4()}`);
 		await fs.mkdir(tempFolderPath);
 
@@ -96,7 +96,7 @@ suite('Data Resource Data Provider', function () {
 			queryRunner.object,
 			source,
 			resultSet,
-			documentUri,
+			cellModel.object,
 			_notificationService,
 			undefined, // IClipboardService
 			undefined, // IConfigurationService

--- a/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
@@ -103,8 +103,7 @@ suite('Data Resource Data Provider', function () {
 			undefined, // IConfigurationService
 			undefined, // ITextResourcePropertiesService
 			_serializationService,
-			_instantiationService.object,
-			undefined // LogService
+			_instantiationService.object
 		);
 	});
 

--- a/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
@@ -102,6 +102,7 @@ suite('Data Resource Data Provider', function () {
 			undefined, // IConfigurationService
 			undefined, // ITextResourcePropertiesService
 			_serializationService,
+			_instantiationService.object
 		);
 	});
 

--- a/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
@@ -21,6 +21,7 @@ import { SerializationService } from 'sql/platform/serialization/common/serializ
 import { SaveFormat, ResultSerializer } from 'sql/workbench/services/query/common/resultSerializer';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { URI } from 'vs/base/common/uri';
+import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 
 export class TestSerializationProvider implements azdata.SerializationProvider {
 	providerId: string;
@@ -51,6 +52,7 @@ suite('Data Resource Data Provider', function () {
 	let dataResourceDataProvider: DataResourceDataProvider;
 
 	suiteSetup(async () => {
+		let queryRunner: TypeMoq.Mock<QueryRunner> = TypeMoq.Mock.ofType(QueryRunner);
 		// Create test data with two rows and two columns
 		let source: IDataResource = {
 			data: [{ 0: '1', 1: '2' }, { 0: '3', 1: '4' }],
@@ -88,8 +90,8 @@ suite('Data Resource Data Provider', function () {
 		let _instantiationService = TypeMoq.Mock.ofType(InstantiationService, TypeMoq.MockBehavior.Strict);
 		_instantiationService.setup(x => x.createInstance(TypeMoq.It.isValue(ResultSerializer)))
 			.returns(() => serializer);
-
 		dataResourceDataProvider = new DataResourceDataProvider(
+			queryRunner.object,
 			source,
 			resultSet,
 			documentUri,

--- a/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
@@ -21,8 +21,8 @@ import { SerializationService } from 'sql/platform/serialization/common/serializ
 import { SaveFormat, ResultSerializer } from 'sql/workbench/services/query/common/resultSerializer';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { URI } from 'vs/base/common/uri';
-import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 import { CellModel } from 'sql/workbench/services/notebook/browser/models/cell';
+import { createandLoadNotebookModel } from 'sql/workbench/contrib/notebook/test/browser/cellToolbarActions.test';
 
 export class TestSerializationProvider implements azdata.SerializationProvider {
 	providerId: string;
@@ -53,7 +53,6 @@ suite('Data Resource Data Provider', function () {
 	let dataResourceDataProvider: DataResourceDataProvider;
 
 	suiteSetup(async () => {
-		let queryRunner: TypeMoq.Mock<QueryRunner> = TypeMoq.Mock.ofType(QueryRunner);
 		// Create test data with two rows and two columns
 		let source: IDataResource = {
 			data: [{ 0: '1', 1: '2' }, { 0: '3', 1: '4' }],
@@ -67,6 +66,8 @@ suite('Data Resource Data Provider', function () {
 			rowCount: 2
 		};
 		let cellModel = TypeMoq.Mock.ofType(CellModel);
+		let notebookModel = await createandLoadNotebookModel();
+		cellModel.setup(x => x.notebookModel).returns(() => notebookModel);
 		tempFolderPath = path.join(os.tmpdir(), `TestDataResourceDataProvider_${uuid.v4()}`);
 		await fs.mkdir(tempFolderPath);
 
@@ -93,7 +94,7 @@ suite('Data Resource Data Provider', function () {
 		dataResourceDataProvider = new DataResourceDataProvider(
 			0, // batchId
 			0, // id
-			queryRunner.object,
+			undefined, // QueryRunner
 			source,
 			resultSet,
 			cellModel.object,

--- a/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
@@ -91,6 +91,8 @@ suite('Data Resource Data Provider', function () {
 		_instantiationService.setup(x => x.createInstance(TypeMoq.It.isValue(ResultSerializer)))
 			.returns(() => serializer);
 		dataResourceDataProvider = new DataResourceDataProvider(
+			0, // batchId
+			0, // id
 			queryRunner.object,
 			source,
 			resultSet,
@@ -100,7 +102,6 @@ suite('Data Resource Data Provider', function () {
 			undefined, // IConfigurationService
 			undefined, // ITextResourcePropertiesService
 			_serializationService,
-			_instantiationService.object
 		);
 	});
 

--- a/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/dataResourceDataProvider.test.ts
@@ -103,7 +103,8 @@ suite('Data Resource Data Provider', function () {
 			undefined, // IConfigurationService
 			undefined, // ITextResourcePropertiesService
 			_serializationService,
-			_instantiationService.object
+			_instantiationService.object,
+			undefined // LogService
 		);
 	});
 

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
@@ -57,6 +57,8 @@ import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/u
 import { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
 import { workbenchInstantiationService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { IProductService } from 'vs/platform/product/common/productService';
+import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
+import { INotificationService } from 'vs/platform/notification/common/notification';
 
 class NotebookModelStub extends stubs.NotebookModelStub {
 	private _cells: Array<ICellModel> = [new CellModel(undefined, undefined)];
@@ -97,10 +99,11 @@ suite.skip('Test class NotebookEditor:', () => {
 	let queryTextEditor: QueryTextEditor;
 	let untitledNotebookInput: UntitledNotebookInput;
 	let notebookEditorStub: NotebookEditorStub;
+	let notificationService: TypeMoq.Mock<INotificationService>;
 
 	setup(async () => {
 		// setup services
-		({ instantiationService, workbenchThemeService, notebookService, testTitle, extensionService, cellTextEditorGuid, queryTextEditor, untitledNotebookInput, notebookEditorStub } = setupServices({ instantiationService, workbenchThemeService }));
+		({ instantiationService, workbenchThemeService, notebookService, testTitle, extensionService, cellTextEditorGuid, queryTextEditor, untitledNotebookInput, notebookEditorStub, notificationService } = setupServices({ instantiationService, workbenchThemeService }));
 		// Create notebookEditor
 		notebookEditor = createNotebookEditor(instantiationService, workbenchThemeService, notebookService);
 	});
@@ -121,7 +124,7 @@ suite.skip('Test class NotebookEditor:', () => {
 			const untitledTextInput = instantiationService.createInstance(UntitledTextEditorInput, untitledTextEditorService.create({ associatedResource: untitledUri }));
 			const untitledNotebookInput = new UntitledNotebookInput(
 				testTitle, untitledUri, untitledTextInput,
-				undefined, instantiationService, notebookService, extensionService
+				undefined, instantiationService, notebookService, extensionService, notificationService.object
 			);
 			const testNotebookEditor = new NotebookEditorStub({ cellGuid: cellTextEditorGuid, editor: queryTextEditor, model: notebookModel, notebookParams: <INotebookParams>{ notebookUri: untitledNotebookInput.notebookUri } });
 			notebookService.addNotebookEditor(testNotebookEditor);
@@ -669,6 +672,7 @@ function setupServices(arg: { workbenchThemeService?: WorkbenchThemeService, ins
 	const uninstallEvent = new Emitter<IExtensionIdentifier>();
 	const didUninstallEvent = new Emitter<DidUninstallExtensionEvent>();
 
+	const notificationService = TypeMoq.Mock.ofType(TestNotificationService, TypeMoq.MockBehavior.Loose);
 	const instantiationService = arg.instantiationService ?? <TestInstantiationService>workbenchInstantiationService();
 	const workbenchThemeService = arg.workbenchThemeService ?? instantiationService.createInstance(WorkbenchThemeService);
 	instantiationService.stub(IWorkbenchThemeService, workbenchThemeService);
@@ -705,7 +709,7 @@ function setupServices(arg: { workbenchThemeService?: WorkbenchThemeService, ins
 	const untitledTextInput = instantiationService.createInstance(UntitledTextEditorInput, untitledTextEditorService.create({ associatedResource: untitledUri }));
 	const untitledNotebookInput = new UntitledNotebookInput(
 		testTitle, untitledUri, untitledTextInput,
-		undefined, instantiationService, notebookService, extensionService
+		undefined, instantiationService, notebookService, extensionService, notificationService.object
 	);
 
 	const cellTextEditorGuid = generateUuid();
@@ -720,7 +724,7 @@ function setupServices(arg: { workbenchThemeService?: WorkbenchThemeService, ins
 	);
 	const notebookEditorStub = new NotebookEditorStub({ cellGuid: cellTextEditorGuid, editor: queryTextEditor, model: new NotebookModelStub(), notebookParams: <INotebookParams>{ notebookUri: untitledNotebookInput.notebookUri } });
 	notebookService.addNotebookEditor(notebookEditorStub);
-	return { instantiationService, workbenchThemeService, notebookService, testTitle, extensionService, cellTextEditorGuid, queryTextEditor, untitledNotebookInput, notebookEditorStub };
+	return { instantiationService, workbenchThemeService, notebookService, testTitle, extensionService, cellTextEditorGuid, queryTextEditor, untitledNotebookInput, notebookEditorStub, notificationService };
 }
 
 function createNotebookEditor(instantiationService: TestInstantiationService, workbenchThemeService: WorkbenchThemeService, notebookService: NotebookService) {

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookInput.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookInput.test.ts
@@ -20,6 +20,7 @@ import { IExtensionService, NullExtensionService } from 'vs/workbench/services/e
 import { INotebookService, IProviderInfo } from 'sql/workbench/services/notebook/browser/notebookService';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
+import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 
 suite('Notebook Input', function (): void {
 	const instantiationService = workbenchInstantiationService();
@@ -44,6 +45,8 @@ suite('Notebook Input', function (): void {
 
 	(instantiationService as TestInstantiationService).stub(INotebookService, mockNotebookService.object);
 
+	const mockNotificationService = TypeMoq.Mock.ofType(TestNotificationService);
+
 	let untitledTextInput: UntitledTextEditorInput;
 	let untitledNotebookInput: UntitledNotebookInput;
 
@@ -53,14 +56,14 @@ suite('Notebook Input', function (): void {
 		untitledTextInput = instantiationService.createInstance(UntitledTextEditorInput, service.create({ associatedResource: untitledUri }));
 		untitledNotebookInput = new UntitledNotebookInput(
 			testTitle, untitledUri, untitledTextInput,
-			undefined, instantiationService, mockNotebookService.object, mockExtensionService.object);
+			undefined, instantiationService, mockNotebookService.object, mockExtensionService.object, mockNotificationService.object);
 	});
 
 	test('File Notebook Input', async function (): Promise<void> {
 		let fileUri = URI.from({ scheme: Schemas.file, path: 'TestPath' });
 		let fileNotebookInput = new FileNotebookInput(
 			testTitle, fileUri, undefined,
-			undefined, instantiationService, mockNotebookService.object, mockExtensionService.object);
+			undefined, instantiationService, mockNotebookService.object, mockExtensionService.object, mockNotificationService.object);
 
 		let inputId = fileNotebookInput.getTypeId();
 		assert.strictEqual(inputId, FileNotebookInput.ID);

--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -43,6 +43,9 @@ export class NotebookModelStub implements INotebookModel {
 	get sessionLoadFinished(): Promise<void> {
 		throw new Error('method not implemented.');
 	}
+	get gridDataConversionComplete(): Promise<void> {
+		throw new Error('method not implemented.');
+	}
 	get notebookManagers(): INotebookManager[] {
 		throw new Error('method not implemented.');
 	}
@@ -129,6 +132,9 @@ export class NotebookModelStub implements INotebookModel {
 	}
 	requestConnection(): Promise<boolean> {
 		throw new Error('Method not implemented.');
+	}
+	setGridDataConversionComplete(value: boolean) {
+		throw new Error('method not implemented.');
 	}
 }
 

--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -133,9 +133,6 @@ export class NotebookModelStub implements INotebookModel {
 	requestConnection(): Promise<boolean> {
 		throw new Error('Method not implemented.');
 	}
-	setGridDataConversionComplete(value: boolean) {
-		throw new Error('method not implemented.');
-	}
 }
 
 export class NotebookFindModelStub implements INotebookFindModel {

--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -43,7 +43,7 @@ export class NotebookModelStub implements INotebookModel {
 	get sessionLoadFinished(): Promise<void> {
 		throw new Error('method not implemented.');
 	}
-	get gridDataConversionComplete(): Promise<void> {
+	get gridDataConversionComplete(): Promise<any[]> {
 		throw new Error('method not implemented.');
 	}
 	get notebookManagers(): INotebookManager[] {

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -577,6 +577,9 @@ export class CellModel extends Disposable implements ICellModel {
 		//     this._displayIdMap.set(displayId, targets);
 		// }
 		if (output) {
+			if (output.output_type === 'execute_result') {
+				this.notebookModel.setGridDataConversionComplete((<nb.IExecuteResult>output).conversionComplete);
+			}
 			let outputExists = false;
 			for (let i = 0; i < this._outputs.length; i++) {
 				let o = this._outputs[i];
@@ -588,7 +591,6 @@ export class CellModel extends Disposable implements ICellModel {
 					delete output['transient'];
 					// update output with correct mimeType and html data
 					this._outputs[i] = this.rewriteOutputUrls(output);
-					this.sendChangeToNotebook(NotebookChangeType.CellOutputUpdated);
 					break;
 				}
 			}
@@ -596,10 +598,10 @@ export class CellModel extends Disposable implements ICellModel {
 				// deletes transient node in the serialized JSON
 				delete output['transient'];
 				this._outputs.push(this.rewriteOutputUrls(output));
+				// Only scroll on 1st output being added
+				let shouldScroll = this._outputs.length === 1;
+				this.fireOutputsChanged(shouldScroll);
 			}
-			// Only scroll on 1st output being added
-			let shouldScroll = this._outputs.length === 1;
-			this.fireOutputsChanged(shouldScroll);
 		}
 	}
 

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -537,8 +537,8 @@ export class CellModel extends Disposable implements ICellModel {
 		}
 	}
 
-	public get gridDataConversionComplete(): Promise<void[]> {
-		return Promise.all(this._gridDataConversionComplete);
+	public get gridDataConversionComplete(): Promise<void> {
+		return Promise.all(this._gridDataConversionComplete).then();
 	}
 
 	public addGridDataConversionPromise(complete: Promise<void>): void {

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -577,21 +577,21 @@ export class CellModel extends Disposable implements ICellModel {
 		//     this._displayIdMap.set(displayId, targets);
 		// }
 		if (output) {
+			let outputExists = false;
 			if (output.output_type === 'execute_result') {
 				this.notebookModel.setGridDataConversionComplete((<nb.IExecuteResult>output).conversionComplete);
-			}
-			let outputExists = false;
-			for (let i = 0; i < this._outputs.length; i++) {
-				let o = this._outputs[i];
-				if (o.output_type === 'execute_result'
-					&& (<nb.IExecuteResult>o).batchId === (<nb.IExecuteResult>output).batchId
-					&& (<nb.IExecuteResult>o).id === (<nb.IExecuteResult>output).id) {
-					outputExists = true;
-					// deletes transient node in the serialized JSON
-					delete output['transient'];
-					// update output with correct mimeType and html data
-					this._outputs[i] = this.rewriteOutputUrls(output);
-					break;
+				// if output already exists, update the output's data and don't re-render output component
+				for (let i = 0; i < this._outputs.length; i++) {
+					let o = this._outputs[i];
+					if (o.output_type === 'execute_result'
+						&& (<nb.IExecuteResult>o).batchId === (<nb.IExecuteResult>output).batchId
+						&& (<nb.IExecuteResult>o).id === (<nb.IExecuteResult>output).id) {
+						outputExists = true;
+						delete output['transient'];
+						// update output with correct mimeType and html data
+						this._outputs[i] = this.rewriteOutputUrls(output);
+						break;
+					}
 				}
 			}
 			if (!outputExists) {

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -339,6 +339,8 @@ export class CellModel extends Disposable implements ICellModel {
 
 	public async runCell(notificationService?: INotificationService, connectionManagementService?: IConnectionManagementService): Promise<boolean> {
 		try {
+			// Clear grid data conversion promises from previous execution results
+			this._gridDataConversionComplete = [];
 			if (!this.active && this !== this.notebookModel.activeCell) {
 				this.notebookModel.updateActiveCell(this);
 				this.active = true;

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -601,7 +601,22 @@ export class CellModel extends Disposable implements ICellModel {
 		if (output) {
 			// deletes transient node in the serialized JSON
 			delete output['transient'];
-			this._outputs.push(this.rewriteOutputUrls(output));
+			// display message outputs before grid outputs
+			if (output.output_type === 'display_data' && this._outputs.length > 0) {
+				let added = false;
+				for (let i = 0; i < this._outputs.length; i++) {
+					if (this._outputs[i].output_type === 'execute_result') {
+						this._outputs.splice(i, 0, this.rewriteOutputUrls(output));
+						added = true;
+						break;
+					}
+				}
+				if (!added) {
+					this._outputs.push(this.rewriteOutputUrls(output));
+				}
+			} else {
+				this._outputs.push(this.rewriteOutputUrls(output));
+			}
 			// Only scroll on 1st output being added
 			let shouldScroll = this._outputs.length === 1;
 			this.fireOutputsChanged(shouldScroll);

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -238,6 +238,10 @@ export interface INotebookModel {
 	 */
 	readonly sessionLoadFinished: Promise<void>;
 	/**
+	 * Promise indicating when output grid data is converted to mimeType and html.
+	 */
+	gridDataConversionComplete: Promise<void>;
+	/**
 	 * LanguageInfo saved in the notebook
 	 */
 	readonly languageInfo: nb.ILanguageInfo;
@@ -395,6 +399,8 @@ export interface INotebookModel {
 	standardKernels: IStandardKernelWithProvider[];
 
 	requestConnection(): Promise<boolean>;
+
+	setGridDataConversionComplete(complete: boolean): void;
 
 }
 

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -484,7 +484,7 @@ export interface ICellModel {
 	showPreview: boolean;
 	readonly onCellPreviewChanged: Event<boolean>;
 	sendChangeToNotebook(change: NotebookChangeType): void;
-	gridDataConversionComplete: Promise<void[]>;
+	gridDataConversionComplete: Promise<void>;
 	addGridDataConversionPromise(complete: Promise<void>): void;
 	updateOutputData(batchId: number, id: number, data: any): void;
 }

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -240,7 +240,7 @@ export interface INotebookModel {
 	/**
 	 * Promise indicating when output grid data is converted to mimeType and html.
 	 */
-	gridDataConversionComplete: Promise<any[]>;
+	gridDataConversionComplete: Promise<any>;
 	/**
 	 * LanguageInfo saved in the notebook
 	 */
@@ -484,7 +484,9 @@ export interface ICellModel {
 	showPreview: boolean;
 	readonly onCellPreviewChanged: Event<boolean>;
 	sendChangeToNotebook(change: NotebookChangeType): void;
-	gridDataConversionComplete: Promise<void>
+	gridDataConversionComplete: Promise<void[]>;
+	addGridDataConversionPromise(complete: Promise<void>): void;
+	updateOutputData(batchId: number, id: number, data: any): void;
 }
 
 export interface IModelFactory {

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -240,7 +240,7 @@ export interface INotebookModel {
 	/**
 	 * Promise indicating when output grid data is converted to mimeType and html.
 	 */
-	gridDataConversionComplete: Promise<void>;
+	gridDataConversionComplete: Promise<any[]>;
 	/**
 	 * LanguageInfo saved in the notebook
 	 */
@@ -400,8 +400,6 @@ export interface INotebookModel {
 
 	requestConnection(): Promise<boolean>;
 
-	setGridDataConversionComplete(complete: boolean): void;
-
 }
 
 export interface NotebookContentChange {
@@ -486,6 +484,7 @@ export interface ICellModel {
 	showPreview: boolean;
 	readonly onCellPreviewChanged: Event<boolean>;
 	sendChangeToNotebook(change: NotebookChangeType): void;
+	gridDataConversionComplete: Promise<void>
 }
 
 export interface IModelFactory {

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -56,7 +56,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private _inErrorState: boolean = false;
 	private _activeClientSession: IClientSession;
 	private _sessionLoadFinished = new Deferred<void>();
-	private _gridDataConversionComplete = new Deferred<void>();
 	private _onClientSessionReady = new Emitter<IClientSession>();
 	private _onProviderIdChanged = new Emitter<string>();
 	private _trustedMode: boolean;
@@ -107,7 +106,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			this._notebookOptions.layoutChanged(() => this._layoutChanged.fire());
 		}
 		this._defaultKernel = _notebookOptions.defaultKernel;
-		this._gridDataConversionComplete.resolve();
 	}
 
 	public get notebookManagers(): INotebookManager[] {
@@ -266,16 +264,12 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	/**
 	 * Indicates all result grid output has been converted to mimeType and html.
 	 */
-	public get gridDataConversionComplete(): Promise<void> {
-		return this._gridDataConversionComplete;
-	}
-
-	public setGridDataConversionComplete(complete: boolean): void {
-		if (complete) {
-			this._gridDataConversionComplete.resolve();
-		} else {
-			this._gridDataConversionComplete = new Deferred<void>();
+	public get gridDataConversionComplete(): Promise<any[]> {
+		let promises = [];
+		for (let cell of this._cells) {
+			promises.push(cell.gridDataConversionComplete);
 		}
+		return Promise.all(promises);
 	}
 
 	/**

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -56,6 +56,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private _inErrorState: boolean = false;
 	private _activeClientSession: IClientSession;
 	private _sessionLoadFinished = new Deferred<void>();
+	private _gridDataConversionComplete = new Deferred<void>();
 	private _onClientSessionReady = new Emitter<IClientSession>();
 	private _onProviderIdChanged = new Emitter<string>();
 	private _trustedMode: boolean;
@@ -106,6 +107,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			this._notebookOptions.layoutChanged(() => this._layoutChanged.fire());
 		}
 		this._defaultKernel = _notebookOptions.defaultKernel;
+		this._gridDataConversionComplete.resolve();
 	}
 
 	public get notebookManagers(): INotebookManager[] {
@@ -259,6 +261,21 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	 */
 	public get sessionLoadFinished(): Promise<void> {
 		return this._sessionLoadFinished;
+	}
+
+	/**
+	 * Indicates all result grid output has been converted to mimeType and html.
+	 */
+	public get gridDataConversionComplete(): Promise<void> {
+		return this._gridDataConversionComplete;
+	}
+
+	public setGridDataConversionComplete(complete: boolean): void {
+		if (complete) {
+			this._gridDataConversionComplete.resolve();
+		} else {
+			this._gridDataConversionComplete = new Deferred<void>();
+		}
 	}
 
 	/**

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -264,7 +264,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	/**
 	 * Indicates all result grid output has been converted to mimeType and html.
 	 */
-	public get gridDataConversionComplete(): Promise<any[]> {
+	public get gridDataConversionComplete(): Promise<any> {
 		let promises = [];
 		for (let cell of this._cells) {
 			promises.push(cell.gridDataConversionComplete);

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -14,6 +14,7 @@ import { Deferred } from 'sql/base/common/promise';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IErrorMessageService } from 'sql/platform/errorMessage/common/errorMessageService';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
+import { escape } from 'sql/base/common/strings';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -502,7 +502,7 @@ export class SQLFuture extends Disposable implements FutureInternal {
 			if (!Array.isArray(resultSet)) {
 				resultsToAdd = [resultSet];
 			} else {
-				resultsToAdd = resultSet.splice(0);
+				resultsToAdd = resultSet?.splice(0);
 			}
 			for (let set of resultsToAdd) {
 				this.sendIOPubMessage(set, false);

--- a/src/sql/workbench/services/query/common/queryManagement.ts
+++ b/src/sql/workbench/services/query/common/queryManagement.ts
@@ -39,6 +39,7 @@ export interface IQueryManagementService {
 	isProviderRegistered(providerId: string): boolean;
 	getRegisteredProviders(): string[];
 	registerRunner(runner: QueryRunner, uri: string): void;
+	getRunner(uri: string): QueryRunner;
 
 	cancelQuery(ownerUri: string): Promise<QueryCancelResult>;
 	runQuery(ownerUri: string, range?: IRange, runOptions?: ExecutionPlanOptions): Promise<void>;
@@ -136,6 +137,10 @@ export class QueryManagementService implements IQueryManagementService {
 		if (!runner.hasCompleted) {
 			this._queryRunners.set(uri, runner);
 		}
+	}
+
+	public getRunner(uri: string): QueryRunner {
+		return this._queryRunners.get(uri);
 	}
 
 	// Handles logic to run the given handlerCallback at the appropriate time. If the given runner is

--- a/src/sql/workbench/services/query/common/queryManagement.ts
+++ b/src/sql/workbench/services/query/common/queryManagement.ts
@@ -139,7 +139,7 @@ export class QueryManagementService implements IQueryManagementService {
 		}
 	}
 
-	public getRunner(uri: string): QueryRunner {
+	public getRunner(uri: string): QueryRunner | undefined {
 		return this._queryRunners.get(uri);
 	}
 

--- a/src/sql/workbench/services/query/common/queryManagement.ts
+++ b/src/sql/workbench/services/query/common/queryManagement.ts
@@ -39,7 +39,7 @@ export interface IQueryManagementService {
 	isProviderRegistered(providerId: string): boolean;
 	getRegisteredProviders(): string[];
 	registerRunner(runner: QueryRunner, uri: string): void;
-	getRunner(uri: string): QueryRunner;
+	getRunner(uri: string): QueryRunner | undefined;
 
 	cancelQuery(ownerUri: string): Promise<QueryCancelResult>;
 	runQuery(ownerUri: string, range?: IRange, runOptions?: ExecutionPlanOptions): Promise<void>;

--- a/src/sql/workbench/services/query/test/common/testQueryManagementService.ts
+++ b/src/sql/workbench/services/query/test/common/testQueryManagementService.ts
@@ -26,6 +26,9 @@ export class TestQueryManagementService implements IQueryManagementService {
 	registerRunner(runner: QueryRunner, uri: string): void {
 		return;
 	}
+	getRunner(uri: string): QueryRunner {
+		throw new Error('Method not implemented.');
+	}
 	async cancelQuery(ownerUri: string): Promise<azdata.QueryCancelResult> {
 		return { messages: undefined };
 	}


### PR DESCRIPTION
This PR adds grid streaming support for notebooks. 

Previous grid rendering behavior: wait for entire query result to be returned before converting rows to data types (mimeType and html) and then displaying data.

Changes for streaming: 
- Added listeners for onResultSet and onResultSetUpdate
- Start updating the table before converting rows to mimeType and html
- Moved data conversion logic from sqlSessionManager to DataResourceDataProvider
- Added gridDataConversionComplete to notebook model to make sure that all rows have been converted (in case user tries to save the notebook before conversion is complete) 

