### PR TITLE
Fix root group name check

### DIFF
--- a/src/sql/platform/connection/common/connectionProfileGroup.ts
+++ b/src/sql/platform/connection/common/connectionProfileGroup.ts
@@ -37,7 +37,7 @@ export class ConnectionProfileGroup extends Disposable implements IConnectionPro
 	) {
 		super();
 		this.parentId = parent ? parent.id : undefined;
-		if (this.name === ConnectionProfileGroup.RootGroupName) {
+		if (ConnectionProfileGroup.isRoot(this.name)) {
 			this.name = '';
 			this.isRoot = true;
 		}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/12587 - casing shouldn't matter for the root group name. Group names aren't case sensitive so users can't add their own groups named root so this is safe. 