### PR TITLE
Fix postgres product name

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -721,7 +721,6 @@
                           "textValidationRequired": true,
                           "textValidationRegex": "^[a-z]([-a-z0-9]{0,8}[a-z0-9])?$",
                           "textValidationDescription": "%arc.postgres.server.group.name.validation.description%",
-                          "defaultValue": "postgres1",
                           "required": true
                         },
                         {

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -67,7 +67,7 @@
 	"resource.type.arc.sql.display.name": "Azure SQL managed instance - Azure Arc (preview)",
 	"resource.type.arc.postgres.display.name": "PostgreSQL Hyperscale server groups - Azure Arc (preview)",
 	"resource.type.arc.sql.description": "Managed SQL Instance service for app developers in a customer-managed environment",
-	"resource.type.arc.postgres.description": "Deploy PostgreSQL server groups into an Azure Arc environment",
+	"resource.type.arc.postgres.description": "Deploy PosgreSQL Hyperscale server groups into an Azure Arc environment",
 	"arc.controller": "Target Azure Arc Controller",
 
 
@@ -100,7 +100,7 @@
 	"arc.azure.subscription": "Azure subscription",
 	"arc.azure.resource.group": "Azure resource group",
 	"arc.azure.location": "Azure location",
-	"arc.postgres.new.dialog.title": "Deploy a PostgreSQL server group on Azure Arc (preview)",
+	"arc.postgres.new.dialog.title": "Deploy an Azure Arc enabled PostgreSQL Hyperscale server group (Preview)",
 	"arc.postgres.settings.section.title": "PostgreSQL server group settings",
 	"arc.postgres.settings.resource.title": "PostgreSQL server group resource settings",
 	"arc.postgres.settings.storage.title": "PostgreSQL server group storage settings",
@@ -124,6 +124,6 @@
 	"arc.postgres.server.group.memory.limit": "Max memory MB (per node) to allow",
 	"arc.agreement": "I accept {0} and {1}.",
 	"arc.agreement.sql.terms.conditions":"Azure SQL managed instance - Azure Arc terms and conditions",
-	"arc.agreement.postgres.terms.conditions":"PostgreSQL server groups - Azure Arc terms and conditions",
+	"arc.agreement.postgres.terms.conditions":"Azure Arc enabled PostgreSQL Hyperscale terms and conditions",
 	"arc.deploy.action":"Deploy"
 }

--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -13,7 +13,7 @@ export function miaaDashboard(name: string): string { return localize('arc.miaaD
 export function postgresDashboard(name: string): string { return localize('arc.postgresDashboard', "Postgres Dashboard (Preview) - {0}", name); }
 
 export const dataControllersType = localize('arc.dataControllersType', "Azure Arc Data Controller");
-export const pgSqlType = localize('arc.pgSqlType', "PostgreSQL Server group - Azure Arc");
+export const pgSqlType = localize('arc.pgSqlType', "PostgreSQL Hyperscale - Azure Arc");
 export const miaaType = localize('arc.miaaType', "SQL instance - Azure Arc");
 
 export const overview = localize('arc.overview', "Overview");


### PR DESCRIPTION
Use the official Postgres hyperscale product name.  Fixes:

https://github.com/microsoft/azuredatastudio/issues/12431
https://github.com/microsoft/azuredatastudio/issues/12432
https://github.com/microsoft/azuredatastudio/issues/12433
https://github.com/microsoft/azuredatastudio/issues/12435
https://github.com/microsoft/azuredatastudio/issues/12438

Before and after screenshots:

![image](https://user-images.githubusercontent.com/3500406/93553583-30be3000-f928-11ea-8261-bd4cc2b82b0d.png)
![image](https://user-images.githubusercontent.com/3500406/93553609-4895b400-f928-11ea-878c-c55975ab64f7.png)
![image](https://user-images.githubusercontent.com/3500406/93553521-0a989000-f928-11ea-9316-da3bd5586a43.png)
