### PR TITLE
Fix duplicate db references being allowed

### DIFF
--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -435,6 +435,12 @@ export class Project {
 	 */
 	public async addProjectReference(settings: IProjectReferenceSettings): Promise<void> {
 		const projectReferenceEntry = new SqlProjectReferenceProjectEntry(settings);
+
+		// check if reference to this database already exists
+		if (this.databaseReferenceExists(projectReferenceEntry)) {
+			throw new Error(constants.databaseReferenceAlreadyExists);
+		}
+
 		await this.addToProjFile(projectReferenceEntry);
 	}
 
@@ -621,7 +627,7 @@ export class Project {
 	}
 
 	private databaseReferenceExists(entry: IDatabaseReferenceProjectEntry): boolean {
-		const found = this.databaseReferences.find(reference => reference.fsUri.fsPath === entry.fsUri.fsPath) !== undefined;
+		const found = this.databaseReferences.find(reference => reference.pathForSqlProj() === entry.pathForSqlProj()) !== undefined;
 		return found;
 	}
 


### PR DESCRIPTION
This PR fixes #12794. Fixes two things: 
1. Wasn't checking if project reference already exists before adding
2. On mac, duplicate references weren't being caught if a project already with a db reference was loaded because the uri read from the sqlproj had Window's slashes. Fix is to make sure slashes are all consistent when doing the comparison
