### PR TITLE
Fix Spark kernel connections and switch from Kusto to Spark kernels

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -457,7 +457,9 @@ export class AttachToDropdown extends SelectBox {
 		try {
 			// Get all providers to show all available connections in connection dialog
 			let providers = this.model.getApplicableConnectionProviderIds(this.model.clientSession.kernel.name);
-			// Spark Kernels should only have MSSQL connections in connection dialog
+			// Spark kernels are unable to get providers from above, therefore ensure that we get the
+			// correct providers for the selected kernel and load the proper connections for the connection dialog
+			// Example Scenario: Spark Kernels should only have MSSQL connections in connection dialog
 			if (!this.model.kernelAliases.includes(this.model.selectedKernelDisplayName) && this.model.clientSession.kernel.name !== 'SQL') {
 				providers = providers.concat(this.model.getApplicableConnectionProviderIds(this.model.selectedKernelDisplayName));
 			} else {

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -457,8 +457,13 @@ export class AttachToDropdown extends SelectBox {
 		try {
 			// Get all providers to show all available connections in connection dialog
 			let providers = this.model.getApplicableConnectionProviderIds(this.model.clientSession.kernel.name);
-			for (let alias of this.model.kernelAliases) {
-				providers = providers.concat(this.model.getApplicableConnectionProviderIds(alias));
+			// Spark Kernels should only have MSSQL connections in connection dialog
+			if (!this.model.kernelAliases.includes(this.model.selectedKernelDisplayName) && this.model.clientSession.kernel.name !== 'SQL') {
+				providers = providers.concat(this.model.getApplicableConnectionProviderIds(this.model.selectedKernelDisplayName));
+			} else {
+				for (let alias of this.model.kernelAliases) {
+					providers = providers.concat(this.model.getApplicableConnectionProviderIds(alias));
+				}
 			}
 			let connection = await this._connectionDialogService.openDialogAndWait(this._connectionManagementService,
 				{

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -658,8 +658,11 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			let providerFeatures = this._capabilitiesService.getCapabilities(profile.providerName);
 			if (connectionProviderIds?.length) {
 				this._currentKernelAlias = providerFeatures?.connection.notebookKernelAlias;
-				// Adds Kernel Alias and Connection Provider to Map if new Notebook connection contains notebookKernelAlias
-				if (this._currentKernelAlias) {
+				// Reset the connection when switching from Kusto to Spark
+				if (this._selectedKernelDisplayName !== this._currentKernelAlias && this._selectedKernelDisplayName) {
+					this._currentKernelAlias = undefined;
+				} else {
+					// Adds Kernel Alias and Connection Provider to Map if new Notebook connection contains notebookKernelAlias
 					this._kernelDisplayNameToConnectionProviderIds.set(this._currentKernelAlias, [profile.providerName]);
 				}
 			}

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -658,7 +658,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			let providerFeatures = this._capabilitiesService.getCapabilities(profile.providerName);
 			if (connectionProviderIds?.length) {
 				this._currentKernelAlias = providerFeatures?.connection.notebookKernelAlias;
-				// Reset the connection when switching from Kusto to Spark
+				// Switching from Kusto to another kernel should set the currentKernelAlias to undefined
 				if (this._selectedKernelDisplayName !== this._currentKernelAlias && this._selectedKernelDisplayName) {
 					this._currentKernelAlias = undefined;
 				} else {


### PR DESCRIPTION


This PR fixes:
- All Spark kernel connections are being limited to Kusto connections in notebook connection picker
- Issue when Kusto has a connection and is unable to switch to PySpark

Spark kernel connections will display only MSSQL connections. 