### PR TITLE
Fix connection when changing kernel from Kusto to SQL

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -425,13 +425,6 @@ export class AttachToDropdown extends SelectBox {
 		if ((connProviderIds && connProviderIds.length === 0) || currentKernel === noKernel) {
 			this.setOptions([msgLocalHost]);
 		} else {
-			// Removes kernel to connection provider mapping of SQL kernel to KUSTO connection
-			for (let kernelAlias of this.model.kernelAliases) {
-				if (connProviderIds.findIndex(e => e === kernelAlias.toUpperCase()) > -1 && currentKernel === 'SQL') {
-					let kernelAliasIndex = connProviderIds.findIndex(e => e === kernelAlias.toUpperCase());
-					connProviderIds.splice(kernelAliasIndex, 1);
-				}
-			}
 			let connections: string[] = model.context && model.context.title && (connProviderIds.includes(this.model.context.providerName)) ? [model.context.title] : [msgSelectConnection];
 			if (!connections.find(x => x === msgChangeConnection)) {
 				connections.push(msgChangeConnection);

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -425,6 +425,13 @@ export class AttachToDropdown extends SelectBox {
 		if ((connProviderIds && connProviderIds.length === 0) || currentKernel === noKernel) {
 			this.setOptions([msgLocalHost]);
 		} else {
+			// Removes kernel to connection provider mapping of SQL kernel to KUSTO connection
+			for (let kernelAlias of this.model.kernelAliases) {
+				if (connProviderIds.findIndex(e => e === kernelAlias.toUpperCase()) > -1 && currentKernel === 'SQL') {
+					let kernelAliasIndex = connProviderIds.findIndex(e => e === kernelAlias.toUpperCase());
+					connProviderIds.splice(kernelAliasIndex, 1);
+				}
+			}
 			let connections: string[] = model.context && model.context.title && (connProviderIds.includes(this.model.context.providerName)) ? [model.context.title] : [msgSelectConnection];
 			if (!connections.find(x => x === msgChangeConnection)) {
 				connections.push(msgChangeConnection);

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -845,6 +845,13 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			if (newConnection) {
 				if (newConnection.serverCapabilities?.notebookKernelAlias) {
 					this._currentKernelAlias = newConnection.serverCapabilities.notebookKernelAlias;
+					// Removes SQL kernel to Kernel Alias Connection Provider map
+					let sqlConnectionProvider = this._kernelDisplayNameToConnectionProviderIds.get('SQL');
+					let index = sqlConnectionProvider.indexOf(newConnection.serverCapabilities.notebookKernelAlias.toUpperCase());
+					if (index > -1) {
+						sqlConnectionProvider.splice(index, 1);
+					}
+					this._kernelDisplayNameToConnectionProviderIds.set('SQL', sqlConnectionProvider);
 					this._kernelDisplayNameToConnectionProviderIds.set(newConnection.serverCapabilities.notebookKernelAlias, [newConnection.providerName]);
 				}
 				this._activeConnection = newConnection;
@@ -971,6 +978,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private async loadActiveContexts(kernelChangedArgs: nb.IKernelChangedArgs): Promise<void> {
 		if (kernelChangedArgs && kernelChangedArgs.newValue && kernelChangedArgs.newValue.name) {
 			let kernelDisplayName = this.getDisplayNameFromSpecName(kernelChangedArgs.newValue);
+			if (this.context?.serverCapabilities?.notebookKernelAlias && this.selectedKernelDisplayName === this.context?.serverCapabilities?.notebookKernelAlias) {
+				kernelDisplayName = this.context.serverCapabilities?.notebookKernelAlias;
+			}
 			let context;
 			if (this._activeConnection) {
 				context = NotebookContexts.getContextForKernel(this._activeConnection, this.getApplicableConnectionProviderIds(kernelDisplayName));

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -847,11 +847,13 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					this._currentKernelAlias = newConnection.serverCapabilities.notebookKernelAlias;
 					// Removes SQL kernel to Kernel Alias Connection Provider map
 					let sqlConnectionProvider = this._kernelDisplayNameToConnectionProviderIds.get('SQL');
-					let index = sqlConnectionProvider.indexOf(newConnection.serverCapabilities.notebookKernelAlias.toUpperCase());
-					if (index > -1) {
-						sqlConnectionProvider.splice(index, 1);
+					if (sqlConnectionProvider) {
+						let index = sqlConnectionProvider.indexOf(newConnection.serverCapabilities.notebookKernelAlias.toUpperCase());
+						if (index > -1) {
+							sqlConnectionProvider.splice(index, 1);
+						}
+						this._kernelDisplayNameToConnectionProviderIds.set('SQL', sqlConnectionProvider);
 					}
-					this._kernelDisplayNameToConnectionProviderIds.set('SQL', sqlConnectionProvider);
 					this._kernelDisplayNameToConnectionProviderIds.set(newConnection.serverCapabilities.notebookKernelAlias, [newConnection.providerName]);
 				}
 				this._activeConnection = newConnection;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses #12862.

It fixes Kusto to SQL kernel change by removing the connection based on the appropriate kernel.

reverts changes done here: #12750 and address the connection issue that needs to utilize kernel Alias to retrieve the right context.
