### PR TITLE
MIAA: Add vCore Number to Dashboard

### DIFF
--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -266,7 +266,6 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 		this._instanceProperties.dataController = config?.metadata.name || this._instanceProperties.dataController;
 		this._instanceProperties.region = this._azurecoreApi.getRegionDisplayName(config?.spec.settings.azure.location) || this._instanceProperties.region;
 		this._instanceProperties.subscriptionId = config?.spec.settings.azure.subscription || this._instanceProperties.subscriptionId;
-		// this._instanceProperties.vCores = reg.vCores || '';
 		this.refreshDisplayedProperties();
 	}
 
@@ -274,6 +273,7 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 		if (this._miaaModel.config) {
 			this._instanceProperties.status = this._miaaModel.config.status.state || '-';
 			this._instanceProperties.externalEndpoint = this._miaaModel.config.status.externalEndpoint || loc.notConfigured;
+			this._instanceProperties.vCores = this._miaaModel.config.spec.limits?.vcores?.toString() || '';
 			this._databasesMessage.value = !this._miaaModel.config.status.externalEndpoint ? loc.noExternalEndpoint : '';
 		}
 

--- a/extensions/azdata/src/typings/azdata-ext.d.ts
+++ b/extensions/azdata/src/typings/azdata-ext.d.ts
@@ -118,6 +118,9 @@ declare module 'azdata-ext' {
 			uid: string // "cea737aa-3f82-4f6a-9bed-2b51c2c33dff"
 		},
 		spec: {
+			limits?: {
+				vcores?: number // 4
+			}
 			service: {
 				type: string // "NodePort"
 			}


### PR DESCRIPTION
Fixes #12024. Populating the vCore field if it's returned by azdata (only set if the user specifies it during a `create` or `edit` command; otherwise, show '-'; confirmed with PM):

vcore limit returned by azdata:
![image](https://user-images.githubusercontent.com/40371649/92688076-87f14e80-f2f1-11ea-90d6-cff88655d407.png)

no vcore limit returned:
![image](https://user-images.githubusercontent.com/40371649/92688109-98a1c480-f2f1-11ea-99ff-55d68e96cda6.png)
