### PR TITLE
Notebook Parameterization - Papermill Compatibility 

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterKernel.ts
+++ b/extensions/notebook/src/jupyter/jupyterKernel.ts
@@ -82,7 +82,8 @@ export class JupyterKernel implements nb.IKernel {
 		let specImpl = await this.kernelImpl.getSpec();
 		return {
 			name: specImpl.name,
-			display_name: specImpl.display_name
+			display_name: specImpl.display_name,
+			language: specImpl.language
 		};
 	}
 

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
@@ -15,7 +15,6 @@ import { NotebookEditor } from 'sql/workbench/contrib/notebook/browser/notebookE
 import { NBTestQueryManagementService } from 'sql/workbench/contrib/notebook/test/nbTestQueryManagementService';
 import * as stubs from 'sql/workbench/contrib/notebook/test/stubs';
 import { NotebookEditorStub } from 'sql/workbench/contrib/notebook/test/testCommon';
-import { CellModel } from 'sql/workbench/services/notebook/browser/models/cell';
 import { ICellModel, NotebookContentChange } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { INotebookEditor, INotebookParams, INotebookService, NotebookRange } from 'sql/workbench/services/notebook/browser/notebookService';
 import { NotebookService } from 'sql/workbench/services/notebook/browser/notebookServiceImpl';
@@ -61,13 +60,12 @@ import { TestNotificationService } from 'vs/platform/notification/test/common/te
 import { INotificationService } from 'vs/platform/notification/common/notification';
 
 class NotebookModelStub extends stubs.NotebookModelStub {
-	private _cells: Array<ICellModel> = [new CellModel(undefined, undefined)];
 	public contentChangedEmitter = new Emitter<NotebookContentChange>();
 	private _kernelChangedEmitter = new Emitter<nb.IKernelChangedArgs>();
 	private _onActiveCellChanged = new Emitter<ICellModel>();
 
-	get cells(): ReadonlyArray<ICellModel> {
-		return this._cells;
+	get cells(): ICellModel[] {
+		return this.cells;
 	}
 	public get contentChanged(): Event<NotebookContentChange> {
 		return this.contentChangedEmitter.event;

--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -19,7 +19,7 @@ import { QueryTextEditor } from 'sql/workbench/browser/modelComponents/queryText
 import { IContextViewProvider, IDelegate } from 'vs/base/browser/ui/contextview/contextview';
 
 export class NotebookModelStub implements INotebookModel {
-	constructor(private _languageInfo?: nb.ILanguageInfo) {
+	constructor(private _languageInfo?: nb.ILanguageInfo, private _cells?: ICellModel[]) {
 	}
 	trustedMode: boolean;
 	language: string;
@@ -31,8 +31,8 @@ export class NotebookModelStub implements INotebookModel {
 	onCellChange(cell: ICellModel, change: NotebookChangeType): void {
 		// Default: do nothing
 	}
-	get cells(): ReadonlyArray<ICellModel> {
-		throw new Error('method not implemented.');
+	get cells(): ICellModel[] | undefined {
+		return this._cells;
 	}
 	get activeCell(): ICellModel {
 		throw new Error('method not implemented.');

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -356,7 +356,9 @@ export class CellModel extends Disposable implements ICellModel {
 			return;
 		}
 
-		// There can only be one tagged parameters cell in the Notebook
+		/**
+		 * The value will not be updated if there is already a parameter cell in the Notebook.
+		**/
 		value = this.notebookModel?.cells?.find(cell => cell.isParameter) ? false : value;
 
 		let stateChanged = this._isParameter !== value;

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -357,11 +357,7 @@ export class CellModel extends Disposable implements ICellModel {
 		}
 
 		// There can only be one tagged parameters cell in the Notebook
-		for (let cell of this.notebookModel.cells) {
-			if (cell.isParameter) {
-				value = false;
-			}
-		}
+		value = this.notebookModel?.cells?.find(cell => cell.isParameter) ? false : value;
 
 		let stateChanged = this._isParameter !== value;
 		this._isParameter = value;
@@ -809,13 +805,10 @@ export class CellModel extends Disposable implements ICellModel {
 		this.executionCount = cell.execution_count;
 		this._source = this.getMultilineSource(cell.source);
 		this._metadata = cell.metadata || {};
-
-		if (this._metadata.tags && this._metadata.tags.some(x => x === HideInputTag) && this._cellType === CellTypes.Code) {
-			this._isCollapsed = true;
-		} else if (this._metadata.tags && this._metadata.tags.some(x => x === ParametersTag) && this._cellType === CellTypes.Code) {
-			this._isParameter = true;
-		} else if (this._metadata.tags && this._metadata.tags.some(x => x === InjectedParametersTag) && this._cellType === CellTypes.Code) {
-			this._isInjectedParameter = true;
+		if (this._metadata.tags && this._cellType === CellTypes.Code) {
+			this._isCollapsed = this._metadata.tags.some(x => x === HideInputTag);
+			this._isParameter = this._metadata.tags.some(x => x === ParametersTag);
+			this._isInjectedParameter = this._metadata.tags.some(x => x === InjectedParametersTag);
 		} else {
 			this._isCollapsed = false;
 			this._isParameter = false;

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -494,6 +494,7 @@ export interface ICellModel {
 	gridDataConversionComplete: Promise<void>;
 	addGridDataConversionPromise(complete: Promise<void>): void;
 	updateOutputData(batchId: number, id: number, data: any): void;
+	metadata: { language?: string; tags?: string[]; cellGuid?: string; };
 }
 
 export interface IModelFactory {

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -494,7 +494,6 @@ export interface ICellModel {
 	gridDataConversionComplete: Promise<void>;
 	addGridDataConversionPromise(complete: Promise<void>): void;
 	updateOutputData(batchId: number, id: number, data: any): void;
-	metadata: { language?: string; tags?: string[]; cellGuid?: string; };
 }
 
 export interface IModelFactory {

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -359,6 +359,14 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				if (contents.cells && contents.cells.length > 0) {
 					this._cells = contents.cells.map(c => {
 						let cellModel = factory.createCell(c, { notebook: this, isTrusted: isTrusted });
+						/*
+						In a parameterized notebook there will be a injected parameter cell.
+						We need to indicate to the user the difference between this cell and the parameters cell.
+						*/
+						if (cellModel.metadata?.tags?.includes('injected-parameters')) {
+							cellModel.source = cellModel.source.slice(1);
+							cellModel.source = '# Injected-Parameters\n' + cellModel.source;
+						}
 						this.trackMarkdownTelemetry(<nb.ICellContents>c, cellModel);
 						return cellModel;
 					});

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -360,10 +360,10 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					this._cells = contents.cells.map(c => {
 						let cellModel = factory.createCell(c, { notebook: this, isTrusted: isTrusted });
 						/*
-						In a parameterized notebook there will be a injected parameter cell.
+						In a parameterized notebook there will be an injected parameter cell.
 						We need to indicate to the user the difference between this cell and the parameters cell.
 						*/
-						if (cellModel.metadata?.tags?.includes('injected-parameters')) {
+						if (cellModel.isInjectedParameter) {
 							cellModel.source = cellModel.source.slice(1);
 							cellModel.source = '# Injected-Parameters\n' + cellModel.source;
 						}

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -361,7 +361,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						let cellModel = factory.createCell(c, { notebook: this, isTrusted: isTrusted });
 						/*
 						In a parameterized notebook there will be an injected parameter cell.
-						We need to indicate to the user the difference between this cell and the parameters cell.
+						Papermill originally inserts the injected parameter with the comment "# Parameters"
+						which would make it confusing to the user between the difference between this cell and the tagged parameters cell.
+						So to make it clear we edit the injected parameters comment to indicate it is the Injected-Parameters cell.
 						*/
 						if (cellModel.isInjectedParameter) {
 							cellModel.source = cellModel.source.slice(1);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR ensures that when a user creates a new Notebook in ADS and adds the parameter tag (via cellToolbar). They will be able to utilize papermill properly (this was done by including the language of the kernel to the kernelSpec).

Moreover, we want to ensure that once a user opens the Parameterized notebook in ADS they can visually see the difference between an injected parameter via Papermill and the original parameters cell.

Exposing the metadata allows us to make sure that the user is only able to create one tagged parameter cell. 
