### PR TITLE
Fix search for pinned notebooks

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -65,7 +65,7 @@
           "default": [],
           "description": "%notebook.pinnedNotebooks.description%",
           "items": {
-            "type": "string"
+            "type": "object"
           }
         }
       }

--- a/extensions/notebook/src/book/bookModel.ts
+++ b/extensions/notebook/src/book/bookModel.ts
@@ -35,7 +35,8 @@ export class BookModel {
 		public readonly bookPath: string,
 		public readonly openAsUntitled: boolean,
 		public readonly isNotebook: boolean,
-		private _extensionContext: vscode.ExtensionContext) {
+		private _extensionContext: vscode.ExtensionContext,
+		public readonly notebookRootPath?: string) {
 		this._bookItems = [];
 	}
 
@@ -107,7 +108,7 @@ export class BookModel {
 		let notebookItem = new BookTreeItem({
 			title: pathDetails.name,
 			contentPath: this.bookPath,
-			root: pathDetails.dir,
+			root: this.notebookRootPath ? this.notebookRootPath : pathDetails.dir,
 			tableOfContents: { sections: undefined },
 			page: { sections: undefined },
 			type: BookTreeItemType.Notebook,

--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -39,6 +39,7 @@ export class BookTreeItem extends vscode.TreeItem {
 	private _nextUri: string;
 	public readonly version: string;
 	public command: vscode.Command;
+	public resourceUri: vscode.Uri;
 
 	constructor(public book: BookTreeItemFormat, icons: any) {
 		super(book.title, book.treeItemCollapsibleState);
@@ -74,6 +75,7 @@ export class BookTreeItem extends vscode.TreeItem {
 		}
 		else {
 			this.tooltip = this.book.type === BookTreeItemType.Book ? (this.book.version === BookVersion.v1 ? path.join(this.book.root, content) : this.book.root) : this.book.contentPath;
+			this.resourceUri = vscode.Uri.file(this.book.root);
 		}
 	}
 

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -43,7 +43,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.openBook', () => bookTreeViewProvider.openNewBook()));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.closeBook', (book: any) => bookTreeViewProvider.closeBook(book)));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.closeNotebook', (book: any) => bookTreeViewProvider.closeBook(book)));
-	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.openNotebookFolder', (folderPath?: string, urlToOpen?: string, showPreview?: boolean,) => bookTreeViewProvider.openNotebookFolder(folderPath, urlToOpen, showPreview)));
+	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.openNotebookFolder', (folderPath?: string, urlToOpen?: string, showPreview?: boolean) => bookTreeViewProvider.openNotebookFolder(folderPath, urlToOpen, showPreview)));
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.pinNotebook', async (book: any) => {
 		await bookTreeViewProvider.pinNotebook(book);
 		await pinnedBookTreeViewProvider.addNotebookToPinnedView(book);

--- a/extensions/notebook/src/test/common/utils.test.ts
+++ b/extensions/notebook/src/test/common/utils.test.ts
@@ -340,7 +340,7 @@ describe('Utils Tests', function () {
 
 	describe('getPinnedNotebooks', function (): void {
 		it('Should NOT have any pinned notebooks', async function (): Promise<void> {
-			let pinnedNotebooks: string[] = utils.getPinnedNotebooks();
+			let pinnedNotebooks: utils.IBookNotebook[] = utils.getPinnedNotebooks();
 
 			should(pinnedNotebooks.length).equal(0, 'Should not have any pinned notebooks');
 		});

--- a/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch.ts
@@ -259,7 +259,7 @@ export class NotebookSearchView extends SearchView {
 			progressComplete();
 
 			// Do final render, then expand if just 1 file with less than 50 matches
-			await this.onSearchResultsChanged();
+			this.onSearchResultsChanged();
 
 			const collapseResults = this.searchConfig.collapseResults;
 			if (collapseResults !== 'alwaysCollapse' && this.viewModel.searchResult.matches().length === 1) {


### PR DESCRIPTION
* fix search for pinned notebooks

* fix filtering when verifying that a search folder is not a subdirectory from the current folder queries path

* Show book node on pinned notebooks search results

* fix parent node on pinned notebooks search results

* fix search for pinned notebook and modify how pinned notebooks are stored in workspace

* update format of pinned notebooks for users that used the september release version

* removed unused functions

* Address PR comments

* fix parent node for legacy version of jupyter books

* remove cast from book path


This PR fixes #12459
