### PR TITLE
Notebooks: Fast update WYSIWYG support for source update

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
@@ -400,6 +400,87 @@ suite('Notebook Editor Model', function (): void {
 		assert(!notebookEditorModel.lastEditFullReplacement);
 	});
 
+	test('should not replace entire text model but replace entire source when no modelContentChangedEvent passed in', async function (): Promise<void> {
+		await createNewNotebookModel();
+		let notebookEditorModel = await createTextEditorModel(this);
+		notebookEditorModel.replaceEntireTextEditorModel(notebookModel, undefined);
+
+		let newCell = notebookModel.addCell(CellTypes.Code);
+
+		let contentChange: NotebookContentChange = {
+			changeType: NotebookChangeType.CellsModified,
+			cells: [newCell],
+			cellIndex: 0
+		};
+		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
+		assert(notebookEditorModel.lastEditFullReplacement);
+
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+
+		newCell.source = 'This is a test';
+
+		contentChange = {
+			changeType: NotebookChangeType.CellSourceUpdated,
+			cells: [newCell],
+			cellIndex: 0,
+			modelContentChangedEvent: undefined
+		};
+
+		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellSourceUpdated);
+
+		assert(!notebookEditorModel.lastEditFullReplacement, 'should not do a full replacement for a source update');
+
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test"');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '            ],');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(25), '            "execution_count": null');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '        }');
+
+	});
+
+	test('should not replace entire text model but replace entire source when no modelContentChangedEvent passed in multiline change', async function (): Promise<void> {
+		await createNewNotebookModel();
+		let notebookEditorModel = await createTextEditorModel(this);
+		notebookEditorModel.replaceEntireTextEditorModel(notebookModel, undefined);
+
+		let newCell = notebookModel.addCell(CellTypes.Code);
+
+		let contentChange: NotebookContentChange = {
+			changeType: NotebookChangeType.CellsModified,
+			cells: [newCell],
+			cellIndex: 0
+		};
+		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellsModified);
+		assert(notebookEditorModel.lastEditFullReplacement);
+
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
+
+		newCell.source = 'This is a test' + os.EOL + 'Line 2 test' + os.EOL + 'Line 3 test';
+
+		contentChange = {
+			changeType: NotebookChangeType.CellSourceUpdated,
+			cells: [newCell],
+			cellIndex: 0,
+			modelContentChangedEvent: undefined
+		};
+
+		notebookEditorModel.updateModel(contentChange, NotebookChangeType.CellSourceUpdated);
+
+		assert(!notebookEditorModel.lastEditFullReplacement, 'should not do a full replacement for a source update');
+
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(9), '                "This is a test\\n",');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(10), '                "Line 2 test\\n",');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(11), '                "Line 3 test"');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '            ],');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(16), '            "outputs": [');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(27), '            "execution_count": null');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(28), '        }');
+	});
+
 	test('should not replace entire text model for single line source change then delete', async function (): Promise<void> {
 		await createNewNotebookModel();
 		let notebookEditorModel = await createTextEditorModel(this);


### PR DESCRIPTION
Add support in our notebookTextFileModel to overwrite a cell's source. This addresses #12287. 

When in WYSIWYG mode, we cannot rely on their being an editor present, so we don't get the editor content change events for free here. To mitigate this, I've added the ability to overwrite the entirety of a cell's source if a contentChangedEvent isn't present, so that we can localize the changes necessary to at least that cell's source. For a 68MB test notebook, I don't see any noticeable lag when editing a text cell in WYSIWYG after this.

Added tests to ensure consistency, and tried a bunch of manual scenarios as well.