### PR TITLE
Fix maximize bug

### DIFF
--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -269,12 +269,13 @@ export class GridPanel extends Disposable {
 
 		for (let i = this.tables.length - 1; i >= 0; i--) {
 			if (this.tables[i].id === tableid) {
-				this.tables[i].state.maximized = true;
-				this.maximizedGrid = this.tables[i];
-				continue;
+				const selectedTable = this.tables[i];
+				selectedTable.state.maximized = true;
+				this.maximizedGrid = selectedTable;
+				this.scrollableView.clear();
+				this.scrollableView.addViews([selectedTable]);
+				break;
 			}
-
-			this.scrollableView.clear();
 		}
 	}
 


### PR DESCRIPTION
This PR will fix https://github.com/microsoft/azuredatastudio/issues/12273 in main and will have to be ported to release for September.

This bug was somehow introduced in https://github.com/microsoft/azuredatastudio/pull/11566

Examples of 2 different resultsets maximized-

![Screen Shot 2020-09-15 at 6 56 03 PM](https://user-images.githubusercontent.com/6411451/93283757-07fe3500-f786-11ea-86b0-f740f9f160a9.png)

![Screen Shot 2020-09-15 at 6 56 17 PM](https://user-images.githubusercontent.com/6411451/93283766-0c2a5280-f786-11ea-9ea1-2b799e8e2c30.png)

![Screen Shot 2020-09-15 at 6 56 33 PM](https://user-images.githubusercontent.com/6411451/93283774-0fbdd980-f786-11ea-8e5b-077d05622ecd.png)
