### PR TITLE
update welcome page to use context menu service and some code clean up

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -27,13 +27,7 @@ export default () => `
 									<div class="caption-container">
 										<span class="icon xs"></span><h1 class="caption"></h1>
 									</div>
-									<div class="flex btn-container">
-										<div id="dropdown-btn-container" class="btn btn-primary dropdown">
-										</div>
-										<div id="open-file-btn-container" class="btn btn-secondary">
-										</div>
-										<div id="open-folder-btn-container" class="btn btn-secondary">
-										</div>
+									<div id="welcome-page-button-container" class="flex btn-container">
 									</div>
 								</div>
 							</div>

--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -32,6 +32,8 @@ export default () => `
 										</div>
 										<div id="open-file-btn-container" class="btn btn-secondary">
 										</div>
+										<div id="open-folder-btn-container" class="btn btn-secondary">
+										</div>
 									</div>
 								</div>
 							</div>

--- a/src/sql/workbench/contrib/welcome/page/browser/welcomePage.css
+++ b/src/sql/workbench/contrib/welcome/page/browser/welcomePage.css
@@ -154,7 +154,7 @@
 
 .ads-homepage.XS .btn {
 	margin: 0 8px 0 0;
-	width: 77px;
+	min-width: 77px;
 	line-height: 18px
 }
 

--- a/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -353,10 +353,12 @@ class WelcomePage extends Disposable {
 	}
 
 	private createButtons(welcomePageContainer: HTMLElement): void {
-		const container = welcomePageContainer.querySelector('.ads-homepage .hero');
+		const container = welcomePageContainer.querySelector('#welcome-page-button-container');
 
 		// New button, contains a down arrow, invoking the button will open a context menu.
-		const newButtonContainer = welcomePageContainer.querySelector('#dropdown-btn-container') as HTMLElement;
+		const newButtonContainer = document.createElement('div');
+		newButtonContainer.classList.add('btn', 'btn-primary');
+		container.appendChild(newButtonContainer);
 		const newButton = this._register(new Button(newButtonContainer));
 		newButton.label = localize('welcomePage.new', "New");
 		const newButtonHtmlElement = newButton.element;
@@ -375,22 +377,33 @@ class WelcomePage extends Disposable {
 		});
 
 		// Secondary buttons
-		const secondaryButtons = [
+		// We are handling macOS specially here because the same dialog is being used to select both file and folder on macOS.
+		const macSecondaryButtons = [
 			{
-				command: 'workbench.action.files.openFile',
-				title: localize('welcomePage.openFile', "Open file"),
-				containerId: 'open-file-btn-container'
-			},
-			{
-				command: 'workbench.action.files.openFolder',
-				title: localize('welcomePage.openFolder', "Open folder"),
-				containerId: 'open-folder-btn-container'
+				command: 'workbench.action.files.openLocalFileFolder',
+				title: localize('welcomePage.open', "Open…")
 			}
 		];
 
+		const nonMacSecondaryButtons = [
+			{
+				command: 'workbench.action.files.openFile',
+				title: localize('welcomePage.openFile', "Open file…")
+			},
+			{
+				command: 'workbench.action.files.openFolder',
+				title: localize('welcomePage.openFolder', "Open folder…")
+			}
+		];
+
+		const secondaryButtons = document.body.classList.contains('mac') ? macSecondaryButtons : nonMacSecondaryButtons;
+
 		secondaryButtons.forEach(item => {
-			const btnContainer = container.querySelector(`#${item.containerId}`) as HTMLElement;
-			let secondaryButton = this._register(new Button(btnContainer));
+
+			const btnContainer = document.createElement('div');
+			btnContainer.classList.add('btn', 'btn-secondary');
+			container.appendChild(btnContainer);
+			const secondaryButton = this._register(new Button(btnContainer));
 			secondaryButton.label = item.title;
 			secondaryButton.element.classList.add('btn-secondary');
 			secondaryButton.onDidClick(async () => {


### PR DESCRIPTION
This PR fixes #11545

1. use context menu service to show the popup menu
2. fix the open file menu item bug, it is opening file on windows/linux but open folder on mac, since the open folder action doesn't really fall under 'New', I have moved it out as a separate secondary button.
3. cleanup and reorganize the code

this is how the buttons look now and the pop up menu behaves just like other places in ADS, for example the '...' button on the Connections view container.

![image](https://user-images.githubusercontent.com/13777222/94327454-1e637800-ff60-11ea-8a6f-b8eb6042ce9b.png)

on macOS:
<img width="643" alt="Screen Shot 2020-09-25 at 6 28 04 PM" src="https://user-images.githubusercontent.com/13777222/94326986-e73f9780-ff5c-11ea-93ef-5cef3dfe832c.png">
