### PR TITLE
Notebooks: Add setting for default text cell edit behavior

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -74,8 +74,8 @@ export class MarkdownToolbarComponent {
 		let heading3 = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.heading3', this.optionHeading3, 'heading 3', this.optionHeading3, this.cellModel, MarkdownButtonType.HEADING3);
 		let paragraph = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.paragraph', this.optionParagraph, 'paragraph', this.optionParagraph, this.cellModel, MarkdownButtonType.PARAGRAPH);
 
-		this._toggleTextViewAction = this._instantiationService.createInstance(ToggleViewAction, 'notebook.toggleTextView', '', 'masked-icon show-text active', this.textViewButton, true, false);
-		this._toggleSplitViewAction = this._instantiationService.createInstance(ToggleViewAction, 'notebook.toggleSplitView', '', 'masked-icon split-toggle-on', this.splitViewButton, true, true);
+		this._toggleTextViewAction = this._instantiationService.createInstance(ToggleViewAction, 'notebook.toggleTextView', '', this.cellModel.defaultToWYSIWYG ? 'masked-icon show-text active' : 'masked-icon show-text', this.textViewButton, true, false);
+		this._toggleSplitViewAction = this._instantiationService.createInstance(ToggleViewAction, 'notebook.toggleSplitView', '', this.cellModel.defaultToWYSIWYG ? 'masked-icon split-toggle-on' : 'masked-icon split-toggle-on active', this.splitViewButton, true, true);
 		this._toggleMarkdownViewAction = this._instantiationService.createInstance(ToggleViewAction, 'notebook.toggleMarkdownView', '', 'masked-icon show-markdown', this.markdownButton, false, true);
 
 		let taskbar = <HTMLElement>this.mdtoolbar.nativeElement;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -38,9 +38,9 @@ export class MarkdownToolbarComponent {
 	public optionHeading3 = localize('optionHeading3', "Heading 3");
 	public optionParagraph = localize('optionParagraph', "Paragraph");
 
-	public textViewButton = localize('textViewButton', "View as Text");
-	public splitViewButton = localize('splitViewButton', "View as Split");
-	public markdownButton = localize('markdownButton', "View as Markdown");
+	public richTextViewButton = localize('richTextViewButton', "Rich Text View");
+	public splitViewButton = localize('splitViewButton', "Split View");
+	public markdownViewButton = localize('markdownViewButton', "Markdown View");
 
 	@Input() public cellModel: ICellModel;
 	private _actionBar: Taskbar;
@@ -74,9 +74,9 @@ export class MarkdownToolbarComponent {
 		let heading3 = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.heading3', this.optionHeading3, 'heading 3', this.optionHeading3, this.cellModel, MarkdownButtonType.HEADING3);
 		let paragraph = this._instantiationService.createInstance(TransformMarkdownAction, 'notebook.paragraph', this.optionParagraph, 'paragraph', this.optionParagraph, this.cellModel, MarkdownButtonType.PARAGRAPH);
 
-		this._toggleTextViewAction = this._instantiationService.createInstance(ToggleViewAction, 'notebook.toggleTextView', '', this.cellModel.defaultToWYSIWYG ? 'masked-icon show-text active' : 'masked-icon show-text', this.textViewButton, true, false);
+		this._toggleTextViewAction = this._instantiationService.createInstance(ToggleViewAction, 'notebook.toggleTextView', '', this.cellModel.defaultToWYSIWYG ? 'masked-icon show-text active' : 'masked-icon show-text', this.richTextViewButton, true, false);
 		this._toggleSplitViewAction = this._instantiationService.createInstance(ToggleViewAction, 'notebook.toggleSplitView', '', this.cellModel.defaultToWYSIWYG ? 'masked-icon split-toggle-on' : 'masked-icon split-toggle-on active', this.splitViewButton, true, true);
-		this._toggleMarkdownViewAction = this._instantiationService.createInstance(ToggleViewAction, 'notebook.toggleMarkdownView', '', 'masked-icon show-markdown', this.markdownButton, false, true);
+		this._toggleMarkdownViewAction = this._instantiationService.createInstance(ToggleViewAction, 'notebook.toggleMarkdownView', '', 'masked-icon show-markdown', this.markdownViewButton, false, true);
 
 		let taskbar = <HTMLElement>this.mdtoolbar.nativeElement;
 		this._actionBar = new Taskbar(taskbar);

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -279,6 +279,8 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		if (!this.isEditMode) {
 			this.previewMode = true;
 			this.markdownMode = false;
+		} else {
+			this.markdownMode = this.cellModel.showMarkdown;
 		}
 		this.updatePreview();
 		this._changeRef.detectChanges();

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -216,9 +216,9 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			this._lastTrustedMode = this.cellModel.trustedMode;
 			if ((!cellModelSourceJoined) && !this.isEditMode) {
 				if (this.doubleClickEditEnabled) {
-					this._content = localize('doubleClickEdit', "Double-click to edit");
+					this._content = localize('doubleClickEdit', "<i>Double-click to edit</i>");
 				} else {
-					this._content = localize('addContent', "Add content here...");
+					this._content = localize('addContent', "<i>Add content here...</i>");
 				}
 			} else {
 				this._content = this.cellModel.source[0] === '' ? '<p>&nbsp;</p>' : this.cellModel.source;

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -225,6 +225,11 @@ configurationRegistry.registerConfiguration({
 			'type': 'boolean',
 			'default': true,
 			'description': localize('notebook.enableDoubleClickEdit', "Enable double click to edit for text cells in notebooks")
+		},
+		'notebook.setWYSIWYG ByDefault': {
+			'type': 'boolean',
+			'default': true,
+			'description': localize('notebook.setWYSIWYGByDefault', "Set WYSIWYG mode by default for text cells")
 		}
 	}
 });

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -226,10 +226,10 @@ configurationRegistry.registerConfiguration({
 			'default': true,
 			'description': localize('notebook.enableDoubleClickEdit', "Enable double click to edit for text cells in notebooks")
 		},
-		'notebook.setWYSIWYG ByDefault': {
+		'notebook.setRichTextViewByDefault': {
 			'type': 'boolean',
 			'default': true,
-			'description': localize('notebook.setWYSIWYGByDefault', "Set WYSIWYG mode by default for text cells")
+			'description': localize('notebook.setRichTextViewByDefault', "Set Rich Text View mode by default for text cells")
 		}
 	}
 });

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -855,7 +855,7 @@ export class CellModel extends Disposable implements ICellModel {
 
 	private populatePropertiesFromSettings() {
 		if (this._configurationService) {
-			const enableWYSIWYGByDefaultKey = 'notebook.setWYSIWYG ByDefault';
+			const enableWYSIWYGByDefaultKey = 'notebook.setRichTextViewByDefault';
 			this._defaultToWYSIWYG = this._configurationService.getValue(enableWYSIWYGByDefaultKey);
 			if (!this._defaultToWYSIWYG) {
 				this.showMarkdown = true;

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -68,6 +68,7 @@ export class CellModel extends Disposable implements ICellModel {
 	private _showMarkdown: boolean = false;
 	private _cellSourceChanged: boolean = false;
 	private _gridDataConversionComplete: Promise<void>[] = [];
+	private _defaultToWYSIWYG: boolean;
 
 	constructor(cellData: nb.ICellContents,
 		private _options: ICellModelOptions,
@@ -95,15 +96,7 @@ export class CellModel extends Disposable implements ICellModel {
 		// if the fromJson() method was already called and _cellGuid was previously set, don't generate another UUID unnecessarily
 		this._cellGuid = this._cellGuid || generateUuid();
 		this.createUri();
-		if (this._configurationService) {
-			const allowADSCommandsKey = 'notebook.allowAzureDataStudioCommands';
-			this._isCommandExecutionSettingEnabled = this._configurationService.getValue(allowADSCommandsKey);
-			this._register(this._configurationService.onDidChangeConfiguration(e => {
-				if (e.affectsConfiguration(allowADSCommandsKey)) {
-					this._isCommandExecutionSettingEnabled = this._configurationService.getValue(allowADSCommandsKey);
-				}
-			}));
-		}
+		this.populatePropertiesFromSettings();
 	}
 
 	public equals(other: ICellModel) {
@@ -167,6 +160,9 @@ export class CellModel extends Disposable implements ICellModel {
 
 	public set isEditMode(isEditMode: boolean) {
 		this._isEditMode = isEditMode;
+		if (this._isEditMode) {
+			this.showMarkdown = !this._defaultToWYSIWYG;
+		}
 		this._onCellModeChanged.fire(this._isEditMode);
 		// Note: this does not require a notebook update as it does not change overall state
 	}
@@ -326,6 +322,9 @@ export class CellModel extends Disposable implements ICellModel {
 		this._onCellMarkdownChanged.fire(this._showMarkdown);
 	}
 
+	public get defaultToWYSIWYG(): boolean {
+		return this._defaultToWYSIWYG;
+	}
 
 	public get cellSourceChanged(): boolean {
 		return this._cellSourceChanged;
@@ -852,5 +851,24 @@ export class CellModel extends Disposable implements ICellModel {
 			this._future.dispose();
 		}
 		this._future = undefined;
+	}
+
+	private populatePropertiesFromSettings() {
+		if (this._configurationService) {
+			const enableWYSIWYGByDefaultKey = 'notebook.setWYSIWYG ByDefault';
+			this._defaultToWYSIWYG = this._configurationService.getValue(enableWYSIWYGByDefaultKey);
+			if (!this._defaultToWYSIWYG) {
+				this.showMarkdown = true;
+			}
+			const allowADSCommandsKey = 'notebook.allowAzureDataStudioCommands';
+			this._isCommandExecutionSettingEnabled = this._configurationService.getValue(allowADSCommandsKey);
+			this._register(this._configurationService.onDidChangeConfiguration(e => {
+				if (e.affectsConfiguration(allowADSCommandsKey)) {
+					this._isCommandExecutionSettingEnabled = this._configurationService.getValue(allowADSCommandsKey);
+				} else if (e.affectsConfiguration(enableWYSIWYGByDefaultKey)) {
+					this._defaultToWYSIWYG = this._configurationService.getValue(enableWYSIWYGByDefaultKey);
+				}
+			}));
+		}
 	}
 }

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -483,6 +483,7 @@ export interface ICellModel {
 	isEditMode: boolean;
 	showPreview: boolean;
 	showMarkdown: boolean;
+	defaultToWYSIWYG: boolean;
 	readonly onCellPreviewModeChanged: Event<boolean>;
 	readonly onCellMarkdownModeChanged: Event<boolean>;
 	sendChangeToNotebook(change: NotebookChangeType): void;


### PR DESCRIPTION
Fixes #12242. Adds setting for default text cell behavior. Defaults to WYSIWYG.