### PR TITLE
Fix notebook issue when creating Kusto notebooks 2nd time after launching ADS

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -846,8 +846,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			if (newConnection) {
 				if (newConnection.serverCapabilities?.notebookKernelAlias) {
 					this._currentKernelAlias = newConnection.serverCapabilities.notebookKernelAlias;
-					let sqlConnectionProvider = this._kernelDisplayNameToConnectionProviderIds.get('SQL');
-					this._kernelDisplayNameToConnectionProviderIds.set('SQL', sqlConnectionProvider);
 					this._kernelDisplayNameToConnectionProviderIds.set(newConnection.serverCapabilities.notebookKernelAlias, [newConnection.providerName]);
 				}
 				this._activeConnection = newConnection;

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -847,10 +847,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				if (newConnection.serverCapabilities?.notebookKernelAlias) {
 					this._currentKernelAlias = newConnection.serverCapabilities.notebookKernelAlias;
 					let sqlConnectionProvider = this._kernelDisplayNameToConnectionProviderIds.get('SQL');
-					let index = sqlConnectionProvider.indexOf(newConnection.serverCapabilities.notebookKernelAlias.toUpperCase());
-					if (index > -1) {
-						sqlConnectionProvider.splice(index, 1);
-					}
 					this._kernelDisplayNameToConnectionProviderIds.set('SQL', sqlConnectionProvider);
 					this._kernelDisplayNameToConnectionProviderIds.set(newConnection.serverCapabilities.notebookKernelAlias, [newConnection.providerName]);
 				}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
Currently, notebooks doesn't work properly (query and intellisense part) for Kusto clusters after opening first notebook from the Kusto database right click option. This was happening because "Kusto" was getting removed from the list of connectionProvidersIds after loading correct Kusto notebook for the first time, so it was getting default sql config.
