### PR TITLE
Added escape to display value when loading data

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -1088,7 +1088,7 @@ export class EditDataGridPanel extends GridParentComponent {
 			cellClasses += ' missing-value';
 		}
 		else if (Services.DBCellValue.isDBCellValue(value)) {
-			valueToDisplay = value.displayValue + '';
+			valueToDisplay = (value.displayValue + '');
 			valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
 		}
 		else if (typeof value === 'string' || (value && value.text)) {

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -904,11 +904,11 @@ export class EditDataGridPanel extends GridParentComponent {
 				let currentRow = self.dataSet.dataRows.at(activeRow);
 				let colIndex = self.getColumnIndex(this._args.column.name);
 				let dataLength: number = self.dataSet.dataRows.getLength();
-
+				let safeState = escape(state);
 				// If this is not the "new row" at the very bottom
 				if (activeRow !== dataLength) {
-					currentRow[colIndex] = state;
-					this._textEditor.applyValue(item, state);
+					currentRow[colIndex] = safeState;
+					this._textEditor.applyValue(item, safeState);
 				}
 			}
 

--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -231,7 +231,7 @@ export class EditDataGridPanel extends GridParentComponent {
 						// skip the first column since its a number column
 						for (let i = 1; i < this.dataSet.columnDefinitions.length; i++) {
 							dataWithSchema[this.dataSet.columnDefinitions[i].field] = {
-								displayValue: r.cells[i - 1].displayValue,
+								displayValue: escape(r.cells[i - 1].displayValue),
 								ariaLabel: escape(r.cells[i - 1].displayValue),
 								isNull: r.cells[i - 1].isNull
 							};
@@ -1088,7 +1088,7 @@ export class EditDataGridPanel extends GridParentComponent {
 			cellClasses += ' missing-value';
 		}
 		else if (Services.DBCellValue.isDBCellValue(value)) {
-			valueToDisplay = (value.displayValue + '');
+			valueToDisplay = value.displayValue + '';
 			valueToDisplay = escape(valueToDisplay.length > 250 ? valueToDisplay.slice(0, 250) + '...' : valueToDisplay);
 		}
 		else if (typeof value === 'string' || (value && value.text)) {


### PR DESCRIPTION
This adds an escape value to the display value of the cell in Edit Data (which also seems to be the actual data of the cell) so that it will not execute (from a SlickGrid call) when the grid is being restored (from switching tabs for instance).

The name of the server and its tables/database will be looked at in another PR. They do not seem to execute so far. 

The header name of the table is rendered within the SlickGrid module and the column name is passed to the table constructor already escaped, so it may not be an issue on the Edit Data code side. 

Attempts to change the name of the database when initializing the editor resulted in the database failing to load.