### PR TITLE
[Port] start with eulaCheckButton hidden (#12427)

### DIFF
--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -39,6 +39,7 @@ export class ResourceTypePickerDialog extends DialogBase {
 		this._selectedResourceType = defaultResourceType;
 		this._installToolButton = azdata.window.createButton(localize('deploymentDialog.InstallToolsButton', "Install tools"));
 		this._recheckEulaButton = azdata.window.createButton(localize('deploymentDialog.RecheckEulaButton', "Validate EULA"));
+		this._recheckEulaButton.hidden = true;
 		this._toDispose.push(this._installToolButton.onClick(() => {
 			this.installTools().catch(error => console.log(error));
 		}));
@@ -102,6 +103,8 @@ export class ResourceTypePickerDialog extends DialogBase {
 				iconPosition: 'left'
 			}).component();
 			this._toDispose.push(this._cardGroup.onSelectionChanged(({ cardId }) => {
+				this._recheckEulaButton.hidden = true;
+				this._dialogObject.okButton.enabled = true;
 				const resourceType = resourceTypes.find(rt => { return rt.name === cardId; });
 				if (resourceType) {
 					this.selectResourceType(resourceType);


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/12422

The "Validate EULA" button added to the Deployment Dialog in a previous PR wasn't being hidden immediately so would show up when initially opening the page even if an item that was selected didn't need the button shown (which most don't)