### PR TITLE
Fix manage action for arc view

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -96,7 +96,7 @@
       "view/item/context": [
         {
           "command": "arc.openDashboard",
-          "when": "view == azureArc && viewItem == sqlManagedInstances",
+          "when": "view == azureArc && viewItem && viewItem != postgresInstances)",
           "group": "navigation@1"
         },
         {

--- a/extensions/arc/src/ui/tree/noInstancesTreeNode.ts
+++ b/extensions/arc/src/ui/tree/noInstancesTreeNode.ts
@@ -13,6 +13,6 @@ import { TreeNode } from './treeNode';
 export class NoInstancesTreeNode extends TreeNode {
 
 	constructor() {
-		super(loc.noInstancesAvailable, vscode.TreeItemCollapsibleState.None, 'noInstances');
+		super(loc.noInstancesAvailable, vscode.TreeItemCollapsibleState.None, '');
 	}
 }

--- a/extensions/arc/src/ui/tree/refreshTreeNode.ts
+++ b/extensions/arc/src/ui/tree/refreshTreeNode.ts
@@ -14,7 +14,7 @@ import { refreshActionId } from '../../constants';
 export class RefreshTreeNode extends TreeNode {
 
 	constructor(private _parent: TreeNode) {
-		super(loc.refreshToEnterCredentials, vscode.TreeItemCollapsibleState.None, 'refresh');
+		super(loc.refreshToEnterCredentials, vscode.TreeItemCollapsibleState.None, '');
 	}
 
 	public command: vscode.Command = {


### PR DESCRIPTION
The "Manage" action was showing up for nodes it wasn't supposed to be - fix it so that only resource nodes have a truthy viewItem value so the option only appears for them (minus PG until that's fixed)