### PR TITLE
version bump of flat file services

### DIFF
--- a/extensions/import/config.json
+++ b/extensions/import/config.json
@@ -1,7 +1,7 @@
 {
 	"downloadUrl": "https://sqlopsextensions.blob.core.windows.net/extensions/import/service/{#version#}/{#fileName#}",
 	"useDefaultLinuxRuntime": true,
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"downloadFileNames": {
 		"Windows_64": "win-x64.zip",
 		"Windows_86": "win-x86.zip",


### PR DESCRIPTION
This PR bumps up the flat file service version. It includes an updated version of Prose (7.20.0) that fixes the bug which skips backslashes in the import data. 


This PR fixes #12593 
