### PR TITLE
Remove old projects tree provider

### DIFF
--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -10,7 +10,6 @@ import * as constants from '../common/constants';
 import * as path from 'path';
 import * as newProjectTool from '../tools/newProjectTool';
 
-import { SqlDatabaseProjectTreeViewProvider } from './databaseProjectTreeViewProvider';
 import { getErrorMessage } from '../common/utils';
 import { ProjectsController } from './projectController';
 import { NetCoreTool } from '../tools/netcoreTool';
@@ -23,12 +22,11 @@ import { SqlDatabaseProjectProvider } from '../projectProvider/projectProvider';
  * The main controller class that initializes the extension
  */
 export default class MainController implements vscode.Disposable {
-	protected dbProjectTreeViewProvider: SqlDatabaseProjectTreeViewProvider = new SqlDatabaseProjectTreeViewProvider();
 	protected projectsController: ProjectsController;
 	protected netcoreTool: NetCoreTool;
 
 	public constructor(private context: vscode.ExtensionContext) {
-		this.projectsController = new ProjectsController(this.dbProjectTreeViewProvider);
+		this.projectsController = new ProjectsController();
 		this.netcoreTool = new NetCoreTool();
 	}
 

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -46,8 +46,8 @@ export class ProjectsController {
 		this.buildHelper = new BuildHelper();
 	}
 
-	public refreshProjectsTree(treeProvider: vscode.TreeDataProvider<any>) {
-		(treeProvider as SqlDatabaseProjectTreeViewProvider).notifyTreeDataChanged();
+	public refreshProjectsTree(workspaceTreeItem: dataworkspace.WorkspaceTreeItem) {
+		(workspaceTreeItem.treeDataProvider as SqlDatabaseProjectTreeViewProvider).notifyTreeDataChanged();
 	}
 
 	public async openProject(projectFile: vscode.Uri): Promise<Project> {
@@ -261,7 +261,7 @@ export class ProjectsController {
 			}
 
 			await project.addFolderItem(relativeFolderPath);
-			this.refreshProjectsTree(treeNode.treeDataProvider);
+			this.refreshProjectsTree(treeNode);
 		} catch (err) {
 			vscode.window.showErrorMessage(utils.getErrorMessage(err));
 		}
@@ -337,7 +337,7 @@ export class ProjectsController {
 			vscode.window.showErrorMessage(constants.unableToPerformAction(constants.excludeAction, node.uri.path));
 		}
 
-		this.refreshProjectsTree(context.treeDataProvider);
+		this.refreshProjectsTree(context);
 	}
 
 	public async delete(context: dataworkspace.WorkspaceTreeItem): Promise<void> {
@@ -364,7 +364,7 @@ export class ProjectsController {
 		}
 
 		if (success) {
-			this.refreshProjectsTree(context.treeDataProvider);
+			this.refreshProjectsTree(context);
 		} else {
 			vscode.window.showErrorMessage(constants.unableToPerformAction(constants.deleteAction, node.uri.path));
 		}
@@ -434,7 +434,7 @@ export class ProjectsController {
 		if (project) {
 			// won't open any newly referenced projects, but otherwise matches the behavior of reopening the project
 			await project.readProjFile();
-			this.refreshProjectsTree(context.treeDataProvider);
+			this.refreshProjectsTree(context);
 		} else {
 			throw new Error(constants.invalidProjectReload);
 		}
@@ -448,14 +448,14 @@ export class ProjectsController {
 		const project = this.getProjectFromContext(context);
 
 		const addDatabaseReferenceDialog = this.getAddDatabaseReferenceDialog(project);
-		addDatabaseReferenceDialog.addReference = async (proj, prof) => await this.addDatabaseReferenceCallback(proj, prof, (<dataworkspace.WorkspaceTreeItem>context).treeDataProvider);
+		addDatabaseReferenceDialog.addReference = async (proj, prof) => await this.addDatabaseReferenceCallback(proj, prof, context as dataworkspace.WorkspaceTreeItem);
 
 		addDatabaseReferenceDialog.openDialog();
 
 		return addDatabaseReferenceDialog;
 	}
 
-	public async addDatabaseReferenceCallback(project: Project, settings: ISystemDatabaseReferenceSettings | IDacpacReferenceSettings | IProjectReferenceSettings, treeDataProvider: vscode.TreeDataProvider<BaseProjectTreeItem>): Promise<void> {
+	public async addDatabaseReferenceCallback(project: Project, settings: ISystemDatabaseReferenceSettings | IDacpacReferenceSettings | IProjectReferenceSettings, context: dataworkspace.WorkspaceTreeItem): Promise<void> {
 		try {
 			if ((<IProjectReferenceSettings>settings).projectName !== undefined) {
 				// get project path and guid
@@ -482,7 +482,7 @@ export class ProjectsController {
 				await project.addDatabaseReference(<IDacpacReferenceSettings>settings);
 			}
 
-			this.refreshProjectsTree(treeDataProvider);
+			this.refreshProjectsTree(context);
 		} catch (err) {
 			vscode.window.showErrorMessage(utils.getErrorMessage(err));
 		}

--- a/extensions/sql-database-projects/src/models/dataSources/dataSources.ts
+++ b/extensions/sql-database-projects/src/models/dataSources/dataSources.ts
@@ -5,7 +5,6 @@
 
 import { promises as fs } from 'fs';
 import * as constants from '../../common/constants';
-import { SqlConnectionDataSource } from './sqlConnectionStringSource';
 
 /**
  * Abstract class for a datasource in a project
@@ -53,11 +52,11 @@ export async function load(dataSourcesFilePath: string): Promise<DataSource[]> {
 	// TODO: do we have a construct for parsing version numbers?
 	switch (rawJsonContents.version) {
 		case '0.0.0':
-			const dataSources: DataSourceFileJson = rawJsonContents as DataSourceFileJson;
+			// const dataSources: DataSourceFileJson = rawJsonContents as DataSourceFileJson;
 
-			for (const source of dataSources.datasources) {
-				output.push(createDataSource(source));
-			}
+			// for (const source of dataSources.datasources) {
+			// 	output.push(createDataSource(source));
+			// }
 
 			break;
 		default:
@@ -70,11 +69,12 @@ export async function load(dataSourcesFilePath: string): Promise<DataSource[]> {
 /**
  * Creates DataSource object from JSON
  */
-function createDataSource(json: DataSourceJson): DataSource {
-	switch (json.type) {
-		case SqlConnectionDataSource.type:
-			return SqlConnectionDataSource.fromJson(json);
-		default:
-			throw new Error(constants.unknownDataSourceType + json.type);
-	}
-}
+// Commenting this out because circular dependency with SqlConnectionDataSource was causing extension to not activate
+// function createDataSource(json: DataSourceJson): DataSource {
+// 	switch (json.type) {
+// 		case SqlConnectionDataSource.type:
+// 			return SqlConnectionDataSource.fromJson(json);
+// 		default:
+// 			throw new Error(constants.unknownDataSourceType + json.type);
+// 	}
+// }

--- a/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
@@ -14,7 +14,6 @@ import * as TypeMoq from 'typemoq';
 
 import { PublishDatabaseDialog } from '../../dialogs/publishDatabaseDialog';
 import { Project } from '../../models/project';
-import { SqlDatabaseProjectTreeViewProvider } from '../../controllers/databaseProjectTreeViewProvider';
 import { ProjectsController } from '../../controllers/projectController';
 import { IPublishSettings, IGenerateScriptSettings } from '../../models/IPublishSettings';
 
@@ -25,7 +24,7 @@ describe.skip('Publish Database Dialog', () => {
 	});
 
 	it('Should open dialog successfully ', async function (): Promise<void> {
-		const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+		const projController = new ProjectsController();
 		const projFileDir = path.join(os.tmpdir(), `TestProject_${new Date().getTime()}`);
 
 		const projFilePath = await projController.createNewProject('TestProjectName', vscode.Uri.file(projFileDir), true, 'BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575');
@@ -36,7 +35,7 @@ describe.skip('Publish Database Dialog', () => {
 	});
 
 	it('Should create default database name correctly ', async function (): Promise<void> {
-		const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+		const projController = new ProjectsController();
 		const projFolder = `TestProject_${new Date().getTime()}`;
 		const projFileDir = path.join(os.tmpdir(), projFolder);
 

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -573,7 +573,7 @@ describe('ProjectsController', function (): void {
 				projectRelativePath: undefined,
 				suppressMissingDependenciesErrors: false
 			},
-			new SqlDatabaseProjectTreeViewProvider());
+				new SqlDatabaseProjectTreeViewProvider());
 			should(showErrorMessageSpy.called).be.true('showErrorMessage should have been called');
 		});
 

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -10,6 +10,7 @@ import * as azdata from 'azdata';
 import * as vscode from 'vscode';
 import * as TypeMoq from 'typemoq';
 import * as sinon from 'sinon';
+import * as dataworkspace from 'dataworkspace';
 import * as baselines from './baselines/baselines';
 import * as templates from '../templates/templates';
 import * as testUtils from './testUtils';
@@ -65,7 +66,7 @@ describe('ProjectsController', function (): void {
 	describe('project controller operations', function (): void {
 		describe('Project file operations and prompting', function (): void {
 			it('Should create new sqlproj file with correct values', async function (): Promise<void> {
-				const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+				const projController = new ProjectsController();
 				const projFileDir = path.join(os.tmpdir(), `TestProject_${new Date().getTime()}`);
 
 				const projFilePath = await projController.createNewProject('TestProjectName', vscode.Uri.file(projFileDir), false, 'BA5EBA11-C0DE-5EA7-ACED-BABB1E70A575');
@@ -81,18 +82,18 @@ describe('ProjectsController', function (): void {
 				const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.openProjectFileBaseline, folderPath);
 				await testUtils.createTestDataSources(baselines.openDataSourcesBaseline, folderPath);
 
-				const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+				const projController = new ProjectsController();
 
 				const project = await projController.openProject(vscode.Uri.file(sqlProjPath));
 
 				should(project.files.length).equal(9); // detailed sqlproj tests in their own test file
-				should(project.dataSources.length).equal(3); // detailed datasources tests in their own test file
+				// should(project.dataSources.length).equal(3); // detailed datasources tests in their own test file
 			});
 
 			it('Should not keep failed to load project in project list.', async function (): Promise<void> {
 				const folderPath = await testUtils.generateTestFolderPath();
 				const sqlProjPath = await testUtils.createTestSqlProjFile('empty file with no valid xml', folderPath);
-				const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+				const projController = new ProjectsController();
 
 				try {
 					await projController.openProject(vscode.Uri.file(sqlProjPath));
@@ -107,7 +108,7 @@ describe('ProjectsController', function (): void {
 				for (const name of ['', '    ', undefined]) {
 					const showInputBoxStub = sinon.stub(vscode.window, 'showInputBox').resolves(name);
 					const showErrorMessageSpy = sinon.spy(vscode.window, 'showErrorMessage');
-					const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+					const projController = new ProjectsController();
 					const project = new Project('FakePath');
 
 					should(project.files.length).equal(0);
@@ -123,7 +124,7 @@ describe('ProjectsController', function (): void {
 				const tableName = 'table1';
 				sinon.stub(vscode.window, 'showInputBox').resolves(tableName);
 				const spy = sinon.spy(vscode.window, 'showErrorMessage');
-				const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+				const projController = new ProjectsController();
 				const project = await testUtils.createTestProject(baselines.newProjectFileBaseline);
 
 				should(project.files.length).equal(0, 'There should be no files');
@@ -139,14 +140,13 @@ describe('ProjectsController', function (): void {
 				const folderName = 'folder1';
 				const stub = sinon.stub(vscode.window, 'showInputBox').resolves(folderName);
 
-				const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+				const projController = new ProjectsController();
 				const project = await testUtils.createTestProject(baselines.newProjectFileBaseline);
 				const projectRoot = new ProjectRootTreeItem(project);
 
 				should(project.files.length).equal(0, 'There should be no other folders');
-				await projController.addFolderPrompt(projectRoot);
+				await projController.addFolderPrompt(createWorkspaceTreeItem(projectRoot));
 				should(project.files.length).equal(1, 'Folder should be successfully added');
-				projController.refreshProjectsTree();
 				stub.restore();
 				await verifyFolderNotAdded(folderName, projController, project, projectRoot);
 
@@ -160,7 +160,7 @@ describe('ProjectsController', function (): void {
 				const folderName = 'folder1';
 				const stub = sinon.stub(vscode.window, 'showInputBox').resolves(folderName);
 
-				const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+				const projController = new ProjectsController();
 				const project = await testUtils.createTestProject(baselines.openProjectFileBaseline);
 				const projectRoot = new ProjectRootTreeItem(project);
 
@@ -175,7 +175,7 @@ describe('ProjectsController', function (): void {
 			async function verifyFolderAdded(folderName: string, projController: ProjectsController, project: Project, node: BaseProjectTreeItem): Promise<void> {
 				const beforeFileCount = project.files.length;
 				const stub = sinon.stub(vscode.window, 'showInputBox').resolves(folderName);
-				await projController.addFolderPrompt(node);
+				await projController.addFolderPrompt(createWorkspaceTreeItem(node));
 				should(project.files.length).equal(beforeFileCount + 1, `File count should be increased by one after adding the folder ${folderName}`);
 				stub.restore();
 			}
@@ -184,7 +184,7 @@ describe('ProjectsController', function (): void {
 				const beforeFileCount = project.files.length;
 				const showInputBoxStub = sinon.stub(vscode.window, 'showInputBox').resolves(folderName);
 				const showErrorMessageSpy = sinon.spy(vscode.window, 'showErrorMessage');
-				await projController.addFolderPrompt(node);
+				await projController.addFolderPrompt(createWorkspaceTreeItem(node));
 				should(showErrorMessageSpy.calledOnce).be.true('showErrorMessage should have been called exactly once');
 				const msg = constants.folderAlreadyExists(folderName);
 				should(showErrorMessageSpy.calledWith(msg)).be.true(`showErrorMessage not called with expected message '${msg}' Actual '${showErrorMessageSpy.getCall(0).args[0]}'`);
@@ -198,13 +198,13 @@ describe('ProjectsController', function (): void {
 				const setupResult = await setupDeleteExcludeTest(proj);
 				const scriptEntry = setupResult[0], projTreeRoot = setupResult[1], preDeployEntry = setupResult[2], postDeployEntry = setupResult[3], noneEntry = setupResult[4];
 
-				const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+				const projController = new ProjectsController();
 
-				await projController.delete(projTreeRoot.children.find(x => x.friendlyName === 'UpperFolder')!.children[0] /* LowerFolder */);
-				await projController.delete(projTreeRoot.children.find(x => x.friendlyName === 'anotherScript.sql')!);
-				await projController.delete(projTreeRoot.children.find(x => x.friendlyName === 'Script.PreDeployment1.sql')!);
-				await projController.delete(projTreeRoot.children.find(x => x.friendlyName === 'Script.PreDeployment2.sql')!);
-				await projController.delete(projTreeRoot.children.find(x => x.friendlyName === 'Script.PostDeployment1.sql')!);
+				await projController.delete(createWorkspaceTreeItem(projTreeRoot.children.find(x => x.friendlyName === 'UpperFolder')!.children[0]) /* LowerFolder */);
+				await projController.delete(createWorkspaceTreeItem(projTreeRoot.children.find(x => x.friendlyName === 'anotherScript.sql')!));
+				await projController.delete(createWorkspaceTreeItem(projTreeRoot.children.find(x => x.friendlyName === 'Script.PreDeployment1.sql')!));
+				await projController.delete(createWorkspaceTreeItem(projTreeRoot.children.find(x => x.friendlyName === 'Script.PreDeployment2.sql')!));
+				await projController.delete(createWorkspaceTreeItem(projTreeRoot.children.find(x => x.friendlyName === 'Script.PostDeployment1.sql')!));
 
 				proj = await Project.openProject(proj.projectFilePath); // reload edited sqlproj from disk
 
@@ -226,13 +226,13 @@ describe('ProjectsController', function (): void {
 				const setupResult = await setupDeleteExcludeTest(proj);
 				const scriptEntry = setupResult[0], projTreeRoot = setupResult[1], preDeployEntry = setupResult[2], postDeployEntry = setupResult[3], noneEntry = setupResult[4];
 
-				const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+				const projController = new ProjectsController();
 
-				await projController.exclude(<FolderNode>projTreeRoot.children.find(x => x.friendlyName === 'UpperFolder')!.children[0] /* LowerFolder */);
-				await projController.exclude(<FileNode>projTreeRoot.children.find(x => x.friendlyName === 'anotherScript.sql')!);
-				await projController.exclude(<FileNode>projTreeRoot.children.find(x => x.friendlyName === 'Script.PreDeployment1.sql')!);
-				await projController.exclude(<FileNode>projTreeRoot.children.find(x => x.friendlyName === 'Script.PreDeployment2.sql')!);
-				await projController.exclude(<FileNode>projTreeRoot.children.find(x => x.friendlyName === 'Script.PostDeployment1.sql')!);
+				await projController.exclude(createWorkspaceTreeItem(<FolderNode>projTreeRoot.children.find(x => x.friendlyName === 'UpperFolder')!.children[0]) /* LowerFolder */);
+				await projController.exclude(createWorkspaceTreeItem(<FileNode>projTreeRoot.children.find(x => x.friendlyName === 'anotherScript.sql')!));
+				await projController.exclude(createWorkspaceTreeItem(<FileNode>projTreeRoot.children.find(x => x.friendlyName === 'Script.PreDeployment1.sql')!));
+				await projController.exclude(createWorkspaceTreeItem(<FileNode>projTreeRoot.children.find(x => x.friendlyName === 'Script.PreDeployment2.sql')!));
+				await projController.exclude(createWorkspaceTreeItem(<FileNode>projTreeRoot.children.find(x => x.friendlyName === 'Script.PostDeployment1.sql')!));
 
 				proj = await Project.openProject(proj.projectFilePath); // reload edited sqlproj from disk
 
@@ -254,18 +254,22 @@ describe('ProjectsController', function (): void {
 				const folderPath = await testUtils.generateTestFolderPath();
 				const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.newProjectFileBaseline, folderPath);
 				const treeProvider = new SqlDatabaseProjectTreeViewProvider();
-				const projController = new ProjectsController(treeProvider);
+				const projController = new ProjectsController();
 				const project = await projController.openProject(vscode.Uri.file(sqlProjPath));
+				treeProvider.load([project]);
 
 				// change the sql project file
 				await fs.writeFile(sqlProjPath, baselines.newProjectFileWithScriptBaseline);
 				should(project.files.length).equal(0);
 
 				// call reload project
-				await projController.reloadProject(vscode.Uri.file(project.projectFilePath));
-				should(project.files.length).equal(1);
+				await projController.reloadProject({ treeDataProvider: treeProvider, element: { root: { project: project } } });
+				// calling this because this gets called in the projectProvider.getProjectTreeDataProvider(), which is called by workspaceTreeDataProvider
+				// when notifyTreeDataChanged() happens
+				treeProvider.load([project]);
 
 				// check that the new project is in the tree
+				should(project.files.length).equal(1);
 				should(treeProvider.getChildren()[0].children.find(c => c.friendlyName === 'Script1.sql')).not.equal(undefined);
 			});
 
@@ -273,7 +277,7 @@ describe('ProjectsController', function (): void {
 				const preDeployScriptName = 'PreDeployScript1.sql';
 				const postDeployScriptName = 'PostDeployScript1.sql';
 
-				const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+				const projController = new ProjectsController();
 				const project = await testUtils.createTestProject(baselines.newProjectFileBaseline);
 
 				sinon.stub(vscode.window, 'showInputBox').resolves(preDeployScriptName);
@@ -378,7 +382,7 @@ describe('ProjectsController', function (): void {
 		it('Should create list of all files and folders correctly', async function (): Promise<void> {
 			const testFolderPath = await testUtils.createDummyFileStructure();
 
-			const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+			const projController = new ProjectsController();
 			const fileList = await projController.generateList(testFolderPath);
 
 			should(fileList.length).equal(15);	// Parent folder + 2 files under parent folder + 2 directories with 5 files each
@@ -390,7 +394,7 @@ describe('ProjectsController', function (): void {
 			let testFolderPath = await testUtils.generateTestFolderPath();
 			testFolderPath += '_nonexistentFolder';	// Modify folder path to point to a nonexistent location
 
-			const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+			const projController = new ProjectsController();
 
 			await projController.generateList(testFolderPath);
 			should(spy.calledOnce).be.true('showErrorMessage should have been called');
@@ -403,7 +407,7 @@ describe('ProjectsController', function (): void {
 				sinon.stub(vscode.window, 'showInputBox').resolves(name);
 				const spy = sinon.spy(vscode.window, 'showErrorMessage');
 
-				const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+				const projController = new ProjectsController();
 				await projController.createProjectFromDatabase({ connectionProfile: mockConnectionProfile });
 				should(spy.calledOnce).be.true('showErrorMessage should have been called');
 				should(spy.calledWith(constants.projectNameRequired)).be.true(`showErrorMessage not called with expected message '${constants.projectNameRequired}' Actual '${spy.getCall(0).args[0]}'`);
@@ -417,7 +421,7 @@ describe('ProjectsController', function (): void {
 			sinon.stub(vscode.window, 'showOpenDialog').resolves([vscode.Uri.file('fakePath')]);
 			const spy = sinon.spy(vscode.window, 'showErrorMessage');
 
-			const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+			const projController = new ProjectsController();
 			await projController.createProjectFromDatabase({ connectionProfile: mockConnectionProfile });
 			should(spy.calledOnce).be.true('showErrorMessage should have been called');
 			should(spy.calledWith(constants.extractTargetRequired)).be.true(`showErrorMessage not called with expected message '${constants.extractTargetRequired}' Actual '${spy.getCall(0).args[0]}'`);
@@ -429,7 +433,7 @@ describe('ProjectsController', function (): void {
 			sinon.stub(vscode.window, 'showQuickPick').resolves({ label: constants.file });
 			const spy = sinon.spy(vscode.window, 'showErrorMessage');
 
-			const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+			const projController = new ProjectsController();
 			await projController.createProjectFromDatabase({ connectionProfile: mockConnectionProfile });
 			should(spy.calledOnce).be.true('showErrorMessage should have been called');
 			should(spy.calledWith(constants.projectLocationRequired)).be.true(`showErrorMessage not called with expected message '${constants.projectLocationRequired}' Actual '${spy.getCall(0).args[0]}'`);
@@ -441,7 +445,7 @@ describe('ProjectsController', function (): void {
 			sinon.stub(vscode.window, 'showOpenDialog').resolves(undefined);
 			const spy = sinon.spy(vscode.window, 'showErrorMessage');
 
-			const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+			const projController = new ProjectsController();
 			await projController.createProjectFromDatabase({ connectionProfile: mockConnectionProfile });
 			should(spy.calledOnce).be.true('showErrorMessage should have been called');
 			should(spy.calledWith(constants.projectLocationRequired)).be.true(`showErrorMessage not called with expected message '${constants.projectLocationRequired}' Actual '${spy.getCall(0).args[0]}'`);
@@ -486,7 +490,7 @@ describe('ProjectsController', function (): void {
 				options: {}
 			});
 
-			let projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+			let projController = new ProjectsController();
 
 			let result = await projController.getModelFromContext(undefined);
 
@@ -524,14 +528,14 @@ describe('ProjectsController', function (): void {
 			const addDbReferenceDialog = TypeMoq.Mock.ofType(AddDatabaseReferenceDialog, undefined, undefined, proj);
 			addDbReferenceDialog.callBase = true;
 			addDbReferenceDialog.setup(x => x.addReferenceClick()).returns(() => {
-				projController.object.addDatabaseReferenceCallback(proj, { systemDb: SystemDatabase.master, databaseName: 'master', suppressMissingDependenciesErrors: false });
+				projController.object.addDatabaseReferenceCallback(proj, { systemDb: SystemDatabase.master, databaseName: 'master', suppressMissingDependenciesErrors: false }, new SqlDatabaseProjectTreeViewProvider());
 				return Promise.resolve(undefined);
 			});
 
 			const projController = TypeMoq.Mock.ofType(ProjectsController);
 			projController.callBase = true;
 			projController.setup(x => x.getAddDatabaseReferenceDialog(TypeMoq.It.isAny())).returns(() => addDbReferenceDialog.object);
-			projController.setup(x => x.addDatabaseReferenceCallback(TypeMoq.It.isAny(), TypeMoq.It.is((_): _ is IDacpacReferenceSettings => true))).returns(() => {
+			projController.setup(x => x.addDatabaseReferenceCallback(TypeMoq.It.isAny(), TypeMoq.It.is((_): _ is IDacpacReferenceSettings => true), TypeMoq.It.isAny())).returns(() => {
 				holler = addDbRefHoller;
 				return Promise.resolve(undefined);
 			});
@@ -547,7 +551,7 @@ describe('ProjectsController', function (): void {
 
 			const projPath1 = await testUtils.createTestSqlProjFile(baselines.openProjectFileBaseline);
 			const projPath2 = await testUtils.createTestSqlProjFile(baselines.newProjectFileBaseline);
-			const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+			const projController = new ProjectsController();
 
 			const project1 = await projController.openProject(vscode.Uri.file(projPath1));
 			const project2 = await projController.openProject(vscode.Uri.file(projPath2));
@@ -558,7 +562,8 @@ describe('ProjectsController', function (): void {
 				projectName: 'TestProject',
 				projectRelativePath: undefined,
 				suppressMissingDependenciesErrors: false
-			});
+			},
+				new SqlDatabaseProjectTreeViewProvider());
 			should(showErrorMessageSpy.notCalled).be.true('showErrorMessage should not have been called');
 
 			// try to add circular reference
@@ -567,7 +572,8 @@ describe('ProjectsController', function (): void {
 				projectName: 'TestProjectName',
 				projectRelativePath: undefined,
 				suppressMissingDependenciesErrors: false
-			});
+			},
+			new SqlDatabaseProjectTreeViewProvider());
 			should(showErrorMessageSpy.called).be.true('showErrorMessage should have been called');
 		});
 
@@ -583,7 +589,7 @@ describe.skip('ProjectsController: round trip feature with SSDT', function (): v
 		const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.SSDTProjectFileBaseline, folderPath);
 		await testUtils.createTestDataSources(baselines.openDataSourcesBaseline, folderPath);
 
-		const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+		const projController = new ProjectsController();
 
 		await projController.openProject(vscode.Uri.file(sqlProjPath));
 		should(stub.calledOnce).be.true('showWarningMessage should have been called exactly once');
@@ -596,7 +602,7 @@ describe.skip('ProjectsController: round trip feature with SSDT', function (): v
 		const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.openProjectFileBaseline, folderPath);
 		await testUtils.createTestDataSources(baselines.openDataSourcesBaseline, folderPath);
 
-		const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+		const projController = new ProjectsController();
 
 		const project = await projController.openProject(vscode.Uri.file(sqlProjPath));	// no error thrown
 
@@ -610,7 +616,7 @@ describe.skip('ProjectsController: round trip feature with SSDT', function (): v
 		const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.SSDTProjectFileBaseline, folderPath);
 		await testUtils.createTestDataSources(baselines.openDataSourcesBaseline, folderPath);
 
-		const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+		const projController = new ProjectsController();
 
 		const project = await projController.openProject(vscode.Uri.file(sqlProjPath));
 
@@ -626,7 +632,7 @@ describe.skip('ProjectsController: round trip feature with SSDT', function (): v
 		const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.SSDTProjectFileBaseline, folderPath);
 		await testUtils.createTestDataSources(baselines.openDataSourcesBaseline, folderPath);
 
-		const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+		const projController = new ProjectsController();
 
 		const project = await projController.openProject(vscode.Uri.file(sqlProjPath));
 
@@ -658,4 +664,11 @@ async function setupDeleteExcludeTest(proj: Project): Promise<[FileProjectEntry,
 	should((await fs.readFile(scriptEntry.fsUri.fsPath)).toString()).equal('not a real script');
 
 	return [scriptEntry, projTreeRoot, preDeployEntry, postDeployEntry, noneEntry];
+}
+
+function createWorkspaceTreeItem(node: BaseProjectTreeItem): dataworkspace.WorkspaceTreeItem {
+	return {
+		element: node,
+		treeDataProvider: new SqlDatabaseProjectTreeViewProvider()
+	};
 }

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -528,7 +528,9 @@ describe('ProjectsController', function (): void {
 			const addDbReferenceDialog = TypeMoq.Mock.ofType(AddDatabaseReferenceDialog, undefined, undefined, proj);
 			addDbReferenceDialog.callBase = true;
 			addDbReferenceDialog.setup(x => x.addReferenceClick()).returns(() => {
-				projController.object.addDatabaseReferenceCallback(proj, { systemDb: SystemDatabase.master, databaseName: 'master', suppressMissingDependenciesErrors: false }, new SqlDatabaseProjectTreeViewProvider());
+				projController.object.addDatabaseReferenceCallback(proj,
+					{ systemDb: SystemDatabase.master, databaseName: 'master', suppressMissingDependenciesErrors: false },
+					{ treeDataProvider: new SqlDatabaseProjectTreeViewProvider(), element: undefined });
 				return Promise.resolve(undefined);
 			});
 
@@ -563,7 +565,7 @@ describe('ProjectsController', function (): void {
 				projectRelativePath: undefined,
 				suppressMissingDependenciesErrors: false
 			},
-				new SqlDatabaseProjectTreeViewProvider());
+				{ treeDataProvider: new SqlDatabaseProjectTreeViewProvider(), element: undefined });
 			should(showErrorMessageSpy.notCalled).be.true('showErrorMessage should not have been called');
 
 			// try to add circular reference
@@ -573,7 +575,7 @@ describe('ProjectsController', function (): void {
 				projectRelativePath: undefined,
 				suppressMissingDependenciesErrors: false
 			},
-				new SqlDatabaseProjectTreeViewProvider());
+				{ treeDataProvider: new SqlDatabaseProjectTreeViewProvider(), element: undefined });
 			should(showErrorMessageSpy.called).be.true('showErrorMessage should have been called');
 		});
 

--- a/extensions/sql-database-projects/src/test/publishProfile.test.ts
+++ b/extensions/sql-database-projects/src/test/publishProfile.test.ts
@@ -12,7 +12,6 @@ import * as baselines from './baselines/baselines';
 import * as testUtils from './testUtils';
 import * as constants from '../common/constants';
 import { ProjectsController } from '../controllers/projectController';
-import { SqlDatabaseProjectTreeViewProvider } from '../controllers/databaseProjectTreeViewProvider';
 import { TestContext, createContext, mockDacFxOptionsResult } from './testContext';
 import { load } from '../models/publishProfile/publishProfile';
 
@@ -82,7 +81,7 @@ describe('Publish profile tests', function (): void {
 	it('Should throw error when connecting does not work', async function (): Promise<void> {
 		await baselines.loadBaselines();
 		let profilePath = await testUtils.createTestFile(baselines.publishProfileIntegratedSecurityBaseline, 'publishProfile.publish.xml');
-		const projController = new ProjectsController(new SqlDatabaseProjectTreeViewProvider());
+		const projController = new ProjectsController();
 
 		sinon.stub(azdata.connection, 'connect').throws(new Error('Could not connect'));
 


### PR DESCRIPTION
- Removed old projects tree provider because now those are kept track of in project workspace extension
- fixed tests failing and causing build errors from these changes and tree refresh fix #12692
- Commented out some data sources code for now (isn't being used anyway) because a circular dependency between dataSources.ts and sqlConnectionStringSource.ts started causing the extension to not activate
