### PR TITLE
Update HDFS mount path (#12865)

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/controller/apiGenerated.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/controller/apiGenerated.ts
@@ -1168,7 +1168,7 @@ export class DefaultApi {
      * @param {*} [options] Override http request options.
      */
     public createMount (xRequestId: string, connection: string, remote: string, mount: string, credentials?: any, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
-        const localVarPath = this.basePath + '/api/v1/storage/mounts';
+        const localVarPath = this.basePath + '/api/v1/bdc/services/hdfs/mounts';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
@@ -1316,7 +1316,7 @@ export class DefaultApi {
      * @param {*} [options] Override http request options.
      */
     public deleteMount (xRequestId: string, connection: string, mount: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
-        const localVarPath = this.basePath + '/api/v1/storage/mounts';
+        const localVarPath = this.basePath + '/api/v1/bdc/services/hdfs/mounts';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
@@ -1600,7 +1600,7 @@ export class DefaultApi {
      * @param {*} [options] Override http request options.
      */
     public listMounts (xRequestId: string, connection: string, mount?: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
-        const localVarPath = this.basePath + '/api/v1/storage/mounts';
+        const localVarPath = this.basePath + '/api/v1/bdc/services/hdfs/mounts';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
@@ -1669,7 +1669,7 @@ export class DefaultApi {
      * @param {*} [options] Override http request options.
      */
     public refreshMount (xRequestId: string, connection: string, mount: string, options: any = {}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
-        const localVarPath = this.basePath + '/api/v1/storage/mounts/refresh';
+        const localVarPath = this.basePath + '/api/v1/bdc/services/hdfs/mounts/refresh';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/12867

The path was changed before GA but never got updated here. Both paths existed up until recently when the older path was removed so we don't need to be concerned about backwards compat since only pre-GA controllers would be affected by this.

cherry-picked from https://github.com/microsoft/azuredatastudio/commit/9389a9289661882e3039a04618dffcec845ba8b4