### PR TITLE
12360 Notebook UI - Mac/Win fix for Select all. (#12383)

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -67,17 +67,18 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		this.enableActiveCellEditOnDoubleClick();
 	}
 
-	@HostListener('document:keydown.meta.a', ['$event'])
+	@HostListener('document:keydown', ['$event'])
 	onkeydown(e) {
 		// use preventDefault() to avoid invoking the editor's select all
 		// select the active .
-		e.preventDefault();
-		document.execCommand('selectAll');
-	}
-
-	@HostListener('document:keydown.meta.z', ['$event'])
-	onUndo(e) {
-		document.execCommand('undo');
+		if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
+			e.preventDefault();
+			document.execCommand('selectAll');
+		}
+		if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
+			e.preventDefault();
+			document.execCommand('undo');
+		}
 	}
 
 	private _content: string | string[];


### PR DESCRIPTION
* 12360 Notebook UI - Mac/Win fix for Select all.

* Fix for ctrl key selecting all in windows

* Fix undo as well

* preventDefault to prevent confusing behavior

Co-authored-by: chlafreniere <hichise@gmail.com>

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #12360
