### PR TITLE
Fix notebook toolbar screen reader reading order

### DIFF
--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -336,6 +336,7 @@ export class SelectBox extends vsSelectBox {
 		if (selectOptions && selectOptions.labelText && selectOptions.labelText !== undefined) {
 			let outerContainer = document.createElement('div');
 			let selectContainer = document.createElement('div');
+			selectContainer.setAttribute('role', 'presentation');
 
 			outerContainer.className = selectOptions.labelOnTop ? 'labelOnTopContainer' : 'labelOnLeftContainer';
 

--- a/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
@@ -162,9 +162,6 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean, conf
 		if (dropdownArrowColor) {
 			collector.addRule(`.monaco-workbench .notebookEditor .select-container:after { color: ${dropdownArrowColor};}`);
 		}
-		// Empty string hides the dropdownArrow from the accessibility tree (arrow does not need to be focusable)
-		let content: string = '\"\\eab4\" / \"\"';
-		collector.addRule(`.monaco-workbench .notebookEditor .select-container:after { content: ${content};}`);
 		const buttonMenuArrowColor = theme.getColor(buttonMenuArrow);
 		if (buttonMenuArrowColor) {
 			collector.addRule(`.notebookEditor .notebook-button.masked-pseudo-after:after { background-color: ${buttonMenuArrowColor};}`);

--- a/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookStyles.ts
@@ -162,6 +162,9 @@ export function registerNotebookThemes(overrideEditorThemeSetting: boolean, conf
 		if (dropdownArrowColor) {
 			collector.addRule(`.monaco-workbench .notebookEditor .select-container:after { color: ${dropdownArrowColor};}`);
 		}
+		// Empty string hides the dropdownArrow from the accessibility tree (arrow does not need to be focusable)
+		let content: string = '\"\\eab4\" / \"\"';
+		collector.addRule(`.monaco-workbench .notebookEditor .select-container:after { content: ${content};}`);
 		const buttonMenuArrowColor = theme.getColor(buttonMenuArrow);
 		if (buttonMenuArrowColor) {
 			collector.addRule(`.notebookEditor .notebook-button.masked-pseudo-after:after { background-color: ${buttonMenuArrowColor};}`);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/11554

Now the "Kernel" and "Attach to" dropdown content is read before the "V" icon.

