### PR TITLE
Remove arc preview setting

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -94,11 +94,6 @@
         "type": "object",
         "title": "Azure",
         "properties": {
-          "azure.enableArcFeatures": {
-            "type": "boolean",
-            "default": false,
-            "description": "%config.enableArcFeatures%"
-          },
           "azure.noSystemKeychain": {
             "type": "boolean",
             "default": true,

--- a/extensions/azurecore/package.nls.json
+++ b/extensions/azurecore/package.nls.json
@@ -29,6 +29,5 @@
 	"config.azureCodeGrantMethod": "Code Grant Method",
 	"config.azureDeviceCodeMethod": "Device Code Method",
 	"config.noSystemKeychain": "Disable system keychain integration. Credentials will be stored in a flat file in the user's home directory.",
-	"config.enableArcFeatures": "Should features related to Azure Arc be enabled (preview)",
 	"config.piiLogging": "Should Personally Identifiable Information (PII) be logged in the console view locally"
 }

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -228,14 +228,6 @@ function registerAzureServices(appContext: AppContext): void {
 }
 
 async function onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent): Promise<void> {
-	if (e.affectsConfiguration('azure.enableArcFeatures')) {
-		const response = await vscode.window.showInformationMessage(loc.requiresReload, loc.reload);
-		if (response === loc.reload) {
-			await vscode.commands.executeCommand('workbench.action.reloadWindow');
-		}
-		return;
-	}
-
 	if (e.affectsConfiguration('azure.piiLogging')) {
 		updatePiiLoggingLevel();
 	}


### PR DESCRIPTION
Seems we removed the logic that actually used this setting a while back so this just isn't doing anything anymore. 