### PR TITLE
Don't open schema compare if project build fails

### DIFF
--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -133,6 +133,7 @@ export const projectLocationRequired = localize('projectLocationRequired', "Loca
 export const projectLocationNotEmpty = localize('projectLocationNotEmpty', "Current project location is not empty. Select an empty folder for precise extraction.");
 export const extractTargetRequired = localize('extractTargetRequired', "Target information for extract is required to create database project.");
 export const schemaCompareNotInstalled = localize('schemaCompareNotInstalled', "Schema compare extension installation is required to run schema compare");
+export const buildFailedCannotStartSchemaCompare = localize('buildFailedCannotStartSchemaCompare', "Schema compare could not start because build failed");
 export const updateProjectForRoundTrip = localize('updateProjectForRoundTrip', "To build this project, Azure Data Studio needs to update targets, references, and system database references. If the project is created in SSDT, it will continue to work in both tools. Do you want Azure Data Studio to update the project?");
 export const updateProjectDatabaseReferencesForRoundTrip = localize('updateProjectDatabaseReferencesForRoundTrip', "To build this project, Azure Data Studio needs to update system database references. If the project is created in SSDT, it will continue to work in both tools. Do you want Azure Data Studio to update the project?");
 export const databaseReferenceTypeRequired = localize('databaseReferenceTypeRequired', "Database reference type is required for adding a reference to a database");

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -133,7 +133,6 @@ export const projectLocationRequired = localize('projectLocationRequired', "Loca
 export const projectLocationNotEmpty = localize('projectLocationNotEmpty', "Current project location is not empty. Select an empty folder for precise extraction.");
 export const extractTargetRequired = localize('extractTargetRequired', "Target information for extract is required to create database project.");
 export const schemaCompareNotInstalled = localize('schemaCompareNotInstalled', "Schema compare extension installation is required to run schema compare");
-export const buildDacpacNotFound = localize('buildDacpacNotFound', "Dacpac created from build not found");
 export const updateProjectForRoundTrip = localize('updateProjectForRoundTrip', "To build this project, Azure Data Studio needs to update targets, references, and system database references. If the project is created in SSDT, it will continue to work in both tools. Do you want Azure Data Studio to update the project?");
 export const updateProjectDatabaseReferencesForRoundTrip = localize('updateProjectDatabaseReferencesForRoundTrip', "To build this project, Azure Data Studio needs to update system database references. If the project is created in SSDT, it will continue to work in both tools. Do you want Azure Data Studio to update the project?");
 export const databaseReferenceTypeRequired = localize('databaseReferenceTypeRequired', "Database reference type is required for adding a reference to a database");

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -272,17 +272,11 @@ export class ProjectsController {
 		// check if schema compare extension is installed
 		if (vscode.extensions.getExtension(constants.schemaCompareExtensionId)) {
 			// build project
-			await this.buildProject(treeNode);
-
-			// start schema compare with the dacpac produced from build
-			const project = this.getProjectFromContext(treeNode);
-			const dacpacPath = path.join(project.projectFolderPath, 'bin', 'Debug', `${project.projectFileName}.dacpac`);
+			const dacpacPath = await this.buildProject(treeNode);
 
 			// check that dacpac exists
 			if (await utils.exists(dacpacPath)) {
 				await vscode.commands.executeCommand(constants.schemaCompareStartCommand, dacpacPath);
-			} else {
-				vscode.window.showErrorMessage(constants.buildDacpacNotFound);
 			}
 		} else {
 			vscode.window.showErrorMessage(constants.schemaCompareNotInstalled);

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -277,6 +277,8 @@ export class ProjectsController {
 			// check that dacpac exists
 			if (await utils.exists(dacpacPath)) {
 				await vscode.commands.executeCommand(constants.schemaCompareStartCommand, dacpacPath);
+			} else {
+				vscode.window.showErrorMessage(constants.buildFailedCannotStartSchemaCompare);
 			}
 		} else {
 			vscode.window.showErrorMessage(constants.schemaCompareNotInstalled);


### PR DESCRIPTION
This PR fixes #12715. Previously, schema compare would open if there was a dacpac in the project's bin folder. buildProject() returns the undefined if the build failed and the dacpac path if successful, so we can use that instead of creating the dacpac path again.
