### PR TITLE
Use static name value for azdata sudo commands

### DIFF
--- a/extensions/azdata/src/common/childProcess.ts
+++ b/extensions/azdata/src/common/childProcess.ts
@@ -87,7 +87,7 @@ export async function executeCommand(command: string, args: string[], additional
 export async function executeSudoCommand(command: string): Promise<ProcessOutput> {
 	return new Promise((resolve, reject) => {
 		Logger.log(loc.executingCommand(`sudo ${command}`, []));
-		sudo.exec(command, { name: vscode.env.appName }, (error, stdout, stderr) => {
+		sudo.exec(command, { name: 'Azure Data Studio' }, (error, stdout, stderr) => {
 			stdout = stdout?.toString() ?? '';
 			stderr = stderr?.toString() ?? '';
 			if (stdout) {

--- a/extensions/azdata/src/common/childProcess.ts
+++ b/extensions/azdata/src/common/childProcess.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import * as cp from 'child_process';
 import * as sudo from 'sudo-prompt';
 import * as loc from '../localizedConstants';


### PR DESCRIPTION
The name option doesn't allow non-alphanumeric characters except for space so was failing on insiders builds (which have `- Insiders` in the name)

`
![image](https://user-images.githubusercontent.com/28519865/96905724-b06e7b80-144d-11eb-8987-4afe637b5690.png)
