### PR TITLE
Fix error when clicking empty dropdown

### DIFF
--- a/product.json
+++ b/product.json
@@ -76,7 +76,7 @@
 	"builtInExtensions": [
 		{
 			"name": "Microsoft.sqlservernotebook",
-			"version": "0.3.7",
+			"version": "0.3.8",
 			"repo": "https://github.com/Microsoft/azuredatastudio"
 		}
 	],

--- a/product.json
+++ b/product.json
@@ -76,7 +76,7 @@
 	"builtInExtensions": [
 		{
 			"name": "Microsoft.sqlservernotebook",
-			"version": "0.3.8",
+			"version": "0.3.7",
 			"repo": "https://github.com/Microsoft/azuredatastudio"
 		}
 	],

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -715,8 +715,8 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 				}
 			});
 
+			container.innerHTML = this.options[longest]?.text + (!!this.options[longest]?.decoratorRight ? (this.options[longest].decoratorRight + ' ') : ''); // {{ SQL CARBON EDIT }} Don't error if no option found (empty list)
 
-			container.innerHTML = this.options[longest].text + (!!this.options[longest].decoratorRight ? (this.options[longest].decoratorRight + ' ') : '');
 
 			elementWidth = dom.getTotalWidth(container);
 		}


### PR DESCRIPTION
When clicking on empty dropdown this error would show up in the console

```
TypeError: Cannot read property 'text' of undefined
    at SelectBoxList.setWidthControlElement (file:///C:/src/AzureDataStudio/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:547:61)
```

(since there's no options the "longest" one is undefined)

We really probably should always be showing an option - even if it's just `Loading...` or `No items found` or something similar. But we don't always do this and making it so an error isn't thrown in those cases seems like a safe thing to do anyways. 