### PR TITLE
Save username/password for BDC HDFS connections

### DIFF
--- a/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
@@ -255,7 +255,7 @@ export class SqlClusterSession {
 
 	public async getSqlClusterConnection(): Promise<SqlClusterConnection> {
 		if (!this._sqlClusterConnection) {
-			const sqlClusterConnectionParams = await getSqlClusterConnectionParams(this._sqlConnectionProfile);
+			const sqlClusterConnectionParams = await getSqlClusterConnectionParams(this._sqlConnectionProfile, this._appContext);
 			this._sqlClusterConnection = new SqlClusterConnection(sqlClusterConnectionParams);
 		}
 		return this._sqlClusterConnection;

--- a/extensions/mssql/src/sparkFeature/dialog/dialogCommands.ts
+++ b/extensions/mssql/src/sparkFeature/dialog/dialogCommands.ts
@@ -103,7 +103,7 @@ export class OpenSparkJobSubmissionDialogCommand extends Command {
 		let sqlConnection = connectionMap.get(selectedHost);
 		if (!sqlConnection) { throw new Error(errorMsg); }
 
-		let sqlClusterConnection = await SqlClusterLookUp.getSqlClusterConnectionParams(sqlConnection);
+		let sqlClusterConnection = await SqlClusterLookUp.getSqlClusterConnectionParams(sqlConnection, this.appContext);
 		if (!sqlClusterConnection) {
 			throw new Error(localize('errorNotSqlBigDataCluster', "The selected server does not belong to a SQL Server Big Data Cluster"));
 		}

--- a/extensions/mssql/src/sqlClusterLookUp.ts
+++ b/extensions/mssql/src/sqlClusterLookUp.ts
@@ -101,7 +101,9 @@ async function createSqlClusterConnInfo(sqlConnInfo: azdata.IConnectionProfile |
 		const savedUsername = appContext.extensionContext.globalState.get(usernameKey);
 		const credentialProvider = await azdata.credentials.getProvider('mssql.bdc.password');
 		const savedPassword = (await credentialProvider.readCredential(connectionId)).password;
-		clusterConnInfo.options[constants.userPropName] = savedUsername ?? sqlConnInfo.options[constants.userPropName]; //should be the same user as sql master
+		// If we don't have a previously saved username/password then use the SQL connection credentials as a best guess,
+		// if those don't work then we'll prompt the user for the info
+		clusterConnInfo.options[constants.userPropName] = savedUsername ?? sqlConnInfo.options[constants.userPropName];
 		clusterConnInfo.options[constants.passwordPropName] = savedPassword ?? credentials.password;
 		try {
 			clusterController = await getClusterController(controllerEndpoint.endpoint, clusterConnInfo);


### PR DESCRIPTION
Final part of https://sqlhelsinki.visualstudio.com/aris/_workitems/edit/11806 - save the username/password for the BDC/HDFS connections so we don't re-prompt users each time. 