### PR TITLE
12284 Removed custom CSS that positioned editor text beneath overlapp…

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
@@ -34,9 +34,6 @@ text-cell-component .show-markdown .notebook-preview {
 .notebook-preview.actionselect {
 	user-select: text;
 }
-text-cell-component code-component .monaco-scrollable-element.editor-scrollable.vs {
-	left: 16px!important;
-}
 text-cell-component .monaco-editor .margin,
 text-cell-component code-component .monaco-editor,
 text-cell-component code-component .monaco-editor-background,


### PR DESCRIPTION
Fixes #12284.