### PR TITLE
Add preview to Arc controller deployment

### DIFF
--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -12,7 +12,7 @@
 	"command.editConnection.title": "Edit Connection",
 	"arc.openDashboard": "Manage",
 
-	"resource.type.azure.arc.display.name": "Azure Arc data controller",
+	"resource.type.azure.arc.display.name": "Azure Arc data controller (preview)",
 	"resource.type.azure.arc.description": "Creates an Azure Arc data controller",
 
 	"arc.control.plane.new.wizard.title": "Create Azure Arc data controller",


### PR DESCRIPTION
Part of https://github.com/microsoft/azuredatastudio/issues/12148

Adding preview text to Controller deployment to align with rest of Arc items. 

![image](https://user-images.githubusercontent.com/28519865/93631825-1d9b7680-f9a1-11ea-935a-2c4267b6b072.png)
