### PR TITLE
Fix checkbox change event not firing on enter press

### DIFF
--- a/src/sql/base/browser/ui/checkbox/checkbox.ts
+++ b/src/sql/base/browser/ui/checkbox/checkbox.ts
@@ -48,6 +48,7 @@ export class Checkbox extends Widget {
 		this.onkeydown(this._el, e => {
 			if (e.equals(KeyCode.Enter)) {
 				this.checked = !this.checked;
+				this._onChange.fire(this.checked);
 				e.stopPropagation();
 			}
 		});

--- a/src/sql/base/browser/ui/checkbox/checkbox.ts
+++ b/src/sql/base/browser/ui/checkbox/checkbox.ts
@@ -48,6 +48,8 @@ export class Checkbox extends Widget {
 		this.onkeydown(this._el, e => {
 			if (e.equals(KeyCode.Enter)) {
 				this.checked = !this.checked;
+				// Manually fire the event since we stop the event propagation which means
+				// the onchange event won't fire.
 				this._onChange.fire(this.checked);
 				e.stopPropagation();
 			}


### PR DESCRIPTION
The key handler was stopping the event from propagating so we never got the onchange event - which was then breaking the model view stuff since the extension side would never get its property value updated.