### PR TITLE
Fix pinned notebooks navigator

### DIFF
--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -59,7 +59,7 @@ export class BookTreeItem extends vscode.TreeItem {
 				if (book.isUntitled) {
 					this.contextValue = 'unsavedNotebook';
 				} else {
-					this.contextValue = 'savedNotebook';
+					this.contextValue = isBookItemPinned(book.contentPath) ? 'pinnedNotebook' : 'savedNotebook';
 				}
 			} else {
 				this.contextValue = book.type === BookTreeItemType.Notebook ? (isBookItemPinned(book.contentPath) ? 'pinnedNotebook' : 'savedNotebook') : 'section';

--- a/extensions/notebook/src/common/appContext.ts
+++ b/extensions/notebook/src/common/appContext.ts
@@ -25,7 +25,7 @@ export class AppContext {
 		let workspaceFolders = vscode.workspace.workspaceFolders?.slice() ?? [];
 		this.bookTreeViewProvider = new BookTreeViewProvider(workspaceFolders, extensionContext, false, BOOKS_VIEWID, NavigationProviders.NotebooksNavigator);
 		this.providedBookTreeViewProvider = new BookTreeViewProvider([], extensionContext, true, PROVIDED_BOOKS_VIEWID, NavigationProviders.ProvidedBooksNavigator);
-		this.pinnedBookTreeViewProvider = new BookTreeViewProvider([], extensionContext, false, PINNED_BOOKS_VIEWID, NavigationProviders.NotebooksNavigator);
+		this.pinnedBookTreeViewProvider = new BookTreeViewProvider([], extensionContext, false, PINNED_BOOKS_VIEWID, NavigationProviders.PinnedNotebooksNavigator);
 		this.outputChannel = vscode.window.createOutputChannel(extensionOutputChannelName);
 	}
 }

--- a/extensions/notebook/src/common/constants.ts
+++ b/extensions/notebook/src/common/constants.ts
@@ -69,7 +69,8 @@ export enum PythonPkgType {
 
 export enum NavigationProviders {
 	NotebooksNavigator = 'BookNavigator.Notebooks',
-	ProvidedBooksNavigator = 'BookNavigator.ProvidedBooks'
+	ProvidedBooksNavigator = 'BookNavigator.ProvidedBooks',
+	PinnedNotebooksNavigator = 'BookNavigator.PinnedNotebooks'
 }
 
 export const unsavedBooksContextKey = 'unsavedBooks';


### PR DESCRIPTION
This PR fixes #12103
Next and Previous buttons where not visible on books because _getNavigation_ was getting the pinnedBookTreeViewProvider instead of the bookTreeViewProvider.