### PR TITLE
update new button role on welcome page

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -361,13 +361,13 @@ class WelcomePage extends Disposable {
 
 		const getDropdownBtn = container.querySelector('#dropdown-btn-container .monaco-button') as HTMLElement;
 		getDropdownBtn.id = 'dropdown-btn';
-		getDropdownBtn.setAttribute('role', 'navigation');
+		getDropdownBtn.setAttribute('role', 'button');
 		getDropdownBtn.setAttribute('aria-haspopup', 'true');
 		getDropdownBtn.setAttribute('aria-controls', 'dropdown');
 		nav.setAttribute('role', 'navigation');
 		nav.classList.add('dropdown-nav');
 		dropdownUl.classList.add('dropdown');
-		getDropdownBtn.id = 'dropdown-btn';
+		getDropdownBtn.setAttribute('aria-expanded', 'false');
 		getDropdownBtn.appendChild(i);
 		nav.appendChild(dropdownUl);
 		dropdownButtonContainer.appendChild(nav);


### PR DESCRIPTION
This PR fixes #11544
not sure why the role was set to navigation, I am updating it to match the '...' button in the following screenshot, they are same type of control.
![image](https://user-images.githubusercontent.com/13777222/94238287-ff63d800-fec4-11ea-9bb2-de7993412070.png)
