### PR TITLE
Remove command link from deployment error

### DIFF
--- a/extensions/arc/src/common/utils.ts
+++ b/extensions/arc/src/common/utils.ts
@@ -189,8 +189,12 @@ export async function promptAndConfirmPassword(validate: (input: string) => stri
 /**
  * Gets the message to display for a given error object that may be a variety of types.
  * @param error The error object
+ * @param useMessageWithLink Whether to use the messageWithLink - if available
  */
-export function getErrorMessage(error: any): string {
+export function getErrorMessage(error: any, useMessageWithLink: boolean = false): string {
+	if (useMessageWithLink && error.messageWithLink) {
+		return error.messageWithLink;
+	}
 	return error.message ?? error;
 }
 

--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -163,7 +163,7 @@ export function instanceDeletionWarning(name: string): string { return localize(
 export function invalidInstanceDeletionName(name: string): string { return localize('arc.invalidInstanceDeletionName', "The value '{0}' does not match the instance name. Try again or press escape to exit", name); }
 export function couldNotFindAzureResource(name: string): string { return localize('arc.couldNotFindAzureResource', "Could not find Azure resource for {0}", name); }
 export function passwordResetFailed(error: any): string { return localize('arc.passwordResetFailed', "Failed to reset password. {0}", getErrorMessage(error)); }
-export function errorConnectingToController(error: any): string { return localize('arc.errorConnectingToController', "Error connecting to controller. {0}", getErrorMessage(error)); }
+export function errorConnectingToController(error: any): string { return localize('arc.errorConnectingToController', "Error connecting to controller. {0}", getErrorMessage(error, true)); }
 export function passwordAcquisitionFailed(error: any): string { return localize('arc.passwordAcquisitionFailed', "Failed to acquire password. {0}", getErrorMessage(error)); }
 export const invalidPassword = localize('arc.invalidPassword', "The password did not work, try again.");
 export function errorVerifyingPassword(error: any): string { return localize('arc.errorVerifyingPassword', "Error encountered while verifying password. {0}", getErrorMessage(error)); }

--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -12,7 +12,7 @@ import * as vscode from 'vscode';
 import { executeCommand, executeSudoCommand, ExitCodeError, ProcessOutput } from './common/childProcess';
 import { HttpClient } from './common/httpClient';
 import Logger from './common/logger';
-import { getErrorMessage, searchForCmd } from './common/utils';
+import { getErrorMessage, NoAzdataError, searchForCmd } from './common/utils';
 import { azdataAcceptEulaKey, azdataConfigSection, azdataFound, azdataInstallKey, azdataUpdateKey, debugConfigKey, eulaAccepted, eulaUrl, microsoftPrivacyStatementUrl } from './constants';
 import * as loc from './localizedConstants';
 import { getPlatformDownloadLink, getPlatformReleaseVersion } from './azdataReleaseInfo';
@@ -195,7 +195,7 @@ export class AzdataTool implements IAzdataTool {
 					} catch (e) {
 						// this.path does not exist
 						await vscode.commands.executeCommand('setContext', azdataFound, false);
-						throw (loc.noAzdata);
+						throw new NoAzdataError();
 					}
 					throw err; // rethrow the original error
 				}

--- a/extensions/azdata/src/common/utils.ts
+++ b/extensions/azdata/src/common/utils.ts
@@ -3,8 +3,19 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as azdataExt from 'azdata-ext';
 import * as which from 'which';
+import * as loc from '../localizedConstants';
 
+export class NoAzdataError extends Error implements azdataExt.ErrorWithLink {
+	constructor() {
+		super(loc.noAzdata);
+	}
+
+	public get messageWithLink(): string {
+		return loc.noAzdataWithLink;
+	}
+}
 /**
  * Searches for the first instance of the specified executable in the PATH environment variable
  * @param exe The executable to search for

--- a/extensions/azdata/src/extension.ts
+++ b/extensions/azdata/src/extension.ts
@@ -7,6 +7,7 @@ import * as azdataExt from 'azdata-ext';
 import * as vscode from 'vscode';
 import { checkAndInstallAzdata, checkAndUpdateAzdata, findAzdata, IAzdataTool, promptForEula } from './azdata';
 import Logger from './common/logger';
+import { NoAzdataError } from './common/utils';
 import * as constants from './constants';
 import * as loc from './localizedConstants';
 
@@ -166,7 +167,7 @@ function throwIfNoAzdataOrEulaNotAccepted(): void {
 function throwIfNoAzdata() {
 	if (!localAzdata) {
 		Logger.log(loc.noAzdata);
-		throw new Error(loc.noAzdata);
+		throw new NoAzdataError();
 	}
 }
 

--- a/extensions/azdata/src/localizedConstants.ts
+++ b/extensions/azdata/src/localizedConstants.ts
@@ -46,7 +46,8 @@ export const updateError = (err: any): string => localize('azdata.updateError', 
 export const platformUnsupported = (platform: string): string => localize('azdata.platformUnsupported', "Platform '{0}' is currently unsupported", platform);
 export const unexpectedCommandError = (errMsg: string): string => localize('azdata.unexpectedCommandError', "Unexpected error executing command: {0}", errMsg);
 export const unexpectedExitCode = (code: number, err: string): string => localize('azdata.unexpectedExitCode', "Unexpected exit code from command: {1} ({0})", code, err);
-export const noAzdata = localize('azdata.NoAzdata', "No Azure Data CLI is available, [install the Azure Data CLI](command:azdata.install) to enable the features that require it.");
+export const noAzdata = localize('azdata.noAzdata', "No Azure Data CLI is available, run the command 'Azure Data CLI: Install' to enable the features that require it.");
+export const noAzdataWithLink = localize('azdata.noAzdataWithLink', "No Azure Data CLI is available, [install the Azure Data CLI](command:azdata.install) to enable the features that require it.");
 export const skipInstall = (config: string): string => localize('azdata.skipInstall', "Skipping installation of Azure Data CLI, since the operation was not user requested and config option: {0}.{1} is {2}", azdataConfigSection, azdataInstallKey, config);
 export const skipUpdate = (config: string): string => localize('azdata.skipUpdate', "Skipping update of Azure Data CLI, since the operation was not user requested and config option: {0}.{1} is {2}", azdataConfigSection, azdataUpdateKey, config);
 export const noReleaseVersion = (platform: string, releaseInfo: string): string => localize('azdata.noReleaseVersion', "No release version available for platform '{0}'\nRelease info: ${1}", platform, releaseInfo);

--- a/extensions/azdata/src/typings/azdata-ext.d.ts
+++ b/extensions/azdata/src/typings/azdata-ext.d.ts
@@ -16,6 +16,10 @@ declare module 'azdata-ext' {
 		name = 'Microsoft.azdata'
 	}
 
+	export interface ErrorWithLink extends Error {
+		messageWithLink: string;
+	}
+
 	export interface DcEndpointListResult {
 		description: string, // "Management Proxy"
 		endpoint: string, // "https://10.91.86.39:30777"

--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -288,7 +288,7 @@ export class ResourceTypePickerDialog extends DialogBase {
 			if (messages.length > 1) {
 				messages = messages.map(message => `•	${message}`);
 			}
-			messages.push(localize('deploymentDialog.VersionInformationDebugHint', "You will need to restart Azure Data Studio if the tools are installed manually to pick up the change. You may find additional details in 'Deployments' and 'azdata' output channels"));
+			messages.push(localize('deploymentDialog.VersionInformationDebugHint', "You will need to restart Azure Data Studio if the tools are installed manually to pick up the change. You may find additional details in 'Deployments' and 'Azure Data CLI' output channels"));
 			this._dialogObject.message = {
 				level: azdata.window.MessageLevel.Error,
 				text: messages.join(EOL)


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/12365

The error interface doesn't strictly need to be in the typings file like that - but I want other extensions to easily be able to see the shape in case we do other things with it. 

![image](https://user-images.githubusercontent.com/28519865/93936208-a6d0e700-fcda-11ea-848b-8acf89c358f7.png)
![image](https://user-images.githubusercontent.com/28519865/93936244-b6e8c680-fcda-11ea-856d-387c56bf1755.png)
