### PR TITLE
3707 Kusto Icon Fix

### DIFF
--- a/extensions/kusto/package.json
+++ b/extensions/kusto/package.json
@@ -223,7 +223,8 @@
           "path": {
             "light": "resources/light/azureDE.svg",
             "dark": "resources/dark/azureDE_inverse.svg"
-          }
+          },
+          "default": true
         },
         {
           "id": "kusto:cluster",

--- a/src/sql/platform/capabilities/common/capabilitiesService.ts
+++ b/src/sql/platform/capabilities/common/capabilitiesService.ts
@@ -22,7 +22,7 @@ export const clientCapabilities = {
 
 export interface ConnectionProviderProperties {
 	providerId: string;
-	iconPath?: URI | IconPath | { id: string, path: IconPath, default: boolean }[]
+	iconPath?: URI | IconPath | { id: string, path: IconPath, default?: boolean }[]
 	displayName: string;
 	notebookKernelAlias?: string;
 	azureResource?: string;

--- a/src/sql/platform/capabilities/common/capabilitiesService.ts
+++ b/src/sql/platform/capabilities/common/capabilitiesService.ts
@@ -22,7 +22,7 @@ export const clientCapabilities = {
 
 export interface ConnectionProviderProperties {
 	providerId: string;
-	iconPath?: URI | IconPath | { id: string, path: IconPath }[]
+	iconPath?: URI | IconPath | { id: string, path: IconPath, default: boolean }[]
 	displayName: string;
 	notebookKernelAlias?: string;
 	azureResource?: string;

--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
@@ -264,10 +264,10 @@ function getIconPath(connection: ConnectionProfile, connectionManagementService:
 	if (!providerProperties) { return undefined; }
 
 	let iconPath: IconPath | undefined = undefined;
-	let pathConfig: URI | IconPath | { id: string, path: IconPath }[] | undefined = providerProperties['iconPath'];
+	let pathConfig: URI | IconPath | { id: string, path: IconPath, default?: boolean }[] | undefined = providerProperties['iconPath'];
 	if (Array.isArray(pathConfig)) {
 		for (const e of pathConfig) {
-			if (!e.id || e.id === iconId || iconId === undefined) {
+			if (!e.id || e.id === iconId || e.default) {
 				iconPath = e.path;
 				connection['iconPath'] = iconPath;
 				break;

--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
@@ -99,7 +99,6 @@ class ConnectionProfileTemplate extends Disposable {
 
 	set(element: ConnectionProfile) {
 		if (!this._isCompact) {
-			let iconPath: IconPath | undefined = getIconPath(element, this._connectionManagementService);
 			if (this._connectionManagementService.isConnected(undefined, element)) {
 				this._connectionStatusBadge.classList.remove('disconnected');
 				this._connectionStatusBadge.classList.add('connected');
@@ -107,8 +106,10 @@ class ConnectionProfileTemplate extends Disposable {
 				this._connectionStatusBadge.classList.remove('connected');
 				this._connectionStatusBadge.classList.add('disconnected');
 			}
-			renderServerIcon(this._icon, iconPath);
 		}
+
+		let iconPath: IconPath | undefined = getIconPath(element, this._connectionManagementService);
+		renderServerIcon(this._icon, iconPath);
 
 		let label = element.title;
 		if (!element.isConnectionOptionsValid) {
@@ -259,8 +260,6 @@ function getIconPath(connection: ConnectionProfile, connectionManagementService:
 	}
 
 	let iconId = connectionManagementService.getConnectionIconId(connection.id);
-	if (!iconId) { return undefined; }
-
 	let providerProperties = connectionManagementService.getProviderProperties(connection.providerName);
 	if (!providerProperties) { return undefined; }
 
@@ -268,7 +267,7 @@ function getIconPath(connection: ConnectionProfile, connectionManagementService:
 	let pathConfig: URI | IconPath | { id: string, path: IconPath }[] | undefined = providerProperties['iconPath'];
 	if (Array.isArray(pathConfig)) {
 		for (const e of pathConfig) {
-			if (!e.id || e.id === iconId) {
+			if (!e.id || e.id === iconId || iconId === undefined) {
 				iconPath = e.path;
 				connection['iconPath'] = iconPath;
 				break;

--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
@@ -267,7 +267,7 @@ function getIconPath(connection: ConnectionProfile, connectionManagementService:
 	let pathConfig: URI | IconPath | { id: string, path: IconPath, default?: boolean }[] | undefined = providerProperties['iconPath'];
 	if (Array.isArray(pathConfig)) {
 		for (const e of pathConfig) {
-			if (!e.id || e.id === iconId || e.default) {
+			if (!e.id || e.id === iconId || (!iconId && e.default)) {
 				iconPath = e.path;
 				connection['iconPath'] = iconPath;
 				break;

--- a/src/sql/workbench/services/objectExplorer/browser/iconRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/iconRenderer.ts
@@ -10,7 +10,7 @@ import { URI } from 'vs/base/common/uri';
 class IconRenderer {
 	private iconRegistered: Set<string> = new Set<string>();
 
-	public registerIcon(path: URI | IconPath): string | undefined {
+	public registerIcon(path: URI | IconPath | undefined): string | undefined {
 		if (!path) { return undefined; }
 		let iconPath: IconPath = this.toIconPath(path);
 		let iconUid: string | undefined = this.getIconUid(iconPath);
@@ -37,8 +37,7 @@ class IconRenderer {
 		}
 	}
 
-	public putIcon(element: HTMLElement, path: URI | IconPath): void {
-		if (!element || !path) { return undefined; }
+	public putIcon(element: HTMLElement, path: URI | IconPath | undefined): void {
 		let iconUid: string | undefined = this.registerIcon(path);
 		element.id = iconUid ?? '';
 	}

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
@@ -178,7 +178,7 @@ export class ServerTreeRenderer implements IRenderer {
 		let pathConfig: URI | IconPath | { id: string, path: IconPath, default?: boolean }[] | undefined = providerProperties.iconPath;
 		if (Array.isArray(pathConfig)) {
 			for (const e of pathConfig) {
-				if (!e.id || e.id === iconId || e.default) {
+				if (!e.id || e.id === iconId || (!iconId && e.default)) {
 					iconPath = e.path;
 					connection['iconPath'] = iconPath;
 					break;

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
@@ -175,7 +175,7 @@ export class ServerTreeRenderer implements IRenderer {
 		if (!providerProperties) { return undefined; }
 
 		let iconPath: IconPath | undefined = undefined;
-		let pathConfig: URI | IconPath | { id: string, path: IconPath, default: boolean }[] | undefined = providerProperties.iconPath;
+		let pathConfig: URI | IconPath | { id: string, path: IconPath, default?: boolean }[] | undefined = providerProperties.iconPath;
 		if (Array.isArray(pathConfig)) {
 			for (const e of pathConfig) {
 				if (!e.id || e.id === iconId || e.default) {

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
@@ -122,10 +122,6 @@ export class ServerTreeRenderer implements IRenderer {
 	 */
 	public renderElement(tree: ITree, element: any, templateId: string, templateData: any): void {
 		if (templateId === ServerTreeRenderer.CONNECTION_TEMPLATE_ID) {
-			// if (templateData.icon) {
-			// 	templateData.icon.id = '';
-			// }
-			// }
 			this.renderConnection(element, templateData);
 		} else if (templateId === ServerTreeRenderer.CONNECTION_GROUP_TEMPLATE_ID) {
 			this.renderConnectionProfileGroup(element, templateData);
@@ -201,9 +197,7 @@ export class ServerTreeRenderer implements IRenderer {
 
 	private renderServerIcon(element: HTMLElement, iconPath: IconPath | undefined, isConnected: boolean): void {
 		if (!element) { return; }
-		if (iconPath) {
-			iconRenderer.putIcon(element, iconPath);
-		}
+		iconRenderer.putIcon(element, iconPath);
 		let badgeToRemove: string = isConnected ? badgeRenderer.serverDisconnected : badgeRenderer.serverConnected;
 		let badgeToAdd: string = isConnected ? badgeRenderer.serverConnected : badgeRenderer.serverDisconnected;
 		badgeRenderer.removeBadge(element, badgeToRemove);

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
@@ -122,6 +122,10 @@ export class ServerTreeRenderer implements IRenderer {
 	 */
 	public renderElement(tree: ITree, element: any, templateId: string, templateData: any): void {
 		if (templateId === ServerTreeRenderer.CONNECTION_TEMPLATE_ID) {
+			// if (templateData.icon) {
+			// 	templateData.icon.id = '';
+			// }
+			// }
 			this.renderConnection(element, templateData);
 		} else if (templateId === ServerTreeRenderer.CONNECTION_GROUP_TEMPLATE_ID) {
 			this.renderConnectionProfileGroup(element, templateData);
@@ -175,10 +179,10 @@ export class ServerTreeRenderer implements IRenderer {
 		if (!providerProperties) { return undefined; }
 
 		let iconPath: IconPath | undefined = undefined;
-		let pathConfig: URI | IconPath | { id: string, path: IconPath }[] | undefined = providerProperties.iconPath;
+		let pathConfig: URI | IconPath | { id: string, path: IconPath, default: boolean }[] | undefined = providerProperties.iconPath;
 		if (Array.isArray(pathConfig)) {
 			for (const e of pathConfig) {
-				if (!e.id || e.id === iconId || iconId === undefined) {
+				if (!e.id || e.id === iconId || e.default) {
 					iconPath = e.path;
 					connection['iconPath'] = iconPath;
 					break;

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
@@ -171,8 +171,6 @@ export class ServerTreeRenderer implements IRenderer {
 		}
 
 		let iconId = this._connectionManagementService.getConnectionIconId(connection.id);
-		if (!iconId) { return undefined; }
-
 		let providerProperties = this._connectionManagementService.getProviderProperties(connection.providerName);
 		if (!providerProperties) { return undefined; }
 
@@ -180,7 +178,7 @@ export class ServerTreeRenderer implements IRenderer {
 		let pathConfig: URI | IconPath | { id: string, path: IconPath }[] | undefined = providerProperties.iconPath;
 		if (Array.isArray(pathConfig)) {
 			for (const e of pathConfig) {
-				if (!e.id || e.id === iconId) {
+				if (!e.id || e.id === iconId || iconId === undefined) {
 					iconPath = e.path;
 					connection['iconPath'] = iconPath;
 					break;
@@ -209,18 +207,20 @@ export class ServerTreeRenderer implements IRenderer {
 	}
 
 	private renderConnection(connection: ConnectionProfile, templateData: IConnectionTemplateData): void {
+
+		let isConnected = this._connectionManagementService.isConnected(undefined, connection);
 		if (!this._isCompact) {
-			let iconPath = this.getIconPath(connection);
-			if (this._connectionManagementService.isConnected(undefined, connection)) {
+			if (isConnected) {
 				templateData.icon.classList.remove('disconnected');
 				templateData.icon.classList.add('connected');
-				this.renderServerIcon(templateData.icon, iconPath, true);
 			} else {
 				templateData.icon.classList.remove('connected');
 				templateData.icon.classList.add('disconnected');
-				this.renderServerIcon(templateData.icon, iconPath, false);
 			}
 		}
+
+		let iconPath = this.getIconPath(connection);
+		this.renderServerIcon(templateData.icon, iconPath, isConnected);
 
 		let label = connection.title;
 		if (!connection.isConnectionOptionsValid) {


### PR DESCRIPTION
Changed getIconpath in serverTreeRenderer to always set iconPath if iconId is undefined. Changed renderConnection to always renderServerIcon

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #11495 