### PR TITLE
Allow non-admin BDC connections to see BDC features

### DIFF
--- a/extensions/big-data-cluster/src/bdc.d.ts
+++ b/extensions/big-data-cluster/src/bdc.d.ts
@@ -8,10 +8,30 @@ declare module 'bdc' {
 		getClusterController(url: string, authType: AuthType, username?: string, password?: string): IClusterController;
 	}
 
+	export interface IEndpointModel {
+		name?: string;
+		description?: string;
+		endpoint?: string;
+		protocol?: string;
+	}
+
+	export interface IHttpResponse {
+		method?: string;
+		url?: string;
+		statusCode?: number;
+		statusMessage?: string;
+	}
+
+	export interface IEndPointsResponse {
+		response: IHttpResponse;
+		endPoints: IEndpointModel[];
+	}
+
 	export type AuthType = 'integrated' | 'basic';
 
 	export interface IClusterController {
 		getClusterConfig(): Promise<any>;
 		getKnoxUsername(clusterUsername: string): Promise<string>;
+		getEndPoints(promptConnect?: boolean): Promise<IEndPointsResponse>
 	}
 }

--- a/extensions/big-data-cluster/src/bigDataCluster/controller/apiGenerated.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/controller/apiGenerated.ts
@@ -10,6 +10,7 @@
 
 import localVarRequest = require('request');
 import http = require('http');
+import * as bdc from 'bdc';
 
 let defaultBasePath = 'https://localhost';
 
@@ -203,7 +204,7 @@ export class Dashboards {
     }
 }
 
-export class EndpointModel {
+export class EndpointModel implements bdc.IEndpointModel {
     'name'?: string;
     'description'?: string;
     'endpoint'?: string;

--- a/extensions/big-data-cluster/src/bigDataCluster/dialog/hdfsDialogBase.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/dialog/hdfsDialogBase.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
-import { ClusterController, ControllerError, IEndPointsResponse } from '../controller/clusterControllerApi';
+import { ClusterController, ControllerError } from '../controller/clusterControllerApi';
 import { Deferred } from '../../common/promise';
 import * as loc from '../localizedConstants';
-import { AuthType } from 'bdc';
+import { AuthType, IEndPointsResponse } from 'bdc';
 
 function getAuthCategory(name: AuthType): azdata.CategoryValue {
 	if (name === 'basic') {

--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.35",
+	"version": "3.0.0-release.37",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",

--- a/extensions/mssql/src/dashboard/serviceEndpoints.ts
+++ b/extensions/mssql/src/dashboard/serviceEndpoints.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as azdata from 'azdata';
+import * as bdc from 'bdc';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
@@ -23,15 +24,15 @@ const hyperlinkedEndpoints = [grafanaEndpointName, logsuiEndpointName, sparkHist
 
 export function registerServiceEndpoints(context: vscode.ExtensionContext): void {
 	azdata.ui.registerModelViewProvider('bdc-endpoints', async (view) => {
-		let endpointsArray: Array<utils.IEndpoint> = Object.assign([], utils.getClusterEndpoints(view.serverInfo));
+		let endpointsArray: Array<bdc.IEndpointModel> = Object.assign([], utils.getClusterEndpoints(view.serverInfo));
 
 		if (endpointsArray.length > 0) {
-			const grafanaEp = endpointsArray.find(e => e.serviceName === grafanaEndpointName);
+			const grafanaEp = endpointsArray.find(e => e.name === grafanaEndpointName);
 			if (grafanaEp && grafanaEp.endpoint && grafanaEp.endpoint.indexOf('/d/wZx3OUdmz') === -1) {
 				// Update to have correct URL
 				grafanaEp.endpoint += '/d/wZx3OUdmz';
 			}
-			const kibanaEp = endpointsArray.find(e => e.serviceName === logsuiEndpointName);
+			const kibanaEp = endpointsArray.find(e => e.name === logsuiEndpointName);
 			if (kibanaEp && kibanaEp.endpoint && kibanaEp.endpoint.indexOf('/app/kibana#/discover') === -1) {
 				// Update to have correct URL
 				kibanaEp.endpoint += '/app/kibana#/discover';
@@ -40,13 +41,13 @@ export function registerServiceEndpoints(context: vscode.ExtensionContext): void
 			if (!grafanaEp) {
 				// We are on older CTP, need to manually add some endpoints.
 				// TODO remove once CTP support goes away
-				const managementProxyEp = endpointsArray.find(e => e.serviceName === mgmtProxyName);
+				const managementProxyEp = endpointsArray.find(e => e.name === mgmtProxyName);
 				if (managementProxyEp) {
 					endpointsArray.push(getCustomEndpoint(managementProxyEp, grafanaEndpointName, grafanaDescription, '/grafana/d/wZx3OUdmz'));
 					endpointsArray.push(getCustomEndpoint(managementProxyEp, logsuiEndpointName, logsuiDescription, '/kibana/app/kibana#/discover'));
 				}
 
-				const gatewayEp = endpointsArray.find(e => e.serviceName === 'gateway');
+				const gatewayEp = endpointsArray.find(e => e.name === 'gateway');
 				if (gatewayEp) {
 					endpointsArray.push(getCustomEndpoint(gatewayEp, sparkHistoryEndpointName, sparkHistoryDescription, '/gateway/default/sparkhistory'));
 					endpointsArray.push(getCustomEndpoint(gatewayEp, yarnUiEndpointName, yarnHistoryDescription, '/gateway/default/yarn'));
@@ -54,14 +55,14 @@ export function registerServiceEndpoints(context: vscode.ExtensionContext): void
 			}
 
 			endpointsArray = endpointsArray.map(e => {
-				e.description = getEndpointDisplayText(e.serviceName, e.description);
+				e.description = getEndpointDisplayText(e.name, e.description);
 				return e;
 			});
 
 			// Sort the endpoints. The sort method is that SQL Server Master is first - followed by all
 			// others in alphabetical order by endpoint
-			const sqlServerMasterEndpoints = endpointsArray.filter(e => e.serviceName === Endpoint.sqlServerMaster);
-			endpointsArray = endpointsArray.filter(e => e.serviceName !== Endpoint.sqlServerMaster)
+			const sqlServerMasterEndpoints = endpointsArray.filter(e => e.name === Endpoint.sqlServerMaster);
+			endpointsArray = endpointsArray.filter(e => e.name !== Endpoint.sqlServerMaster)
 				.sort((e1, e2) => e1.endpoint.localeCompare(e2.endpoint));
 			endpointsArray.unshift(...sqlServerMasterEndpoints);
 
@@ -70,7 +71,7 @@ export function registerServiceEndpoints(context: vscode.ExtensionContext): void
 				const endPointRow = view.modelBuilder.flexContainer().withLayout({ flexFlow: 'row' }).component();
 				const nameCell = view.modelBuilder.text().withProperties<azdata.TextComponentProperties>({ value: endpointInfo.description }).component();
 				endPointRow.addItem(nameCell, { CSSStyles: { 'width': '35%', 'font-weight': '600', 'user-select': 'text' } });
-				if (hyperlinkedEndpoints.findIndex(e => e === endpointInfo.serviceName) >= 0) {
+				if (hyperlinkedEndpoints.findIndex(e => e === endpointInfo.name) >= 0) {
 					const linkCell = view.modelBuilder.hyperlink()
 						.withProperties<azdata.HyperlinkComponentProperties>({
 							label: endpointInfo.endpoint,
@@ -111,10 +112,10 @@ export function registerServiceEndpoints(context: vscode.ExtensionContext): void
 	});
 }
 
-function getCustomEndpoint(parentEndpoint: utils.IEndpoint, serviceName: string, description: string, serviceUrl?: string): utils.IEndpoint {
+function getCustomEndpoint(parentEndpoint: bdc.IEndpointModel, serviceName: string, description: string, serviceUrl?: string): bdc.IEndpointModel {
 	if (parentEndpoint) {
-		let endpoint: utils.IEndpoint = {
-			serviceName: serviceName,
+		let endpoint: bdc.IEndpointModel = {
+			name: serviceName,
 			description: description,
 			endpoint: parentEndpoint.endpoint + serviceUrl,
 			protocol: 'https'

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -221,7 +221,7 @@ async function handleOpenNotebookTask(profile: azdata.IConnectionProfile): Promi
 
 async function handleOpenClusterDashboardTask(profile: azdata.IConnectionProfile, appContext: AppContext): Promise<void> {
 	const serverInfo = await azdata.connection.getServerInfo(profile.id);
-	const controller = Utils.getClusterEndpoints(serverInfo).find(e => e.serviceName === Endpoint.controller);
+	const controller = Utils.getClusterEndpoints(serverInfo).find(e => e.name === Endpoint.controller);
 	if (!controller) {
 		vscode.window.showErrorMessage(localize('noController', "Could not find the controller endpoint for this instance"));
 		return;

--- a/extensions/mssql/src/objectExplorerNodeProvider/hdfsCommands.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/hdfsCommands.ts
@@ -406,7 +406,7 @@ export class ManageAccessCommand extends Command {
 		try {
 			let node = await getNode<HdfsFileSourceNode>(context, this.appContext);
 			if (node) {
-				new ManageAccessDialog(node.hdfsPath, node.fileSource).openDialog();
+				new ManageAccessDialog(node.hdfsPath, await node.getFileSource()).openDialog();
 			} else {
 				vscode.window.showErrorMessage(LocalizedConstants.msgMissingNodeContext);
 			}

--- a/extensions/mssql/src/objectExplorerNodeProvider/hdfsProvider.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/hdfsProvider.ts
@@ -52,7 +52,8 @@ export abstract class HdfsFileSourceNode extends TreeNode {
 	}
 
 	public async delete(recursive: boolean = false): Promise<void> {
-		await (await this.getFileSource()).delete(this.hdfsPath, recursive);
+		const fileSource = await this.getFileSource();
+		await fileSource.delete(this.hdfsPath, recursive);
 		// Notify parent should be updated. If at top, will return undefined which will refresh whole tree
 		(<HdfsFileSourceNode>this.parent).onChildRemoved();
 		this.context.changeHandler.notifyNodeChanged(this.parent);
@@ -201,11 +202,6 @@ export class ConnectionNode extends FolderNode {
 		return item;
 	}
 
-	async getChildren(refreshChildren: boolean): Promise<TreeNode[]> {
-		await this.getFileSource();
-		return super.getChildren(refreshChildren);
-	}
-
 	public async getFileSource(): Promise<IFileSource | undefined> {
 		// The node is initially created without a filesource and then one is created only once an action is
 		// taken that requires a connection
@@ -276,12 +272,14 @@ export class FileNode extends HdfsFileSourceNode implements IFileNode {
 	}
 
 	public async getFileContentsAsString(maxBytes?: number): Promise<string> {
-		let contents: Buffer = await (await this.getFileSource()).readFile(this.hdfsPath, maxBytes);
+		const fileSource = await this.getFileSource();
+		let contents: Buffer = await fileSource.readFile(this.hdfsPath, maxBytes);
 		return contents ? contents.toString('utf8') : '';
 	}
 
 	public async getFileLinesAsString(maxLines: number): Promise<string> {
-		let contents: Buffer = await (await this.getFileSource()).readFileLines(this.hdfsPath, maxLines);
+		const fileSource = await this.getFileSource();
+		let contents: Buffer = await fileSource.readFileLines(this.hdfsPath, maxLines);
 		return contents ? contents.toString('utf8') : '';
 	}
 

--- a/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
@@ -277,7 +277,7 @@ class SqlClusterRootNode extends TreeNode {
 		private _treeDataContext: TreeDataContext,
 		private _nodePathValue: string
 	) {
-		super();
+		super(undefined);
 	}
 
 	public get session(): SqlClusterSession {

--- a/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
@@ -13,23 +13,22 @@ import { SqlClusterConnection } from './connection';
 import * as utils from '../utils';
 import { TreeNode } from './treeNodes';
 import { ConnectionNode, TreeDataContext, ITreeChangeHandler } from './hdfsProvider';
-import { IFileSource } from './fileSources';
 import { AppContext } from '../appContext';
 import * as constants from '../constants';
-import * as SqlClusterLookUp from '../sqlClusterLookUp';
 import { ICommandObjectExplorerContext } from './command';
 import { IPrompter, IQuestion, QuestionTypes } from '../prompts/question';
+import { getSqlClusterConnectionParams } from '../sqlClusterLookUp';
 
 export const mssqlOutputChannel = vscode.window.createOutputChannel(constants.providerId);
 
 export class MssqlObjectExplorerNodeProvider extends ProviderBase implements azdata.ObjectExplorerNodeProvider, ITreeChangeHandler {
 	public readonly supportedProviderId: string = constants.providerId;
-	private sessionMap: Map<string, SqlClusterSession>;
+	private clusterSessionMap: Map<string, SqlClusterSession>;
 	private expandCompleteEmitter = new vscode.EventEmitter<azdata.ObjectExplorerExpandInfo>();
 
 	constructor(private prompter: IPrompter, private appContext: AppContext) {
 		super();
-		this.sessionMap = new Map<string, SqlClusterSession>();
+		this.clusterSessionMap = new Map<string, SqlClusterSession>();
 		this.appContext.registerService<MssqlObjectExplorerNodeProvider>(constants.ObjectExplorerService, this);
 	}
 
@@ -49,12 +48,8 @@ export class MssqlObjectExplorerNodeProvider extends ProviderBase implements azd
 		let sqlConnProfile = await azdata.objectexplorer.getSessionConnectionProfile(session.sessionId);
 		if (!sqlConnProfile) { return false; }
 
-		let clusterConnInfo = await SqlClusterLookUp.getSqlClusterConnection(sqlConnProfile);
-		if (!clusterConnInfo) { return false; }
-
-		let clusterConnection = new SqlClusterConnection(clusterConnInfo);
-		let clusterSession = new SqlClusterSession(clusterConnection, session, sqlConnProfile, this.appContext, this);
-		this.sessionMap.set(session.sessionId, clusterSession);
+		let clusterSession = new SqlClusterSession(session, sqlConnProfile, this.appContext, this);
+		this.clusterSessionMap.set(session.sessionId, clusterSession);
 		return true;
 	}
 
@@ -69,7 +64,7 @@ export class MssqlObjectExplorerNodeProvider extends ProviderBase implements azd
 	}
 
 	private async doExpandNode(nodeInfo: azdata.ExpandNodeInfo, isRefresh: boolean = false): Promise<boolean> {
-		let session = this.sessionMap.get(nodeInfo.sessionId);
+		let session = this.clusterSessionMap.get(nodeInfo.sessionId);
 		let response: azdata.ObjectExplorerExpandInfo = {
 			sessionId: nodeInfo.sessionId,
 			nodePath: nodeInfo.nodePath,
@@ -117,20 +112,31 @@ export class MssqlObjectExplorerNodeProvider extends ProviderBase implements azd
 					// Only child returned when failure happens : When failed with 'Unauthorized' error, prompt for password.
 					if (children.length === 1 && this.hasExpansionError(children)) {
 						if (children[0].errorStatusCode === 401) {
+							const sqlClusterConnection = await session.getSqlClusterConnection();
 							// First prompt for username (defaulting to existing username)
-							let username: string = await this.promptInput(localize('promptUsername', "Please provide the username to connect to HDFS:"), session.sqlClusterConnection.user);
+							let username = await this.prompter.promptSingle<string>(<IQuestion>{
+								type: QuestionTypes.input,
+								name: 'inputPrompt',
+								message: localize('promptUsername', "Please provide the username to connect to HDFS:"),
+								default: sqlClusterConnection.user
+							});
 							// Only update the username if it's different than the original (the update functions ignore falsy values)
-							if (username === session.sqlClusterConnection.user) {
+							if (username === sqlClusterConnection.user) {
 								username = '';
 							}
-							session.sqlClusterConnection.updateUsername(username);
+							sqlClusterConnection.updateUsername(username);
 
 							// And then prompt for password
-							const password: string = await this.promptPassword(localize('prmptPwd', "Please provide the password to connect to HDFS:"));
-							session.sqlClusterConnection.updatePassword(password);
+							const password = await this.prompter.promptSingle<string>(<IQuestion>{
+								type: QuestionTypes.password,
+								name: 'passwordPrompt',
+								message: localize('prmptPwd', "Please provide the password to connect to HDFS:"),
+								default: ''
+							});
+							sqlClusterConnection.updatePassword(password);
 
 							if (username || password) {
-								await node.updateFileSource(session.sqlClusterConnection);
+								await node.updateFileSource(sqlClusterConnection);
 								children = await node.getChildren(true);
 							}
 						}
@@ -150,31 +156,13 @@ export class MssqlObjectExplorerNodeProvider extends ProviderBase implements azd
 		this.expandCompleteEmitter.fire(expandResult);
 	}
 
-	private async promptInput(promptMsg: string, defaultValue: string): Promise<string> {
-		return await this.prompter.promptSingle(<IQuestion>{
-			type: QuestionTypes.input,
-			name: 'inputPrompt',
-			message: promptMsg,
-			default: defaultValue
-		}).then(confirmed => <string>confirmed);
-	}
-
-	private async promptPassword(promptMsg: string): Promise<string> {
-		return await this.prompter.promptSingle(<IQuestion>{
-			type: QuestionTypes.password,
-			name: 'passwordPrompt',
-			message: promptMsg,
-			default: ''
-		}).then(confirmed => <string>confirmed);
-	}
-
 	refreshNode(nodeInfo: azdata.ExpandNodeInfo): Thenable<boolean> {
 		// TODO #3815 implement properly
 		return this.expandNode(nodeInfo, true);
 	}
 
 	handleSessionClose(closeSessionInfo: azdata.ObjectExplorerCloseSessionInfo): void {
-		this.sessionMap.delete(closeSessionInfo.sessionId);
+		this.clusterSessionMap.delete(closeSessionInfo.sessionId);
 	}
 
 	findNodes(findNodesInfo: azdata.FindNodesInfo): Thenable<azdata.ObjectExplorerFindNodesResponse> {
@@ -242,7 +230,7 @@ export class MssqlObjectExplorerNodeProvider extends ProviderBase implements azd
 	}
 
 	public findSqlClusterSessionBySqlConnProfile(connectionProfile: azdata.IConnectionProfile): SqlClusterSession {
-		for (let session of this.sessionMap.values()) {
+		for (let session of this.clusterSessionMap.values()) {
 			if (session.isMatchedSqlConnection(connectionProfile)) {
 				return session;
 			}
@@ -251,11 +239,10 @@ export class MssqlObjectExplorerNodeProvider extends ProviderBase implements azd
 	}
 }
 
-class SqlClusterSession {
+export class SqlClusterSession {
 	private _rootNode: SqlClusterRootNode;
-
+	private _sqlClusterConnection: SqlClusterConnection | undefined = undefined;
 	constructor(
-		private _sqlClusterConnection: SqlClusterConnection,
 		private _sqlSession: azdata.ObjectExplorerSession,
 		private _sqlConnectionProfile: azdata.IConnectionProfile,
 		private _appContext: AppContext,
@@ -266,7 +253,13 @@ class SqlClusterSession {
 			this._sqlSession.rootNode.nodePath);
 	}
 
-	public get sqlClusterConnection(): SqlClusterConnection { return this._sqlClusterConnection; }
+	public async getSqlClusterConnection(): Promise<SqlClusterConnection> {
+		if (!this._sqlClusterConnection) {
+			const sqlClusterConnectionParams = await getSqlClusterConnectionParams(this._sqlConnectionProfile);
+			this._sqlClusterConnection = new SqlClusterConnection(sqlClusterConnectionParams);
+		}
+		return this._sqlClusterConnection;
+	}
 	public get sqlSession(): azdata.ObjectExplorerSession { return this._sqlSession; }
 	public get sqlConnectionProfile(): azdata.IConnectionProfile { return this._sqlConnectionProfile; }
 	public get sessionId(): string { return this._sqlSession.sessionId; }
@@ -304,8 +297,8 @@ class SqlClusterRootNode extends TreeNode {
 
 	private async refreshChildren(): Promise<TreeNode[]> {
 		this._children = [];
-		let fileSource: IFileSource = await this.session.sqlClusterConnection.createHdfsFileSource();
-		let hdfsNode = new ConnectionNode(this._treeDataContext, localize('hdfsFolder', "HDFS"), fileSource);
+
+		let hdfsNode = new ConnectionNode(this._treeDataContext, localize('hdfsFolder', "HDFS"), this.session);
 		hdfsNode.parent = this;
 		this._children.push(hdfsNode);
 		return this._children;

--- a/extensions/mssql/src/objectExplorerNodeProvider/treeNodes.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/treeNodes.ts
@@ -13,7 +13,7 @@ type TreeNodePredicate = (node: TreeNode) => boolean;
 
 export abstract class TreeNode implements ITreeNode {
 	private _parent: TreeNode = undefined;
-	protected fileSource: IFileSource;
+	protected fileSource: IFileSource | undefined;
 	private _errorStatusCode: number;
 
 	public get parent(): TreeNode {

--- a/extensions/mssql/src/objectExplorerNodeProvider/treeNodes.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/treeNodes.ts
@@ -13,8 +13,9 @@ type TreeNodePredicate = (node: TreeNode) => boolean;
 
 export abstract class TreeNode implements ITreeNode {
 	private _parent: TreeNode = undefined;
-	protected fileSource: IFileSource | undefined;
 	private _errorStatusCode: number;
+
+	constructor(private _fileSource: IFileSource | undefined) { }
 
 	public get parent(): TreeNode {
 		return this._parent;
@@ -77,8 +78,13 @@ export abstract class TreeNode implements ITreeNode {
 	}
 
 	public async updateFileSource(connection: SqlClusterConnection): Promise<void> {
-		this.fileSource = await connection.createHdfsFileSource();
+		this._fileSource = await connection.createHdfsFileSource();
 	}
+
+	public async getFileSource(): Promise<IFileSource | undefined> {
+		return this._fileSource;
+	}
+
 	/**
 	 * The value to use for this node in the node path
 	 */

--- a/extensions/mssql/src/sparkFeature/dialog/dialogCommands.ts
+++ b/extensions/mssql/src/sparkFeature/dialog/dialogCommands.ts
@@ -38,7 +38,7 @@ export class OpenSparkJobSubmissionDialogCommand extends Command {
 		try {
 			let sqlClusterConnection: SqlClusterConnection = undefined;
 			if (context.type === constants.ObjectExplorerService) {
-				sqlClusterConnection = SqlClusterLookUp.findSqlClusterConnection(context, this.appContext);
+				sqlClusterConnection = await SqlClusterLookUp.findSqlClusterConnection(context, this.appContext);
 			}
 			if (!sqlClusterConnection) {
 				sqlClusterConnection = await this.selectConnection();
@@ -103,7 +103,7 @@ export class OpenSparkJobSubmissionDialogCommand extends Command {
 		let sqlConnection = connectionMap.get(selectedHost);
 		if (!sqlConnection) { throw new Error(errorMsg); }
 
-		let sqlClusterConnection = await SqlClusterLookUp.getSqlClusterConnection(sqlConnection);
+		let sqlClusterConnection = await SqlClusterLookUp.getSqlClusterConnectionParams(sqlConnection);
 		if (!sqlClusterConnection) {
 			throw new Error(localize('errorNotSqlBigDataCluster', "The selected server does not belong to a SQL Server Big Data Cluster"));
 		}
@@ -159,7 +159,7 @@ export class OpenSparkJobSubmissionDialogTask {
 
 	async execute(profile: azdata.IConnectionProfile, ...args: any[]): Promise<void> {
 		try {
-			let sqlClusterConnection = SqlClusterLookUp.findSqlClusterConnection(profile, this.appContext);
+			let sqlClusterConnection = await SqlClusterLookUp.findSqlClusterConnection(profile, this.appContext);
 			if (!sqlClusterConnection) {
 				throw new Error(LocalizedConstants.sparkJobSubmissionNoSqlBigDataClusterFound);
 			}

--- a/extensions/mssql/src/sparkFeature/historyTask.ts
+++ b/extensions/mssql/src/sparkFeature/historyTask.ts
@@ -16,7 +16,7 @@ export class OpenSparkYarnHistoryTask {
 
 	async execute(sqlConnProfile: azdata.IConnectionProfile, isSpark: boolean): Promise<void> {
 		try {
-			let sqlClusterConnection = SqlClusterLookUp.findSqlClusterConnection(sqlConnProfile, this.appContext);
+			let sqlClusterConnection = await SqlClusterLookUp.findSqlClusterConnection(sqlConnProfile, this.appContext);
 			if (!sqlClusterConnection) {
 				let name = isSpark ? 'Spark' : 'Yarn';
 				vscode.window.showErrorMessage(loc.sparkConnectionRequired(name));

--- a/extensions/mssql/src/sqlClusterLookUp.ts
+++ b/extensions/mssql/src/sqlClusterLookUp.ts
@@ -138,7 +138,7 @@ async function getClusterController(controllerEndpoint: string, connInfo: Connec
 	} catch (err) {
 		// Initial username/password failed so prompt user for username password until either user
 		// cancels out or we successfully connect
-		console.log(`Error connecting to cluster controller ${err}`);
+		console.log(`Error connecting to cluster controller: ${err}`);
 		let errorMessage = '';
 		while (true) {
 			const prompter = new CodeAdapter();

--- a/extensions/mssql/src/sqlClusterLookUp.ts
+++ b/extensions/mssql/src/sqlClusterLookUp.ts
@@ -104,6 +104,7 @@ async function createSqlClusterConnInfo(sqlConnInfo: azdata.IConnectionProfile |
 			clusterConnInfo.options[constants.userPropName] = await clusterController.getKnoxUsername(clusterConnInfo.options[constants.userPropName]);
 		} catch (err) {
 			console.log(`Unexpected error getting Knox username for SQL Cluster connection: ${err}`);
+			throw err;
 		}
 	} else {
 		clusterController = await getClusterController(controllerEndpoint.endpoint, clusterConnInfo);
@@ -147,14 +148,18 @@ async function getClusterController(controllerEndpoint: string, connInfo: Connec
 				message: localize('promptBDCUsername', "{0}Please provide the username to connect to the BDC Controller:", errorMessage),
 				default: connInfo.options[constants.userPropName]
 			});
+			if (!username) {
+				console.log(`User cancelled out of username prompt for BDC Controller`);
+				break;
+			}
 			const password = await prompter.promptSingle<string>(<IQuestion>{
 				type: QuestionTypes.password,
 				name: 'passwordPrompt',
 				message: localize('promptBDCPassword', "Please provide the password to connect to the BDC Controller"),
 				default: ''
 			});
-			if (!username || !password) {
-				console.log(`User cancelled out of username/password prompt for BDC Controller`);
+			if (!password) {
+				console.log(`User cancelled out of password prompt for BDC Controller`);
 				break;
 			}
 			const controller = bdcApi.getClusterController(controllerEndpoint, authType, username, password);
@@ -168,7 +173,7 @@ async function getClusterController(controllerEndpoint: string, connInfo: Connec
 				errorMessage = localize('bdcConnectError', "Error: {0}. ", err.message ?? err);
 			}
 		}
-		throw new Error(localize('usernameAndPasswordRequired', "Username and password are required to connect to the BDC Controller"));
+		throw new Error(localize('usernameAndPasswordRequired', "Username and password are required"));
 	}
 
 }

--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -5,6 +5,7 @@
 
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
+import * as bdc from 'bdc';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import * as os from 'os';
@@ -222,15 +223,15 @@ export function getUserHome(): string {
 	return process.env.HOME || process.env.USERPROFILE;
 }
 
-export function getClusterEndpoints(serverInfo: azdata.ServerInfo): IEndpoint[] | undefined {
+export function getClusterEndpoints(serverInfo: azdata.ServerInfo): bdc.IEndpointModel[] | undefined {
 	let endpoints: RawEndpoint[] = serverInfo.options[constants.clusterEndpointsProperty];
 	if (!endpoints || endpoints.length === 0) { return []; }
 
 	return endpoints.map(e => {
 		// If endpoint is missing, we're on CTP bits. All endpoints from the CTP serverInfo should be treated as HTTPS
 		let endpoint = e.endpoint ? e.endpoint : `https://${e.ipAddress}:${e.port}`;
-		let updatedEndpoint: IEndpoint = {
-			serviceName: e.serviceName,
+		let updatedEndpoint: bdc.IEndpointModel = {
+			name: e.serviceName,
 			description: e.description,
 			endpoint: endpoint,
 			protocol: e.protocol
@@ -264,13 +265,6 @@ interface RawEndpoint {
 	protocol?: string;
 	ipAddress?: string;
 	port?: number;
-}
-
-export interface IEndpoint {
-	serviceName: string;
-	description: string;
-	endpoint: string;
-	protocol: string;
 }
 
 export function isValidNumber(maybeNumber: any) {

--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -305,6 +305,8 @@ export class JupyterSession implements nb.ISession {
 						connectionProfile.options[USER] = await controller.getKnoxUsername(connectionProfile.userName);
 					} catch (err) {
 						console.log(`Unexpected error getting Knox username for Spark kernel: ${err}`);
+						// Optimistically use the SQL login name - that's going to normally be the case after CU5
+						connectionProfile.options[USER] = connectionProfile.userName;
 					}
 				}
 			}

--- a/extensions/notebook/src/test/model/sessionManager.test.ts
+++ b/extensions/notebook/src/test/model/sessionManager.test.ts
@@ -27,6 +27,12 @@ export class TestClusterController implements bdc.IClusterController {
 	getKnoxUsername(clusterUsername: string): Promise<string> {
 		return Promise.resolve('knoxUsername');
 	}
+	getEndPoints(promptConnect?: boolean): Promise<bdc.IEndPointsResponse> {
+		return Promise.resolve( {
+			response: undefined,
+			endPoints: []
+		});
+	}
 }
 
 describe('Jupyter Session Manager', function (): void {


### PR DESCRIPTION
For https://sqlhelsinki.visualstudio.com/aris/_workitems/edit/11806

Logins who didn't have access to the sys.dm_cluster_endpoints weren't seeing any BDC related items (HDFS folder node, BDC tab on dashboard) - even though the logins are separate and so shouldn't be tied to each other.

To support this a SERVERPROPERTY was added 'ControllerEndpoint' that can be queried for the controller endpoint. SqlToolsService was updated to use this server property if the DMV is not able to be accessed already - this PR is for updating ADS to handle the new authentication flow that is required.

The first big change is that now we don't try to connect to HDFS until the node is expanded - this prevents the username/password inputs from popping up until the node is attempted to be expanded.

Next - we now go through this flow for users attempting to expand the node :

1. Get controller endpoint from server property
1. Connect to controller using sql login/password
1. If that fails then prompt user for username/password
1. Once that succeeds determine the username to use for HDFS (root is used for older CUs) and the HDFS endpoint if needed
1. Try to log in to the HDFS endpoint with the same username/password as the controller - this is expected to succeed since they don't currently support multiple logins there. But in case it doesn't then we will prompt the user for the HDFS username/password.

Note that currently I'm not storing the username/password values so users will have to re-enter them each time they try to connect. I will be following up with a separate PR to add this functionality in to keep the PRs smaller.  

Experience with normal admin connection (username/password for sql same as Controller/HDFS) : 

![Admin](https://user-images.githubusercontent.com/28519865/94591132-7b9b4a00-023c-11eb-8fbb-a685d7770179.gif)

Experience with non-admin connection (username/password for sql different than Controller/HDFS)

![NonAdmin](https://user-images.githubusercontent.com/28519865/94591423-ef3d5700-023c-11eb-8f39-e9592af2eebd.gif)
