### PR TITLE
Fix component items in declarative table not showing (#12330)

### DIFF
--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.html
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.html
@@ -34,8 +34,8 @@
 						<span *ngIf="isLabel(c)" (click)="onCellClick(r)">
 							{{cellData.value}}
 						</span>
-						<model-component-wrapper *ngIf="isComponent(c) && getItemDescriptor(cellData)"
-							[descriptor]="getItemDescriptor(cellData)" [modelStore]="modelStore">
+						<model-component-wrapper *ngIf="isComponent(c) && getItemDescriptor(cellData.value)"
+							[descriptor]="getItemDescriptor(cellData.value)" [modelStore]="modelStore">
 						</model-component-wrapper>
 					</td>
 				</ng-container>


### PR DESCRIPTION
(cherry picked from commit 4dd04cb25038c414b7a09f10de1beb381efc9599)

Fixes https://github.com/microsoft/azuredatastudio/issues/12304

A change was made to the Declarative Table component (used by extensions) which breaks the functionality to allow embedding other components (such as links/images/etc) in the cells for the table. This affects any extension which uses this - of which there's a lot (the BDC/Arc dashboards for example). Uses will just see a blank cell instead of the actual component. 