### PR TITLE
Arc - Enable Postgres dashboard

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -96,7 +96,7 @@
       "view/item/context": [
         {
           "command": "arc.openDashboard",
-          "when": "view == azureArc && viewItem && viewItem != postgresInstances)",
+          "when": "view == azureArc",
           "group": "navigation@1"
         },
         {

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -96,7 +96,7 @@
       "view/item/context": [
         {
           "command": "arc.openDashboard",
-          "when": "view == azureArc",
+          "when": "view == azureArc && viewItem",
           "group": "navigation@1"
         },
         {

--- a/extensions/arc/src/models/controllerModel.ts
+++ b/extensions/arc/src/models/controllerModel.ts
@@ -20,7 +20,6 @@ export type Registration = {
 export class ControllerModel {
 	private readonly _azdataApi: azdataExt.IExtension;
 	private _endpoints: azdataExt.DcEndpointListResult[] = [];
-	private _namespace: string = '';
 	private _registrations: Registration[] = [];
 	private _controllerConfig: azdataExt.DcConfigShowResult | undefined = undefined;
 
@@ -158,10 +157,6 @@ export class ControllerModel {
 		return this._endpoints.find(e => e.name === name);
 	}
 
-	public get namespace(): string {
-		return this._namespace;
-	}
-
 	public get registrations(): Registration[] {
 		return this._registrations;
 	}
@@ -174,15 +169,6 @@ export class ControllerModel {
 		return this._registrations.find(r => {
 			return r.instanceType === type && r.instanceName === name;
 		});
-	}
-
-	public async deleteRegistration(_type: ResourceType, _name: string) {
-		/* TODO chgagnon
-		if (r && !r.isDeleted && r.customObjectName) {
-			const r = this.getRegistration(type, name);
-			await this._registrationRouter.apiV1RegistrationNsNameIsDeletedDelete(this._namespace, r.customObjectName, true);
-		}
-		*/
 	}
 
 	/**

--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -23,20 +23,24 @@ export class PostgresModel extends ResourceModel {
 		this._azdataApi = <azdataExt.IExtension>vscode.extensions.getExtension(azdataExt.extension.name)?.exports;
 	}
 
+	/** Returns the configuration of Postgres */
 	public get config(): azdataExt.PostgresServerShowResult | undefined {
 		return this._config;
 	}
 
-	/** Returns the IP address and port of the server */
-	public get endpoint(): { ip: string, port: string } {
-		return this._config
-			? parseIpAndPort(this._config.status.externalEndpoint)
-			: { ip: '', port: '' };
+	/** Returns the major version of Postgres */
+	public get engineVersion(): string | undefined {
+		const kind = this._config?.kind;
+		return kind
+			? kind.substring(kind.lastIndexOf('-') + 1)
+			: undefined;
 	}
 
-	/** Returns the server's configuration e.g. '3 nodes, 1.5 vCores, 1GiB RAM, 2GiB storage per node' */
-	public get configuration(): string {
-		return ''; // TODO
+	/** Returns the IP address and port of the server */
+	public get endpoint(): { ip: string, port: string } | undefined {
+		return this._config?.status.externalEndpoint
+			? parseIpAndPort(this._config.status.externalEndpoint)
+			: undefined;
 	}
 
 	/** Refreshes the model */

--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -50,10 +50,10 @@ export class PostgresModel extends ResourceModel {
 			return undefined;
 		}
 
-		const cpuLimit = this._config.spec.scheduling?.default?.resources?.limits?.['cpu'];
-		const ramLimit = this._config.spec.scheduling?.default?.resources?.limits?.['memory'];
-		const cpuRequest = this._config.spec.scheduling?.default?.resources?.requests?.['cpu'];
-		const ramRequest = this._config.spec.scheduling?.default?.resources?.requests?.['memory'];
+		const cpuLimit = this._config.spec.scheduling?.default?.resources?.limits?.cpu;
+		const ramLimit = this._config.spec.scheduling?.default?.resources?.limits?.memory;
+		const cpuRequest = this._config.spec.scheduling?.default?.resources?.requests?.cpu;
+		const ramRequest = this._config.spec.scheduling?.default?.resources?.requests?.memory;
 		const storage = this._config.spec.storage?.data?.size;
 		const nodes = (this._config.spec.scale?.shards ?? 0) + 1; // An extra node for the coordinator
 

--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -37,14 +37,14 @@ export class PostgresModel extends ResourceModel {
 			: undefined;
 	}
 
-	/** Returns the IP address and port of the server */
+	/** Returns the IP address and port of Postgres */
 	public get endpoint(): { ip: string, port: string } | undefined {
 		return this._config?.status.externalEndpoint
 			? parseIpAndPort(this._config.status.externalEndpoint)
 			: undefined;
 	}
 
-	/** Returns the scale configuration of Postgres e.g. '3 nodes, 1.5 vCores, 1GiB RAM, 2GiB storage per node' */
+	/** Returns the scale configuration of Postgres e.g. '3 nodes, 1.5 vCores, 1Gi RAM, 2Gi storage per node' */
 	public get scaleConfiguration(): string | undefined {
 		if (!this._config) {
 			return undefined;

--- a/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
@@ -219,23 +219,16 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 						iconHeight: iconSize,
 						iconWidth: iconSize
 					}).component();
-				let nameComponent: azdata.Component;
-				if (r.instanceType === ResourceType.postgresInstances) {
-					nameComponent = this.modelView.modelBuilder.text()
-						.withProperties<azdata.TextComponentProperties>({
-							value: r.instanceName || '',
-							CSSStyles: { ...cssStyles.text, 'margin-block-start': '0px', 'margin-block-end': '0px' }
-						}).component();
-				} else {
-					nameComponent = this.modelView.modelBuilder.hyperlink()
-						.withProperties<azdata.HyperlinkComponentProperties>({
-							label: r.instanceName || '',
-							url: ''
-						}).component();
-					(<azdata.HyperlinkComponent>nameComponent).onDidClick(async () => {
-						await this._controllerModel.treeDataProvider.openResourceDashboard(this._controllerModel, r.instanceType || '', r.instanceName);
-					});
-				}
+
+				const nameComponent = this.modelView.modelBuilder.hyperlink()
+					.withProperties<azdata.HyperlinkComponentProperties>({
+						label: r.instanceName || '',
+						url: ''
+					}).component();
+
+				this.disposables.push(nameComponent.onDidClick(async () => {
+					await this._controllerModel.treeDataProvider.openResourceDashboard(this._controllerModel, r.instanceType || '', r.instanceName);
+				}));
 
 				// TODO chgagnon
 				return [imageComponent, nameComponent, resourceTypeToDisplayName(r.instanceType), '-'/* loc.numVCores(r.vCores) */];

--- a/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
@@ -98,7 +98,10 @@ export class PostgresConnectionStringsPage extends DashboardPage {
 	}
 
 	private getConnectionStrings(): KeyValue[] {
-		const endpoint: { ip: string, port: string } = this._postgresModel.endpoint;
+		const endpoint = this._postgresModel.endpoint;
+		if (!endpoint) {
+			return [];
+		}
 
 		return [
 			new InputKeyValue(this.modelView.modelBuilder, 'ADO.NET', `Server=${endpoint.ip};Database=postgres;Port=${endpoint.port};User Id=postgres;Password={your_password_here};Ssl Mode=Require;`),

--- a/extensions/arc/src/ui/dashboards/postgres/postgresDiagnoseAndSolveProblemsPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresDiagnoseAndSolveProblemsPage.ts
@@ -52,7 +52,7 @@ export class PostgresDiagnoseAndSolveProblemsPage extends DashboardPage {
 			troubleshootButton.onDidClick(() => {
 				process.env['POSTGRES_SERVER_NAMESPACE'] = this._postgresModel.config?.metadata.namespace;
 				process.env['POSTGRES_SERVER_NAME'] = this._postgresModel.info.name;
-				// TODO set env POSTGRES_SERVER_VERSION
+				process.env['POSTGRES_SERVER_VERSION'] = this._postgresModel.engineVersion;
 				vscode.commands.executeCommand('bookTreeView.openBook', this._context.asAbsolutePath('notebooks/arcDataServices'), true, 'postgres/tsg100-troubleshoot-postgres');
 			}));
 

--- a/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
@@ -240,22 +240,18 @@ export class PostgresOverviewPage extends DashboardPage {
 	}
 
 	private getProperties(): azdata.PropertiesContainerItem[] {
-		/*
-		const registration = this._controllerModel.getRegistration(ResourceType.postgresInstances, this._postgresModel.namespace, this._postgresModel.name);
-		const endpoint: { ip?: string, port?: number } = this._postgresModel.endpoint;
+		const endpoint = this._postgresModel.endpoint;
 
 		return [
-			{ displayName: loc.name, value: this._postgresModel.name },
-			{ displayName: loc.coordinatorEndpoint, value: `postgresql://postgres@${endpoint.ip}:${endpoint.port}` },
-			{ displayName: loc.status, value: this._postgresModel.service?.status?.state ?? '' },
+			{ displayName: loc.name, value: this._postgresModel.info.name },
+			{ displayName: loc.coordinatorEndpoint, value: endpoint ? `postgresql://postgres@${endpoint.ip}:${endpoint.port}` : '-' },
+			{ displayName: loc.status, value: this._postgresModel.config?.status.state || '-' },
 			{ displayName: loc.postgresAdminUsername, value: 'postgres' },
-			{ displayName: loc.dataController, value: this._controllerModel?.namespace ?? '' },
-			{ displayName: loc.nodeConfiguration, value: this._postgresModel.configuration },
-			{ displayName: loc.subscriptionId, value: registration?.subscriptionId ?? '' },
-			{ displayName: loc.postgresVersion, value: this._postgresModel.service?.spec?.engine?.version?.toString() ?? '' }
+			{ displayName: loc.dataController, value: this._controllerModel?.namespace || '-' },
+			{ displayName: loc.nodeConfiguration, value: '-' }, // TODO
+			{ displayName: loc.subscriptionId, value: this._controllerModel.controllerConfig?.spec.settings.azure.subscription ?? '' },
+			{ displayName: loc.postgresVersion, value: this._postgresModel.engineVersion ?? '-' }
 		];
-		*/
-		return [];
 	}
 
 	private getKibanaLink(): string {

--- a/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
@@ -12,6 +12,7 @@ import { DashboardPage } from '../../components/dashboardPage';
 import { ControllerModel } from '../../../models/controllerModel';
 import { PostgresModel } from '../../../models/postgresModel';
 import { promptAndConfirmPassword, promptForInstanceDeletion } from '../../../common/utils';
+import { ResourceType } from 'arc';
 
 export class PostgresOverviewPage extends DashboardPage {
 
@@ -154,7 +155,13 @@ export class PostgresOverviewPage extends DashboardPage {
 				try {
 					const password = await promptAndConfirmPassword(input => !input ? loc.enterANonEmptyPassword : '');
 					if (password) {
-						// TODO: azdata arc postgres server edit --admin-password
+						await this._azdataApi.azdata.arc.postgres.server.edit(
+							this._postgresModel.info.name,
+							{
+								adminPassword: true,
+								noWait: true
+							},
+							{ 'AZDATA_PASSWORD': password });
 						vscode.window.showInformationMessage(loc.passwordReset);
 					}
 				} catch (error) {
@@ -220,15 +227,13 @@ export class PostgresOverviewPage extends DashboardPage {
 
 		this.disposables.push(
 			openInAzurePortalButton.onDidClick(async () => {
-				/*
-				const r = this._controllerModel.getRegistration(ResourceType.postgresInstances, this._postgresModel.namespace, this._postgresModel.name);
-				if (!r) {
-					vscode.window.showErrorMessage(loc.couldNotFindAzureResource(this._postgresModel.fullName));
-				} else {
+				const azure = this._controllerModel.controllerConfig?.spec.settings.azure;
+				if (azure) {
 					vscode.env.openExternal(vscode.Uri.parse(
-						`https://portal.azure.com/#resource/subscriptions/${r.subscriptionId}/resourceGroups/${r.resourceGroupName}/providers/Microsoft.AzureData/${ResourceType.postgresInstances}/${r.instanceName}`));
+						`https://portal.azure.com/#resource/subscriptions/${azure.subscription}/resourceGroups/${azure.resourceGroup}/providers/Microsoft.AzureData/${ResourceType.postgresInstances}/${this._postgresModel.info.name}`));
+				} else {
+					vscode.window.showErrorMessage(loc.couldNotFindControllerRegistration);
 				}
-				*/
 			}));
 
 		return this.modelView.modelBuilder.toolbarContainer().withToolbarItems([
@@ -247,8 +252,8 @@ export class PostgresOverviewPage extends DashboardPage {
 			{ displayName: loc.coordinatorEndpoint, value: endpoint ? `postgresql://postgres@${endpoint.ip}:${endpoint.port}` : '-' },
 			{ displayName: loc.status, value: this._postgresModel.config?.status.state || '-' },
 			{ displayName: loc.postgresAdminUsername, value: 'postgres' },
-			{ displayName: loc.dataController, value: this._controllerModel?.namespace || '-' },
-			{ displayName: loc.nodeConfiguration, value: '-' }, // TODO
+			{ displayName: loc.dataController, value: this._controllerModel?.controllerConfig?.metadata.namespace || '-' },
+			{ displayName: loc.nodeConfiguration, value: this._postgresModel.scaleConfiguration || '-' },
 			{ displayName: loc.subscriptionId, value: this._controllerModel.controllerConfig?.spec.settings.azure.subscription ?? '' },
 			{ displayName: loc.postgresVersion, value: this._postgresModel.engineVersion ?? '-' }
 		];

--- a/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
@@ -96,10 +96,10 @@ export class PostgresPropertiesPage extends DashboardPage {
 		return [
 			new InputKeyValue(this.modelView.modelBuilder, loc.coordinatorEndpoint, endpoint ? `postgresql://postgres@${endpoint.ip}:${endpoint.port}` : ''),
 			new InputKeyValue(this.modelView.modelBuilder, loc.postgresAdminUsername, 'postgres'),
-			new TextKeyValue(this.modelView.modelBuilder, loc.status, this._postgresModel.config?.status?.state ?? 'Unknown'),
+			new TextKeyValue(this.modelView.modelBuilder, loc.status, this._postgresModel.config?.status.state ?? 'Unknown'),
 			// TODO: Make this a LinkKeyValue that opens the controller dashboard
-			new TextKeyValue(this.modelView.modelBuilder, loc.dataController, this._controllerModel.namespace ?? ''),
-			new TextKeyValue(this.modelView.modelBuilder, loc.nodeConfiguration, ''), // TODO
+			new TextKeyValue(this.modelView.modelBuilder, loc.dataController, this._controllerModel.controllerConfig?.metadata.namespace ?? ''),
+			new TextKeyValue(this.modelView.modelBuilder, loc.nodeConfiguration, this._postgresModel.scaleConfiguration ?? ''),
 			new TextKeyValue(this.modelView.modelBuilder, loc.postgresVersion, this._postgresModel.engineVersion ?? ''),
 			new TextKeyValue(this.modelView.modelBuilder, loc.resourceGroup, this._controllerModel.controllerConfig?.spec.settings.azure.resourceGroup ?? ''),
 			new TextKeyValue(this.modelView.modelBuilder, loc.subscriptionId, this._controllerModel.controllerConfig?.spec.settings.azure.subscription ?? '')

--- a/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
@@ -96,7 +96,7 @@ export class PostgresPropertiesPage extends DashboardPage {
 		return [
 			new InputKeyValue(this.modelView.modelBuilder, loc.coordinatorEndpoint, endpoint ? `postgresql://postgres@${endpoint.ip}:${endpoint.port}` : ''),
 			new InputKeyValue(this.modelView.modelBuilder, loc.postgresAdminUsername, 'postgres'),
-			new TextKeyValue(this.modelView.modelBuilder, loc.status, this._postgresModel.config?.status.state ?? 'Unknown'),
+			new TextKeyValue(this.modelView.modelBuilder, loc.status, this._postgresModel.config?.status.state ?? loc.unknown),
 			// TODO: Make this a LinkKeyValue that opens the controller dashboard
 			new TextKeyValue(this.modelView.modelBuilder, loc.dataController, this._controllerModel.controllerConfig?.metadata.namespace ?? ''),
 			new TextKeyValue(this.modelView.modelBuilder, loc.nodeConfiguration, this._postgresModel.scaleConfiguration ?? ''),

--- a/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as loc from '../../../localizedConstants';
 import { IconPathHelper, cssStyles } from '../../../constants';
-import { KeyValueContainer, KeyValue } from '../../components/keyValueContainer';
+import { KeyValueContainer, KeyValue, InputKeyValue, TextKeyValue } from '../../components/keyValueContainer';
 import { DashboardPage } from '../../components/dashboardPage';
 import { ControllerModel } from '../../../models/controllerModel';
 import { PostgresModel } from '../../../models/postgresModel';
@@ -91,24 +91,19 @@ export class PostgresPropertiesPage extends DashboardPage {
 	}
 
 	private getProperties(): KeyValue[] {
-		/*
-		const endpoint: { ip?: string, port?: number } = this._postgresModel.endpoint;
-		const connectionString = `postgresql://postgres@${endpoint.ip}:${endpoint.port}`;
-		const registration = this._controllerModel.getRegistration(ResourceType.postgresInstances, this._postgresModel.namespace, this._postgresModel.name);
+		const endpoint = this._postgresModel.endpoint;
 
 		return [
-			new InputKeyValue(this.modelView.modelBuilder, loc.coordinatorEndpoint, connectionString),
+			new InputKeyValue(this.modelView.modelBuilder, loc.coordinatorEndpoint, endpoint ? `postgresql://postgres@${endpoint.ip}:${endpoint.port}` : ''),
 			new InputKeyValue(this.modelView.modelBuilder, loc.postgresAdminUsername, 'postgres'),
-			new TextKeyValue(this.modelView.modelBuilder, loc.status, this._postgresModel.service?.status?.state ?? 'Unknown'),
+			new TextKeyValue(this.modelView.modelBuilder, loc.status, this._postgresModel.config?.status?.state ?? 'Unknown'),
 			// TODO: Make this a LinkKeyValue that opens the controller dashboard
 			new TextKeyValue(this.modelView.modelBuilder, loc.dataController, this._controllerModel.namespace ?? ''),
-			new TextKeyValue(this.modelView.modelBuilder, loc.nodeConfiguration, this._postgresModel.configuration),
-			new TextKeyValue(this.modelView.modelBuilder, loc.postgresVersion, this._postgresModel.service?.spec?.engine?.version?.toString() ?? ''),
-			new TextKeyValue(this.modelView.modelBuilder, loc.resourceGroup, registration?.resourceGroupName ?? ''),
-			new TextKeyValue(this.modelView.modelBuilder, loc.subscriptionId, registration?.subscriptionId ?? '')
+			new TextKeyValue(this.modelView.modelBuilder, loc.nodeConfiguration, ''), // TODO
+			new TextKeyValue(this.modelView.modelBuilder, loc.postgresVersion, this._postgresModel.engineVersion ?? ''),
+			new TextKeyValue(this.modelView.modelBuilder, loc.resourceGroup, this._controllerModel.controllerConfig?.spec.settings.azure.resourceGroup ?? ''),
+			new TextKeyValue(this.modelView.modelBuilder, loc.subscriptionId, this._controllerModel.controllerConfig?.spec.settings.azure.subscription ?? '')
 		];
-		*/
-		return [];
 	}
 
 	private handleRegistrationsUpdated() {

--- a/extensions/azdata/src/extension.ts
+++ b/extensions/azdata/src/extension.ts
@@ -97,22 +97,24 @@ export async function activate(context: vscode.ExtensionContext): Promise<azdata
 							throwIfNoAzdataOrEulaNotAccepted();
 							return localAzdata!.arc.postgres.server.show(name);
 						},
-						edit: async (args: {
+						edit: async (
 							name: string,
-							adminPassword?: boolean,
-							coresLimit?: string,
-							coresRequest?: string,
-							engineSettings?: string,
-							extensions?: string,
-							memoryLimit?: string,
-							memoryRequest?: string,
-							noWait?: boolean,
-							port?: number,
-							replaceEngineSettings?: boolean,
-							workers?: number
-						}) => {
+							args: {
+								adminPassword?: boolean,
+								coresLimit?: string,
+								coresRequest?: string,
+								engineSettings?: string,
+								extensions?: string,
+								memoryLimit?: string,
+								memoryRequest?: string,
+								noWait?: boolean,
+								port?: number,
+								replaceEngineSettings?: boolean,
+								workers?: number
+							},
+							additionalEnvVars?: { [key: string]: string }) => {
 							await throwIfNoAzdataOrEulaNotAccepted();
-							return localAzdata!.arc.postgres.server.edit(args);
+							return localAzdata!.arc.postgres.server.edit(name, args, additionalEnvVars);
 						}
 					}
 				},

--- a/extensions/azdata/src/extension.ts
+++ b/extensions/azdata/src/extension.ts
@@ -86,7 +86,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<azdata
 				postgres: {
 					server: {
 						delete: async (name: string) => {
-							await throwIfNoAzdataOrEulaNotAccepted();
+							throwIfNoAzdataOrEulaNotAccepted();
 							return localAzdata!.arc.postgres.server.delete(name);
 						},
 						list: async () => {
@@ -113,7 +113,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<azdata
 								workers?: number
 							},
 							additionalEnvVars?: { [key: string]: string }) => {
-							await throwIfNoAzdataOrEulaNotAccepted();
+							throwIfNoAzdataOrEulaNotAccepted();
 							return localAzdata!.arc.postgres.server.edit(name, args, additionalEnvVars);
 						}
 					}

--- a/extensions/azdata/src/typings/azdata-ext.d.ts
+++ b/extensions/azdata/src/typings/azdata-ext.d.ts
@@ -162,7 +162,7 @@ declare module 'azdata-ext' {
 					name: string // "citus"
 				}[],
 				settings: {
-					default: {} // { "max_connections": "101", "work_mem": "4MB" }
+					default: { [key: string]: string } // { "max_connections": "101", "work_mem": "4MB" }
 				}
 			},
 			scale: {

--- a/extensions/azdata/src/typings/azdata-ext.d.ts
+++ b/extensions/azdata/src/typings/azdata-ext.d.ts
@@ -162,7 +162,7 @@ declare module 'azdata-ext' {
 					name: string // "citus"
 				}[],
 				settings: {
-					default: { } // { "max_connections": "101", "work_mem": "4MB" }
+					default: {} // { "max_connections": "101", "work_mem": "4MB" }
 				}
 			},
 			scale: {
@@ -233,20 +233,22 @@ declare module 'azdata-ext' {
 					delete(name: string): Promise<AzdataOutput<void>>,
 					list(): Promise<AzdataOutput<PostgresServerListResult[]>>,
 					show(name: string): Promise<AzdataOutput<PostgresServerShowResult>>,
-					edit(args: {
+					edit(
 						name: string,
-						adminPassword?: boolean,
-						coresLimit?: string,
-						coresRequest?: string,
-						engineSettings?: string,
-						extensions?: string,
-						memoryLimit?: string,
-						memoryRequest?: string,
-						noWait?: boolean,
-						port?: number,
-						replaceEngineSettings?: boolean,
-						workers?: number
-					}): Promise<AzdataOutput<void>>
+						args: {
+							adminPassword?: boolean,
+							coresLimit?: string,
+							coresRequest?: string,
+							engineSettings?: string,
+							extensions?: string,
+							memoryLimit?: string,
+							memoryRequest?: string,
+							noWait?: boolean,
+							port?: number,
+							replaceEngineSettings?: boolean,
+							workers?: number
+						},
+						additionalEnvVars?: { [key: string]: string }): Promise<AzdataOutput<void>>
 				}
 			},
 			sql: {


### PR DESCRIPTION
Re-enables the Arc Postgres dashboard.  Gets the overview, connection strings, and properties pages wired up.  Enables reset password, link to azure portal.

Needs workarounds for 2 UI issues.

- Loading components get stuck spinning if you visit the page for the first time after the loading -> !loading transition.  Probably just won't use them on anything other than the default page (overview).
- Properties and connection strings pages get stuck with their initial data.  UI doesn't show the updated values when the text/inputbox component values are modified.