### PR TITLE
Fix notebook table rendering with multiple code cells

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -4902,6 +4902,8 @@ declare module 'azdata' {
 			 *
 			 * @param disposeOnDone - Whether to dispose of the future when done.
 			 *
+			 * @param cellId - Cell id (used by queryRunner)
+			 *
 			 * @returns A kernel future.
 			 *
 			 * #### Notes
@@ -4916,7 +4918,7 @@ declare module 'azdata' {
 			 *
 			 * **See also:** [[IExecuteReply]]
 			 */
-			requestExecute(content: IExecuteRequest, disposeOnDone?: boolean): IFuture;
+			requestExecute(content: IExecuteRequest, disposeOnDone?: boolean, cellId?: string): IFuture;
 
 			/**
 			 * Send a `complete_request` message.

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -4918,7 +4918,7 @@ declare module 'azdata' {
 			 *
 			 * **See also:** [[IExecuteReply]]
 			 */
-			requestExecute(content: IExecuteRequest, disposeOnDone?: boolean, cellId?: string): IFuture;
+			requestExecute(content: IExecuteRequest, disposeOnDone?: boolean, cellUri?: string): IFuture;
 
 			/**
 			 * Send a `complete_request` message.

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -41,6 +41,7 @@ import { IQueryManagementService } from 'sql/workbench/services/query/common/que
 import { values } from 'vs/base/common/collections';
 import { URI } from 'vs/base/common/uri';
 import { assign } from 'vs/base/common/objects';
+import { escape } from 'sql/base/common/strings';
 
 @Component({
 	selector: GridOutputComponent.SELECTOR,
@@ -372,7 +373,7 @@ export class DataResourceDataProvider implements IGridDataProvider {
 	}
 
 	public async convertAllData(result: ResultSetSummary): Promise<void> {
-		// Querying 50 rows at a time. Querying large amount of rows will be slow and
+		// Querying 100 rows at a time. Querying large amount of rows will be slow and
 		// affect table rendering since each time the user scrolls, getRowData is called.
 		let numRows = 100;
 		for (let i = 0; i < result.rowCount; i += 100) {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -778,7 +778,7 @@ suite('Cell Model', function (): void {
 
 		test('Execute returns error status', async function (): Promise<void> {
 			mockKernel.setup(k => k.requiresConnection).returns(() => false);
-			mockKernel.setup(k => k.requestExecute(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
+			mockKernel.setup(k => k.requestExecute(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
 				let replyMsg: nb.IExecuteReplyMsg = <nb.IExecuteReplyMsg>{
 					content: <nb.IExecuteReply>{
 						execution_count: 1,
@@ -796,7 +796,7 @@ suite('Cell Model', function (): void {
 
 		test('Execute returns abort status', async function (): Promise<void> {
 			mockKernel.setup(k => k.requiresConnection).returns(() => false);
-			mockKernel.setup(k => k.requestExecute(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
+			mockKernel.setup(k => k.requestExecute(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
 				let replyMsg: nb.IExecuteReplyMsg = <nb.IExecuteReplyMsg>{
 					content: <nb.IExecuteReply>{
 						execution_count: 1,
@@ -815,7 +815,7 @@ suite('Cell Model', function (): void {
 		test('Execute throws exception', async function (): Promise<void> {
 			let testMsg = 'Test message';
 			mockKernel.setup(k => k.requiresConnection).returns(() => false);
-			mockKernel.setup(k => k.requestExecute(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
+			mockKernel.setup(k => k.requestExecute(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
 				throw new Error(testMsg);
 			});
 

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -408,7 +408,7 @@ export class CellModel extends Disposable implements ICellModel {
 						const future = kernel.requestExecute({
 							code: content,
 							stop_on_error: true
-						}, false, this.id);
+						}, false, this._cellUri.toString());
 						this.setFuture(future as FutureInternal);
 						this.fireExecutionStateChanged();
 						// For now, await future completion. Later we should just track and handle cancellation based on model notifications

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -408,7 +408,7 @@ export class CellModel extends Disposable implements ICellModel {
 						const future = kernel.requestExecute({
 							code: content,
 							stop_on_error: true
-						}, false);
+						}, false, this.id);
 						this.setFuture(future as FutureInternal);
 						this.fireExecutionStateChanged();
 						// For now, await future completion. Later we should just track and handle cancellation based on model notifications

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -349,18 +349,16 @@ class SqlKernel extends Disposable implements nb.IKernel {
 	}
 
 	public async disconnect(): Promise<void> {
-		if (this._queryRunners.size > 0) {
-			this._queryRunners.forEach(async (queryRunner: QueryRunner, uri: string) => {
-				if (this._connectionManagementService.isConnected(uri)) {
-					try {
-						await this._connectionManagementService.disconnect(uri);
-					} catch (err) {
-						this.logService.error(err);
-					}
-
+		this._queryRunners.forEach(async (queryRunner: QueryRunner, uri: string) => {
+			if (this._connectionManagementService.isConnected(uri)) {
+				try {
+					await this._connectionManagementService.disconnect(uri);
+				} catch (err) {
+					this.logService.error(err);
 				}
-			});
-		}
+
+			}
+		});
 		return;
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses https://github.com/microsoft/azuredatastudio/issues/12275

Added unique query runners for each code cell to prevent updates to result tables in later code cells from affecting/changing tables in earlier code cells. 

Manually tested run all cells, add/delete cells then run again, save notebook, and change connection to make sure there are no regressions. Only change is when a new cell is run for the first time, there is a couple seconds wait time since a new query runner is being added (same wait time as running first cell in a new notebook before). 

Note: Also added missing escape import to gridOutput.component.ts that was causing some column headers to be saved incorrectly.
