### PR TITLE
Change default Select query label to "Take 10" for Kusto tables

### DIFF
--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -108,7 +108,7 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 	order: 1,
 	command: {
 		id: commands.OE_SCRIPT_AS_SELECT_COMMAND_ID,
-		title: localize('scriptKustoSelect', 'Take 10')
+		title: localize('scriptKustoSelect', "Take 10")
 	},
 	when: ContextKeyExpr.and(
 		ConnectionContextKey.Provider.isEqualTo('KUSTO'),

--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -94,7 +94,26 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		id: commands.OE_SCRIPT_AS_SELECT_COMMAND_ID,
 		title: localize('scriptSelect', "Select Top 1000")
 	},
-	when: ContextKeyExpr.or(TreeNodeContextKey.NodeType.isEqualTo('Table'), TreeNodeContextKey.NodeType.isEqualTo('View'))
+	when: ContextKeyExpr.and(
+		ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
+		ContextKeyExpr.or(
+			TreeNodeContextKey.NodeType.isEqualTo('Table'),
+			TreeNodeContextKey.NodeType.isEqualTo('View')
+		)
+	)
+});
+
+MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
+	group: '0_query',
+	order: 1,
+	command: {
+		id: commands.OE_SCRIPT_AS_SELECT_COMMAND_ID,
+		title: localize('scriptKustoSelect', 'Take 10')
+	},
+	when: ContextKeyExpr.and(
+		ConnectionContextKey.Provider.isEqualTo('KUSTO'),
+		TreeNodeContextKey.NodeType.isEqualTo('Table')
+	)
 });
 
 MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
Change default "Select Top 1000" query label to "Take 10" for Kusto tables
