### PR TITLE
Revert "Bump SQL Tools to 3.0.0-release.42 (#12929)"

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.42",
+	"version": "3.0.0-release.40",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",


### PR DESCRIPTION
Getting this error on startup now : 

```
System.Reflection.ReflectionTypeLoadException
  HResult=0x80131602
  Message=Unable to load one or more of the requested types.
Could not load type 'Microsoft.SqlServer.Management.Assessment.IAssessmentRequest' from assembly 'Microsoft.SqlServer.Assessment, Version=1.100.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91'.
  Source=System.Private.CoreLib
  StackTrace:
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeAssembly.get_DefinedTypes()
```