### PR TITLE
Notebooks: Watch for changes outside of ADS

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
+++ b/src/sql/workbench/contrib/notebook/browser/models/notebookInput.ts
@@ -36,6 +36,7 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 import { INotification, INotificationService } from 'vs/platform/notification/common/notification';
 import Severity from 'vs/base/common/severity';
 import * as nls from 'vs/nls';
+import { NotebookModel } from 'sql/workbench/services/notebook/browser/models/notebookModel';
 
 export type ModeViewSaveHandler = (handle: number) => Thenable<boolean>;
 
@@ -86,6 +87,12 @@ export class NotebookEditorModel extends EditorModel {
 				this._register(this.textEditorModel.onDidChangeDirty(() => {
 					let dirty = this.textEditorModel instanceof ResourceEditorModel ? false : this.textEditorModel.isDirty();
 					this.setDirty(dirty);
+				}));
+				this._register(this.textEditorModel.onDidLoad(async (e) => {
+					if (this.textEditorModel instanceof TextFileEditorModel) {
+						let model = this.getNotebookModel() as NotebookModel;
+						await model.loadContents(model.trustedMode, true);
+					}
 				}));
 			}
 		}

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -339,6 +339,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 		this._register(model.onProviderIdChange((provider) => this.handleProviderIdChanged(provider)));
 		this._register(model.kernelChanged((kernelArgs) => this.handleKernelChanged(kernelArgs)));
 		this._register(model.onCellTypeChanged(() => this.detectChanges()));
+		this._register(model.layoutChanged(() => this.detectChanges()));
 		this._model = this._register(model);
 		await this._model.loadContents(trusted);
 		this.setLoading(false);

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -322,7 +322,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return !ids ? [] : ids;
 	}
 
-	public async loadContents(isTrusted: boolean = false): Promise<void> {
+	public async loadContents(isTrusted = false, forceLayoutChange = false): Promise<void> {
 		try {
 			this._trustedMode = isTrusted;
 
@@ -368,6 +368,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			// Trust notebook by default if there are no code cells
 			if (this._cells.length === 0 || this._cells.every(cell => cell.cellType === CellTypes.Markdown)) {
 				this.trustedMode = true;
+			}
+			if (forceLayoutChange) {
+				this._layoutChanged.fire();
 			}
 		} catch (error) {
 			this._inErrorState = true;


### PR DESCRIPTION
Addresses #12310.

The onLoad() event doesn't get fired when opening a notebook, because we hook into the event after it's initially loaded. Verified that there are no issues when making the transition from untitled to saved.

Note: discussed with PM and the decision to deliver value incrementally was made (as opposed to waiting for the full experience where the viewlet is updated as well); the viewlet work will be handled separately in an upcoming release.


![NotebookSaveLoad](https://user-images.githubusercontent.com/40371649/93251024-80de9c00-f748-11ea-9c2e-cad90fef372b.gif)
