### PR TITLE
Enable double click edit

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
@@ -107,4 +107,10 @@ export class CellToolbarComponent {
 
 		this._actionBar.setContent(taskbarContent);
 	}
+
+	public enableCellEditMode() {
+		if (!this._editCellAction.editMode) {
+			this._editCellAction.editMode = !this._editCellAction.editMode;
+		}
+	}
 }

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
@@ -108,10 +108,7 @@ export class CellToolbarComponent {
 		this._actionBar.setContent(taskbarContent);
 	}
 
-	// Changes edit icon from edit to cancel
-	public enableCellEditModeIcon() {
-		if (!this._editCellAction.editMode) {
-			this._editCellAction.editMode = !this._editCellAction.editMode;
-		}
+	public getEditCellAction(): EditCellAction {
+		return this._editCellAction;
 	}
 }

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component.ts
@@ -108,7 +108,8 @@ export class CellToolbarComponent {
 		this._actionBar.setContent(taskbarContent);
 	}
 
-	public enableCellEditMode() {
+	// Changes edit icon from edit to cancel
+	public enableCellEditModeIcon() {
 		if (!this._editCellAction.editMode) {
 			this._editCellAction.editMode = !this._editCellAction.editMode;
 		}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -61,12 +61,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 
 	// Double click to edit text cell in notebook
 	@HostListener('dblclick', ['$event']) onDblClick() {
-		if (!this.isEditMode && this.doubleClickEditEnabled) {
-			this.toggleEditMode(true);
-		}
-		this.cellModel.active = true;
-		this._model.updateActiveCell(this.cellModel);
-
+		this.enableActiveCellEditOnDoubleClick();
 	}
 
 	@HostListener('document:keydown.meta.a', ['$event'])
@@ -192,7 +187,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 
 	/**
 	 * Updates the preview of markdown component with latest changes
-	 * If content is empty and in non-edit mode, default it to 'Add content here...'
+	 * If content is empty and in non-edit mode, default it to 'Add content here...' or 'Double-click to edit' depending on setting
 	 * Sanitizes the data to be shown in markdown cell
 	 */
 	private updatePreview(): void {
@@ -369,5 +364,14 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			}
 		});
 		return textOutput;
+	}
+
+	// Enables edit mode on double clicking active cell
+	private enableActiveCellEditOnDoubleClick() {
+		if (!this.isEditMode && this.doubleClickEditEnabled) {
+			this.toggleEditMode(true);
+		}
+		this.cellModel.active = true;
+		this._model.updateActiveCell(this.cellModel);
 	}
 }

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -103,7 +103,6 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			this.previewFeaturesEnabled = this._configurationService.getValue('workbench.enablePreviewFeatures');
 		}));
-		this.doubleClickEditEnabled = this._configurationService.getValue('notebook.enableDoubleClickEdit');
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			this.doubleClickEditEnabled = this._configurationService.getValue('notebook.enableDoubleClickEdit');
 		}));

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -28,7 +28,6 @@ import { NotebookRange, ICellEditorProvider } from 'sql/workbench/services/noteb
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
-
 export const TEXT_SELECTOR: string = 'text-cell-component';
 const USER_SELECT_CLASS = 'actionselect';
 

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.html
@@ -7,14 +7,14 @@
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div #toolbar class="editor-toolbar actionbar-container" style="flex: 0 0 auto; display: flex; flex-flow: row; width: 100%; align-items: center;">
 	</div>
-	<div #container class="scrollable" style="flex: 1 1 auto; position: relative; outline: none" (click)="unselectActiveCell()" (scroll)="scrollHandler($event)">
+	<div #container class="scrollable" style="flex: 1 1 auto; position: relative; outline: none" (click)="unselectActiveCell()" (scroll)="scrollHandler($event)" >
 		<loading-spinner [loading]="isLoading"></loading-spinner>
 		<div *ngFor="let cell of cells">
 			<div class="notebook-cell" (click)="selectCell(cell, $event)" [class.active]="cell.active">
 				<cell-toolbar-component *ngIf="cell.active" [cellModel]="cell" [model]="model"></cell-toolbar-component>
 				<code-cell-component *ngIf="cell.cellType === 'code'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">
 				</code-cell-component>
-				<text-cell-component *ngIf="cell.cellType === 'markdown'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">
+				<text-cell-component *ngIf="cell.cellType === 'markdown'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId" (dblclick)="editActiveCell()">
 				</text-cell-component>
 			</div>
 		</div>

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.html
@@ -7,7 +7,7 @@
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div #toolbar class="editor-toolbar actionbar-container" style="flex: 0 0 auto; display: flex; flex-flow: row; width: 100%; align-items: center;">
 	</div>
-	<div #container class="scrollable" style="flex: 1 1 auto; position: relative; outline: none" (click)="unselectActiveCell()" (scroll)="scrollHandler($event)" >
+	<div #container class="scrollable" style="flex: 1 1 auto; position: relative; outline: none" (click)="unselectActiveCell()" (scroll)="scrollHandler($event)">
 		<loading-spinner [loading]="isLoading"></loading-spinner>
 		<div *ngFor="let cell of cells">
 			<div class="notebook-cell" (click)="selectCell(cell, $event)" [class.active]="cell.active">

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.html
@@ -14,7 +14,7 @@
 				<cell-toolbar-component *ngIf="cell.active" [cellModel]="cell" [model]="model"></cell-toolbar-component>
 				<code-cell-component *ngIf="cell.cellType === 'code'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId">
 				</code-cell-component>
-				<text-cell-component *ngIf="cell.cellType === 'markdown'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId" (dblclick)="editActiveCell()">
+				<text-cell-component *ngIf="cell.cellType === 'markdown'" [cellModel]="cell" [model]="model" [activeCellId]="activeCellId" (dblclick)="enableActiveCellIconOnDoubleClick()">
 				</text-cell-component>
 			</div>
 		</div>

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -89,7 +89,6 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	public previewFeaturesEnabled: boolean = false;
 	public doubleClickEditEnabled: boolean;
 
-
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
 		@Inject(IWorkbenchThemeService) private themeService: IWorkbenchThemeService,

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -116,7 +116,6 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			this.previewFeaturesEnabled = this._configurationService.getValue('workbench.enablePreviewFeatures');
 		}));
-		this.doubleClickEditEnabled = this._configurationService.getValue('notebook.enableDoubleClickEdit');
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			this.doubleClickEditEnabled = this._configurationService.getValue('notebook.enableDoubleClickEdit');
 		}));
@@ -214,7 +213,11 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	// See textcell.component.ts for changing edit behavior
 	public enableActiveCellIconOnDoubleClick() {
 		if (this.doubleClickEditEnabled) {
-			this.cellToolbar.first.enableCellEditModeIcon();
+			const toolbarComponent = (<CellToolbarComponent>this.cellToolbar.first);
+			const toolbarEditCellAction = toolbarComponent.getEditCellAction();
+			if (!toolbarEditCellAction.editMode) {
+				toolbarEditCellAction.editMode = !toolbarEditCellAction.editMode;
+			}
 		}
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -210,9 +210,12 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		this.model.updateActiveCell(undefined);
 		this.detectChanges();
 	}
-	public editActiveCell() {
+
+	// Handles double click to edit icon change
+	// See textcell.component.ts for changing edit behavior
+	public enableActiveCellIconOnDoubleClick() {
 		if (this.doubleClickEditEnabled) {
-			this.cellToolbar.first.enableCellEditMode();
+			this.cellToolbar.first.enableCellEditModeIcon();
 		}
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -57,6 +57,7 @@ import { NotebookInput } from 'sql/workbench/contrib/notebook/browser/models/not
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { CellToolbarComponent } from 'sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.component';
 
 export const NOTEBOOK_SELECTOR: string = 'notebook-component';
 
@@ -71,6 +72,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 
 	@ViewChildren(CodeCellComponent) private codeCells: QueryList<CodeCellComponent>;
 	@ViewChildren(TextCellComponent) private textCells: QueryList<TextCellComponent>;
+	@ViewChildren(CellToolbarComponent) private cellToolbar: QueryList<CellToolbarComponent>;
 
 	private _model: NotebookModel;
 	protected _actionBar: Taskbar;
@@ -85,6 +87,8 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	private _navProvider: INavigationProvider;
 	private navigationResult: nb.NavigationResult;
 	public previewFeaturesEnabled: boolean = false;
+	public doubleClickEditEnabled: boolean;
+
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
@@ -112,6 +116,10 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		this.isLoading = true;
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			this.previewFeaturesEnabled = this._configurationService.getValue('workbench.enablePreviewFeatures');
+		}));
+		this.doubleClickEditEnabled = this._configurationService.getValue('notebook.enableDoubleClickEdit');
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			this.doubleClickEditEnabled = this._configurationService.getValue('notebook.enableDoubleClickEdit');
 		}));
 	}
 
@@ -201,6 +209,11 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	public unselectActiveCell() {
 		this.model.updateActiveCell(undefined);
 		this.detectChanges();
+	}
+	public editActiveCell() {
+		if (this.doubleClickEditEnabled) {
+			this.cellToolbar.first.enableCellEditMode();
+		}
 	}
 
 	// Add cell based on cell type

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -224,7 +224,7 @@ configurationRegistry.registerConfiguration({
 		'notebook.enableDoubleClickEdit': {
 			'type': 'boolean',
 			'default': true,
-			'description': localize('notebook.enableDoublClickEdit', "Enable double click to edit for text cells in notebooks")
+			'description': localize('notebook.enableDoubleClickEdit', "Enable double click to edit for text cells in notebooks")
 		}
 	}
 });

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -220,6 +220,11 @@ configurationRegistry.registerConfiguration({
 			'type': 'boolean',
 			'default': false,
 			'description': localize('notebook.allowADSCommands', "Allow notebooks to run Azure Data Studio commands.")
+		},
+		'notebook.enableDoubleClickEdit': {
+			'type': 'boolean',
+			'default': true,
+			'description': localize('notebook.enableDoublClickEdit', "Enable double click to edit for text cells in notebooks")
 		}
 	}
 });


### PR DESCRIPTION
This PR fixes #12076 
- Adds double click to edit functionality to notebook text cells
- Adds setting to enable or disable feature (enabled by default)
