### PR TITLE
[Port] Fix HDFS node to only show up for BDC connections (#12714)

### DIFF
--- a/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/objectExplorerNodeProvider.ts
@@ -48,6 +48,9 @@ export class MssqlObjectExplorerNodeProvider extends ProviderBase implements azd
 		let sqlConnProfile = await azdata.objectexplorer.getSessionConnectionProfile(session.sessionId);
 		if (!sqlConnProfile) { return false; }
 
+		const isBigDataCluster = await utils.isBigDataCluster(sqlConnProfile.id);
+		if (!isBigDataCluster) { return false; }
+
 		let clusterSession = new SqlClusterSession(session, sqlConnProfile, this.appContext, this);
 		this.clusterSessionMap.set(session.sessionId, clusterSession);
 		return true;

--- a/extensions/mssql/src/utils.ts
+++ b/extensions/mssql/src/utils.ts
@@ -240,6 +240,12 @@ export function getClusterEndpoints(serverInfo: azdata.ServerInfo): bdc.IEndpoin
 	});
 }
 
+export async function isBigDataCluster(connectionId: string): Promise<boolean> {
+	const serverInfo = await azdata.connection.getServerInfo(connectionId);
+
+	return !!serverInfo?.options?.[constants.isBigDataClusterProperty];
+}
+
 export type HostAndIp = { host: string, port: string };
 
 export function getHostAndPortFromEndpoint(endpoint: string): HostAndIp {


### PR DESCRIPTION
Fixes #12713

When I refactored the node logic to delay creating the HDFS connection until the folder was expanded the logic that short-circuited the creation of the session node was also removed. I'm still leaving that part as it is but now just doing a simple check on the connection before creating the session node.

cherry-picked from 572310b9067368be952368b951dea60adb746ddc