### PR TITLE
Cleanup ProjectsController

### DIFF
--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -115,7 +115,7 @@ export default class MainController implements vscode.Disposable {
 
 			const newProjFolderUri = (selectionResult as vscode.Uri[])[0];
 			const newProjFilePath = await this.projectsController.createNewProject(<string>newProjName, newProjFolderUri, true);
-			const proj = await this.projectsController.openProject(vscode.Uri.file(newProjFilePath));
+			const proj = await Project.openProject(vscode.Uri.file(newProjFilePath).fsPath);
 
 			newProjectTool.updateSaveLocationSetting();
 

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -57,7 +57,7 @@ export class Project {
 	/**
 	 * Reads the project setting and contents from the file
 	 */
-	public async readProjFile() {
+	public async readProjFile(): Promise<void> {
 		this.resetProject();
 
 		const projFileText = await fs.readFile(this.projectFilePath);
@@ -166,7 +166,7 @@ export class Project {
 		}
 	}
 
-	private resetProject() {
+	private resetProject(): void {
 		this.files = [];
 		this.importedTargets = [];
 		this.databaseReferences = [];
@@ -414,7 +414,7 @@ export class Project {
 	 * @param name name of the variable
 	 * @param defaultValue
 	 */
-	public async addSqlCmdVariable(name: string, defaultValue: string) {
+	public async addSqlCmdVariable(name: string, defaultValue: string): Promise<void> {
 		const sqlCmdVariableEntry = new SqlCmdVariableProjectEntry(name, defaultValue);
 		await this.addToProjFile(sqlCmdVariableEntry);
 	}
@@ -760,7 +760,7 @@ export class Project {
 		}
 	}
 
-	private async addToProjFile(entry: ProjectEntry, xmlTag?: string) {
+	private async addToProjFile(entry: ProjectEntry, xmlTag?: string): Promise<void> {
 		switch (entry.type) {
 			case EntryType.File:
 				this.addFileToProjFile((<FileProjectEntry>entry).relativePath, xmlTag ? xmlTag : constants.Build);
@@ -779,7 +779,7 @@ export class Project {
 		await this.serializeToProjFile(this.projFileXmlDoc);
 	}
 
-	private async removeFromProjFile(entries: ProjectEntry | ProjectEntry[]) {
+	private async removeFromProjFile(entries: ProjectEntry | ProjectEntry[]): Promise<void> {
 		if (entries instanceof ProjectEntry) {
 			entries = [entries];
 		}
@@ -803,7 +803,7 @@ export class Project {
 		await this.serializeToProjFile(this.projFileXmlDoc);
 	}
 
-	private async serializeToProjFile(projFileContents: any) {
+	private async serializeToProjFile(projFileContents: any): Promise<void> {
 		let xml = new xmldom.XMLSerializer().serializeToString(projFileContents);
 		xml = xmlFormat(xml, <any>{ collapseContent: true, indentation: '  ', lineSeparator: os.EOL }); // TODO: replace <any>
 

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -350,7 +350,7 @@ describe('ProjectsController', function (): void {
 		});
 	});
 
-	describe('import operations', function (): void {
+	describe('Create project from database', function (): void {
 		it('Should create list of all files and folders correctly', async function (): Promise<void> {
 			const testFolderPath = await testUtils.createDummyFileStructure();
 

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -76,34 +76,6 @@ describe('ProjectsController', function (): void {
 				should(projFileText).equal(baselines.newProjectFileBaseline);
 			});
 
-			it('Should load Project and associated DataSources', async function (): Promise<void> {
-				// setup test files
-				const folderPath = await testUtils.generateTestFolderPath();
-				const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.openProjectFileBaseline, folderPath);
-				await testUtils.createTestDataSources(baselines.openDataSourcesBaseline, folderPath);
-
-				const projController = new ProjectsController();
-
-				const project = await projController.openProject(vscode.Uri.file(sqlProjPath));
-
-				should(project.files.length).equal(9); // detailed sqlproj tests in their own test file
-				// should(project.dataSources.length).equal(3); // detailed datasources tests in their own test file
-			});
-
-			it('Should not keep failed to load project in project list.', async function (): Promise<void> {
-				const folderPath = await testUtils.generateTestFolderPath();
-				const sqlProjPath = await testUtils.createTestSqlProjFile('empty file with no valid xml', folderPath);
-				const projController = new ProjectsController();
-
-				try {
-					await projController.openProject(vscode.Uri.file(sqlProjPath));
-					should.fail(null, null, 'The given project not expected to open');
-				}
-				catch {
-					should(projController.projects.length).equal(0, 'The added project should be removed');
-				}
-			});
-
 			it('Should return silently when no SQL object name provided in prompts', async function (): Promise<void> {
 				for (const name of ['', '    ', undefined]) {
 					const showInputBoxStub = sinon.stub(vscode.window, 'showInputBox').resolves(name);
@@ -255,7 +227,7 @@ describe('ProjectsController', function (): void {
 				const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.newProjectFileBaseline, folderPath);
 				const treeProvider = new SqlDatabaseProjectTreeViewProvider();
 				const projController = new ProjectsController();
-				const project = await projController.openProject(vscode.Uri.file(sqlProjPath));
+				const project = await Project.openProject(vscode.Uri.file(sqlProjPath).fsPath);
 				treeProvider.load([project]);
 
 				// change the sql project file
@@ -325,12 +297,12 @@ describe('ProjectsController', function (): void {
 				let projController = TypeMoq.Mock.ofType(ProjectsController);
 				projController.callBase = true;
 				projController.setup(x => x.getPublishDialog(TypeMoq.It.isAny())).returns(() => publishDialog.object);
-				projController.setup(x => x.executionCallback(TypeMoq.It.isAny(), TypeMoq.It.is((_): _ is IPublishSettings => true))).returns(() => {
+				projController.setup(x => x.publishProjectCallback(TypeMoq.It.isAny(), TypeMoq.It.is((_): _ is IPublishSettings => true))).returns(() => {
 					holler = publishHoller;
 					return Promise.resolve(undefined);
 				});
 
-				projController.setup(x => x.executionCallback(TypeMoq.It.isAny(), TypeMoq.It.is((_): _ is IGenerateScriptSettings => true))).returns(() => {
+				projController.setup(x => x.publishProjectCallback(TypeMoq.It.isAny(), TypeMoq.It.is((_): _ is IGenerateScriptSettings => true))).returns(() => {
 					holler = generateHoller;
 					return Promise.resolve(undefined);
 				});
@@ -368,7 +340,7 @@ describe('ProjectsController', function (): void {
 
 				projController.setup(x => x.getDaxFxService()).returns(() => Promise.resolve(testContext.dacFxService.object));
 
-				await projController.object.executionCallback(new Project(''), { connectionUri: '', databaseName: '' });
+				await projController.object.publishProjectCallback(new Project(''), { connectionUri: '', databaseName: '' });
 
 				should(builtDacpacPath).not.equal('', 'built dacpac path should be set');
 				should(publishedDacpacPath).not.equal('', 'published dacpac path should be set');
@@ -549,14 +521,16 @@ describe('ProjectsController', function (): void {
 		});
 
 		it('Should not allow adding circular project references', async function (): Promise<void> {
-			const showErrorMessageSpy = sinon.spy(vscode.window, 'showErrorMessage');
-
 			const projPath1 = await testUtils.createTestSqlProjFile(baselines.openProjectFileBaseline);
 			const projPath2 = await testUtils.createTestSqlProjFile(baselines.newProjectFileBaseline);
 			const projController = new ProjectsController();
 
-			const project1 = await projController.openProject(vscode.Uri.file(projPath1));
-			const project2 = await projController.openProject(vscode.Uri.file(projPath2));
+			const project1 = await Project.openProject(vscode.Uri.file(projPath1).fsPath);
+			const project2 = await Project.openProject(vscode.Uri.file(projPath2).fsPath);
+			const showErrorMessageSpy = sinon.spy(vscode.window, 'showErrorMessage');
+			const dataWorkspaceMock = TypeMoq.Mock.ofType<dataworkspace.IExtension>();
+			dataWorkspaceMock.setup(x => x.getProjectsInWorkspace()).returns(() => [vscode.Uri.file(project1.projectFilePath), vscode.Uri.file(project2.projectFilePath)]);
+			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: dataWorkspaceMock.object });
 
 			// add project reference from project1 to project2
 			await projController.addDatabaseReferenceCallback(project1, {
@@ -581,68 +555,6 @@ describe('ProjectsController', function (): void {
 
 	});
 });
-
-describe.skip('ProjectsController: round trip feature with SSDT', function (): void {
-	it('Should show warning message for SSDT project opened in Azure Data Studio', async function (): Promise<void> {
-		const stub = sinon.stub(vscode.window, 'showWarningMessage').returns(<any>Promise.resolve(constants.noString));
-
-		// setup test files
-		const folderPath = await testUtils.generateTestFolderPath();
-		const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.SSDTProjectFileBaseline, folderPath);
-		await testUtils.createTestDataSources(baselines.openDataSourcesBaseline, folderPath);
-
-		const projController = new ProjectsController();
-
-		await projController.openProject(vscode.Uri.file(sqlProjPath));
-		should(stub.calledOnce).be.true('showWarningMessage should have been called exactly once');
-		should(stub.calledWith(constants.updateProjectForRoundTrip)).be.true(`showWarningMessage not called with expected message '${constants.updateProjectForRoundTrip}' Actual '${stub.getCall(0).args[0]}'`);
-	});
-
-	it('Should not show warning message for non-SSDT projects that have the additional information for Build', async function (): Promise<void> {
-		// setup test files
-		const folderPath = await testUtils.generateTestFolderPath();
-		const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.openProjectFileBaseline, folderPath);
-		await testUtils.createTestDataSources(baselines.openDataSourcesBaseline, folderPath);
-
-		const projController = new ProjectsController();
-
-		const project = await projController.openProject(vscode.Uri.file(sqlProjPath));	// no error thrown
-
-		should(project.importedTargets.length).equal(3); // additional target should exist by default
-	});
-
-	it('Should not update project and no backup file should be created when update to project is rejected', async function (): Promise<void> {
-		sinon.stub(vscode.window, 'showWarningMessage').returns(<any>Promise.resolve(constants.noString));
-		// setup test files
-		const folderPath = await testUtils.generateTestFolderPath();
-		const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.SSDTProjectFileBaseline, folderPath);
-		await testUtils.createTestDataSources(baselines.openDataSourcesBaseline, folderPath);
-
-		const projController = new ProjectsController();
-
-		const project = await projController.openProject(vscode.Uri.file(sqlProjPath));
-
-		should(await exists(sqlProjPath + '_backup')).equal(false);	// backup file should not be generated
-		should(project.importedTargets.length).equal(2); // additional target should not be added by updateProjectForRoundTrip method
-	});
-
-	it('Should load Project and associated import targets when update to project is accepted', async function (): Promise<void> {
-		sinon.stub(vscode.window, 'showWarningMessage').returns(<any>Promise.resolve(constants.yesString));
-
-		// setup test files
-		const folderPath = await testUtils.generateTestFolderPath();
-		const sqlProjPath = await testUtils.createTestSqlProjFile(baselines.SSDTProjectFileBaseline, folderPath);
-		await testUtils.createTestDataSources(baselines.openDataSourcesBaseline, folderPath);
-
-		const projController = new ProjectsController();
-
-		const project = await projController.openProject(vscode.Uri.file(sqlProjPath));
-
-		should(await exists(sqlProjPath + '_backup')).equal(true);	// backup file should be generated before the project is updated
-		should(project.importedTargets.length).equal(3); // additional target added by updateProjectForRoundTrip method
-	});
-});
-
 
 async function setupDeleteExcludeTest(proj: Project): Promise<[FileProjectEntry, ProjectRootTreeItem, FileProjectEntry, FileProjectEntry, FileProjectEntry]> {
 	await proj.addFolderItem('UpperFolder');


### PR DESCRIPTION
- Removed openProject() from ProjectsController because Project.openProject() is used directly by SqlDatabaseProjectProvider
- Removed ProjectsController openProject() tests, moved a couple SSDT roundtrip tests to Project.test.ts
- some general cleanup (added return types, a little renaming, moved createProjectFromDatabase() out of helper methods region)