### PR TITLE
Add script to validate extension gallery files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - release/extensions
+  pull_request:
+    branches:
+      - release/extensions
+
+jobs:
+  validate-galleries:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.2.0
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    # TODO: cache node modules
+    - run: node scripts/validateGalleries.js
+      name: Validate Extension Galleries

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3763,7 +3763,8 @@
 							]
 						}
 					],
-					"statistics": []
+					"statistics": [],
+					"flags": "preview"
 				}
 			],
 			"resultMetadata": [

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3763,8 +3763,7 @@
 							]
 						}
 					],
-					"statistics": [],
-					"flags": "preview"
+					"statistics": []
 				}
 			],
 			"resultMetadata": [

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3773,7 +3773,7 @@
 					"metadataItems": [
 						{
 							"name": "TotalCount",
-							"count": 62
+							"count": 64
 						}
 					]
 				}

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -17,6 +17,9 @@ const fs = require('fs');
  *
  * Note that while most checks are falsy checks some specifically check for undefined when an empty string or 0 is
  * an expected value.
+ *
+ * You can run this manually from the command line with :
+ *      node scripts/validateGalleries.js
  */
 
 /**

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -1,0 +1,234 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+/**
+ * This file is for validating the extension gallery files to ensure that they adhere to the expected schema defined in
+ * https://github.com/microsoft/azuredatastudio/blob/main/src/vs/platform/extensionManagement/common/extensionGalleryService.ts#L64
+ *
+ * It would be ideal to use the actual parsing logic ADS uses for more thorough validation and automatic updates if the schema ever
+ * changes, but given how unlikely that is this is fine for now.
+ *
+ * Note that while most checks are falsy checks some specifically check for undefined when an empty string or 0 is
+ * an expected value.
+ */
+
+/**
+ * Validate the extension gallery json according to
+ * interface IRawGalleryQueryResult {
+ *    results: {
+ *        extensions: IRawGalleryExtension[];
+ *        resultMetadata: {
+ *            metadataType: string;
+ *            metadataItems: {
+ *                name: string;
+ *                count: number;
+ *            }[];
+ *        }[]
+ *    }[];
+ * }
+ */
+function validateExtensionGallery(path) {
+    let galleryJson;
+    try {
+        galleryJson = JSON.parse(fs.readFileSync(path).toString());
+    } catch (err) {
+        throw new Error(`Unable to parse extension gallery file ${path} : ${err}`);
+    }
+    if (!galleryJson.results || !galleryJson.results[0]) {
+        throw new Error(`${path} - results invalid`);
+    }
+    validateResults(path, galleryJson.results[0]);
+}
+
+/**
+ * Validate results blob according to
+ * {
+ *     extensions: IRawGalleryExtension[];
+ *     resultMetadata: {
+ *         metadataType: string;
+ *         metadataItems: {
+ *             name: string;
+ *             count: number;
+ *         }[];
+ *     }[]
+ * }
+ */
+function validateResults(path, resultsJson) {
+    if (!resultsJson.extensions || !resultsJson.extensions.length) {
+        throw new Error(`${path} - No extensions\n${JSON.stringify(resultsJson)}`)
+    }
+    resultsJson.extensions.forEach(extension => validateExtension(path, extension));
+
+    if (!resultsJson.resultMetadata || !resultsJson.resultMetadata.length) {
+        throw new Error(`${path} - No resultMetadata\n${JSON.stringify(resultsJson)}`)
+    }
+    resultsJson.resultMetadata.forEach(resultMetadata => validateResultMetadata(path, resultsJson.extensions.length, resultMetadata));
+}
+
+/**
+ * Validate extension blob according to
+ * interface IRawGalleryExtension {
+ * 	extensionId: string;
+ * 	extensionName: string;
+ * 	displayName: string;
+ * 	shortDescription: string;
+ * 	publisher: { displayName: string, publisherId: string, publisherName: string; };
+ * 	versions: IRawGalleryExtensionVersion[];
+ * 	statistics: IRawGalleryExtensionStatistics[];
+ * 	flags: string;
+ * }
+ */
+function validateExtension(path, extensionJson) {
+    if (!extensionJson.extensionId) {
+        throw new Error(`${path} - No extensionId\n${JSON.stringify(extensionJson)}`)
+    }
+    let extensionName = extensionJson.extensionName;
+    if (!extensionName) {
+        throw new Error(`${path} - No extensionName\n${JSON.stringify(extensionJson)}`)
+    }
+    if (!extensionJson.displayName) {
+        throw new Error(`${path} - No displayName\n${JSON.stringify(extensionJson)}`)
+    }
+    if (!extensionJson.shortDescription) {
+        throw new Error(`${path} - No shortDescription\n${JSON.stringify(extensionJson)}`)
+    }
+    if (!extensionJson.publisher || !extensionJson.publisher.displayName || !extensionJson.publisher.publisherId || !extensionJson.publisher.publisherName) {
+        throw new Error(`${path} - Invalid publisher\n${JSON.stringify(extensionJson)}`)
+    }
+
+    if (!extensionJson.versions || !extensionJson.versions.length) {
+        throw new Error(`${path} - Invalid versions\n${JSON.stringify(extensionJson)}`)
+    }
+    extensionJson.versions.forEach(version => validateVersion(path, extensionName, version));
+
+    if (!extensionJson.statistics || extensionJson.statistics.length === undefined) {
+        throw new Error(`${path} - Invalid statistics\n${JSON.stringify(extensionJson)}`)
+    }
+    extensionJson.statistics.forEach(statistics => validateExtensionStatistics(path, extensionName, statistics));
+
+    if (extensionJson.flags === undefined) {
+        throw new Error(`${path} - No flags\n${JSON.stringify(extensionJson)}`)
+    }
+}
+
+/**
+ * Validate an extension statistics blob according to
+ *
+ * interface IRawGalleryExtensionStatistics {
+ *      statisticName: string;
+ *      value: number;
+ *  }
+ */
+function validateExtensionStatistics(path, extensionName, extensionStatisticsJson) {
+    if (!extensionStatisticsJson.statisticName) {
+        throw new Error(`${path} - ${extensionName} - Invalid statisticName\n${JSON.stringify(extensionStatisticsJson)}`)
+    }
+    if (extensionStatisticsJson.value === undefined) {
+        throw new Error(`${path} - ${extensionName} - Invalid value\n${JSON.stringify(extensionStatisticsJson)}`)
+    }
+}
+
+/**
+ * Validate an extension version blob according to
+ * interface IRawGalleryExtensionVersion {
+ *     version: string;
+ *     lastUpdated: string;
+ *     assetUri: string;
+ *     fallbackAssetUri: string;
+ *     files: IRawGalleryExtensionFile[];
+ *     properties?: IRawGalleryExtensionProperty[];
+ * }
+ */
+function validateVersion(path, extensionName, extensionVersionJson) {
+    if (!extensionVersionJson.version) {
+        throw new Error(`${path} - ${extensionName} - No version\n${JSON.stringify(extensionVersionJson)}`)
+    }
+    if (extensionVersionJson.lastUpdated === undefined) {
+        throw new Error(`${path} - ${extensionName} - No last updated\n${JSON.stringify(extensionVersionJson)}`)
+    }
+    if (extensionVersionJson.assetUri === undefined) {
+        throw new Error(`${path} - ${extensionName} - No asset URI\n${JSON.stringify(extensionVersionJson)}`)
+    }
+    if (!extensionVersionJson.fallbackAssetUri) {
+        throw new Error(`${path} - ${extensionName} - No fallbackAssetUri\n${JSON.stringify(extensionVersionJson)}`)
+    }
+    if (!extensionVersionJson.files || !extensionVersionJson.files[0]) {
+        throw new Error(`${path} - ${extensionName} - Invalid version files\n${JSON.stringify(extensionVersionJson)}`)
+    }
+    extensionVersionJson.files.forEach(file => validateExtensionFile(path, extensionName, file));
+    if (extensionVersionJson.properties && extensionVersionJson.properties.length) {
+        extensionVersionJson.properties.forEach(property => validateExtensionProperty(path, extensionName, property));
+    }
+}
+
+/**
+ * Validate an extension property blob according to
+ * interface IRawGalleryExtensionProperty {
+ *     key: string;
+ *     value: string;
+ * }
+ */
+function validateExtensionProperty(path, extensionName, extensionPropertyJson) {
+    if (!extensionPropertyJson.key) {
+        throw new Error(`${path} - ${extensionName} - No key\n${JSON.stringify(extensionPropertyJson)}`)
+    }
+    if (extensionPropertyJson.value === undefined) {
+        throw new Error(`${path} - ${extensionName} - No value\n${JSON.stringify(extensionPropertyJson)}`)
+    }
+}
+
+/**
+ * Validate an extension file blob according to
+ * interface IRawGalleryExtensionFile {
+ *     assetType: string;
+ *     source: string;
+ * }
+ */
+function validateExtensionFile(path, extensionName, extensionFileJson) {
+    if (!extensionFileJson.assetType) {
+        throw new Error(`${path} - ${extensionName} - No assetType\n${JSON.stringify(extensionFileJson)}`)
+    }
+    if (!extensionFileJson.source) {
+        throw new Error(`${path} - ${extensionName} - No source\n${JSON.stringify(extensionFileJson)}`)
+    }
+}
+
+/**
+ * Validate a result metadata blob according to
+ * {
+ *     metadataType: string;
+ *     metadataItems: {
+ *         name: string;
+ *         count: number;
+ * }
+ */
+function validateResultMetadata(path, extensionCount, resultMetadataJson) {
+    if (!resultMetadataJson.metadataType) {
+        throw new Error(`${path} - No metadataType\n${JSON.stringify(resultMetadataJson)}`)
+    }
+    if (!resultMetadataJson.metadataItems || !resultMetadataJson.metadataItems.length) {
+        throw new Error(`${path} - Invalid metadataItems\n${JSON.stringify(resultMetadataJson)}`)
+    }
+    resultMetadataJson.metadataItems.forEach(metadataItem => {
+        if (!metadataItem.name) {
+            throw new Error(`${path} - No name\n${JSON.stringify(metadataItem)}`)
+        }
+        if (metadataItem.count === undefined) {
+            throw new Error(`${path} - No count\n${JSON.stringify(metadataItem)}`)
+        }
+        // Extra check here for validating that the total count of extensions is correct
+        if (metadataItem.name === 'TotalCount' && metadataItem.count !== extensionCount) {
+            throw new Error(`${path} - Invalid TotalCount, this needs to be updated if adding/removing a new extension. Actual count : ${extensionCount}\n${JSON.stringify(metadataItem)}`)
+        }
+    })
+}
+
+validateExtensionGallery(path.join(__dirname, '..', 'extensionsGallery.json'));
+validateExtensionGallery(path.join(__dirname, '..', 'extensionsGallery-insider.json'));


### PR DESCRIPTION
This should help reduce the manual effort in validating the gallery files - I keep finding issues with updates people do to these so automating this is going to be very useful I think.

As the script mentions ideally I would have liked to use the actual code ADS uses to parse it - but I didn't want to spend a whole bunch of time getting the right files and setting up an environment they could run in so I just went for the quick and easy solution. The schema should basically never change so this should be fine.

I also didn't do very specific validation such as making sure certain values are correct - we should consider adding that in too. But I wanted to get this out now and then we can add more updates as we see fit. 