### PR TITLE
port extension view filter icon fix from vscode

### DIFF
--- a/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
+++ b/src/vs/base/browser/ui/dropdown/dropdownActionViewItem.ts
@@ -62,7 +62,7 @@ export class DropdownMenuActionViewItem extends BaseActionViewItem {
 			let classNames: string[] = [];
 
 			if (typeof this.options.classNames === 'string') {
-				classNames = this.options.classNames.split(/\W+/g).filter(s => !!s);
+				classNames = this.options.classNames.split(/\s+/g).filter(s => !!s);
 			} else if (this.options.classNames) {
 				classNames = this.options.classNames;
 			}


### PR DESCRIPTION
porting https://github.com/microsoft/vscode/commit/989f251ff175fe336d36ecc88ee4ba41d9f35416 from vscode.

vscode introduced an issue that splits the css class names into to, codicon-filter is changed to 'codicon filter', and our filter icon is picked up accidentally without a proper size, for vscode, the symptom is filter icon is not showing.

now in Main branch:
![image](https://user-images.githubusercontent.com/13777222/95262902-d9ea9e80-07e1-11eb-9b72-4cf711b3b6a3.png)

with this fix:
![image](https://user-images.githubusercontent.com/13777222/95549803-c47d9c00-09bc-11eb-9a29-a0cba87c4494.png)

@cssuh FYI since this one looks pretty silly, I decided to cherry pick it to main directly without waiting for the merge bot.

This PR fixes #12774 
