### PR TITLE
Fix undefined error in server tree data source

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeDataSource.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeDataSource.ts
@@ -30,6 +30,11 @@ export class ServerTreeDataSource implements IDataSource {
 	 * No more than one element may use a given identifier.
 	 */
 	public getId(tree: ITree, element?: any): string {
+		// Note there really shouldn't be any undefined elements in the tree, but the original implementation
+		// didn't do that correctly and since this is going to replaced by the async tree at some point just
+		// making it so we handle the undefined case here.
+		// This should be safe to do since the undefined element is only used when we want to clear the tree
+		// so it'll be the only "element" in the tree and thus there shouldn't be any duplicate ids
 		return element?.id || '';
 	}
 

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeDataSource.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeDataSource.ts
@@ -29,8 +29,8 @@ export class ServerTreeDataSource implements IDataSource {
 	 * Returns the unique identifier of the given element.
 	 * No more than one element may use a given identifier.
 	 */
-	public getId(tree: ITree, element: any): string {
-		return element.id;
+	public getId(tree: ITree, element?: any): string {
+		return element?.id || '';
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/12615

This was "broken" in https://github.com/microsoft/azuredatastudio/commit/503090856a291232cc564e397d258e7a2ae03f4f#diff-7159ef3349b8a0d975ddfc700bd99a12

We aren't really using the old tree control correctly (it doesn't really support passing undefined as an item) but refactoring it to be correct is probably not worth it given that this will be replaced with the async server tree at some point anyways.

Using an empty string as the id here should be safe since it'll be the only item in the tree so no chance of collisions. 