### PR TITLE
Skip getting icon if we don't have a server info

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -573,8 +573,12 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 
 		let iconProvider = this._iconProviders.get(connectionManagementInfo.providerId);
 		if (iconProvider) {
-			let serverInfo: azdata.ServerInfo = this.getServerInfo(connectionProfile.id);
-			let profile: interfaces.IConnectionProfile = connectionProfile.toIConnectionProfile();
+			const serverInfo: azdata.ServerInfo | undefined = this.getServerInfo(connectionProfile.id);
+			if (!serverInfo) {
+				this._logService.warn(`Could not find ServerInfo for connection ${connectionProfile.id} when updating icon`);
+				return;
+			}
+			const profile: interfaces.IConnectionProfile = connectionProfile.toIConnectionProfile();
 			iconProvider.getConnectionIconId(profile, serverInfo).then(iconId => {
 				if (iconId && this._mementoObj && this._mementoContext) {
 					if (!this._mementoObj.CONNECTION_ICON_ID) {
@@ -1376,10 +1380,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		if (!profile) {
 			return undefined;
 		}
-
-		let serverInfo = profile.serverInfo;
-
-		return serverInfo;
+		return profile.serverInfo;
 	}
 
 	public getConnectionProfileById(profileId: string): interfaces.IConnectionProfile {


### PR DESCRIPTION
Noticed this while looking at https://github.com/microsoft/azuredatastudio/issues/12992

In my testing it doesn't seem to actually be the cause of the issue - if I manually cause the icon provider function to throw it still expands correctly. It just won't have the new icon.

This is just fixing it so we adhere to the signature as defined in https://github.com/microsoft/azuredatastudio/blob/main/src/sql/azdata.d.ts#L1302 - serverInfo isn't optional and so we probably shouldn't be passing a possibly undefined object.

We could also considerallowing that value to be undefined though - since perhaps a provider doesn't actually care what the exact type of the connection is (for example all kusto icons are set regardless of the server info). But doing so would be a breaking change so I'm a little more hesitant to do that - although since an error being thrown doesn't seem to break anything it might be ok in this case. And server info being undefined here shouldn't happen normally - I'm still not sure how the client got in that state since we should have a connection with the info by the time we get here. 