### PR TITLE
[Port] Fix root group name check (#12660)

### DIFF
--- a/src/sql/platform/connection/common/connectionProfileGroup.ts
+++ b/src/sql/platform/connection/common/connectionProfileGroup.ts
@@ -37,7 +37,7 @@ export class ConnectionProfileGroup extends Disposable implements IConnectionPro
 	) {
 		super();
 		this.parentId = parent ? parent.id : undefined;
-		if (this.name === ConnectionProfileGroup.RootGroupName) {
+		if (ConnectionProfileGroup.isRoot(this.name)) {
 			this.name = '';
 			this.isRoot = true;
 		}


### PR DESCRIPTION
Fixes #12587 - casing shouldn't matter for the root group name. Group names aren't case sensitive so users can't add their own groups named root so this is safe.

cherry-picked from 253aa7865033c493cbf67a7404ee59a9d181ff8d