### PR TITLE
Null check for updatedetail

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -862,8 +862,8 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 
 	private updateDetail(selectedIndex: number): void {
 		this.selectionDetailsPane.innerText = '';
-		const description = (this.options.length > 0) ? this.options[selectedIndex].description : undefined;
-		const descriptionIsMarkdown = (this.options.length > 0) ? this.options[selectedIndex].descriptionIsMarkdown : undefined;
+		const description = this.options[selectedIndex]?.description;
+		const descriptionIsMarkdown = this.options[selectedIndex]?.descriptionIsMarkdown;
 
 		if (description) {
 			if (descriptionIsMarkdown) {

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -862,8 +862,8 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 
 	private updateDetail(selectedIndex: number): void {
 		this.selectionDetailsPane.innerText = '';
-		const description = this.options[selectedIndex].description;
-		const descriptionIsMarkdown = this.options[selectedIndex].descriptionIsMarkdown;
+		const description = (this.options.length > 0) ? this.options[selectedIndex].description : undefined;
+		const descriptionIsMarkdown = (this.options.length > 0) ? this.options[selectedIndex].descriptionIsMarkdown : undefined;
 
 		if (description) {
 			if (descriptionIsMarkdown) {


### PR DESCRIPTION
Fixes a null error that happens when you click on a dropdown without any items in it, uses regular handling to resolve the issue.