### PR TITLE
[Port] Fetch arc dc config profile list from azdata #12678

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -202,15 +202,9 @@
                           "variableName": "AZDATA_NB_VAR_ARC_PROFILE",
                           "editable": false,
                           "options": {
-                            "values": [
-                              "azure-arc-ake",
-                              "azure-arc-aks-default-storage",
-                              "azure-arc-aks-premium-storage",
-                              "azure-arc-azure-openshift",
-                              "azure-arc-eks",
-                              "azure-arc-kubeadm",
-                              "azure-arc-openshift"
-                            ],
+                            "source": {
+                              "type": "ArcControllerConfigProfilesOptionsSource"
+                            },
                             "defaultValue": "azure-arc-aks-default-storage",
                             "optionsType": "radio"
                           }

--- a/extensions/resource-deployment/src/interfaces.ts
+++ b/extensions/resource-deployment/src/interfaces.ts
@@ -174,9 +174,9 @@ export type ComponentCSSStyles = {
 };
 
 export interface IOptionsSource {
-	readonly type: OptionsSourceType,
-	readonly variableNames: { [index: string]: string; },
-	getOptions(): Promise<string[] | azdata.CategoryValue[]>,
+	readonly type: OptionsSourceType;
+	readonly variableNames: { [index: string]: string; };
+	getOptions(): Promise<string[] | azdata.CategoryValue[]>;
 	getVariableValue(variableName: string, input: string): Promise<string>;
 	getIsPassword(variableName: string): boolean;
 }

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -9,7 +9,7 @@ import { EOL, homedir as os_homedir } from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import { ArcControllersOptionsSource, OptionsSourceType } from '../helpers/optionSources';
+import { ArcControllerConfigProfilesOptionsSource, ArcControllersOptionsSource, OptionsSourceType } from '../helpers/optionSources';
 import { AzureAccountFieldInfo, AzureLocationsFieldInfo, ComponentCSSStyles, DialogInfoBase, FieldInfo, FieldType, FilePickerFieldInfo, IOptionsSource, KubeClusterContextFieldInfo, LabelPosition, NoteBookEnvironmentVariablePrefix, OptionsInfo, OptionsType, PageInfoBase, RowInfo, SectionInfo, TextCSSStyles } from '../interfaces';
 import * as loc from '../localizedConstants';
 import { apiService } from '../services/apiService';
@@ -438,6 +438,9 @@ async function processOptionsTypeField(context: FieldContext): Promise<void> {
 			switch (context.fieldInfo.options.source.type) {
 				case OptionsSourceType.ArcControllersOptionsSource:
 					optionsSource = new ArcControllersOptionsSource(context.fieldInfo.options.source.variableNames, context.fieldInfo.options.source.type);
+					break;
+				case OptionsSourceType.ArcControllerConfigProfilesOptionsSource:
+					optionsSource = new ArcControllerConfigProfilesOptionsSource(context.fieldInfo.options.source.variableNames, context.fieldInfo.options.source.type);
 					break;
 				default:
 					throw new Error(loc.noOptionsSourceDefined(context.fieldInfo.options.source.type));


### PR DESCRIPTION
Adds a new options source to fetch dc config profile list from azdata arc dc config list command. Also did some code refactoring to simplify creation of OptionsSource object.

This PR fixes #12372

Testing:

End to end testing of dc create scenario
Extension unit tests.

cherry-pickd from 7bfea07b9bf879f8de307c05dfe3fb040d64e1aa