### PR TITLE
Update db reference dialog to show projects in the workspace

### DIFF
--- a/extensions/data-workspace/src/common/dataWorkspaceExtension.ts
+++ b/extensions/data-workspace/src/common/dataWorkspaceExtension.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { IExtension } from 'dataworkspace';
+
+export class DataWorkspaceExtension implements IExtension {
+	constructor(public getProjectsInWorkspace: () => vscode.Uri[]) {
+	}
+}

--- a/extensions/data-workspace/src/common/dataWorkspaceExtension.ts
+++ b/extensions/data-workspace/src/common/dataWorkspaceExtension.ts
@@ -5,8 +5,13 @@
 
 import * as vscode from 'vscode';
 import { IExtension } from 'dataworkspace';
+import { WorkspaceService } from '../services/workspaceService';
 
 export class DataWorkspaceExtension implements IExtension {
-	constructor(public getProjectsInWorkspace: () => vscode.Uri[]) {
+	constructor(private workspaceService: WorkspaceService) {
+	}
+
+	getProjectsInWorkspace(): vscode.Uri[] {
+		return this.workspaceService.getProjectsInWorkspace();
 	}
 }

--- a/extensions/data-workspace/src/common/interfaces.ts
+++ b/extensions/data-workspace/src/common/interfaces.ts
@@ -45,7 +45,7 @@ export interface IWorkspaceService {
 	/**
 	 * Gets the project files in current workspace
 	 */
-	getProjectsInWorkspace(): Promise<vscode.Uri[]>;
+	getProjectsInWorkspace(): vscode.Uri[];
 
 	/**
 	 * Gets the project provider by project file

--- a/extensions/data-workspace/src/dataworkspace.d.ts
+++ b/extensions/data-workspace/src/dataworkspace.d.ts
@@ -13,12 +13,7 @@ declare module 'dataworkspace' {
 	 * dataworkspace extension
 	 */
 	export interface IExtension {
-		/**
-		 * register a project provider
-		 * @param provider new project provider
-		 * @requires a disposable object, upon disposal, the provider will be unregistered.
-		 */
-		registerProjectProvider(provider: IProjectProvider): vscode.Disposable;
+		getProjectsInWorkspace(): vscode.Uri[];
 	}
 
 	/**

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -11,9 +11,8 @@ import { AllProjectTypes, SelectProjectFileActionName } from './common/constants
 import { WorkspaceTreeItem, IExtension } from 'dataworkspace';
 import { DataWorkspaceExtension } from './common/dataWorkspaceExtension';
 
-let workspaceService: WorkspaceService;
 export function activate(context: vscode.ExtensionContext): Promise<IExtension> {
-	workspaceService = new WorkspaceService();
+	const workspaceService = new WorkspaceService();
 	const workspaceTreeDataProvider = new WorkspaceTreeDataProvider(workspaceService);
 	context.subscriptions.push(vscode.window.registerTreeDataProvider('dataworkspace.views.main', workspaceTreeDataProvider));
 	context.subscriptions.push(vscode.commands.registerCommand('projects.addProject', async () => {

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -48,11 +48,7 @@ export function activate(context: vscode.ExtensionContext): Promise<IExtension> 
 		await workspaceService.removeProject(vscode.Uri.file(treeItem.element.project.projectFilePath));
 	}));
 
-	const getProjectsInWorkspace = (): vscode.Uri[] => {
-		return workspaceService.getProjectsInWorkspace();
-	};
-
-	const dataWorkspaceExtension = new DataWorkspaceExtension(getProjectsInWorkspace);
+	const dataWorkspaceExtension = new DataWorkspaceExtension(workspaceService);
 	return Promise.resolve(dataWorkspaceExtension);
 }
 

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -8,10 +8,12 @@ import * as path from 'path';
 import { WorkspaceTreeDataProvider } from './common/workspaceTreeDataProvider';
 import { WorkspaceService } from './services/workspaceService';
 import { AllProjectTypes, SelectProjectFileActionName } from './common/constants';
-import { WorkspaceTreeItem } from 'dataworkspace';
+import { WorkspaceTreeItem, IExtension } from 'dataworkspace';
+import { DataWorkspaceExtension } from './common/dataWorkspaceExtension';
 
-export function activate(context: vscode.ExtensionContext): WorkspaceService {
-	const workspaceService = new WorkspaceService();
+let workspaceService: WorkspaceService;
+export function activate(context: vscode.ExtensionContext): Promise<IExtension> {
+	workspaceService = new WorkspaceService();
 	const workspaceTreeDataProvider = new WorkspaceTreeDataProvider(workspaceService);
 	context.subscriptions.push(vscode.window.registerTreeDataProvider('dataworkspace.views.main', workspaceTreeDataProvider));
 	context.subscriptions.push(vscode.commands.registerCommand('projects.addProject', async () => {
@@ -47,7 +49,12 @@ export function activate(context: vscode.ExtensionContext): WorkspaceService {
 		await workspaceService.removeProject(vscode.Uri.file(treeItem.element.project.projectFilePath));
 	}));
 
-	return workspaceService;
+	const getProjectsInWorkspace = (): vscode.Uri[] => {
+		return workspaceService.getProjectsInWorkspace();
+	};
+
+	const dataWorkspaceExtension = new DataWorkspaceExtension(getProjectsInWorkspace);
+	return Promise.resolve(dataWorkspaceExtension);
 }
 
 export function deactivate(): void {

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -10,7 +10,7 @@ import { WorkspaceService } from './services/workspaceService';
 import { AllProjectTypes, SelectProjectFileActionName } from './common/constants';
 import { WorkspaceTreeItem } from 'dataworkspace';
 
-export function activate(context: vscode.ExtensionContext): void {
+export function activate(context: vscode.ExtensionContext): WorkspaceService {
 	const workspaceService = new WorkspaceService();
 	const workspaceTreeDataProvider = new WorkspaceTreeDataProvider(workspaceService);
 	context.subscriptions.push(vscode.window.registerTreeDataProvider('dataworkspace.views.main', workspaceTreeDataProvider));
@@ -46,6 +46,8 @@ export function activate(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(vscode.commands.registerCommand('projects.removeProject', async (treeItem: WorkspaceTreeItem) => {
 		await workspaceService.removeProject(vscode.Uri.file(treeItem.element.project.projectFilePath));
 	}));
+
+	return workspaceService;
 }
 
 export function deactivate(): void {

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -20,7 +20,7 @@ export class WorkspaceService implements IWorkspaceService {
 
 	async addProjectsToWorkspace(projectFiles: vscode.Uri[]): Promise<void> {
 		if (vscode.workspace.workspaceFile) {
-			const currentProjects: vscode.Uri[] = await this.getProjectsInWorkspace();
+			const currentProjects: vscode.Uri[] = this.getProjectsInWorkspace();
 			const newWorkspaceFolders: string[] = [];
 			let newProjectFileAdded = false;
 			for (const projectFile of projectFiles) {
@@ -59,7 +59,7 @@ export class WorkspaceService implements IWorkspaceService {
 		return projectTypes;
 	}
 
-	async getProjectsInWorkspace(): Promise<vscode.Uri[]> {
+	public getProjectsInWorkspace(): vscode.Uri[] {
 		return vscode.workspace.workspaceFile ? this.getWorkspaceConfigurationValue<string[]>(ProjectsConfigurationName).map(project => this.toUri(project)) : [];
 	}
 
@@ -74,7 +74,7 @@ export class WorkspaceService implements IWorkspaceService {
 
 	async removeProject(projectFile: vscode.Uri): Promise<void> {
 		if (vscode.workspace.workspaceFile) {
-			const currentProjects: vscode.Uri[] = await this.getProjectsInWorkspace();
+			const currentProjects: vscode.Uri[] = this.getProjectsInWorkspace();
 			const projectIdx = currentProjects.findIndex((p: vscode.Uri) => p.fsPath === projectFile.fsPath);
 			if (projectIdx !== -1) {
 				currentProjects.splice(projectIdx, 1);
@@ -144,5 +144,9 @@ export class WorkspaceService implements IWorkspaceService {
 	private toUri(relativePath: string): vscode.Uri {
 		const fullPath = path.join(path.dirname(vscode.workspace.workspaceFile!.path!), relativePath);
 		return vscode.Uri.file(fullPath);
+	}
+
+	get allProjectsInWorkspace(): vscode.Uri[] {
+		return this.getProjectsInWorkspace();
 	}
 }

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -59,7 +59,7 @@ export class WorkspaceService implements IWorkspaceService {
 		return projectTypes;
 	}
 
-	public getProjectsInWorkspace(): vscode.Uri[] {
+	getProjectsInWorkspace(): vscode.Uri[] {
 		return vscode.workspace.workspaceFile ? this.getWorkspaceConfigurationValue<string[]>(ProjectsConfigurationName).map(project => this.toUri(project)) : [];
 	}
 

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -145,8 +145,4 @@ export class WorkspaceService implements IWorkspaceService {
 		const fullPath = path.join(path.dirname(vscode.workspace.workspaceFile!.path!), relativePath);
 		return vscode.Uri.file(fullPath);
 	}
-
-	get allProjectsInWorkspace(): vscode.Uri[] {
-		return this.getProjectsInWorkspace();
-	}
 }

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -285,7 +285,3 @@ export const systemDbs = ['master', 'msdb', 'tempdb', 'model'];
 export const sameDatabaseExampleUsage = 'SELECT * FROM [Schema1].[Table1]';
 export function differentDbSameServerExampleUsage(db: string) { return `SELECT * FROM [${db}].[Schema1].[Table1]`; }
 export function differentDbDifferentServerExampleUsage(server: string, db: string) { return `SELECT * FROM [${server}].[${db}].[Schema1].[Table1]`; }
-
-// workspace file
-export const ProjectsConfigurationName = 'projects';
-export const WorkspaceConfigurationName = 'dataworkspace';

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -99,7 +99,7 @@ export const defaultUser = localize('default', "default");
 export const addDatabaseReferenceDialogName = localize('addDatabaseReferencedialogName', "Add database reference");
 export const addDatabaseReferenceOkButtonText = localize('addDatabaseReferenceOkButtonText', "Add reference");
 export const referenceRadioButtonsGroupTitle = localize('referenceRadioButtonsGroupTitle', "Type");
-export const projectRadioButtonTitle = localize('projectRadioButtonTitle', "Database project in folder");
+export const projectRadioButtonTitle = localize('projectRadioButtonTitle', "Database project in workspace");
 export const systemDatabaseRadioButtonTitle = localize('systemDatabaseRadioButtonTitle', "System database");
 export const dacpacText = localize('dacpacText', "Data-tier application (.dacpac)");
 export const dacpacPlaceholder = localize('dacpacPlaceholder', "Select .dacpac");
@@ -286,3 +286,7 @@ export const systemDbs = ['master', 'msdb', 'tempdb', 'model'];
 export const sameDatabaseExampleUsage = 'SELECT * FROM [Schema1].[Table1]';
 export function differentDbSameServerExampleUsage(db: string) { return `SELECT * FROM [${db}].[Schema1].[Table1]`; }
 export function differentDbDifferentServerExampleUsage(server: string, db: string) { return `SELECT * FROM [${server}].[${db}].[Schema1].[Table1]`; }
+
+// workspace file
+export const ProjectsConfigurationName = 'projects';
+export const WorkspaceConfigurationName = 'dataworkspace';

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -228,3 +228,26 @@ export async function getSqlProjectFilesInFolder(folderPath: string): Promise<st
 
 	return results;
 }
+
+/**
+ * Gets the Uris of all the SQL projects in the workspace
+ */
+export function getSqlProjectsInWorkspace(): vscode.Uri[] {
+	return vscode.workspace.workspaceFile ? getWorkspaceProjects().map(project => toUri(project)).filter(p => path.parse(p.fsPath).ext === constants.sqlprojExtension) : [];
+}
+
+/**
+ * Gets all the files in dataworkspace.projects
+ */
+function getWorkspaceProjects(): string[] {
+	return (<string[]>vscode.workspace.getConfiguration(constants.WorkspaceConfigurationName).get(constants.ProjectsConfigurationName));
+}
+
+/**
+	 * Gets the Uri of the given relative path
+	 * @param relativePath the relative path
+	 */
+function toUri(relativePath: string): vscode.Uri {
+	const fullPath = path.join(path.dirname(vscode.workspace.workspaceFile!.path!), relativePath);
+	return vscode.Uri.file(fullPath);
+}

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -228,26 +228,3 @@ export async function getSqlProjectFilesInFolder(folderPath: string): Promise<st
 
 	return results;
 }
-
-/**
- * Gets the Uris of all the SQL projects in the workspace
- */
-export function getSqlProjectsInWorkspace(): vscode.Uri[] {
-	return vscode.workspace.workspaceFile ? getWorkspaceProjects().map(project => toUri(project)).filter(p => path.parse(p.fsPath).ext === constants.sqlprojExtension) : [];
-}
-
-/**
- * Gets all the files in dataworkspace.projects
- */
-function getWorkspaceProjects(): string[] {
-	return (<string[]>vscode.workspace.getConfiguration(constants.WorkspaceConfigurationName).get(constants.ProjectsConfigurationName));
-}
-
-/**
-	 * Gets the Uri of the given relative path
-	 * @param relativePath the relative path
-	 */
-function toUri(relativePath: string): vscode.Uri {
-	const fullPath = path.join(path.dirname(vscode.workspace.workspaceFile!.path!), relativePath);
-	return vscode.Uri.file(fullPath);
-}

--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
@@ -5,6 +5,7 @@
 
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
+import * as dataworkspace from 'dataworkspace';
 import * as path from 'path';
 import * as constants from '../common/constants';
 import * as utils from '../common/utils';
@@ -261,8 +262,8 @@ export class AddDatabaseReferenceDialog {
 			this.setDefaultDatabaseValues();
 		});
 
-		// get projects in workspace
-		let projectFiles = await utils.getSqlProjectsInWorkspace();
+		// get projects in workspace and filter to only sql projects
+		let projectFiles: vscode.Uri[] = (vscode.extensions.getExtension(dataworkspace.extension.name)?.exports.allProjectsInWorkspace).filter((p: vscode.Uri) => path.parse(p.fsPath).ext === constants.sqlprojExtension);
 
 		// filter out current project
 		projectFiles = projectFiles.filter(p => p.fsPath !== this.project.projectFilePath);

--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
@@ -263,7 +263,7 @@ export class AddDatabaseReferenceDialog {
 		});
 
 		// get projects in workspace and filter to only sql projects
-		let projectFiles: vscode.Uri[] = (vscode.extensions.getExtension(dataworkspace.extension.name)?.exports.allProjectsInWorkspace).filter((p: vscode.Uri) => path.parse(p.fsPath).ext === constants.sqlprojExtension);
+		let projectFiles: vscode.Uri[] = (vscode.extensions.getExtension(dataworkspace.extension.name)?.exports.getProjectsInWorkspace()).filter((p: vscode.Uri) => path.parse(p.fsPath).ext === constants.sqlprojExtension);
 
 		// filter out current project
 		projectFiles = projectFiles.filter(p => p.fsPath !== this.project.projectFilePath);

--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
@@ -262,25 +262,11 @@ export class AddDatabaseReferenceDialog {
 		});
 
 		// get projects in workspace
-		const workspaceFolders = vscode.workspace.workspaceFolders;
-		if (workspaceFolders?.length) {
-			let projectFiles = await utils.getSqlProjectFilesInFolder(workspaceFolders[0].uri.fsPath);
+		let projectFiles = await utils.getSqlProjectsInWorkspace();
 
-			// check if current project is in same open folder (should only be able to add a reference to another project in
-			// the folder if the current project is also in the folder)
-			if (projectFiles.find(p => p === utils.getPlatformSafeFileEntryPath(this.project.projectFilePath))) {
-				// filter out current project
-				projectFiles = projectFiles.filter(p => p !== utils.getPlatformSafeFileEntryPath(this.project.projectFilePath));
-
-				projectFiles.forEach(p => {
-					projectFiles[projectFiles.indexOf(p)] = path.parse(p).name;
-				});
-
-				this.projectDropdown.values = projectFiles;
-			} else {
-				this.projectDropdown.values = [];
-			}
-		}
+		// filter out current project
+		projectFiles = projectFiles.filter(p => p.fsPath !== this.project.projectFilePath);
+		this.projectDropdown.values = projectFiles.map(p => path.parse(p.fsPath).name);
 
 		return {
 			component: this.projectDropdown,

--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
@@ -263,7 +263,8 @@ export class AddDatabaseReferenceDialog {
 		});
 
 		// get projects in workspace and filter to only sql projects
-		let projectFiles: vscode.Uri[] = (vscode.extensions.getExtension(dataworkspace.extension.name)?.exports.getProjectsInWorkspace()).filter((p: vscode.Uri) => path.parse(p.fsPath).ext === constants.sqlprojExtension);
+		let projectFiles: vscode.Uri[] = (<dataworkspace.IExtension>vscode.extensions.getExtension(dataworkspace.extension.name)?.exports).getProjectsInWorkspace()
+			.filter((p: vscode.Uri) => path.parse(p.fsPath).ext === constants.sqlprojExtension);
 
 		// filter out current project
 		projectFiles = projectFiles.filter(p => p.fsPath !== this.project.projectFilePath);


### PR DESCRIPTION
This PR fixes #12490. Now that projects are part of a workspace, the project dropdown is populated with sql projects in the same workspace instead of sql projects in the same folder. 
