### PR TITLE
capture 'this' to use retrieveVariable as callback

### DIFF
--- a/extensions/arc/src/providers/arcControllersOptionsSourceProvider.ts
+++ b/extensions/arc/src/providers/arcControllersOptionsSourceProvider.ts
@@ -41,7 +41,9 @@ export class ArcControllersOptionsSourceProvider implements rd.IOptionsSourcePro
 	}
 
 	getVariableValue(variableName: string, controllerLabel: string): Promise<string> {
-		return this._cacheManager.getCacheEntry(JSON.stringify([variableName, controllerLabel]), this.retrieveVariable);
+		// capture 'this' in an arrow function object
+		const retrieveVariable = (key: string) => this.retrieveVariable(key);
+		return this._cacheManager.getCacheEntry(JSON.stringify([variableName, controllerLabel]), retrieveVariable);
 	}
 
 	private async getPassword(controller: arc.DataController): Promise<string> {

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -415,7 +415,6 @@ function disableControlButtons(container: azdata.window.Dialog | azdata.window.W
 	if ('okButton' in container) {
 		container.okButton.enabled = false;
 	} else {
-		container.generateScriptButton.enabled = false;
 		container.doneButton.enabled = false;
 		container.nextButton.enabled = false;
 		container.backButton.enabled = false;

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -415,6 +415,7 @@ function disableControlButtons(container: azdata.window.Dialog | azdata.window.W
 	if ('okButton' in container) {
 		container.okButton.enabled = false;
 	} else {
+		container.generateScriptButton.enabled = false;
 		container.doneButton.enabled = false;
 		container.nextButton.enabled = false;
 		container.backButton.enabled = false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes:
1. When submitting an instance method as a callback function we need to capture 'this'. This was missed in 'retrieveVariable' instnace method in ArcControllersOptionsSourceProvider.

This PR addresses #12802.
