### PR TITLE
Add SQL instance name validation

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -579,7 +579,7 @@
                           "required": true,
                           "labelWidth": "100%",
                           "textValidationRequired": true,
-                          "textValidationRegex": "^[a-z]{1}([-a-z0-9]{0,11}[a-z0-9])?$",
+                          "textValidationRegex": "^[a-z]([-a-z0-9]{0,11}[a-z0-9])?$",
                           "textValidationDescription": "%arc.sql.invalidinstancename%"
                         },
                         {

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -724,7 +724,7 @@
                           "variableName": "AZDATA_NB_VAR_POSTGRES_SERVER_GROUP_NAME",
                           "type": "text",
                           "textValidationRequired": true,
-                          "textValidationRegex": "^[a-z]([-a-z0-9]{0,8}[a-z0-9])?$",
+                          "textValidationRegex": "^[a-z]([-a-z0-9]{0,10}[a-z0-9])?$",
                           "textValidationDescription": "%arc.postgres.server.group.name.validation.description%",
                           "required": true
                         },

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -579,7 +579,7 @@
                           "required": true,
                           "labelWidth": "100%",
                           "textValidationRequired": true,
-                          "textValidationRegex": "^[a-z0-9]{1}([a-z0-9\\-]{0,11}[a-z0-9])?$",
+                          "textValidationRegex": "^[a-z0-9]{1}([-a-z0-9]{0,11}[a-z0-9])?$",
                           "textValidationDescription": "%arc.sql.invalidinstancename%"
                         },
                         {

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -577,7 +577,10 @@
                           "type": "text",
                           "defaultValue": "sqlinstance1",
                           "required": true,
-                          "labelWidth": "100%"
+                          "labelWidth": "100%",
+                          "textValidationRequired": true,
+                          "textValidationRegex": "^[a-z0-9]{1}([a-z0-9\\-]{0,11}[a-z0-9])?$",
+                          "textValidationDescription": "%arc.sql.invalidinstancename%"
                         },
                         {
                           "label": "%arc.sql.username%",

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -579,7 +579,7 @@
                           "required": true,
                           "labelWidth": "100%",
                           "textValidationRequired": true,
-                          "textValidationRegex": "^[a-z0-9]{1}([-a-z0-9]{0,11}[a-z0-9])?$",
+                          "textValidationRegex": "^[a-z]{1}([-a-z0-9]{0,11}[a-z0-9])?$",
                           "textValidationDescription": "%arc.sql.invalidinstancename%"
                         },
                         {

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -107,7 +107,7 @@
 	"arc.postgres.settings.resource.title": "PostgreSQL server group resource settings",
 	"arc.postgres.settings.storage.title": "PostgreSQL server group storage settings",
 	"arc.postgres.server.group.name": "Server group name",
-	"arc.postgres.server.group.name.validation.description": "Server group name must consist of lower case alphanumeric characters or '-', start with a letter, end with an alphanumeric character, and be 10 characters or fewer in length.",
+	"arc.postgres.server.group.name.validation.description": "Server group name must consist of lower case alphanumeric characters or '-', start with a letter, end with an alphanumeric character, and be 12 characters or fewer in length.",
 	"arc.postgres.server.group.workers": "Number of workers",
 	"arc.postgres.server.group.port": "Port",
 	"arc.postgres.server.group.engine.version": "Engine Version",

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -77,6 +77,7 @@
 	"arc.sql.instance.name": "Instance name (lower case letters and digits only)",
 	"arc.sql.username": "Username",
 	"arc.sql.invalidusername": "sa username is disabled, please choose another username",
+	"arc.sql.invalidinstancename": "Instance name must be under 14 characters in length, only contain lowercase alphanumeric characters or - and start/end with an alphanumeric character",
 	"arc.storage-class.dc.label": "Storage Class",
 	"arc.sql.storage-class.dc.description": "The storage class to be used for all data and logs persistent volumes for all data controller pods that require them.",
 	"arc.storage-class.data.label": "Storage Class (Data)",

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -77,7 +77,7 @@
 	"arc.sql.instance.name": "Instance name (lower case letters and digits only)",
 	"arc.sql.username": "Username",
 	"arc.sql.invalidusername": "sa username is disabled, please choose another username",
-	"arc.sql.invalidinstancename": "Instance name must be under 14 characters in length, only contain lowercase alphanumeric characters or - and start/end with an alphanumeric character",
+	"arc.sql.invalidinstancename": "Instance name must consist of lower case alphanumeric characters or '-', start with a letter, end with an alphanumeric character, and be 13 characters or fewer in length.",
 	"arc.storage-class.dc.label": "Storage Class",
 	"arc.sql.storage-class.dc.description": "The storage class to be used for all data and logs persistent volumes for all data controller pods that require them.",
 	"arc.storage-class.data.label": "Storage Class (Data)",


### PR DESCRIPTION
Part of https://github.com/microsoft/azuredatastudio/issues/12082

Controller doesn't have any validation on the azdata side so not going to add any for now.

PG has validation but I'm not sure it's correct - current regex is `^[a-z]([-a-z0-9]{0,8}[a-z0-9])?$` but I was able to make an instance with a much longer name. @bergeron should this be changed?

New error message : 
![image](https://user-images.githubusercontent.com/28519865/93650777-4a14ba00-f9c4-11ea-80a4-18e39a021720.png)
