### PR TITLE
Mark dacpac and schema compare integration tests as unstable

### DIFF
--- a/extensions/integration-tests/src/test/dacpac.test.ts
+++ b/extensions/integration-tests/src/test/dacpac.test.ts
@@ -23,7 +23,7 @@ suite('Dacpac integration test suite', () => {
 		console.log(`Start dacpac tests`);
 	});
 
-	test('Deploy and extract dacpac', async function () {
+	test('Deploy and extract dacpac @UNSTABLE@', async function () {
 		const server = await getStandaloneServer();
 		await utils.connectToServer(server);
 

--- a/extensions/integration-tests/src/test/schemaCompare.test.ts
+++ b/extensions/integration-tests/src/test/schemaCompare.test.ts
@@ -39,7 +39,7 @@ suite('Schema compare integration test suite', () => {
 		dacfxService = ((await vscode.extensions.getExtension(mssql.extension.name).activate() as mssql.IExtension)).dacFx;
 		console.log(`Start schema compare tests`);
 	});
-	test('Schema compare dacpac to dacpac comparison and scmp', async function () {
+	test('Schema compare dacpac to dacpac comparison and scmp @UNSTABLE@', async function () {
 		assert(schemaCompareService, 'Schema Compare Service Provider is not available');
 		const now = new Date();
 		const operationId = 'testOperationId_' + now.getTime().toString();
@@ -160,7 +160,7 @@ suite('Schema compare integration test suite', () => {
 			await utils.tryDeleteDB(server, targetDB, ownerUri);
 		}
 	});
-	test('Schema compare dacpac to database comparison, script generation, and scmp', async function () {
+	test('Schema compare dacpac to database comparison, script generation, and scmp @UNSTABLE@', async function () {
 		let server = await getStandaloneServer();
 		await utils.connectToServer(server, SERVER_CONNECTION_TIMEOUT);
 


### PR DESCRIPTION
The dacpac and schema compare integration tests have been flakey and timing out, causing builds to be blocked. Marking the rest of them as unstable now and created https://github.com/microsoft/azuredatastudio/issues/13058 to investigate during the committer months.
