### PR TITLE
Fixed Kusto change connections for previous notebooks

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -455,6 +455,7 @@ export class AttachToDropdown extends SelectBox {
 	 **/
 	public async openConnectionDialog(useProfile: boolean = false): Promise<boolean> {
 		try {
+			//Get all providers to show all available connections in connection dialog
 			let providers = [];
 			providers = this.model.getApplicableConnectionProviderIds(this.model.clientSession.kernel.name);
 			if (this.model.currentKernelAlias) {

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -463,7 +463,7 @@ export class AttachToDropdown extends SelectBox {
 			let connection = await this._connectionDialogService.openDialogAndWait(this._connectionManagementService,
 				{
 					connectionType: ConnectionType.temporary,
-					providers: providers,
+					providers: providers
 				},
 				useProfile ? this.model.connectionProfile : undefined);
 

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -455,11 +455,10 @@ export class AttachToDropdown extends SelectBox {
 	 **/
 	public async openConnectionDialog(useProfile: boolean = false): Promise<boolean> {
 		try {
-			//Get all providers to show all available connections in connection dialog
-			let providers = [];
-			providers = this.model.getApplicableConnectionProviderIds(this.model.clientSession.kernel.name);
-			if (this.model.currentKernelAlias) {
-				providers.push(this.model.getApplicableConnectionProviderIds(this.model.currentKernelAlias).toString());
+			// Get all providers to show all available connections in connection dialog
+			let providers = this.model.getApplicableConnectionProviderIds(this.model.clientSession.kernel.name);
+			for (let alias of this.model.kernelAliases) {
+				providers = providers.concat(this.model.getApplicableConnectionProviderIds(alias));
 			}
 			let connection = await this._connectionDialogService.openDialogAndWait(this._connectionManagementService,
 				{

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -455,10 +455,15 @@ export class AttachToDropdown extends SelectBox {
 	 **/
 	public async openConnectionDialog(useProfile: boolean = false): Promise<boolean> {
 		try {
+			let providers = [];
+			providers = this.model.getApplicableConnectionProviderIds(this.model.clientSession.kernel.name);
+			if (this.model.currentKernelAlias) {
+				providers.push(this.model.getApplicableConnectionProviderIds(this.model.currentKernelAlias).toString());
+			}
 			let connection = await this._connectionDialogService.openDialogAndWait(this._connectionManagementService,
 				{
 					connectionType: ConnectionType.temporary,
-					providers: this.model.getApplicableConnectionProviderIds(this.model.clientSession.kernel.name)
+					providers: providers,
 				},
 				useProfile ? this.model.connectionProfile : undefined);
 

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -644,7 +644,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			let providerFeatures = this._capabilitiesService.getCapabilities(profile.providerName);
 			if (connectionProviderIds.length > 0 && this._currentKernelAlias) {
 				this._currentKernelAlias = providerFeatures?.connection.notebookKernelAlias;
-				this._kernelDisplayNameToConnectionProviderIds.set(providerFeatures?.connection.notebookKernelAlias, [profile.providerName]);
+				this._kernelDisplayNameToConnectionProviderIds.set(this._currentKernelAlias, [profile.providerName]);
 			}
 			return this._currentKernelAlias || profile && connectionProviderIds && find(connectionProviderIds, provider => provider === profile.providerName) !== undefined;
 		}

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -593,8 +593,10 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			let providers = this._capabilitiesService.providers;
 			for (const server in providers) {
 				let alias = providers[server].connection.notebookKernelAlias;
+				//Add Notebook Kernel Alias to kernelAliases
 				if (alias && this._kernelAliases.indexOf(alias) === -1) {
 					this._kernelAliases.push(providers[server].connection.notebookKernelAlias);
+					this._kernelDisplayNameToConnectionProviderIds.set(alias, [providers[server].connection.providerId]);
 				}
 			}
 		}
@@ -640,9 +642,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			let standardKernels = find(this._standardKernels, kernel => this._defaultKernel && kernel.displayName === this._defaultKernel.display_name);
 			let connectionProviderIds = standardKernels ? standardKernels.connectionProviderIds : undefined;
 			let providerFeatures = this._capabilitiesService.getCapabilities(profile.providerName);
-			if (connectionProviderIds.length > 0) {
+			if (connectionProviderIds.length > 0 && this._currentKernelAlias) {
 				this._currentKernelAlias = providerFeatures?.connection.notebookKernelAlias;
-				this._kernelDisplayNameToConnectionProviderIds.set(this._currentKernelAlias, [profile.providerName]);
+				this._kernelDisplayNameToConnectionProviderIds.set(providerFeatures?.connection.notebookKernelAlias, [profile.providerName]);
 			}
 			return this._currentKernelAlias || profile && connectionProviderIds && find(connectionProviderIds, provider => provider === profile.providerName) !== undefined;
 		}

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -593,7 +593,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			let providers = this._capabilitiesService.providers;
 			for (const server in providers) {
 				let alias = providers[server].connection.notebookKernelAlias;
-				//Add Notebook Kernel Alias to kernelAliases
+				// Add Notebook Kernel Alias to kernelAliases
 				if (alias && this._kernelAliases.indexOf(alias) === -1) {
 					this._kernelAliases.push(providers[server].connection.notebookKernelAlias);
 					this._kernelDisplayNameToConnectionProviderIds.set(alias, [providers[server].connection.providerId]);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #12178 by using currentKernelAlias instead of constants. Should load all connections available when the notebook is not connected to anything. 
![image](https://user-images.githubusercontent.com/23587151/92675079-3db5a080-f2e4-11ea-9035-b64cce5cd1b7.png)

