### PR TITLE
fix the legacy card style issue

### DIFF
--- a/src/sql/workbench/browser/modelComponents/card.component.html
+++ b/src/sql/workbench/browser/modelComponents/card.component.html
@@ -15,12 +15,12 @@
 					<div [class]="iconClass" [style.width]="iconWidth" [style.height]="iconHeight"></div>
 				</div>
 				<h4 class="card-label">{{label}}</h4>
-				<div *ngIf="descriptions.length > 0" class="model-card-description-container">
+				<div *ngIf="descriptions.length > 0" class="model-card-description-container-legacy">
 					<div *ngFor="let desc of descriptions">
 						<div *ngIf="desc.label; else separator" [style.font-weight]="desc.fontWeight"
-							class="model-card-list-item-description">
+							class="model-card-list-item-description-legacy">
 							<span>{{desc.label}}</span><span
-								class="model-card-list-item-description-value">{{desc.value}}</span>
+								class="model-card-list-item-description-value-legacy">{{desc.value}}</span>
 						</div>
 						<ng-template #separator>
 							<div style="height: 12px"></div>
@@ -35,7 +35,7 @@
 				<h4 class="card-label">{{label}}</h4>
 				<p class="card-value">{{value}}</p>
 				<span *ngIf="actions">
-					<table class="model-table">
+					<table class="model-table-legacy">
 						<tr *ngFor="let action of actions">
 							<td class="table-row">{{action.label}}</td>
 							<td *ngIf="action.actionTitle" class="table-row">

--- a/src/sql/workbench/browser/modelComponents/card.component.ts
+++ b/src/sql/workbench/browser/modelComponents/card.component.ts
@@ -117,7 +117,7 @@ export default class CardComponent extends ComponentWithIconBase<azdata.CardProp
 	}
 
 	public getClass(): string {
-		let cardClass = this.isListItemCard ? 'model-card-list-item' : 'model-card';
+		let cardClass = this.isListItemCard ? 'model-card-list-item-legacy' : 'model-card-legacy';
 		return (this.selectable && this.selected || this._hasFocus) ? `${cardClass} selected` :
 			`${cardClass} unselected`;
 	}

--- a/src/sql/workbench/browser/modelComponents/card.component.ts
+++ b/src/sql/workbench/browser/modelComponents/card.component.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import 'vs/css!./media/card';
+import 'vs/css!./media/legacycard';
 
 import {
 	Component, Input, Inject, ChangeDetectorRef, forwardRef, ElementRef, OnDestroy, ViewChild

--- a/src/sql/workbench/browser/modelComponents/media/legacycard.css
+++ b/src/sql/workbench/browser/modelComponents/media/legacycard.css
@@ -1,0 +1,219 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.model-card {
+	position: relative;
+	display: inline-block;
+	height: 90%;
+	width: auto;
+	margin: 15px;
+	border-width: 1px;
+	border-style: solid;
+	text-align: left;
+	vertical-align: top;
+	border-color: rgb(214, 214, 214);
+}
+
+.model-card .card-content {
+	position: relative;
+	display: inline-block;
+	height: auto;
+	width: auto;
+	padding: 10px 45px 20px 45px;
+	min-height: 30px;
+	min-width: 30px;
+}
+
+.model-card .card-vertical-button {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	text-align: center;
+	height: auto;
+	width: auto;
+	padding: 5px 5px 5px 5px;
+	min-height: 130px;
+	min-width: 130px;
+}
+
+.model-card .card-label {
+	font-size: 12px;
+	font-weight: bold;
+}
+
+.model-card .card-value {
+	font-size: 12px;
+	line-height: 18px;
+}
+
+.model-card .iconContainer {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	flex-grow: 1;
+	border-bottom-width: 1px;
+	border-bottom-style: solid;
+	padding: 10px 0px 10px 0px;
+	border-color: rgb(214, 214, 214);
+}
+
+.model-card .cardIcon {
+	display: inline-block;
+	flex-grow: 1;
+	width: 100%;
+	height: 100%;
+	max-width: 50px;
+	max-height: 50px;
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: contain;
+}
+
+.model-card .card-status {
+	position: absolute;
+	top: 7px;
+	left: 5px;
+	overflow: hidden;
+	width: 22px;
+	height: 22px;
+}
+
+.model-card .status-content {
+	position: absolute;
+	top: 0px;
+	right: 0px;
+	min-width: 16px;
+	height: 16px;
+	border-radius: 8px;
+	text-align: center;
+}
+
+.model-card-list-item .selection-indicator-container, .model-card .selection-indicator-container {
+	position: absolute;
+	top: 5px;
+	right: 5px;
+	overflow: hidden;
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	background-color: white;
+	border-width: 1px;
+	border-color: rgb(0, 120, 215);
+	border-style: solid;
+}
+
+.model-card-list-item .selection-indicator-container, .model-card .selection-indicator-container {
+	position: absolute;
+	overflow: hidden;
+	width: 16px;
+	height: 16px;
+	border-radius: 50%;
+	background-color: white;
+	border-width: 1px;
+	border-color: rgb(214, 214, 214);
+	border-style: solid;
+}
+
+.model-card-list-item .selection-indicator-container {
+	top: 10px;
+	right: 10px;
+}
+
+.model-card .selection-indicator-container {
+	top: 5px;
+	right: 5px;
+}
+
+.model-card-list-item .selection-indicator, .model-card .selection-indicator {
+	margin: 4px;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background-color: rgb(0, 120, 215);
+}
+
+.model-card .model-table {
+	border-spacing: 5px;
+}
+
+.model-table .table-row {
+	width: auto;
+	clear: both;
+}
+
+.model-table .table-cell {
+	vertical-align: top;
+	padding: 7px;
+}
+
+.model-table a {
+	cursor: pointer;
+	text-decoration: underline
+}
+
+.model-card-list-item {
+	display: inline-block;
+	height: 100%;
+	width: 100%;
+	margin: 5px 0px 5px 0px;
+	border-width: 1px;
+	border-style: solid;
+	text-align: left;
+	vertical-align: top;
+}
+
+.model-card-list-item .list-item-content {
+	height: auto;
+	padding: 5px 26px 5px 5px;
+	min-height: 30px;
+	min-width: 300px;
+}
+
+.model-card-list-item .list-item-icon {
+	background-position: 2px 2px;
+	padding-left: 22px;
+	font-size: 15px;
+	background-repeat: no-repeat;
+	background-size: 16px 16px;
+}
+
+.model-card-list-item .list-item-description {
+	padding-left: 22px;
+}
+
+.model-card-description-container {
+	border-top-width: 1px;
+	border-top-style: solid;
+	border-color: rgb(214, 214, 214);
+	padding: 5px;
+}
+
+.model-card-list-item-description {
+	text-align: left;
+}
+
+.model-card-list-item-description-value {
+	float: right;
+}
+
+.card-group {
+	display: flex;
+	flex-flow: row;
+}
+
+.model-card-description-table {
+	margin-bottom: 10px;
+}
+
+.model-card-description-label-column {
+	text-align: left;
+	width: 100%;
+}
+
+.model-card-description-value-column {
+	text-align: right;
+	white-space: nowrap;
+}

--- a/src/sql/workbench/browser/modelComponents/media/legacycard.css
+++ b/src/sql/workbench/browser/modelComponents/media/legacycard.css
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.model-card {
+.model-card-legacy {
 	position: relative;
 	display: inline-block;
 	height: 90%;
@@ -16,7 +16,7 @@
 	border-color: rgb(214, 214, 214);
 }
 
-.model-card .card-content {
+.model-card-legacy .card-content {
 	position: relative;
 	display: inline-block;
 	height: auto;
@@ -26,7 +26,7 @@
 	min-width: 30px;
 }
 
-.model-card .card-vertical-button {
+.model-card-legacy .card-vertical-button {
 	position: relative;
 	display: flex;
 	flex-direction: column;
@@ -38,17 +38,17 @@
 	min-width: 130px;
 }
 
-.model-card .card-label {
+.model-card-legacy .card-label {
 	font-size: 12px;
 	font-weight: bold;
 }
 
-.model-card .card-value {
+.model-card-legacy .card-value {
 	font-size: 12px;
 	line-height: 18px;
 }
 
-.model-card .iconContainer {
+.model-card-legacy .iconContainer {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
@@ -60,7 +60,7 @@
 	border-color: rgb(214, 214, 214);
 }
 
-.model-card .cardIcon {
+.model-card-legacy .cardIcon {
 	display: inline-block;
 	flex-grow: 1;
 	width: 100%;
@@ -72,7 +72,7 @@
 	background-size: contain;
 }
 
-.model-card .card-status {
+.model-card-legacy .card-status {
 	position: absolute;
 	top: 7px;
 	left: 5px;
@@ -81,7 +81,7 @@
 	height: 22px;
 }
 
-.model-card .status-content {
+.model-card-legacy .status-content {
 	position: absolute;
 	top: 0px;
 	right: 0px;
@@ -91,7 +91,7 @@
 	text-align: center;
 }
 
-.model-card-list-item .selection-indicator-container, .model-card .selection-indicator-container {
+.model-card-list-item-legacy .selection-indicator-container, .model-card-legacy .selection-indicator-container {
 	position: absolute;
 	top: 5px;
 	right: 5px;
@@ -105,7 +105,7 @@
 	border-style: solid;
 }
 
-.model-card-list-item .selection-indicator-container, .model-card .selection-indicator-container {
+.model-card-list-item-legacy .selection-indicator-container, .model-card-legacy .selection-indicator-container {
 	position: absolute;
 	overflow: hidden;
 	width: 16px;
@@ -117,17 +117,17 @@
 	border-style: solid;
 }
 
-.model-card-list-item .selection-indicator-container {
+.model-card-list-item-legacy .selection-indicator-container {
 	top: 10px;
 	right: 10px;
 }
 
-.model-card .selection-indicator-container {
+.model-card-legacy .selection-indicator-container {
 	top: 5px;
 	right: 5px;
 }
 
-.model-card-list-item .selection-indicator, .model-card .selection-indicator {
+.model-card-list-item-legacy .selection-indicator, .model-card-legacy .selection-indicator {
 	margin: 4px;
 	width: 8px;
 	height: 8px;
@@ -135,26 +135,26 @@
 	background-color: rgb(0, 120, 215);
 }
 
-.model-card .model-table {
+.model-card-legacy .model-table-legacy {
 	border-spacing: 5px;
 }
 
-.model-table .table-row {
+.model-table-legacy .table-row {
 	width: auto;
 	clear: both;
 }
 
-.model-table .table-cell {
+.model-table-legacy .table-cell {
 	vertical-align: top;
 	padding: 7px;
 }
 
-.model-table a {
+.model-table-legacy a {
 	cursor: pointer;
 	text-decoration: underline
 }
 
-.model-card-list-item {
+.model-card-list-item-legacy {
 	display: inline-block;
 	height: 100%;
 	width: 100%;
@@ -165,14 +165,14 @@
 	vertical-align: top;
 }
 
-.model-card-list-item .list-item-content {
+.model-card-list-item-legacy .list-item-content {
 	height: auto;
 	padding: 5px 26px 5px 5px;
 	min-height: 30px;
 	min-width: 300px;
 }
 
-.model-card-list-item .list-item-icon {
+.model-card-list-item-legacy .list-item-icon {
 	background-position: 2px 2px;
 	padding-left: 22px;
 	font-size: 15px;
@@ -180,40 +180,21 @@
 	background-size: 16px 16px;
 }
 
-.model-card-list-item .list-item-description {
+.model-card-list-item-legacy .list-item-description {
 	padding-left: 22px;
 }
 
-.model-card-description-container {
+.model-card-description-container-legacy {
 	border-top-width: 1px;
 	border-top-style: solid;
 	border-color: rgb(214, 214, 214);
 	padding: 5px;
 }
 
-.model-card-list-item-description {
+.model-card-list-item-description-legacy {
 	text-align: left;
 }
 
-.model-card-list-item-description-value {
+.model-card-list-item-description-value-legacy {
 	float: right;
-}
-
-.card-group {
-	display: flex;
-	flex-flow: row;
-}
-
-.model-card-description-table {
-	margin-bottom: 10px;
-}
-
-.model-card-description-label-column {
-	text-align: left;
-	width: 100%;
-}
-
-.model-card-description-value-column {
-	text-align: right;
-	white-space: nowrap;
 }


### PR DESCRIPTION
the card.css was shared by the new radioCardGroup component and the deprecated card component. but recently Aasim and Amir have made changes to it for the new style of the radio card group component. the ML extension is still using the card component.

the fix is to copy the content of previous version of card.css and create a new css file that is only used by card component.

after September release, Udeesha will replace the radio component with radio card group component in ML extension and I will remove the card component.

before:
![image](https://user-images.githubusercontent.com/46980425/93536686-77973000-f8fe-11ea-8f52-fa10b1ae46e3.png)


after:
![image](https://user-images.githubusercontent.com/13777222/93540492-ae724380-f908-11ea-9e99-d78ed9356acb.png)

![image](https://user-images.githubusercontent.com/13777222/93540450-8b479400-f908-11ea-9029-0e029a948cba.png)


https://github.com/microsoft/azuredatastudio/issues/12420