### PR TITLE
Quick tweaks to resource viewer (v1)

### DIFF
--- a/src/sql/workbench/contrib/resourceViewer/browser/media/resourceViewerView.css
+++ b/src/sql/workbench/contrib/resourceViewer/browser/media/resourceViewerView.css
@@ -7,3 +7,10 @@
 	height: 100%;
 	width: 100%;
 }
+
+.resource-viewer .actions-container .action-item .action-label {
+	padding-left: 20px;
+	padding-right: 5px;
+	background-size: 16px;
+	background-position: left;
+}

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerEditor.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerEditor.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import 'vs/css!./media/resourceViewerView';
 import { Taskbar } from 'sql/base/browser/ui/taskbar/taskbar';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { CancellationToken } from 'vs/base/common/cancellation';

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
@@ -31,7 +31,8 @@ export class ResourceViewerTable extends Disposable {
 				this._dataView.sort(args);
 			}
 		}, {
-			dataItemColumnValueExtractor: slickGridDataItemColumnValueExtractor
+			dataItemColumnValueExtractor: slickGridDataItemColumnValueExtractor,
+			forceFitColumns: true
 		}));
 		this._resourceViewerTable.setSelectionModel(new RowSelectionModel());
 		let filterPlugin = new HeaderFilter<Slick.SlickData>();
@@ -39,6 +40,7 @@ export class ResourceViewerTable extends Disposable {
 		this._register(attachTableStyler(this._resourceViewerTable, this._themeService));
 		filterPlugin.onFilterApplied.subscribe(() => {
 			this._dataView.filter();
+			this._resourceViewerTable.grid.invalidate();
 			this._resourceViewerTable.grid.render();
 			this._resourceViewerTable.grid.resetActiveCell();
 			this._resourceViewerTable.grid.resizeCanvas();


### PR DESCRIPTION
Super minor tweaks (first part). I'm currently ignoring contributed column widths here in lieu of a full container width experience. Sorry @Charles-Gagnon.

- Filtering now is functional
- CSS tweaks to ensure actions aren't behind labels
- Columns auto-fit to container

![image](https://user-images.githubusercontent.com/40371649/92682951-72c2f280-f2e6-11ea-8765-55769da470e5.png)
