### PR TITLE
Fix adding project references in projects viewlet

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
 import * as constants from './constants';
 import * as path from 'path';
 import * as glob from 'fast-glob';
+import * as dataworkspace from 'dataworkspace';
 import { promises as fs } from 'fs';
 
 /**
@@ -227,4 +228,12 @@ export async function getSqlProjectFilesInFolder(folderPath: string): Promise<st
 	const results = await glob(sqlprojFilter);
 
 	return results;
+}
+
+/**
+ * Get all the projects in the workspace that are sqlproj
+ */
+export function getSqlProjectsInWorkspace(): vscode.Uri[] {
+	return (<dataworkspace.IExtension>vscode.extensions.getExtension(dataworkspace.extension.name)?.exports).getProjectsInWorkspace()
+		.filter((p: vscode.Uri) => path.parse(p.fsPath).ext === constants.sqlprojExtension);
 }

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -495,7 +495,8 @@ export class ProjectsController {
 			if ((<IProjectReferenceSettings>settings).projectName !== undefined) {
 				// get project path and guid
 				const projectReferenceSettings = settings as IProjectReferenceSettings;
-				const referencedProject = this.projects.find(p => p.projectFileName === projectReferenceSettings.projectName);
+				const workspaceProjects = utils.getSqlProjectsInWorkspace();
+				const referencedProject = await Project.openProject(workspaceProjects.filter(p => path.parse(p.fsPath).name === projectReferenceSettings.projectName)[0].fsPath);
 				const relativePath = path.relative(project.projectFolderPath, referencedProject?.projectFilePath!);
 				projectReferenceSettings.projectRelativePath = vscode.Uri.file(relativePath);
 				projectReferenceSettings.projectGuid = referencedProject?.projectGuid!;

--- a/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/addDatabaseReferenceDialog.ts
@@ -5,7 +5,6 @@
 
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
-import * as dataworkspace from 'dataworkspace';
 import * as path from 'path';
 import * as constants from '../common/constants';
 import * as utils from '../common/utils';
@@ -263,8 +262,7 @@ export class AddDatabaseReferenceDialog {
 		});
 
 		// get projects in workspace and filter to only sql projects
-		let projectFiles: vscode.Uri[] = (<dataworkspace.IExtension>vscode.extensions.getExtension(dataworkspace.extension.name)?.exports).getProjectsInWorkspace()
-			.filter((p: vscode.Uri) => path.parse(p.fsPath).ext === constants.sqlprojExtension);
+		let projectFiles: vscode.Uri[] = utils.getSqlProjectsInWorkspace();
 
 		// filter out current project
 		projectFiles = projectFiles.filter(p => p.fsPath !== this.project.projectFilePath);


### PR DESCRIPTION
Because projects aren't being kept track of in the ProjectsController anymore, the adding a project reference code needs to be updated to look for the referenced project in the workspace projects now. 