### PR TITLE
Notebooks: Fix save result grid actions

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -295,6 +295,11 @@ class DataResourceTable extends GridTableBase<any> {
 	public convertData(set: ResultSetSummary): Promise<void> {
 		return this._gridDataProvider.convertAllData(set);
 	}
+
+	public updateResult(resultSet: ResultSetSummary): void {
+		super.updateResult(resultSet);
+		this._gridDataProvider.updateResultSet(resultSet);
+	}
 }
 
 export class DataResourceDataProvider implements IGridDataProvider {
@@ -370,6 +375,10 @@ export class DataResourceDataProvider implements IGridDataProvider {
 			});
 			return rowData;
 		});
+	}
+
+	public updateResultSet(resultSet: ResultSetSummary): void {
+		this._resultSet = resultSet;
 	}
 
 	public async convertAllData(result: ResultSetSummary): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/12476

I added a method in DataResourceDataProvider to update the resultSet. 

Previously the result grid was being updated in DataResourceTable but not in DataResourceDataProvider. This caused issues when serializing the data because the resultSet in DataResourceDataProvider had 0 rows.
