### PR TITLE
Notebooks: Add newline after caption for WYSIWYG

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -441,6 +441,13 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 				return '\n```\n' + node.textContent + '\n```\n';
 			}
 		});
+		this.turndownService.addRule('caption', {
+			filter: 'caption',
+			replacement: function (content, node) {
+				return `${node.outerHTML}
+				`;
+			}
+		});
 		this.turndownService.addRule('span', {
 			filter: function (node, options) {
 				return (


### PR DESCRIPTION
Addresses #12270.

Because of https://github.com/markedjs/marked/issues/1733, tables with captions aren't rendered properly. turndown basically does the following:

```
<caption>blah</caption>
| Rule name | Direction | Priority | Purpose |
| --- | --- | --- | --- |
| AllowSSHRule | Inbound | 100 | Allow inbound SSH |
```

Just need to add a new line here after caption.

I checked with PM + design, and it was determined that we should show/render captions instead of hiding them.