### PR TITLE
Activate arc extension with resource deployment command

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -14,6 +14,7 @@
   "activationEvents": [
     "onCommand:arc.connectToController",
     "onCommand:arc.createController",
+    "onCommand:azdata.resource.deploy",
     "onView:azureArc"
   ],
   "extensionDependencies": [


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/12468

Extension should be activated when resource deployment is launched. 

@alanrenmsft We should consider having the resource deployment extension activate any extensions that it finds which contribute resource types. 