### PR TITLE
Fix kubectl storage class check

### DIFF
--- a/extensions/resource-deployment/src/services/tools/kubeCtlTool.ts
+++ b/extensions/resource-deployment/src/services/tools/kubeCtlTool.ts
@@ -67,10 +67,12 @@ export class KubeCtlTool extends ToolBase {
 	}
 
 	public async getStorageClasses(): Promise<{ storageClasses: string[], defaultStorageClass: string }> {
-		const storageClasses: KubeStorageClass[] = JSON.parse(await this.platformService.runCommand('kubectl get sc -o json')).items;
+		// Ignore any values without metadata - that should never happen but if it doesn't we don't have anything useful to do with it anyways
+		const storageClasses = (JSON.parse(await this.platformService.runCommand('kubectl get sc -o json')).items as KubeStorageClass[])
+			.filter(sc => sc.metadata);
 		return {
 			storageClasses: storageClasses.map(sc => sc.metadata.name),
-			defaultStorageClass: storageClasses.find(sc => sc.metadata.annotations['storageclass.kubernetes.io/is-default-class'] === 'true')?.metadata.name ?? ''
+			defaultStorageClass: storageClasses.find(sc => sc.metadata.annotations?.['storageclass.kubernetes.io/is-default-class'] === 'true')?.metadata.name ?? ''
 		};
 	}
 


### PR DESCRIPTION
People were getting an error when trying to do Arc DC deployments :

![image](https://user-images.githubusercontent.com/28519865/96929820-a5c4de00-146f-11eb-889e-69037d1b5e7c.png)

After some investigation it appears that the annotations property object won't always exist on the storage class objects - but we were assuming it was and so we'd throw when we tried to check the property of the annotations object. 
