### PR TITLE
adding icon for add new and open project

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -57,12 +57,14 @@
       {
         "command": "sqlDatabaseProjects.new",
         "title": "%sqlDatabaseProjects.new%",
-        "category": "%sqlDatabaseProjects.displayName%"
+        "category": "%sqlDatabaseProjects.displayName%",
+        "icon": "$(add)"
       },
       {
         "command": "sqlDatabaseProjects.open",
         "title": "%sqlDatabaseProjects.open%",
-        "category": "%sqlDatabaseProjects.displayName%"
+        "category": "%sqlDatabaseProjects.displayName%",
+        "icon": "$(folder-opened)"
       },
       {
         "command": "sqlDatabaseProjects.close",
@@ -243,6 +245,18 @@
         {
           "command": "sqlDatabaseProjects.exclude",
           "when": "false"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "sqlDatabaseProjects.new",
+          "when": "view == sqlDatabaseProjectsView",
+          "group": "navigation@1"
+        },
+        {
+          "command": "sqlDatabaseProjects.open",
+          "when": "view == sqlDatabaseProjectsView",
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

To address :  https://github.com/microsoft/azuredatastudio/issues/11979

Using vscode icons that look like following. Adding only for current project view in file explorer not the new view since that will be dialog based.
![image](https://user-images.githubusercontent.com/46980425/93129155-67285080-f685-11ea-8f29-f3fcbbfaa476.png)


