### PR TITLE
Update query editor taskbar actions on language flavor change

### DIFF
--- a/src/sql/workbench/contrib/query/browser/flavorStatus.ts
+++ b/src/sql/workbench/contrib/query/browser/flavorStatus.ts
@@ -187,7 +187,7 @@ export class ChangeFlavorAction extends Action {
 
 	public run(): Promise<any> {
 		let activeEditor = this._editorService.activeEditorPane;
-		let currentUri = activeEditor?.input.resource?.toString();
+		let currentUri = activeEditor?.input.resource?.toString(true);
 		if (this._connectionManagementService.isConnected(currentUri)) {
 			let currentProvider = this._connectionManagementService.getProviderIdFromUri(currentUri);
 			return this._showMessage(Severity.Info, nls.localize('alreadyConnected',


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13024

A couple parts to this : 

1. Make it so that certain MSSQL-specific actions only show up when the provider is MSSQL
1. Hook into the language flavor change event to update the actions when the language flavor is changed
1. Modify the logic there slightly to get the provider by looking at these in order - taking the first non-falsy one
a. Connection provider ID if we're connected
a. The provider ID for the URI (file) - this is set for disconnected editors by choosing "Language Flavor" from the bottom
a. Default provider if neither of the above is set 

This also fixes it so that if you have a disconnected editor and set it to the Kusto language then it'll show the correct actions

Changing language mode updates actions : 
![Capture](https://user-images.githubusercontent.com/28519865/97035726-9a2ef100-151b-11eb-8688-5ed860f37755.gif)

Connecting to different provider updates actions : 
![Capture](https://user-images.githubusercontent.com/28519865/97036073-204b3780-151c-11eb-957d-23bf03216991.gif)
