### PR TITLE
Replace vCores property with state for arc controller dashboard

### DIFF
--- a/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
@@ -93,7 +93,7 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 					headerCssStyles: cssStyles.tableHeader,
 					rowCssStyles: cssStyles.tableRow
 				}, {
-					displayName: loc.compute,
+					displayName: loc.state,
 					valueType: azdata.DeclarativeDataType.string,
 					width: '34%',
 					isReadOnly: true,
@@ -230,8 +230,7 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 					await this._controllerModel.treeDataProvider.openResourceDashboard(this._controllerModel, r.instanceType || '', r.instanceName);
 				}));
 
-				// TODO chgagnon
-				return [imageComponent, nameComponent, resourceTypeToDisplayName(r.instanceType), '-'/* loc.numVCores(r.vCores) */];
+				return [imageComponent, nameComponent, resourceTypeToDisplayName(r.instanceType), r.state];
 			});
 		this._arcResourcesLoadingComponent.loading = !this._controllerModel.registrationsLastUpdated;
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/12508

It would be nice to have more information on this page - but currently querying values such as compute/memory requires one query per instance which is going to get very expensive for the controller. Will revisit adding stuff like that later on but for now replace the vCores property value with one we at least have (and is still useful to see). 


![image](https://user-images.githubusercontent.com/28519865/93688316-c9b09080-fa79-11ea-9f3c-d6894cde868c.png)
