### PR TITLE
Fix error when clicking on header for tables with no rows

### DIFF
--- a/src/sql/base/browser/ui/table/tableDataView.ts
+++ b/src/sql/base/browser/ui/table/tableDataView.ts
@@ -15,7 +15,7 @@ export interface IFindPosition {
 }
 
 function defaultSort<T extends { [key: string]: any }>(args: Slick.OnSortEventArgs<T>, data: Array<T>): Array<T> {
-	if (!args.sortCol || !args.sortCol.field) {
+	if (!args.sortCol || !args.sortCol.field || data.length === 0) {
 		return data;
 	}
 	const field = args.sortCol.field;


### PR DESCRIPTION
It would try to access the first element later on and would throw. No behavior change here - just getting rid of the error popping up in the console. 