### PR TITLE
Fix notebook smoke test

### DIFF
--- a/test/automation/src/sql/configurePythonDialog.ts
+++ b/test/automation/src/sql/configurePythonDialog.ts
@@ -39,7 +39,7 @@ export class ConfigurePythonDialog extends Dialog {
 
 	private async _waitForInstallationComplete(): Promise<void> {
 		const installationCompleteNotification = '.notifications-toasts div[aria-label="Notebook dependencies installation is complete, source: Notebook Core Extensions (Extension), notification"]';
-		await this.code.waitForElement(installationCompleteNotification);
+		await this.code.waitForElement(installationCompleteNotification, undefined, 600); // wait up to 1 minute for python installation
 	}
 
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The notebook smoke test failed because the python installation was not complete. I increased the wait time from 20 seconds to one minute. 

Screenshot of when the notebook smoke test failed during product build:
![VSCode_Smoke_Tests__Electron__VSCode_Smoke_Tests__Electron__Notebook_can_open_new_notebook__configure_Python__and_execute_one_cell](https://user-images.githubusercontent.com/23462877/96481147-0219ca80-11f0-11eb-865b-170bc151e073.png)

