### PR TITLE
add table name to models that are imported

### DIFF
--- a/extensions/machine-learning/src/views/models/manageModels/modelImportLocationPage.ts
+++ b/extensions/machine-learning/src/views/models/manageModels/modelImportLocationPage.ts
@@ -99,6 +99,11 @@ export class ModelImportLocationPage extends ModelViewBase implements IPageView,
 		}
 
 		if (this.importTable && this._labelComponent) {
+
+			// Add table name to the models imported.
+			// Since Table name is picked last as per new flow this hasn't been set yet.
+			this.modelsViewData.map(x => x.targetImportTable = this.importTable);
+
 			if (!this.validateImportTableName()) {
 				this._labelComponent.value = constants.selectModelsTableMessage;
 			} else {

--- a/extensions/machine-learning/src/views/models/manageModels/modelImportLocationPage.ts
+++ b/extensions/machine-learning/src/views/models/manageModels/modelImportLocationPage.ts
@@ -102,9 +102,7 @@ export class ModelImportLocationPage extends ModelViewBase implements IPageView,
 
 			// Add table name to the models imported.
 			// Since Table name is picked last as per new flow this hasn't been set yet.
-			if (this.modelsViewData && this.modelsViewData.length > 0) {
-				this.modelsViewData?.map(x => x.targetImportTable = this.importTable);
-			}
+			this.modelsViewData?.forEach(x => x.targetImportTable = this.importTable);
 
 			if (!this.validateImportTableName()) {
 				this._labelComponent.value = constants.selectModelsTableMessage;

--- a/extensions/machine-learning/src/views/models/manageModels/modelImportLocationPage.ts
+++ b/extensions/machine-learning/src/views/models/manageModels/modelImportLocationPage.ts
@@ -102,7 +102,9 @@ export class ModelImportLocationPage extends ModelViewBase implements IPageView,
 
 			// Add table name to the models imported.
 			// Since Table name is picked last as per new flow this hasn't been set yet.
-			this.modelsViewData.map(x => x.targetImportTable = this.importTable);
+			if (this.modelsViewData && this.modelsViewData.length > 0) {
+				this.modelsViewData?.map(x => x.targetImportTable = this.importTable);
+			}
 
 			if (!this.validateImportTableName()) {
 				this._labelComponent.value = constants.selectModelsTableMessage;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

To Address : https://github.com/microsoft/azuredatastudio/issues/12444

The table name of model table in ML extension is not getting picked correctly. It seems to have caused by a change to reorder the pages. 28b0d82

Since we would not want to change the order back - adding this change to setup the table name in the last page.
