### PR TITLE
Fix links on WYSIWYG

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -486,7 +486,8 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		this.turndownService.addRule('a', {
 			filter: 'a',
 			replacement: (content, node) => {
-				//if notebook is untrusted then the link is save on the title
+				//On Windows, if notebook is not trusted then the href attr is removed.
+				// href contains either a hyperlink or an absolute path. (See resolveUrls method in notebookMarkdown.ts)
 				const notebookLink = node.href ? URI.parse(node.href) : (path.isAbsolute(node.title) ? URI.file(node.title) : undefined);
 				const notebookFolder = this.notebookUri ? path.join(path.dirname(this.notebookUri.fsPath), path.sep) : '';
 				let relativePath = findPathRelativeToContent(notebookFolder, notebookLink);
@@ -517,10 +518,12 @@ export function findPathRelativeToContent(notebookFolder: string, contentPath: U
 			if (relativePath.startsWith(path.join('..', path.sep) || path.join('.', path.sep))) {
 				return relativePath;
 			} else {
+				// if the relative path does not contain ./ at the beginning, we need to add it so it's recognized as a link
 				return `.${path.join(path.sep, relativePath)}`;
 			}
 		}
 	}
+	// return empty for hyperlinks
 	return '';
 }
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -487,7 +487,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			filter: 'a',
 			replacement: (content, node) => {
 				//if notebook is untrusted then the link is save on the title
-				const notebookLink = node.href ? URI.parse(node.href) : URI.file(node.title);
+				const notebookLink = node.href ? URI.parse(node.href) : (path.isAbsolute(node.title) ? URI.file(node.title) : undefined);
 				const notebookFolder = this.notebookUri ? path.join(path.dirname(this.notebookUri.fsPath), path.sep) : '';
 				let relativePath = findPathRelativeToContent(notebookFolder, notebookLink);
 				if (relativePath) {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -256,7 +256,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	//Sanitizes the content based on trusted mode of Cell Model
 	private sanitizeContent(content: string): string {
 		if (this.cellModel && !this.cellModel.trustedMode) {
-			content = this.sanitizer.sanitize(content, { allowedTags: ['a'] });
+			content = this.sanitizer.sanitize(content);
 		}
 		return content;
 	}
@@ -493,10 +493,11 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 					path = URI.file(node.title);
 				}
 				let relativePath = this.findPathRelativeToContent(path);
+
 				if (relativePath) {
 					return `[${node.innerText}](${relativePath})`;
 				}
-				return `[${node.innerText}](${node.href})`;
+				return `[${node.innerText}](.${node.href})`;
 			}
 		});
 	}
@@ -515,6 +516,8 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		if (notebookFolder) {
 			if (absolutePathURI?.scheme === 'file') {
 				let relativePath = path.relative(notebookFolder, absolutePathURI.fsPath);
+				//if path contains whitespaces then it's not identified as a link
+				relativePath = relativePath.replace(/\s/g, '%20');
 				if (relativePath.startsWith(path.join('.', path.sep))) {
 					return relativePath;
 				} else {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -514,7 +514,7 @@ export function findPathRelativeToContent(notebookFolder: string, contentPath: U
 			let relativePath = path.relative(notebookFolder, contentPath.fsPath);
 			//if path contains whitespaces then it's not identified as a link
 			relativePath = relativePath.replace(/\s/g, '%20');
-			if (relativePath.startsWith(path.join('.', '.', path.sep) || path.join('.', path.sep))) {
+			if (relativePath.startsWith(path.join('..', path.sep) || path.join('.', path.sep))) {
 				return relativePath;
 			} else {
 				return `.${path.join(path.sep, relativePath)}`;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -495,9 +495,9 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 				let relativePath = this.findPathRelativeToContent(path);
 
 				if (relativePath) {
-					return `[${node.innerText}](${relativePath})`;
+					return `[${node.innerText}](.${relativePath})`;
 				}
-				return `[${node.innerText}](.${node.href})`;
+				return `[${node.innerText}](${node.href})`;
 			}
 		});
 	}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -508,10 +508,10 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	}
 }
 
-export function findPathRelativeToContent(notebookFolder: string, absolutePathURI: URI): string {
+export function findPathRelativeToContent(notebookFolder: string, contentPath: URI): string {
 	if (notebookFolder) {
-		if (absolutePathURI?.scheme === 'file') {
-			let relativePath = path.relative(notebookFolder, absolutePathURI.fsPath);
+		if (contentPath?.scheme === 'file') {
+			let relativePath = path.relative(notebookFolder, contentPath.fsPath);
 			//if path contains whitespaces then it's not identified as a link
 			relativePath = relativePath.replace(/\s/g, '%20');
 			if (relativePath.startsWith(path.join('.', '.', path.sep) || path.join('.', path.sep))) {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -486,9 +486,9 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		this.turndownService.addRule('a', {
 			filter: 'a',
 			replacement: (content, node) => {
-				//On Windows, if notebook is not trusted then the href attr is removed.
-				// href contains either a hyperlink or an absolute path. (See resolveUrls method in notebookMarkdown.ts)
-				const notebookLink = node.href ? URI.parse(node.href) : (path.isAbsolute(node.title) ? URI.file(node.title) : undefined);
+				//On Windows, if notebook is not trusted then the href attr is removed for all non-web URL links
+				// href contains either a hyperlink or a URI-encoded absolute path. (See resolveUrls method in notebookMarkdown.ts)
+				const notebookLink = node.href ? URI.parse(node.href) : URI.file(node.title);
 				const notebookFolder = this.notebookUri ? path.join(path.dirname(this.notebookUri.fsPath), path.sep) : '';
 				let relativePath = findPathRelativeToContent(notebookFolder, notebookLink);
 				if (relativePath) {
@@ -509,7 +509,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	}
 }
 
-export function findPathRelativeToContent(notebookFolder: string, contentPath: URI): string {
+export function findPathRelativeToContent(notebookFolder: string, contentPath: URI | undefined): string {
 	if (notebookFolder) {
 		if (contentPath?.scheme === 'file') {
 			let relativePath = path.relative(notebookFolder, contentPath.fsPath);
@@ -523,7 +523,6 @@ export function findPathRelativeToContent(notebookFolder: string, contentPath: U
 			}
 		}
 	}
-	// return empty for hyperlinks
 	return '';
 }
 


### PR DESCRIPTION
This PR fixes #12899
On windows,  the href attribute from the html element is removed in untrusted notebooks.
When we convert the text to markdown the href attribute is empty that's why the links disappeared when switching between rich text view to split view.
The other thing that I fixed here is that markdown does not identify a path as a link if it contains whitespaces. When switching from markdown to WYSIWYG, we parse the href link so it removes all the encoding, so I replace all the whitespaces to %20 to keep the link working when switching from Split View to Rich Text View.