### PR TITLE
Update SSDT projects opened in projects viewlet

### DIFF
--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -84,29 +84,6 @@ export default class MainController implements vscode.Disposable {
 	}
 
 	/**
-	 * Prompts the user to select a .sqlproj file to open
-	 * TODO: define behavior once projects are automatically opened from workspace
-	 */
-	public async openProjectFromFile(): Promise<void> {
-		try {
-			let filter: { [key: string]: string[] } = {};
-
-			filter[constants.sqlDatabaseProject] = ['sqlproj'];
-
-			let files: vscode.Uri[] | undefined = await vscode.window.showOpenDialog({ filters: filter });
-
-			if (files) {
-				for (const file of files) {
-					await this.projectsController.openProject(file);
-				}
-			}
-		}
-		catch (err) {
-			vscode.window.showErrorMessage(getErrorMessage(err));
-		}
-	}
-
-	/**
 	 * Creates a new SQL database project from a template, prompting the user for a name and location
 	 */
 	public async createNewProject(): Promise<Project | undefined> {

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -49,6 +49,7 @@ export class Project {
 	public static async openProject(projectFilePath: string): Promise<Project> {
 		const proj = new Project(projectFilePath);
 		await proj.readProjFile();
+		await proj.updateProjectForRoundTrip();
 
 		return proj;
 	}
@@ -176,11 +177,27 @@ export class Project {
 		this.projFileXmlDoc = undefined;
 	}
 
-	public async updateProjectForRoundTrip() {
-		await fs.copyFile(this.projectFilePath, this.projectFilePath + '_backup');
-		await this.updateImportToSupportRoundTrip();
-		await this.updatePackageReferenceInProjFile();
-		await this.updateAfterCleanTargetInProjFile();
+	public async updateProjectForRoundTrip(): Promise<void> {
+		if (this.importedTargets.includes(constants.NetCoreTargets) && !this.containsSSDTOnlySystemDatabaseReferences()) {
+			return;
+		}
+
+		if (!this.importedTargets.includes(constants.NetCoreTargets)) {
+			const result = await window.showWarningMessage(constants.updateProjectForRoundTrip, constants.yesString, constants.noString);
+			if (result === constants.yesString) {
+				await fs.copyFile(this.projectFilePath, this.projectFilePath + '_backup');
+				await this.updateImportToSupportRoundTrip();
+				await this.updatePackageReferenceInProjFile();
+				await this.updateAfterCleanTargetInProjFile();
+				await this.updateSystemDatabaseReferencesInProjFile();
+			}
+		} else if (this.containsSSDTOnlySystemDatabaseReferences()) {
+			const result = await window.showWarningMessage(constants.updateProjectDatabaseReferencesForRoundTrip, constants.yesString, constants.noString);
+			if (result === constants.yesString) {
+				await fs.copyFile(this.projectFilePath, this.projectFilePath + '_backup');
+				await this.updateSystemDatabaseReferencesInProjFile();
+			}
+		}
 	}
 
 	private async updateImportToSupportRoundTrip(): Promise<void> {

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -89,21 +89,6 @@ describe('ProjectsController', function (): void {
 				should(project.dataSources.length).equal(3); // detailed datasources tests in their own test file
 			});
 
-			it('Should load both project and referenced project', async function (): Promise<void> {
-				// setup test projects
-				const folderPath = await testUtils.generateTestFolderPath();
-				await fs.mkdir(path.join(folderPath, 'proj1'));
-				await fs.mkdir(path.join(folderPath, 'ReferencedProject'));
-
-				const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.openProjectWithProjectReferencesBaseline, path.join(folderPath, 'proj1'));
-				await testUtils.createTestSqlProjFile(baselines.openProjectFileBaseline, path.join(folderPath, 'ReferencedProject'));
-
-				const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
-				await projController.openProject(vscode.Uri.file(sqlProjPath));
-
-				should(projController.projects.length).equal(2, 'Referenced project should have been opened when the project referencing it was opened');
-			});
-
 			it('Should not keep failed to load project in project list.', async function (): Promise<void> {
 				const folderPath = await testUtils.generateTestFolderPath();
 				const sqlProjPath = await testUtils.createTestSqlProjFile('empty file with no valid xml', folderPath);


### PR DESCRIPTION
This PR fixes #12601. Moved the update SSDT projects out of projectsController.ts and into project.ts so that it happens when the project gets opened by the projectProvider used by the data-workspace extension. I also removed other code that isn't being used anymore now that there's the projects viewlet(opening project from file, opening referenced projects, focusing on opened project)
