### PR TITLE
set aria-hidden for a non-visible control

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -94,8 +94,8 @@ export default () => `
 				<div class="resources-container">
 					<h2>${escape(localize('welcomePage.resources', "Resources"))}</h2>
 					<div class="tabs">
-					<!-- Checkbox is not accessible to user yet, this feature is still in development -->
-					<input tabindex="-1" class="input" name="tabs" type="radio" id="tab-1" checked="checked" />
+					<!-- Radio button is not accessible to user yet, this feature is still in development -->
+					<input tabindex="-1" aria-hidden="true" class="input" name="tabs" type="radio" id="tab-1" checked="checked" />
 					<span id="historyLabel" class="label" for="tab-1" tabIndex="0">${escape(localize('welcomePage.history', "History"))}</span>
 						<div class="panel">
 							<div class="recent history">


### PR DESCRIPTION
last time I checked with Brian, he only set the tabindex to -1, that would not stop screen reader from getting to it, adding aria-hidden to fix the issue.

This PR fixes #11546
