### PR TITLE
edit data: create a temp object for display time required modification

### DIFF
--- a/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridPanel.ts
@@ -886,13 +886,14 @@ export class EditDataGridPanel extends GridParentComponent {
 			}
 
 			loadValue(item, rowNumber): void {
+				const itemForDisplay = deepClone(item);
 				if (self.overrideCellFn) {
-					let overrideValue = self.overrideCellFn(rowNumber, this._args.column.id, item[this._args.column.id]);
+					let overrideValue = self.overrideCellFn(rowNumber, this._args.column.id, itemForDisplay[this._args.column.id]);
 					if (overrideValue !== undefined) {
-						item[this._args.column.id] = overrideValue;
+						itemForDisplay[this._args.column.id] = overrideValue;
 					}
 				}
-				this._textEditor.loadValue(item);
+				this._textEditor.loadValue(itemForDisplay);
 			}
 
 			serializeValue(): string {


### PR DESCRIPTION
 #12572 

I believe these code was introduced by Maddy a while back to fix the issue when editing cells with line breaks, but she modified the actual data instead of an object just for rendering the text edit.

the actual data is not plain string, it is an object with displayValue, ariaLabel and isNull, this block of code will modify the data to plain string and we will lose the aria-label data that was already escaped.

fix: create a temp object for display time required modification