### PR TITLE
Notebooks: Save connection information in metadata

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -71,7 +71,7 @@ declare module 'azdata' {
 		}
 
 		export interface INotebookMetadata {
-			connectionName?: string;
+			connection_name?: string;
 		}
 	}
 

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -69,6 +69,10 @@ declare module 'azdata' {
 			batchId?: number;
 			id?: number;
 		}
+
+		export interface INotebookMetadata {
+			connectionName?: string;
+		}
 	}
 
 	export type SqlDbType = 'BigInt' | 'Binary' | 'Bit' | 'Char' | 'DateTime' | 'Decimal'

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -331,7 +331,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			layoutChanged: this._notebookParams.input.layoutChanged,
 			capabilitiesService: this.capabilitiesService,
 			editorLoadedTimestamp: this._notebookParams.input.editorOpenedTimestamp
-		}, this.profile, this.logService, this.notificationService, this.adstelemetryService, this.capabilitiesService);
+		}, this.profile, this.logService, this.notificationService, this.adstelemetryService, this.connectionManagementService, this.capabilitiesService);
 		let trusted = await this.notebookService.isNotebookTrustCached(this._notebookParams.notebookUri, this.isDirty());
 		this._register(model.onError((errInfo: INotification) => this.handleModelError(errInfo)));
 		this._register(model.contentChanged((change) => this.handleContentChanged(change)));

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -331,7 +331,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 			layoutChanged: this._notebookParams.input.layoutChanged,
 			capabilitiesService: this.capabilitiesService,
 			editorLoadedTimestamp: this._notebookParams.input.editorOpenedTimestamp
-		}, this.profile, this.logService, this.notificationService, this.adstelemetryService, this.connectionManagementService, this.capabilitiesService);
+		}, this.profile, this.logService, this.notificationService, this.adstelemetryService, this.connectionManagementService, this._configurationService, this.capabilitiesService);
 		let trusted = await this.notebookService.isNotebookTrustCached(this._notebookParams.notebookUri, this.isDirty());
 		this._register(model.onError((errInfo: INotification) => this.handleModelError(errInfo)));
 		this._register(model.contentChanged((change) => this.handleContentChanged(change)));

--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -429,7 +429,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 
 			let attachToContainer = document.createElement('li');
 			let attachToDropdown = new AttachToDropdown(attachToContainer, this.contextViewService, this.modelReady,
-				this.connectionManagementService, this.connectionDialogService, this.notificationService, this.capabilitiesService);
+				this.connectionManagementService, this.connectionDialogService, this.notificationService, this.capabilitiesService, this._configurationService);
 			attachToDropdown.render(attachToContainer);
 			attachSelectBoxStyler(attachToDropdown, this.themeService);
 
@@ -493,7 +493,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 
 			let attachToContainer = document.createElement('div');
 			let attachToDropdown = new AttachToDropdown(attachToContainer, this.contextViewService, this.modelReady,
-				this.connectionManagementService, this.connectionDialogService, this.notificationService, this.capabilitiesService);
+				this.connectionManagementService, this.connectionDialogService, this.notificationService, this.capabilitiesService, this._configurationService);
 			attachToDropdown.render(attachToContainer);
 			attachSelectBoxStyler(attachToDropdown, this.themeService);
 

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -230,7 +230,12 @@ configurationRegistry.registerConfiguration({
 			'type': 'boolean',
 			'default': true,
 			'description': localize('notebook.setRichTextViewByDefault', "Set Rich Text View mode by default for text cells")
-		}
+		},
+		'notebook.saveConnectionName': {
+			'type': 'boolean',
+			'default': false,
+			'description': localize('notebook.saveConnectionName', "(Preview) Save connection name in notebook metadata.")
+		},
 	}
 });
 

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -355,6 +355,7 @@ export class KernelsDropdown extends SelectBox {
 }
 
 const attachToDropdownElementId = 'attach-to-dropdown';
+const saveConnectionNameConfigName = 'notebook.saveConnectionName';
 
 export class AttachToDropdown extends SelectBox {
 	private model: NotebookModel;
@@ -365,6 +366,7 @@ export class AttachToDropdown extends SelectBox {
 		@IConnectionDialogService private _connectionDialogService: IConnectionDialogService,
 		@INotificationService private _notificationService: INotificationService,
 		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService,
+		@IConfigurationService private _configurationService: IConfigurationService
 	) {
 		super([msgLoadingContexts], msgLoadingContexts, contextViewProvider, container, { labelText: attachToLabel, labelOnTop: false, ariaLabel: attachToLabel, id: attachToDropdownElementId } as ISelectBoxOptionsWithLabel);
 		if (modelReady) {
@@ -431,7 +433,7 @@ export class AttachToDropdown extends SelectBox {
 			let connections: string[] = [];
 			if (model.context && model.context.title && (connProviderIds.includes(this.model.context.providerName))) {
 				connections.push(model.context.title);
-			} else if (model.savedConnectionName) {
+			} else if (this._configurationService.getValue(saveConnectionNameConfigName) && model.savedConnectionName) {
 				connections.push(model.savedConnectionName);
 			} else {
 				connections.push(msgSelectConnection);

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -428,7 +428,14 @@ export class AttachToDropdown extends SelectBox {
 		if ((connProviderIds && connProviderIds.length === 0) || currentKernel === noKernel) {
 			this.setOptions([msgLocalHost]);
 		} else {
-			let connections: string[] = model.context && model.context.title && (connProviderIds.includes(this.model.context.providerName)) ? [model.context.title] : [msgSelectConnection];
+			let connections: string[] = [];
+			if (model.context && model.context.title && (connProviderIds.includes(this.model.context.providerName))) {
+				connections.push(model.context.title);
+			} else if (model.savedConnectionName) {
+				connections.push(model.savedConnectionName);
+			} else {
+				connections.push(msgSelectConnection);
+			}
 			if (!connections.find(x => x === msgChangeConnection)) {
 				connections.push(msgChangeConnection);
 			}

--- a/src/sql/workbench/contrib/notebook/test/browser/cellToolbarActions.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/cellToolbarActions.test.ts
@@ -213,5 +213,5 @@ export async function createandLoadNotebookModel(codeContent?: nb.INotebookConte
 		layoutChanged: undefined,
 		capabilitiesService: undefined
 	};
-	return new NotebookModel(defaultModelOptions, undefined, undefined, undefined, undefined);
+	return new NotebookModel(defaultModelOptions, undefined, undefined, undefined, undefined, undefined);
 }

--- a/src/sql/workbench/contrib/notebook/test/browser/cellToolbarActions.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/cellToolbarActions.test.ts
@@ -213,5 +213,5 @@ export async function createandLoadNotebookModel(codeContent?: nb.INotebookConte
 		layoutChanged: undefined,
 		capabilitiesService: undefined
 	};
-	return new NotebookModel(defaultModelOptions, undefined, undefined, undefined, undefined, undefined);
+	return new NotebookModel(defaultModelOptions, undefined, undefined, undefined, undefined, undefined, undefined);
 }

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
@@ -971,7 +971,7 @@ suite('Notebook Editor Model', function (): void {
 		let options: INotebookModelOptions = assign({}, defaultModelOptions, <Partial<INotebookModelOptions>><unknown>{
 			factory: mockModelFactory.object
 		});
-		notebookModel = new NotebookModel(options, undefined, logService, undefined, new NullAdsTelemetryService());
+		notebookModel = new NotebookModel(options, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		await notebookModel.loadContents();
 	}
 

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
@@ -971,7 +971,7 @@ suite('Notebook Editor Model', function (): void {
 		let options: INotebookModelOptions = assign({}, defaultModelOptions, <Partial<INotebookModelOptions>><unknown>{
 			factory: mockModelFactory.object
 		});
-		notebookModel = new NotebookModel(options, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		notebookModel = new NotebookModel(options, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await notebookModel.loadContents();
 	}
 

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookFindModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookFindModel.test.ts
@@ -433,7 +433,7 @@ suite('Notebook Find Model', function (): void {
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(contents));
 		defaultModelOptions.contentManager = mockContentManager.object;
 		// Initialize the model
-		model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService());
+		model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		await model.loadContents();
 		await model.requestModelLoad();
 	}

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookFindModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookFindModel.test.ts
@@ -30,6 +30,8 @@ import { NotebookEditorContentManager } from 'sql/workbench/contrib/notebook/bro
 import { NotebookRange } from 'sql/workbench/services/notebook/browser/notebookService';
 import { NotebookMarkdownRenderer } from 'sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown';
 import { NullAdsTelemetryService } from 'sql/platform/telemetry/common/adsTelemetryService';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 
 let expectedNotebookContent: nb.INotebookContents = {
 	cells: [{
@@ -73,6 +75,7 @@ suite('Notebook Find Model', function (): void {
 	const logService = new NullLogService();
 	let model: NotebookModel;
 	let markdownRenderer: NotebookMarkdownRenderer = new NotebookMarkdownRenderer();
+	let configurationService: IConfigurationService;
 
 	setup(async () => {
 		sessionReady = new Deferred<void>();
@@ -84,6 +87,7 @@ suite('Notebook Find Model', function (): void {
 		queryConnectionService.callBase = true;
 
 		instantiationService = new InstantiationService(serviceCollection, true);
+		configurationService = new TestConfigurationService();
 		defaultModelOptions = {
 			notebookUri: defaultUri,
 			factory: new ModelFactory(instantiationService),
@@ -433,7 +437,7 @@ suite('Notebook Find Model', function (): void {
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(contents));
 		defaultModelOptions.contentManager = mockContentManager.object;
 		// Initialize the model
-		model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 		await model.requestModelLoad();
 	}

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -581,7 +581,7 @@ suite('notebook model', function (): void {
 		let notebook: nb.INotebookContents = {
 			cells: [],
 			metadata: {
-				connectionName: connectionName
+				connection_name: connectionName
 			},
 			nbformat: 4,
 			nbformat_minor: 5

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -154,7 +154,7 @@ suite('notebook model', function (): void {
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(emptyNotebook));
 		defaultModelOptions.contentManager = mockContentManager.object;
 		// When I initialize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService());
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		await model.loadContents();
 
 		// Then I expect to have 0 code cell as the contents
@@ -170,7 +170,7 @@ suite('notebook model', function (): void {
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedNotebookContent));
 		defaultModelOptions.contentManager = mockContentManager.object;
 		// When I initialize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService());
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		await model.loadContents(true);
 		await model.requestModelLoad();
 
@@ -187,7 +187,7 @@ suite('notebook model', function (): void {
 
 		// When I initalize the model
 		// Then it should throw
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService());
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		assert.equal(model.inErrorState, false);
 		await assert.rejects(async () => { await model.loadContents(); });
 		assert.equal(model.inErrorState, true);
@@ -200,7 +200,7 @@ suite('notebook model', function (): void {
 		defaultModelOptions.contentManager = mockContentManager.object;
 
 		// When I initalize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService());
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		await model.loadContents();
 
 		// Then I expect all cells to be in the model
@@ -228,7 +228,7 @@ suite('notebook model', function (): void {
 		defaultModelOptions.providerId = 'jupyter';
 
 		// When I initalize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService());
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		await model.loadContents();
 
 		// I expect the default provider to be jupyter
@@ -238,7 +238,7 @@ suite('notebook model', function (): void {
 		defaultModelOptions.providerId = 'SQL';
 
 		// When I initalize the model
-		model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService());
+		model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		await model.loadContents();
 
 		// I expect the default provider to be SQL
@@ -263,7 +263,7 @@ suite('notebook model', function (): void {
 		defaultModelOptions.contentManager = mockContentManager.object;
 
 		// When I initalize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService());
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		await model.loadContents();
 
 		let activeCellChangeCount = 0;
@@ -320,7 +320,7 @@ suite('notebook model', function (): void {
 		defaultModelOptions.contentManager = mockContentManager.object;
 
 		// When I initalize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService());
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		await model.loadContents();
 
 		// Count number of times onError event is fired
@@ -375,7 +375,7 @@ suite('notebook model', function (): void {
 		sessionReady.resolve();
 		let sessionFired = false;
 
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService());
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		model.onClientSessionReady((session) => sessionFired = true);
 		await model.loadContents();
 		await model.requestModelLoad();
@@ -405,7 +405,7 @@ suite('notebook model', function (): void {
 		let mockContentManager = TypeMoq.Mock.ofType(NotebookEditorContentManager);
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedNotebookContent));
 		defaultModelOptions.contentManager = mockContentManager.object;
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService());
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
 		await model.requestModelLoad();
 
 		let actualChanged: NotebookContentChange;
@@ -474,7 +474,7 @@ suite('notebook model', function (): void {
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedNotebookContent));
 		defaultModelOptions.contentManager = mockContentManager.object;
 		// When I initialize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, undefined);
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, undefined, queryConnectionService.object);
 		await model.loadContents();
 
 		let output = model.toJSON();
@@ -583,7 +583,7 @@ suite('notebook model', function (): void {
 		let options: INotebookModelOptions = assign({}, defaultModelOptions, <Partial<INotebookModelOptions>>{
 			factory: mockModelFactory.object
 		});
-		let model = new NotebookModel(options, undefined, logService, undefined, new NullAdsTelemetryService(), capabilitiesService);
+		let model = new NotebookModel(options, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, capabilitiesService);
 		model.onClientSessionReady((session) => actualSession = session);
 		await model.requestModelLoad();
 

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -36,6 +36,8 @@ import { mssqlProviderName } from 'sql/platform/connection/common/constants';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { uriPrefixes } from 'sql/platform/connection/common/utils';
 import { NullAdsTelemetryService } from 'sql/platform/telemetry/common/adsTelemetryService';
+import { TestConfigurationService } from 'sql/platform/connection/test/common/testConfigurationService';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 let expectedNotebookContent: nb.INotebookContents = {
 	cells: [{
@@ -87,6 +89,7 @@ let mockModelFactory: TypeMoq.Mock<ModelFactory>;
 let notificationService: TypeMoq.Mock<INotificationService>;
 let capabilitiesService: ICapabilitiesService;
 let instantiationService: IInstantiationService;
+let configurationService: IConfigurationService;
 
 suite('notebook model', function (): void {
 	let notebookManagers = [new NotebookManagerStub()];
@@ -107,6 +110,7 @@ suite('notebook model', function (): void {
 		queryConnectionService.callBase = true;
 		let serviceCollection = new ServiceCollection();
 		instantiationService = new InstantiationService(serviceCollection, true);
+		configurationService = new TestConfigurationService();
 		defaultModelOptions = {
 			notebookUri: defaultUri,
 			factory: new ModelFactory(instantiationService),
@@ -154,7 +158,7 @@ suite('notebook model', function (): void {
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(emptyNotebook));
 		defaultModelOptions.contentManager = mockContentManager.object;
 		// When I initialize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
 		// Then I expect to have 0 code cell as the contents
@@ -170,7 +174,7 @@ suite('notebook model', function (): void {
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedNotebookContent));
 		defaultModelOptions.contentManager = mockContentManager.object;
 		// When I initialize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents(true);
 		await model.requestModelLoad();
 
@@ -187,7 +191,7 @@ suite('notebook model', function (): void {
 
 		// When I initalize the model
 		// Then it should throw
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		assert.equal(model.inErrorState, false);
 		await assert.rejects(async () => { await model.loadContents(); });
 		assert.equal(model.inErrorState, true);
@@ -200,7 +204,7 @@ suite('notebook model', function (): void {
 		defaultModelOptions.contentManager = mockContentManager.object;
 
 		// When I initalize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
 		// Then I expect all cells to be in the model
@@ -228,7 +232,7 @@ suite('notebook model', function (): void {
 		defaultModelOptions.providerId = 'jupyter';
 
 		// When I initalize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
 		// I expect the default provider to be jupyter
@@ -238,7 +242,7 @@ suite('notebook model', function (): void {
 		defaultModelOptions.providerId = 'SQL';
 
 		// When I initalize the model
-		model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
 		// I expect the default provider to be SQL
@@ -263,7 +267,7 @@ suite('notebook model', function (): void {
 		defaultModelOptions.contentManager = mockContentManager.object;
 
 		// When I initalize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
 		let activeCellChangeCount = 0;
@@ -320,7 +324,7 @@ suite('notebook model', function (): void {
 		defaultModelOptions.contentManager = mockContentManager.object;
 
 		// When I initalize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.loadContents();
 
 		// Count number of times onError event is fired
@@ -375,7 +379,7 @@ suite('notebook model', function (): void {
 		sessionReady.resolve();
 		let sessionFired = false;
 
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		model.onClientSessionReady((session) => sessionFired = true);
 		await model.loadContents();
 		await model.requestModelLoad();
@@ -405,7 +409,7 @@ suite('notebook model', function (): void {
 		let mockContentManager = TypeMoq.Mock.ofType(NotebookEditorContentManager);
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedNotebookContent));
 		defaultModelOptions.contentManager = mockContentManager.object;
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object);
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
 		await model.requestModelLoad();
 
 		let actualChanged: NotebookContentChange;
@@ -474,7 +478,7 @@ suite('notebook model', function (): void {
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedNotebookContent));
 		defaultModelOptions.contentManager = mockContentManager.object;
 		// When I initialize the model
-		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, undefined, queryConnectionService.object);
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, undefined, queryConnectionService.object, configurationService);
 		await model.loadContents();
 
 		let output = model.toJSON();
@@ -583,7 +587,7 @@ suite('notebook model', function (): void {
 		let options: INotebookModelOptions = assign({}, defaultModelOptions, <Partial<INotebookModelOptions>>{
 			factory: mockModelFactory.object
 		});
-		let model = new NotebookModel(options, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, capabilitiesService);
+		let model = new NotebookModel(options, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService, capabilitiesService);
 		model.onClientSessionReady((session) => actualSession = session);
 		await model.requestModelLoad();
 

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -608,7 +608,8 @@ suite('notebook model', function (): void {
 			id: '',
 			options: {}
 		};
-		sinon.stub(queryConnectionService, 'getConnections').returns(expectedConnectionProfile);
+		sinon.stub(queryConnectionService.object, 'getConnections').returns([expectedConnectionProfile]);
+		sinon.stub(configurationService, 'getValue').returns(true);
 
 		// When I initialize the model
 		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);

--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -76,6 +76,9 @@ export class NotebookModelStub implements INotebookModel {
 	get context(): ConnectionProfile {
 		throw new Error('method not implemented.');
 	}
+	get savedConnectionName(): string {
+		throw new Error('method not implemented.');
+	}
 	get providerId(): string {
 		throw new Error('method not implemented.');
 	}

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -301,6 +301,11 @@ export interface INotebookModel {
 	readonly context: ConnectionProfile | undefined;
 
 	/**
+	 * The connection name (alias) saved in the notebook metadata,
+	 * or undefined if none.
+	 */
+	readonly savedConnectionName: string | undefined;
+	/**
 	 * Event fired on first initialization of the cells and
 	 * on subsequent change events
 	 */

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -48,6 +48,8 @@ export class ErrorInfo {
 	}
 }
 
+const saveConnectionNameConfigName = 'notebook.saveConnectionName';
+
 export class NotebookModel extends Disposable implements INotebookModel {
 	private _contextsChangedEmitter = new Emitter<void>();
 	private _contextsLoadingEmitter = new Emitter<void>();
@@ -401,7 +403,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	public async requestConnection(): Promise<boolean> {
 		// If there is a saved connection name with a corresponding connection profile, use that one,
 		// otherwise show connection dialog
-		if (this._savedConnectionName) {
+		if (this.configurationService.getValue(saveConnectionNameConfigName) && this._savedConnectionName) {
 			let profile: ConnectionProfile | undefined = this.getConnectionProfileFromName(this._savedConnectionName);
 			if (profile) {
 				await this.changeContext(this._savedConnectionName, profile);
@@ -1161,7 +1163,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		metadata.kernelspec = this._savedKernelInfo;
 		metadata.language_info = this.languageInfo;
 		metadata.tags = this._tags;
-		if (this.configurationService.getValue('notebook.saveConnectionName')) {
+		if (this.configurationService.getValue(saveConnectionNameConfigName)) {
 			metadata.connectionName = this._savedConnectionName;
 		}
 		Object.keys(this._existingMetadata).forEach(key => {

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -31,6 +31,7 @@ import { Deferred } from 'sql/base/common/promise';
 import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilitiesService';
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 import { values } from 'vs/base/common/collections';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 /*
 * Used to control whether a message in a dialog/wizard is displayed as an error,
@@ -97,6 +98,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		@INotificationService private readonly notificationService: INotificationService,
 		@IAdsTelemetryService private readonly adstelemetryService: IAdsTelemetryService,
 		@IConnectionManagementService private connectionManagementService: IConnectionManagementService,
+		@IConfigurationService private configurationService: IConfigurationService,
 		@ICapabilitiesService private _capabilitiesService?: ICapabilitiesService
 
 	) {
@@ -1159,7 +1161,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		metadata.kernelspec = this._savedKernelInfo;
 		metadata.language_info = this.languageInfo;
 		metadata.tags = this._tags;
-		metadata.connectionName = this._savedConnectionName;
+		if (this.configurationService.getValue('notebook.saveConnectionName')) {
+			metadata.connectionName = this._savedConnectionName;
+		}
 		Object.keys(this._existingMetadata).forEach(key => {
 			metadata[key] = this._existingMetadata[key];
 		});

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -362,7 +362,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						}
 					}
 					Object.keys(contents.metadata).forEach(key => {
-						let expectedKeys = ['kernelspec', 'language_info', 'tags', 'connectionName'];
+						let expectedKeys = ['kernelspec', 'language_info', 'tags', 'connection_name'];
 						// If custom metadata is defined, add to the _existingMetadata object
 						if (expectedKeys.indexOf(key) < 0) {
 							this._existingMetadata[key] = contents.metadata[key];
@@ -923,7 +923,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	// Get saved connection name if saved in notebook file
 	private getSavedConnectionName(notebook: nb.INotebookContents): string | undefined {
-		return notebook?.metadata?.connectionName ? notebook.metadata.connectionName : undefined;
+		return notebook?.metadata?.connection_name ? notebook.metadata.connection_name : undefined;
 	}
 
 	// Get default kernel info if saved in notebook file
@@ -1164,7 +1164,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		metadata.language_info = this.languageInfo;
 		metadata.tags = this._tags;
 		if (this.configurationService.getValue(saveConnectionNameConfigName)) {
-			metadata.connectionName = this._savedConnectionName;
+			metadata.connection_name = this._savedConnectionName;
 		}
 		Object.keys(this._existingMetadata).forEach(key => {
 			metadata[key] = this._existingMetadata[key];

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -408,7 +408,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			if (profile) {
 				await this.changeContext(this._savedConnectionName, profile);
 				return true;
-			} // TODO: No matching connection profile for saved connection name
+			}
 		}
 		if (this.requestConnectionHandler) {
 			return this.requestConnectionHandler();
@@ -923,7 +923,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	// Get saved connection name if saved in notebook file
 	private getSavedConnectionName(notebook: nb.INotebookContents): string | undefined {
-		return (notebook && notebook.metadata && notebook.metadata.connectionName) ? notebook.metadata.connectionName : undefined;
+		return notebook?.metadata?.connectionName ? notebook.metadata.connectionName : undefined;
 	}
 
 	// Get default kernel info if saved in notebook file


### PR DESCRIPTION
This PR adds the ability to save a connection name (alias) in the notebook metadata.  

If a notebook with a saved connection name is opened, the attach to dropdown is updated to show the connection name. When the first cell is run, we search for the connection profile that matches the connection name. If a valid connection profile is found, we use that, otherwise we show the connection dialog as usual. For now, if there is no connection name, nothing is saved and the behavior is the same as before. 

I added a setting for this feature (by default, connection name saving is off and attachTo dropdown won't be updated). 

Note: There was more discussion around saving an alias vs data source name. For now I am using alias and if we decide to save something different in the future, it will be an easy change since the functionality of saving and reading connection information from metadata will be the same.