### PR TITLE
Fix focus order for db projects

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -116,8 +116,8 @@ export class ProjectsController {
 
 	public async focusProject(project?: Project): Promise<void> {
 		if (project && this.projects.includes(project)) {
-			await vscode.commands.executeCommand(constants.sqlDatabaseProjectsViewFocusCommand);
 			await this.projectTreeViewProvider.focus(project);
+			await vscode.commands.executeCommand(constants.sqlDatabaseProjectsViewFocusCommand);
 		}
 	}
 


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/12223

The issue was that executing the command to get focus for the view before setting the tree focus caused a race condition to focus the tree twice. Changing the order fixes the race condition.