### PR TITLE
Notebooks: Fix Grids Not Rendering when Unsaved Notebook Reloaded

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -383,6 +383,7 @@ export class DataResourceDataProvider implements IGridDataProvider {
 			let rows = await this._queryRunner.getQueryRows(i, numRows, this._batchId, this._id);
 			this.convertData(rows);
 		}
+		this.cellModel.sendChangeToNotebook(NotebookChangeType.CellOutputUpdated);
 	}
 
 	private convertData(rows: ResultSetSubset): void {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
@@ -693,9 +693,9 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(8), '            "source": [');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(12), '                "azdata_cell_guid": "' + newCell.cellGuid + '"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(23), '                }, {');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(23), '}, {');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(31), '}');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(32), '            ],');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(32), '],');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(33), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(34), '        }');
 
@@ -734,7 +734,7 @@ suite('Notebook Editor Model', function (): void {
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(14), '            "outputs": [');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(26), '    "text": "[0em"');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(27), '}');
-		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(28), '            ],');
+		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(28), '],');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(29), '            "execution_count": null');
 		assert.equal(notebookEditorModel.editorModel.textEditorModel.getLineContent(30), '        }');
 


### PR DESCRIPTION
This addresses #12473. 

There are changes in how notebook outputs are handled now with how we're doing grid streaming; previously, we would display messages and then the table, but now, we get the messages after we get the grid headers, meaning that we have to insert the messages before the table (whenever we get them).

The notebook text file editor model assumed that outputs could only be appended, and not prepended.

Also needed to tell the text editor model to update once all of the data came back.

Thankfully, we have a "fast" (single-digit ms) version of being able to do clear outputs, so I'm leveraging that to ensure that we're making this change in the JSON file correctly. Is it 100% ideal? No, but as long as it works, I think the mitigation is good enough for now.