### PR TITLE
Add Notebook tests for Kernel Alias connections

### DIFF
--- a/src/sql/platform/capabilities/test/common/testCapabilitiesService.ts
+++ b/src/sql/platform/capabilities/test/common/testCapabilitiesService.ts
@@ -16,7 +16,7 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 export class TestCapabilitiesService implements ICapabilitiesService {
 
 	private pgsqlProviderName = 'PGSQL';
-	private kustoProviderName = 'KUSTO';
+	private fakeProviderName = 'FAKE';
 	public _serviceBrand: undefined;
 
 	public capabilities: { [id: string]: ProviderFeatures } = {};
@@ -107,15 +107,15 @@ export class TestCapabilitiesService implements ICapabilitiesService {
 			displayName: 'PostgreSQL',
 			connectionOptions: connectionProvider,
 		};
-		let kustoCapabilities = {
-			providerId: this.kustoProviderName,
-			displayName: 'Kusto',
+		let fakeCapabilities = {
+			providerId: this.fakeProviderName,
+			displayName: 'fakeName',
 			connectionOptions: connectionProvider,
-			notebookKernelAlias: 'Kusto'
+			notebookKernelAlias: 'fakeAlias'
 		};
 		this.capabilities[mssqlProviderName] = { connection: msSQLCapabilities };
 		this.capabilities[this.pgsqlProviderName] = { connection: pgSQLCapabilities };
-		this.capabilities[this.kustoProviderName] = { connection: kustoCapabilities };
+		this.capabilities[this.fakeProviderName] = { connection: fakeCapabilities };
 	}
 
 	registerConnectionProvider(id: string, properties: ConnectionProviderProperties): IDisposable {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -505,7 +505,7 @@ suite('notebook model', function (): void {
 		queryConnectionService.verify((c) => c.disconnect(TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
-	test('Should change kernel to Fake (kernel alias) connection when connecting to Kusto connection', async function () {
+	test('Should change kernel when connecting to a Fake (kernel alias) connection', async function () {
 		let model = await loadModelAndStartClientSession();
 		// Ensure notebook prefix is present in the connection URI
 		queryConnectionService.setup(c => c.getConnectionUri(TypeMoq.It.isAny())).returns(() => `${uriPrefixes.notebook}some/path`);
@@ -530,7 +530,7 @@ suite('notebook model', function (): void {
 		queryConnectionService.verify((c) => c.disconnect(TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
-	test('Should change kernel from Fake (kernel alias) connection to SQL kernel when connecting to SQL connection', async function () {
+	test('Should change kernel from Fake (kernel alias) to SQL kernel when connecting to SQL connection', async function () {
 		let model = await loadModelAndStartClientSession();
 
 		// Ensure notebook prefix is present in the connection URI

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -560,7 +560,6 @@ suite('notebook model', function (): void {
 		sinon.assert.called(doChangeKernelStub);
 		sinon.restore(doChangeKernelStub);
 
-
 		// After closing the notebook
 		await model.handleClosed();
 

--- a/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionManagementService.test.ts
@@ -1098,7 +1098,7 @@ suite('SQL ConnectionManagementService tests', () => {
 	});
 
 	test('providerNameToDisplayNameMap should return all providers', () => {
-		let expectedNames = ['MSSQL', 'PGSQL', 'KUSTO'];
+		let expectedNames = ['MSSQL', 'PGSQL', 'FAKE'];
 		let providerNames = Object.keys(connectionManagementService.providerNameToDisplayNameMap);
 		assert.equal(providerNames.length, 3);
 		assert.equal(providerNames[0], expectedNames[0]);

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -846,6 +846,12 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			if (newConnection) {
 				if (newConnection.serverCapabilities?.notebookKernelAlias) {
 					this._currentKernelAlias = newConnection.serverCapabilities.notebookKernelAlias;
+					let sqlConnectionProvider = this._kernelDisplayNameToConnectionProviderIds.get('SQL');
+					let index = sqlConnectionProvider.indexOf(newConnection.serverCapabilities.notebookKernelAlias.toUpperCase());
+					if (index > -1) {
+						sqlConnectionProvider.splice(index, 1);
+					}
+					this._kernelDisplayNameToConnectionProviderIds.set('SQL', sqlConnectionProvider);
 					this._kernelDisplayNameToConnectionProviderIds.set(newConnection.serverCapabilities.notebookKernelAlias, [newConnection.providerName]);
 				}
 				this._activeConnection = newConnection;

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -846,12 +846,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			if (newConnection) {
 				if (newConnection.serverCapabilities?.notebookKernelAlias) {
 					this._currentKernelAlias = newConnection.serverCapabilities.notebookKernelAlias;
-					let sqlConnectionProvider = this._kernelDisplayNameToConnectionProviderIds.get('SQL');
-					let index = sqlConnectionProvider.indexOf(newConnection.serverCapabilities.notebookKernelAlias.toUpperCase());
-					if (index > -1) {
-						sqlConnectionProvider.splice(index, 1);
-					}
-					this._kernelDisplayNameToConnectionProviderIds.set('SQL', sqlConnectionProvider);
 					this._kernelDisplayNameToConnectionProviderIds.set(newConnection.serverCapabilities.notebookKernelAlias, [newConnection.providerName]);
 				}
 				this._activeConnection = newConnection;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds tests that ensure we setup Kernel Alias connections and change the kernel appropriately based on the connection. 
- Should connect to Fake (kernel alias) connection and set kernelAliases list properly
- Should change kernel when connecting to Fake (kernel alias) connection 
- Should change kernel from Fake (kernel alias) to SQL when changing to SQL connection 
