### PR TITLE
Fix duplicate arc instance nodes

### DIFF
--- a/extensions/arc/src/models/controllerModel.ts
+++ b/extensions/arc/src/models/controllerModel.ts
@@ -93,7 +93,7 @@ export class ControllerModel {
 	}
 	public async refresh(showErrors: boolean = true, promptReconnect: boolean = false): Promise<void> {
 		await this.azdataLogin(promptReconnect);
-		this._registrations = [];
+		const newRegistrations: Registration[] = [];
 		await Promise.all([
 			this._azdataApi.azdata.arc.dc.config.show().then(result => {
 				this._controllerConfig = result.result;
@@ -125,7 +125,7 @@ export class ControllerModel {
 			}),
 			Promise.all([
 				this._azdataApi.azdata.arc.postgres.server.list().then(result => {
-					this._registrations.push(...result.result.map(r => {
+					newRegistrations.push(...result.result.map(r => {
 						return {
 							instanceName: r.name,
 							state: r.state,
@@ -134,7 +134,7 @@ export class ControllerModel {
 					}));
 				}),
 				this._azdataApi.azdata.arc.sql.mi.list().then(result => {
-					this._registrations.push(...result.result.map(r => {
+					newRegistrations.push(...result.result.map(r => {
 						return {
 							instanceName: r.name,
 							state: r.state,
@@ -143,6 +143,7 @@ export class ControllerModel {
 					}));
 				})
 			]).then(() => {
+				this._registrations = newRegistrations;
 				this.registrationsLastUpdated = new Date();
 				this._onRegistrationsUpdated.fire(this._registrations);
 			})


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/12227

If multiple refreshes were kicked off at the same time (such as tree node expanding + dashboard refreshing) then we'd often end up duplicating the nodes since we were only clearing once when the refresh started. 

I considered also making it so only one refresh could happen at a time but opted not to do that since the refresh has multiple parts that finish async'ly and fire events to indicate they've been updated - which could mess up callers if they expected that after refresh was called they'd get notified for all those events. If an existing refresh had partially finished though they wouldn't get the events for the ones that had already finished. 