### PR TITLE
Backend work for Notebook Parameterization and Tests

### DIFF
--- a/src/sql/platform/notebooks/common/outputRegistry.ts
+++ b/src/sql/platform/notebooks/common/outputRegistry.ts
@@ -10,6 +10,8 @@ export const Extensions = {
 };
 
 export const HideInputTag = 'hide_input';
+export const ParametersTag = 'parameters';
+export const InjectedParametersTag = 'injected-parameters';
 
 export interface ICellComponenetRegistry {
 	registerComponent(component: any): void;

--- a/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
@@ -145,8 +145,8 @@ export class CellToggleMoreActions {
 			instantiationService.createInstance(CollapseCellAction, 'collapseCell', localize('collapseCell', "Collapse Cell"), true),
 			instantiationService.createInstance(CollapseCellAction, 'expandCell', localize('expandCell', "Expand Cell"), false),
 			new Separator(),
-			instantiationService.createInstance(ParmaetersCellAction, 'makeParameterCell', localize('makeParameterCell', "Make parameter cell"), true),
-			instantiationService.createInstance(ParmaetersCellAction, 'RemoveParameterCell', localize('RemoveParameterCell', "Remove parameter cell"), false),
+			instantiationService.createInstance(ParametersCellAction, 'makeParameterCell', localize('makeParameterCell', "Make parameter cell"), true),
+			instantiationService.createInstance(ParametersCellAction, 'removeParameterCell', localize('RemoveParameterCell', "Remove parameter cell"), false),
 			new Separator(),
 			instantiationService.createInstance(ClearCellOutputAction, 'clear', localize('clear', "Clear Result")),
 		);
@@ -368,7 +368,7 @@ export class ToggleMoreActions extends Action {
 	}
 }
 
-export class ParmaetersCellAction extends CellActionBase {
+export class ParametersCellAction extends CellActionBase {
 	constructor(id: string,
 		label: string,
 		private parametersCell: boolean,

--- a/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
@@ -145,6 +145,9 @@ export class CellToggleMoreActions {
 			instantiationService.createInstance(CollapseCellAction, 'collapseCell', localize('collapseCell', "Collapse Cell"), true),
 			instantiationService.createInstance(CollapseCellAction, 'expandCell', localize('expandCell', "Expand Cell"), false),
 			new Separator(),
+			instantiationService.createInstance(ParmaetersCellAction, 'makeParameterCell', localize('makeParameterCell', "Make parameter cell"), true),
+			instantiationService.createInstance(ParmaetersCellAction, 'RemoveParameterCell', localize('RemoveParameterCell', "Remove parameter cell"), false),
+			new Separator(),
 			instantiationService.createInstance(ClearCellOutputAction, 'clear', localize('clear', "Clear Result")),
 		);
 	}
@@ -362,5 +365,43 @@ export class ToggleMoreActions extends Action {
 			getActionsContext: () => this._context
 		});
 		return Promise.resolve(true);
+	}
+}
+
+export class ParmaetersCellAction extends CellActionBase {
+	constructor(id: string,
+		label: string,
+		private parametersCell: boolean,
+		@INotificationService notificationService: INotificationService
+	) {
+		super(id, label, undefined, notificationService);
+	}
+
+	public canRun(context: CellContext): boolean {
+		return context.cell && context.cell.cellType === CellTypes.Code;
+	}
+
+	async doRun(context: CellContext): Promise<void> {
+		try {
+			let cell = context.cell || context.model.activeCell;
+			if (cell) {
+				if (this.parametersCell) {
+					if (!cell.isParameter) {
+						cell.isParameter = true;
+					}
+				} else {
+					if (cell.isParameter) {
+						cell.isParameter = false;
+					}
+				}
+			}
+		} catch (error) {
+			let message = getErrorMessage(error);
+			this.notificationService.notify({
+				severity: Severity.Error,
+				message: message
+			});
+		}
+		return Promise.resolve();
 	}
 }

--- a/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
@@ -378,7 +378,7 @@ export class ParametersCellAction extends CellActionBase {
 	}
 
 	public canRun(context: CellContext): boolean {
-		return context.cell && context.cell.cellType === CellTypes.Code;
+		return context.cell?.cellType === CellTypes.Code;
 	}
 
 	async doRun(context: CellContext): Promise<void> {
@@ -402,6 +402,5 @@ export class ParametersCellAction extends CellActionBase {
 				message: message
 			});
 		}
-		return Promise.resolve();
 	}
 }

--- a/src/sql/workbench/contrib/notebook/test/browser/cellToolbarActions.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/cellToolbarActions.test.ts
@@ -125,7 +125,7 @@ suite('CellToolbarActions', function (): void {
 			cellModelMock.setup(x => x.cellType).returns(() => 'code');
 			const action = new CellToggleMoreActions(instantiationService);
 			action.onInit(testContainer, contextMock.object);
-			assert.equal(action['_moreActions']['viewItems'][0]['_action']['_actions'].length, 15, 'Unexpected number of valid elements');
+			assert.equal(action['_moreActions']['viewItems'][0]['_action']['_actions'].length, 18, 'Unexpected number of valid elements');
 		});
 
 		test('CellToggleMoreActions with Markdown CellType', function (): void {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -340,7 +340,7 @@ suite('Cell Model', function (): void {
 		assert(!isCollapsed);
 	});
 
-	test('Should not allow markdown cells to be collapsible', async function (): Promise<void> {
+	test('Should not allow markdown cells to be collapsible or parameters', async function (): Promise<void> {
 		let mdCellData: nb.ICellContents = {
 			cell_type: CellTypes.Markdown,
 			source: 'some *markdown*',
@@ -349,11 +349,16 @@ suite('Cell Model', function (): void {
 		};
 		let cell = factory.createCell(mdCellData, undefined);
 		assert(cell.isCollapsed === false);
+		assert(cell.isParameter === false);
+
 		cell.isCollapsed = true;
+		cell.isParameter = true;
 		// The typescript compiler will complain if we don't ignore the error from the following line,
 		// claiming that cell.isCollapsed will return true. It doesn't.
 		// @ts-ignore
 		assert(cell.isCollapsed === false);
+		// @ts-ignore
+		assert(cell.isParameter === false);
 
 		let codeCellData: nb.ICellContents = {
 			cell_type: CellTypes.Code,
@@ -364,8 +369,159 @@ suite('Cell Model', function (): void {
 		};
 		cell = factory.createCell(codeCellData, undefined);
 		assert(cell.isCollapsed === false);
+		assert(cell.isParameter === false);
+
 		cell.isCollapsed = true;
 		assert(cell.isCollapsed === true);
+		cell.isParameter = true;
+		assert(cell.isParameter === true);
+	});
+
+	test('Should parse metadata\'s parameters tag correctly', async function (): Promise<void> {
+		// Setup Notebook Model and Contents
+		let notebookModel = new NotebookModelStub({
+			name: '',
+			version: '',
+			mimetype: ''
+		});
+		let contents: nb.ICellContents = {
+			cell_type: CellTypes.Code,
+			source: ''
+		};
+		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+
+		assert(!model.isParameter);
+		model.isParameter = true;
+		assert(model.isParameter);
+		model.isParameter = false;
+		assert(!model.isParameter);
+
+		// Should not have parameters cell
+		let modelJson = model.toJSON();
+		assert(!isUndefinedOrNull(modelJson.metadata.tags));
+		assert(!modelJson.metadata.tags.some(x => x === 'parameter'));
+
+		// Add parameters tag
+		contents.metadata = {
+			tags: ['parameters']
+		};
+		model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+
+		assert(model.isParameter);
+		model.isParameter = false;
+		assert(!model.isParameter);
+		model.isParameter = true;
+		assert(model.isParameter);
+
+		// Should find parameters tag in metadata
+		modelJson = model.toJSON();
+		assert(!isUndefinedOrNull(modelJson.metadata.tags));
+		assert(modelJson.metadata.tags.some(x => x === 'parameters'));
+
+		contents.metadata = {
+			tags: ['not_a_real_tag']
+		};
+		model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+		modelJson = model.toJSON();
+		assert(!isUndefinedOrNull(modelJson.metadata.tags));
+		assert(!modelJson.metadata.tags.some(x => x === 'parameters'));
+
+		contents.metadata = {
+			tags: ['not_a_real_tag', 'parameters']
+		};
+		model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+		modelJson = model.toJSON();
+		assert(!isUndefinedOrNull(modelJson.metadata.tags));
+		assert(modelJson.metadata.tags.some(x => x === 'parameters'));
+	});
+
+	test('Should emit event setting cell as Parameter', async function (): Promise<void> {
+		let notebookModel = new NotebookModelStub({
+			name: '',
+			version: '',
+			mimetype: ''
+		});
+		let contents: nb.ICellContents = {
+			cell_type: CellTypes.Code,
+			source: ''
+		};
+
+		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+		assert(!model.isParameter);
+
+		let createParameterPromise = () => {
+			return new Promise((resolve, reject) => {
+				setTimeout(() => reject(), 2000);
+				model.onParameterStateChanged(isParameter => {
+					resolve(isParameter);
+				});
+			});
+		};
+
+		assert(!model.isParameter);
+		let parameterPromise = createParameterPromise();
+		model.isParameter = true;
+		let isParameter = await parameterPromise;
+		assert(isParameter);
+
+		parameterPromise = createParameterPromise();
+		model.isParameter = false;
+		isParameter = await parameterPromise;
+		assert(!isParameter);
+	});
+
+	test('Should parse metadata\'s injected parameter tag correctly', async function (): Promise<void> {
+		let notebookModel = new NotebookModelStub({
+			name: '',
+			version: '',
+			mimetype: ''
+		});
+		let contents: nb.ICellContents = {
+			cell_type: CellTypes.Code,
+			source: ''
+		};
+		let model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+
+		assert(!model.isInjectedParameter);
+		model.isInjectedParameter = true;
+		assert(model.isInjectedParameter);
+		model.isInjectedParameter = false;
+		assert(!model.isInjectedParameter);
+
+		let modelJson = model.toJSON();
+		assert(!isUndefinedOrNull(modelJson.metadata.tags));
+		assert(!modelJson.metadata.tags.some(x => x === 'injected-parameters'));
+
+		contents.metadata = {
+			tags: ['injected-parameters']
+		};
+		model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+
+		assert(model.isInjectedParameter);
+		model.isInjectedParameter = false;
+		assert(!model.isInjectedParameter);
+		model.isInjectedParameter = true;
+		assert(model.isInjectedParameter);
+
+		modelJson = model.toJSON();
+		assert(!isUndefinedOrNull(modelJson.metadata.tags));
+		assert(modelJson.metadata.tags.some(x => x === 'injected-parameters'));
+
+		contents.metadata = {
+			tags: ['not_a_real_tag']
+		};
+		model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+		modelJson = model.toJSON();
+		assert(!isUndefinedOrNull(modelJson.metadata.tags));
+		assert(!modelJson.metadata.tags.some(x => x === 'injected-parameters'));
+
+		contents.metadata = {
+			tags: ['not_a_real_tag', 'injected-parameters']
+		};
+		model = factory.createCell(contents, { notebook: notebookModel, isTrusted: false });
+		modelJson = model.toJSON();
+		assert(!isUndefinedOrNull(modelJson.metadata.tags));
+		assert(modelJson.metadata.tags.some(x => x === 'injected-parameters'));
 	});
 
 	suite('Model Future handling', function (): void {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/cell.test.ts
@@ -353,8 +353,8 @@ suite('Cell Model', function (): void {
 
 		cell.isCollapsed = true;
 		cell.isParameter = true;
-		// The typescript compiler will complain if we don't ignore the error from the following line,
-		// claiming that cell.isCollapsed will return true. It doesn't.
+		// The typescript compiler will complain if we don't ignore the error from the following lines,
+		// claiming that cell.isCollapsed and cell.isParameter will return true. It doesn't.
 		// @ts-ignore
 		assert(cell.isCollapsed === false);
 		// @ts-ignore

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -22,7 +22,7 @@ import { optional } from 'vs/platform/instantiation/common/instantiation';
 import { getErrorMessage, onUnexpectedError } from 'vs/base/common/errors';
 import { generateUuid } from 'vs/base/common/uuid';
 import { IModelContentChangedEvent } from 'vs/editor/common/model/textModelEvents';
-import { HideInputTag } from 'sql/platform/notebooks/common/outputRegistry';
+import { HideInputTag, ParametersTag, InjectedParametersTag } from 'sql/platform/notebooks/common/outputRegistry';
 import { FutureInternal, notebookConstants } from 'sql/workbench/services/notebook/browser/interfaces';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { tryMatchCellMagic, extractCellMagicCommandPlusArgs } from 'sql/workbench/services/notebook/browser/utils';
@@ -68,6 +68,9 @@ export class CellModel extends Disposable implements ICellModel {
 	private _cellSourceChanged: boolean = false;
 	private _gridDataConversionComplete: Promise<void>[] = [];
 	private _defaultToWYSIWYG: boolean;
+	private _isParameter: boolean;
+	private _onParameterStateChanged = new Emitter<boolean>();
+	private _isInjectedParameter: boolean;
 
 	constructor(cellData: nb.ICellContents,
 		private _options: ICellModelOptions,
@@ -338,6 +341,76 @@ export class CellModel extends Disposable implements ICellModel {
 
 	public get onCellMarkdownModeChanged(): Event<boolean> {
 		return this._onCellMarkdownChanged.event;
+	}
+
+	public get onParameterStateChanged(): Event<boolean> {
+		return this._onParameterStateChanged.event;
+	}
+
+	public get isParameter() {
+		return this._isParameter;
+	}
+
+	public set isParameter(value: boolean) {
+		if (this.cellType !== CellTypes.Code) {
+			return;
+		}
+		let stateChanged = this._isParameter !== value;
+		this._isParameter = value;
+
+		let tagIndex = -1;
+		if (this._metadata.tags) {
+			tagIndex = this._metadata.tags.findIndex(tag => tag === ParametersTag);
+		}
+
+		if (this._isParameter) {
+			if (tagIndex === -1) {
+				if (!this._metadata.tags) {
+					this._metadata.tags = [];
+				}
+				this._metadata.tags.push(ParametersTag);
+			}
+		} else {
+			if (tagIndex > -1) {
+				this._metadata.tags.splice(tagIndex, 1);
+			}
+		}
+
+		if (stateChanged) {
+			this._onParameterStateChanged.fire(this._isParameter);
+			this.sendChangeToNotebook(NotebookChangeType.CellInputVisibilityChanged);
+		}
+	}
+
+	// Injected Parameters will be used for future scenarios
+	// when we need to hide this cell for Parameterization
+	public get isInjectedParameter() {
+		return this._isInjectedParameter;
+	}
+
+	public set isInjectedParameter(value: boolean) {
+		if (this.cellType !== CellTypes.Code) {
+			return;
+		}
+		this._isInjectedParameter = value;
+
+		let tagIndex = -1;
+		if (this._metadata.tags) {
+			tagIndex = this._metadata.tags.findIndex(tag => tag === InjectedParametersTag);
+		}
+
+		if (this._isInjectedParameter) {
+			if (tagIndex === -1) {
+				if (!this._metadata.tags) {
+					this._metadata.tags = [];
+				}
+				this._metadata.tags.push(InjectedParametersTag);
+			}
+		} else {
+			if (tagIndex > -1) {
+				this._metadata.tags.splice(tagIndex, 1);
+			}
+		}
 	}
 
 	private notifyExecutionComplete(): void {
@@ -729,11 +802,16 @@ export class CellModel extends Disposable implements ICellModel {
 		this._source = this.getMultilineSource(cell.source);
 		this._metadata = cell.metadata || {};
 
-		if (this._metadata.tags && this._metadata.tags.some(x => x === HideInputTag) && this._cellType === CellTypes.Code) {
+		if (this._metadata.tags && this._metadata.tags.some(x => x === HideInputTag || x === ParametersTag || x === InjectedParametersTag) && this._cellType === CellTypes.Code) {
 			this._isCollapsed = true;
+			this._isParameter = true;
+			this._isInjectedParameter = true;
 		} else {
 			this._isCollapsed = false;
+			this._isParameter = false;
+			this._isInjectedParameter = false;
 		}
+
 
 		this._cellGuid = cell.metadata && cell.metadata.azdata_cell_guid ? cell.metadata.azdata_cell_guid : generateUuid();
 		this.setLanguageFromContents(cell);

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -812,7 +812,6 @@ export class CellModel extends Disposable implements ICellModel {
 			this._isInjectedParameter = false;
 		}
 
-
 		this._cellGuid = cell.metadata && cell.metadata.azdata_cell_guid ? cell.metadata.azdata_cell_guid : generateUuid();
 		this.setLanguageFromContents(cell);
 		if (cell.outputs) {

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -382,8 +382,10 @@ export class CellModel extends Disposable implements ICellModel {
 		}
 	}
 
-	// Injected Parameters will be used for future scenarios
-	// when we need to hide this cell for Parameterization
+	/**
+	Injected Parameters will be used for future scenarios
+	when we need to hide this cell for Parameterization
+	*/
 	public get isInjectedParameter() {
 		return this._isInjectedParameter;
 	}

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -477,7 +477,10 @@ export interface ICellModel {
 	stdInVisible: boolean;
 	readonly onLoaded: Event<string>;
 	isCollapsed: boolean;
+	isParameter: boolean;
+	isInjectedParameter: boolean;
 	readonly onCollapseStateChanged: Event<boolean>;
+	readonly onParameterStateChanged: Event<boolean>;
 	readonly onCellModeChanged: Event<boolean>;
 	modelContentChangedEvent: IModelContentChangedEvent;
 	isEditMode: boolean;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR introduces the backend cell model work that is required for Parameterization. There are two important tags for parameterization as a whole: **parameters** and **injected-parameters**. This enables the use of [Papermill](https://github.com/nteract/papermill) to work properly with ADS Notebooks. 

The current backend work is demonstrated in the gif below. It focuses on using the cell toolbar action to change the metadata based on the action of "_Make parameter cell_" and "_Remove parameter cell_". I have added tests for both the parameter cell as well as the injected-parameter cell. 
The injected-parameter cell will be added to a notebook below the parameters cell when a user uses Papermill (for example) to parameterize a notebook. 

Please leave any feedback or questions!

**Work to do**: UI components for the visual tag of the parameter cell. 

![parameterization_backend](https://user-images.githubusercontent.com/23587151/95946859-0b9bd080-0db3-11eb-8cdb-0b874385ad83.gif)
Gif: Click cell -> Use toolbar action 'Make parameter cell' -> Save notebook -> View metadata of notebook cell with new tag "parameters" -> Use toolbar action 'Remove parameter cell' -> Save notebook -> View metadata of notebook cell and see that the "parameters" tag is no longer there.