### PR TITLE
Fix for Depoyment defaults to first item when filter filters out all items

### DIFF
--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -255,6 +255,7 @@ export class ResourceTypePickerDialog extends DialogBase {
 				selectedCardId: cards[0].id,
 				cards: cards
 			});
+
 			this.selectResourceType(filteredResourceTypesOnSearch[0]);
 		}
 		else {

--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -255,7 +255,6 @@ export class ResourceTypePickerDialog extends DialogBase {
 				selectedCardId: cards[0].id,
 				cards: cards
 			});
-
 			this.selectResourceType(filteredResourceTypesOnSearch[0]);
 		}
 		else {
@@ -267,6 +266,7 @@ export class ResourceTypePickerDialog extends DialogBase {
 			this._agreementContainer.clearItems();
 			this._optionsContainer.clearItems();
 			this.updateToolsDisplayTable();
+			this._dialogObject.okButton.enabled = false;
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #12851 

This fix just disables the ok button when no resources are found after filtering