### PR TITLE
Notebooks: Fix zoom level change when new cell is added

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component.ts
@@ -70,6 +70,7 @@ export class PlaceholderCellComponent extends CellView implements OnInit, OnChan
 
 	public addCell(cellType: string, event?: Event): void {
 		if (event) {
+			event.preventDefault();
 			event.stopPropagation();
 		}
 		let type: CellType = <CellType>cellType;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/12328

The mouse click event (when clicking +code or +text to add a new cell) was causing the zoom level to change back to the zoom level when ADS was first opened. I'm not sure why this mouse click event is causing the change and other clicks (like selecting a new active cell) isn't. 

This bug was introduced after this vscode merge https://github.com/microsoft/azuredatastudio/commit/0833de1e7cfb76ac3d5a44d2f85157818a5cb9ce,
If anyone has any ideas/clues on what might be the cause please let me know.

