### PR TITLE
Fix arc deployment regions and remove docker summary

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -260,18 +260,18 @@
                           "locationVariableName": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_LOCATION",
                           "displayLocationVariableName": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_DISPLAY_LOCATION",
                           "locations": [
-                            "eastus",
-                            "eastus2",
                             "australiaeast",
                             "centralus",
-                            "westus2",
-                            "westeurope",
-                            "southeastasia",
+                            "eastus",
+                            "eastus2",
+                            "francecentral",
+                            "japaneast",
                             "koreacentral",
                             "northeurope",
-                            "westeurope",
+                            "southeastasia",
                             "uksouth",
-                            "francecentral"
+                            "westeurope",
+                            "westus2"
                           ]
                         },
                         {
@@ -465,12 +465,6 @@
                           "type": "readonly_text",
                           "isEvaluated": true,
                           "defaultValue": "$(AZDATA_NB_VAR_ARC_ADMIN_USERNAME)"
-                        },
-                        {
-                          "label": "%arc.control.plane.summary.docker.username%",
-                          "type": "readonly_text",
-                          "isEvaluated": true,
-                          "defaultValue": "$(AZDATA_NB_VAR_ARC_DOCKER_USERNAME)"
                         }
                       ]
                     },

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -52,7 +52,6 @@
 	"arc.control.plane.summary.cluster.context": "Cluster context",
 	"arc.control.plane.summary.profile": "Config profile",
 	"arc.control.plane.summary.username": "Username",
-	"arc.control.plane.summary.docker.username": "Docker username",
 	"arc.control.plane.summary.azure": "Azure",
 	"arc.control.plane.summary.subscription": "Subscription",
 	"arc.control.plane.summary.resource.group": "Resource group",


### PR DESCRIPTION
Update with latest list of valid regions and remove the docker container summary item (the actual field was removed in an earlier PR)