### PR TITLE
escape the value for display

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/textWithIconColumn.ts
+++ b/src/sql/base/browser/ui/table/plugins/textWithIconColumn.ts
@@ -3,6 +3,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { escape } from 'sql/base/common/strings';
+
 /**
  * Definition for column with icon on the left of text.
  */
@@ -37,7 +39,7 @@ export class TextWithIconColumn<T extends Slick.SlickData> {
 	}
 	private formatter(row: number, cell: number, value: any, columnDef: Slick.Column<T>, dataContext: T): string {
 		const iconColumn = columnDef as TextWithIconColumnDefinition<T>;
-		return `<div class="icon codicon slick-icon-cell-content ${iconColumn.iconCssClassField ? dataContext[iconColumn.iconCssClassField] : ''}">${value}</div>`;
+		return `<div class="icon codicon slick-icon-cell-content ${iconColumn.iconCssClassField ? dataContext[iconColumn.iconCssClassField] : ''}">${escape(value)}</div>`;
 	}
 
 	public get definition(): TextWithIconColumnDefinition<T> {


### PR DESCRIPTION
this is a new column type plugin I introduced a while ago, by default the text will be escaped, but I forgot to do so when I first introduced it.

before:
![image](https://user-images.githubusercontent.com/13777222/93839422-bfd98980-fc41-11ea-9f6a-9655223b0e9c.png)
![image](https://user-images.githubusercontent.com/13777222/93839451-d1229600-fc41-11ea-9df1-2432b577ebfa.png)


after:

![image](https://user-images.githubusercontent.com/13777222/93839363-9587cc00-fc41-11ea-97fe-2c274f190ce3.png)

![image](https://user-images.githubusercontent.com/13777222/93839373-9e789d80-fc41-11ea-98db-82f82dc140c2.png)
