### PR TITLE
12284 - Notebook UI - Text cell - Split view Markdown text section fix.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
@@ -34,9 +34,6 @@ text-cell-component .show-markdown .notebook-preview {
 .notebook-preview.actionselect {
 	user-select: text;
 }
-text-cell-component code-component .monaco-scrollable-element.editor-scrollable.vs {
-	left: 16px!important;
-}
 text-cell-component .monaco-editor .margin,
 text-cell-component code-component .monaco-editor,
 text-cell-component code-component .monaco-editor-background,


### PR DESCRIPTION
Removed custom CSS that positioned editor text beneath overlapping layers. Text is now selectable.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR corrects issue described in #12284 
