### PR TITLE
Only allow one arc controller connection

### DIFF
--- a/extensions/arc/src/extension.ts
+++ b/extensions/arc/src/extension.ts
@@ -26,6 +26,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<arc.IE
 	});
 
 	vscode.commands.registerCommand('arc.connectToController', async () => {
+		const nodes = await treeDataProvider.getChildren();
+		if (nodes.length > 0) {
+			const response = await vscode.window.showErrorMessage(loc.onlyOneControllerSupported, loc.yes, loc.no);
+			if (response !== loc.yes) {
+				return;
+			}
+			await treeDataProvider.removeController(nodes[0] as ControllerTreeNode);
+		}
 		const dialog = new ConnectToControllerDialog(treeDataProvider);
 		dialog.showDialog();
 		const model = await dialog.waitForClose();

--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -167,3 +167,4 @@ export function errorConnectingToController(error: any): string { return localiz
 export function passwordAcquisitionFailed(error: any): string { return localize('arc.passwordAcquisitionFailed', "Failed to acquire password. {0}", getErrorMessage(error)); }
 export const invalidPassword = localize('arc.invalidPassword', "The password did not work, try again.");
 export function errorVerifyingPassword(error: any): string { return localize('arc.errorVerifyingPassword', "Error encountered while verifying password. {0}", getErrorMessage(error)); }
+export const onlyOneControllerSupported = localize('arc.onlyOneControllerSupported', "Only one controller connection is currently supported at this time. Do you wish to remove the existing connection and add a new one?");


### PR DESCRIPTION
I want to avoid someone hitting an issue with the controller connections not being able to handle multiple clusters at the moment so doing this for now. 

This isn't perfect (users can still modify the kube config and we'd never know) but it should prevent the easiest errors to hit. 