### PR TITLE
Azure provider cleanup and add rg property

### DIFF
--- a/extensions/azurecore/src/azureDataGridProvider.ts
+++ b/extensions/azurecore/src/azureDataGridProvider.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from 'azdata';
+import { AppContext } from './appContext';
+import { AzureResourceServiceNames } from './azureResource/constants';
+import { IAzureResourceSubscriptionService } from './azureResource/interfaces';
+import { TokenCredentials } from '@azure/ms-rest-js';
+import { azureResource } from 'azureResource';
+import * as azureResourceUtils from './azureResource/utils';
+import * as constants from './constants';
+import * as loc from './localizedConstants';
+import * as utils from './utils';
+
+const typesClause = [
+	azureResource.AzureResourceType.sqlDatabase,
+	azureResource.AzureResourceType.sqlServer,
+	azureResource.AzureResourceType.sqlManagedInstance,
+	azureResource.AzureResourceType.postgresServer,
+	azureResource.AzureResourceType.azureArcService,
+	azureResource.AzureResourceType.azureArcSqlManagedInstance,
+	azureResource.AzureResourceType.azureArcPostgresServer
+].map(type => `type == "${type}"`).join(' or ');
+
+export class AzureDataGridProvider implements azdata.DataGridProvider {
+	constructor(private _appContext: AppContext) { }
+
+	public providerId = constants.dataGridProviderId;
+	public async getDataGridItems() {
+		const accounts = await azdata.accounts.getAllAccounts();
+		const items: any[] = [];
+		await Promise.all(accounts.map(async (account) => {
+			await Promise.all(account.properties.tenants.map(async (tenant: { id: string; }) => {
+				try {
+					const tokenResponse = await azdata.accounts.getAccountSecurityToken(account, tenant.id, azdata.AzureResource.ResourceManagement);
+					const token = tokenResponse.token;
+					const tokenType = tokenResponse.tokenType;
+					const credential = new TokenCredentials(token, tokenType);
+					const subscriptionService = this._appContext.getService<IAzureResourceSubscriptionService>(AzureResourceServiceNames.subscriptionService);
+					const subscriptions = await subscriptionService.getSubscriptions(account, credential, tenant.id);
+					try {
+						const newItems = (await azureResourceUtils.runResourceQuery(account, subscriptions, true, `where ${typesClause}`)).resources
+							.map(item => {
+								return <azdata.DataGridItem>{
+									id: item.id,
+									// nameLink: <azdata.DataGridHyperlinkInfo>{ displayText: item.name, linkOrCommand: ''},
+									resourceGroup: item.resourceGroup,
+									subscriptionName: subscriptions.find(subscription => subscription.id === item.subscriptionId)?.name ?? item.subscriptionId,
+									locationDisplayName: utils.getRegionDisplayName(item.location),
+									typeDisplayName: utils.getResourceTypeDisplayName(item.type),
+									iconPath: utils.getResourceTypeIcon(this._appContext, item.type)
+								};
+							});
+						items.push(...newItems);
+					} catch (err) {
+						console.log(err);
+					}
+				} catch (err) {
+					console.log(err);
+				}
+			}));
+		}));
+		return items;
+	}
+
+	public async getDataGridColumns(): Promise<azdata.DataGridColumn[]> {
+		return [
+			{ id: 'icon', type: 'image', field: 'iconPath', name: '', width: 25, sortable: false, filterable: false, resizable: false, tooltip: loc.typeIcon },
+			{ id: 'name', type: 'hyperlink', field: 'nameLink', name: loc.name, width: 150 },
+			{ id: 'type', type: 'text', field: 'typeDisplayName', name: loc.resourceType, width: 150 },
+			{ id: 'type', type: 'text', field: 'resourceGroup', name: loc.resourceGroup, width: 150 },
+			{ id: 'location', type: 'text', field: 'locationDisplayName', name: loc.location, width: 150 },
+			{ id: 'subscriptionId', type: 'text', field: 'subscriptionName', name: loc.subscription, width: 150 }
+		];
+	}
+}

--- a/extensions/azurecore/src/azureResource/azure-resource.d.ts
+++ b/extensions/azurecore/src/azureResource/azure-resource.d.ts
@@ -39,6 +39,7 @@ declare module 'azureResource' {
 			name: string;
 			id: string;
 			subscriptionId: string;
+			resourceGroup: string;
 			tenant?: string;
 		}
 

--- a/extensions/azurecore/src/azureResource/azure-resource.d.ts
+++ b/extensions/azurecore/src/azureResource/azure-resource.d.ts
@@ -39,7 +39,7 @@ declare module 'azureResource' {
 			name: string;
 			id: string;
 			subscriptionId: string;
-			resourceGroup: string;
+			resourceGroup?: string;
 			tenant?: string;
 		}
 

--- a/extensions/azurecore/src/azureResource/providers/database/databaseService.ts
+++ b/extensions/azurecore/src/azureResource/providers/database/databaseService.ts
@@ -52,7 +52,8 @@ export class AzureResourceDatabaseService implements IAzureResourceService<azure
 						serverFullName: server.properties.fullyQualifiedDomainName,
 						loginName: server.properties.administratorLogin,
 						subscriptionId: db.subscriptionId,
-						tenant: db.tenantId
+						tenant: db.tenantId,
+						resourceGroup: db.resourceGroup
 					});
 				}
 			}

--- a/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerService.ts
+++ b/extensions/azurecore/src/azureResource/providers/databaseServer/databaseServerService.ts
@@ -31,7 +31,8 @@ export class AzureResourceDatabaseServerService extends ResourceServiceBase<DbSe
 			loginName: resource.properties.administratorLogin,
 			defaultDatabaseName: 'master',
 			subscriptionId: resource.subscriptionId,
-			tenant: resource.tenantId
+			tenant: resource.tenantId,
+			resourceGroup: resource.resourceGroup
 		};
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/kusto/kustoService.ts
+++ b/extensions/azurecore/src/azureResource/providers/kusto/kustoService.ts
@@ -30,7 +30,8 @@ export class KustoResourceService extends ResourceServiceBase<KustoGraphData, az
 			loginName: '',
 			defaultDatabaseName: '',
 			subscriptionId: resource.subscriptionId,
-			tenant: resource.tenantId
+			tenant: resource.tenantId,
+			resourceGroup: resource.resourceGroup
 		};
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerService.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresArcServer/postgresServerService.ts
@@ -28,7 +28,8 @@ export class PostgresServerArcService extends ResourceServiceBase<PostgresArcSer
 			loginName: resource.properties.admin,
 			defaultDatabaseName: 'postgres',
 			subscriptionId: resource.subscriptionId,
-			tenant: resource.tenantId
+			tenant: resource.tenantId,
+			resourceGroup: resource.resourceGroup
 		};
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerService.ts
+++ b/extensions/azurecore/src/azureResource/providers/postgresServer/postgresServerService.ts
@@ -31,7 +31,8 @@ export class PostgresServerService extends ResourceServiceBase<DbServerGraphData
 			loginName: resource.properties.administratorLogin,
 			defaultDatabaseName: 'postgres',
 			subscriptionId: resource.subscriptionId,
-			tenant: resource.tenantId
+			tenant: resource.tenantId,
+			resourceGroup: resource.resourceGroup
 		};
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/sqlinstance/sqlInstanceService.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstance/sqlInstanceService.ts
@@ -29,7 +29,8 @@ export class SqlInstanceResourceService extends ResourceServiceBase<SqlInstanceG
 			loginName: resource.properties.administratorLogin,
 			defaultDatabaseName: 'master',
 			subscriptionId: resource.subscriptionId,
-			tenant: resource.tenantId
+			tenant: resource.tenantId,
+			resourceGroup: resource.resourceGroup
 		};
 	}
 }

--- a/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcService.ts
+++ b/extensions/azurecore/src/azureResource/providers/sqlinstanceArc/sqlInstanceArcService.ts
@@ -28,7 +28,8 @@ export class SqlInstanceArcResourceService extends ResourceServiceBase<SqlInstan
 			loginName: resource.properties.admin,
 			defaultDatabaseName: 'master',
 			subscriptionId: resource.subscriptionId,
-			tenant: resource.tenantId
+			tenant: resource.tenantId,
+			resourceGroup: resource.resourceGroup
 		};
 	}
 }

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -43,8 +43,8 @@ import * as loc from './localizedConstants';
 import * as constants from './constants';
 import { AzureResourceGroupService } from './azureResource/providers/resourceGroup/resourceGroupService';
 import { Logger } from './utils/Logger';
-import { TokenCredentials } from '@azure/ms-rest-js';
 import { FlatAzureResourceTreeProvider } from './azureResource/tree/flatTreeProvider';
+import { AzureDataGridProvider } from './azureDataGridProvider';
 
 let extensionContext: vscode.ExtensionContext;
 
@@ -90,63 +90,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 	pushDisposable(vscode.window.registerTreeDataProvider('azureResourceExplorer', azureResourceTree));
 	pushDisposable(vscode.workspace.onDidChangeConfiguration(e => onDidChangeConfiguration(e), this));
 	registerAzureResourceCommands(appContext, azureResourceTree);
-
-	const typesClause = [
-		azureResource.AzureResourceType.sqlDatabase,
-		azureResource.AzureResourceType.sqlServer,
-		azureResource.AzureResourceType.sqlManagedInstance,
-		azureResource.AzureResourceType.postgresServer,
-		azureResource.AzureResourceType.azureArcService,
-		azureResource.AzureResourceType.azureArcSqlManagedInstance,
-		azureResource.AzureResourceType.azureArcPostgresServer
-	].map(type => `type == "${type}"`).join(' or ');
-	azdata.dataprotocol.registerDataGridProvider({
-		providerId: constants.dataGridProviderId,
-		getDataGridItems: async () => {
-			const accounts = await azdata.accounts.getAllAccounts();
-			const items: any[] = [];
-			await Promise.all(accounts.map(async (account) => {
-				await Promise.all(account.properties.tenants.map(async (tenant: { id: string; }) => {
-					try {
-						const tokenResponse = await azdata.accounts.getAccountSecurityToken(account, tenant.id, azdata.AzureResource.ResourceManagement);
-						const token = tokenResponse.token;
-						const tokenType = tokenResponse.tokenType;
-						const credential = new TokenCredentials(token, tokenType);
-						const subscriptionService = appContext.getService<IAzureResourceSubscriptionService>(AzureResourceServiceNames.subscriptionService);
-						const subscriptions = await subscriptionService.getSubscriptions(account, credential, tenant.id);
-						try {
-							const newItems = (await azureResourceUtils.runResourceQuery(account, subscriptions, true, `where ${typesClause}`)).resources
-								.map(item => {
-									return {
-										...item,
-										subscriptionName: subscriptions.find(subscription => subscription.id === item.subscriptionId)?.name ?? item.subscriptionId,
-										locationDisplayName: utils.getRegionDisplayName(item.location),
-										typeDisplayName: utils.getResourceTypeDisplayName(item.type),
-										iconPath: utils.getResourceTypeIcon(appContext, item.type)
-									};
-								});
-							items.push(...newItems);
-						} catch (err) {
-							console.log(err);
-						}
-					} catch (err) {
-						console.log(err);
-					}
-				}));
-			}));
-			return items;
-		},
-		getDataGridColumns: async () => {
-			return [
-				{ id: 'icon', type: 'image', field: 'iconPath', name: '', width: 25, sortable: false, filterable: false, resizable: false, tooltip: loc.typeIcon },
-				{ id: 'name', type: 'text', field: 'name', name: loc.name, width: 150 },
-				{ id: 'type', type: 'text', field: 'typeDisplayName', name: loc.resourceType, width: 150 },
-				{ id: 'type', type: 'text', field: 'resourceGroup', name: loc.resourceGroup, width: 150 },
-				{ id: 'location', type: 'text', field: 'locationDisplayName', name: loc.location, width: 150 },
-				{ id: 'subscriptionId', type: 'text', field: 'subscriptionName', name: loc.subscription, width: 150 }
-			];
-		}
-	});
+	azdata.dataprotocol.registerDataGridProvider(new AzureDataGridProvider(appContext));
 
 	return {
 		getSubscriptions(account?: azdata.Account, ignoreErrors?: boolean, selectedOnly: boolean = false): Thenable<azurecore.GetSubscriptionsResult> {

--- a/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
@@ -76,7 +76,8 @@ const mockDatabases: azureResource.AzureResourceDatabase[] = [
 		serverName: 'mock database server 1',
 		serverFullName: 'mock database server full name 1',
 		loginName: 'mock login',
-		subscriptionId: 'mock_subscription'
+		subscriptionId: 'mock_subscription',
+		resourceGroup: 'rg1'
 	},
 	{
 		name: 'mock database 2',
@@ -84,7 +85,8 @@ const mockDatabases: azureResource.AzureResourceDatabase[] = [
 		serverName: 'mock database server 2',
 		serverFullName: 'mock database server full name 2',
 		loginName: 'mock login',
-		subscriptionId: 'mock_subscription'
+		subscriptionId: 'mock_subscription',
+		resourceGroup: 'rg2'
 	}
 ];
 

--- a/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
@@ -75,7 +75,8 @@ const mockDatabaseServers: azureResource.AzureResourceDatabaseServer[] = [
 		fullName: 'mock database server full name 1',
 		loginName: 'mock login',
 		defaultDatabaseName: 'master',
-		subscriptionId: 'mock_subscription'
+		subscriptionId: 'mock_subscription',
+		resourceGroup: 'rg1'
 	},
 	{
 		name: 'mock database server 2',
@@ -83,7 +84,8 @@ const mockDatabaseServers: azureResource.AzureResourceDatabaseServer[] = [
 		fullName: 'mock database server full name 2',
 		loginName: 'mock login',
 		defaultDatabaseName: 'master',
-		subscriptionId: 'mock_subscription'
+		subscriptionId: 'mock_subscription',
+		resourceGroup: 'rg2'
 	}
 ];
 


### PR DESCRIPTION
Moving the provider into its own class for cleaner separation of logic.

Adding resource group property to azure resources (it was already a property on those resources - just not defined in the typings)