### PR TITLE
bump sts version

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.29",
+	"version": "3.0.0-release.35",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",


### PR DESCRIPTION
bump the STS version to take the fix for the edit data's delete row issue. all of the changes between .29 and .35 are KUSTO service related (https://github.com/microsoft/sqltoolsservice/compare/v3.0.0-release.29...main), I did some sanity check locally and things look good to me.

