### PR TITLE
Revert "Bump SQL Tools to 3.0.0-release.42"

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.42",
+	"version": "3.0.0-release.40",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",


### PR DESCRIPTION
Reverts microsoft/azuredatastudio#12929

This PR introduced these integration test failures

![Screen Shot 2020-10-15 at 4 54 20 PM](https://user-images.githubusercontent.com/18150417/96184891-136c8980-0f07-11eb-971b-315904b21cbb.png)
