### PR TITLE
Fix PySpark Kernel Connection Change

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -512,7 +512,7 @@ export class AttachToDropdown extends SelectBox {
 			//Changes kernel based on connection attached to
 			if (this.model.kernelAliases.includes(connectionProfile.serverCapabilities.notebookKernelAlias)) {
 				this.model.changeKernel(connectionProfile.serverCapabilities.notebookKernelAlias);
-			} else {
+			} else if (this.model.clientSession.kernel.name === 'SQL') {
 				this.model.changeKernel('SQL');
 			}
 			return true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR address #12488. 

When any Spark Kernel is chosen and the user changes connection via "attach to" to an MSSQL BDC connection it stays as the Spark Kernel. 

Also, this PR ensures another scenario where if a user chooses Kusto, and connects to an MSSQL connection via "attach to", that the kernel will change to SQL.

![image](https://user-images.githubusercontent.com/23587151/93654519-89063800-f9e3-11ea-8adc-7cc286c566a3.png)

