### PR TITLE
Add hyperlink support to DataGrid columns

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -183,6 +183,34 @@ declare module 'azdata' {
 	}
 
 	/**
+	 * Info for a command to execute
+	 */
+	export interface ExecuteCommandInfo {
+		/**
+		 * The ID of the command to execute
+		 */
+		id: string;
+		/**
+		 * The optional args to pass to the command
+		 */
+		args?: string[];
+	}
+
+	/**
+	 * Info for displaying a hyperlink value in a Data Grid table
+	 */
+	export interface DataGridHyperlinkInfo {
+		/**
+		 * The text to display for the link
+		 */
+		displayText: string;
+		/**
+		 * The URL to open or command to execute
+		 */
+		linkOrCommand: string | ExecuteCommandInfo;
+	}
+
+	/**
 	 * An item for displaying in a data grid
 	 */
 	export interface DataGridItem {
@@ -197,7 +225,7 @@ declare module 'azdata' {
 		/**
 		 * The other properties that will be displayed in the grid
 		 */
-		[key: string]: any;
+		[key: string]: string | DataGridHyperlinkInfo;
 	}
 
 	/**

--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -33,7 +33,6 @@ export interface TextCellValue {
 export interface HyperlinkCellValue {
 	displayText: string;
 	linkOrCommand: string | ExecuteCommandInfo;
-	ariaLabel: string;
 }
 
 export namespace DBCellValue {
@@ -116,8 +115,7 @@ export function slickGridDataItemColumnValueExtractor(value: any, columnDef: any
 	if (columnDef.type === 'hyperlink') {
 		return <HyperlinkCellValue>{
 			displayText: fieldValue.displayText,
-			linkOrCommand: fieldValue.linkOrCommand,
-			ariaLabel: ''
+			linkOrCommand: fieldValue.linkOrCommand
 		};
 	} else {
 		return <TextCellValue>{

--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -11,10 +11,43 @@ export interface DBCellValue {
 	isNull: boolean;
 }
 
+/**
+ * Info for executing a command. @see azdata.ExecuteCommandInfo
+ */
+export interface ExecuteCommandInfo {
+	id: string;
+	args?: string[]
+}
+
+/**
+ * The info for a DataGrid Text Cell.
+ */
+export interface TextCellValue {
+	text: string;
+	ariaLabel: string;
+}
+
+/**
+ * The info for a DataGrid Hyperlink Cell.
+ */
+export interface HyperlinkCellValue {
+	displayText: string;
+	linkOrCommand: string | ExecuteCommandInfo;
+	ariaLabel: string;
+}
+
 export namespace DBCellValue {
 	export function isDBCellValue(object: any): boolean {
 		return (object !== undefined && object.displayValue !== undefined && object.isNull !== undefined);
 	}
+}
+
+/**
+ * Checks whether the specified object is a HyperlinkCellValue object or not
+ * @param obj The object to test
+ */
+export function isHyperlinkCellValue(obj: any | undefined): obj is HyperlinkCellValue {
+	return !!(<HyperlinkCellValue>obj)?.linkOrCommand;
 }
 
 
@@ -34,6 +67,8 @@ export function hyperLinkFormatter(row: number | undefined, cell: any | undefine
 		} else {
 			cellClasses += ' missing-value';
 		}
+	} else if (isHyperlinkCellValue(value)) {
+		return `<a class="${cellClasses}" href="#" >${value.displayText}</a>`;
 	}
 	return `<span title="${valueToDisplay}" class="${cellClasses}">${valueToDisplay}</span>`;
 }
@@ -76,18 +111,27 @@ export function imageFormatter(row: number | undefined, cell: any | undefined, v
  * Provide slick grid cell with encoded ariaLabel and plain text.
  * text will be escaped by the textFormatter and ariaLabel will be consumed by slickgrid directly.
  */
-export function slickGridDataItemColumnValueExtractor(value: any, columnDef: any): { text: string; ariaLabel: string; } {
-	let displayValue = value[columnDef.field];
-	return {
-		text: displayValue,
-		ariaLabel: displayValue ? escape(displayValue) : displayValue
-	};
+export function slickGridDataItemColumnValueExtractor(value: any, columnDef: any): TextCellValue | HyperlinkCellValue {
+	let fieldValue = value[columnDef.field];
+	if (columnDef.type === 'hyperlink') {
+		return <HyperlinkCellValue>{
+			displayText: fieldValue.displayText,
+			linkOrCommand: fieldValue.linkOrCommand,
+			ariaLabel: ''
+		};
+	} else {
+		return <TextCellValue>{
+			text: fieldValue,
+			ariaLabel: fieldValue ? escape(fieldValue) : fieldValue
+		};
+	}
+
 }
 
 /**
  * Alternate function to provide slick grid cell with ariaLabel and plain text
  * In this case, for no display value ariaLabel will be set to specific string "no data available" for accessibily support for screen readers
- * Set 'no data' lable only if cell is present and has no value (so that checkbox and other custom plugins do not get 'no data' label)
+ * Set 'no data' label only if cell is present and has no value (so that checkbox and other custom plugins do not get 'no data' label)
  */
 export function slickGridDataItemColumnValueWithNoData(value: any, columnDef: any): { text: string; ariaLabel: string; } {
 	let displayValue = value[columnDef.field];

--- a/src/sql/base/browser/ui/table/formatters.ts
+++ b/src/sql/base/browser/ui/table/formatters.ts
@@ -68,7 +68,7 @@ export function hyperLinkFormatter(row: number | undefined, cell: any | undefine
 			cellClasses += ' missing-value';
 		}
 	} else if (isHyperlinkCellValue(value)) {
-		return `<a class="${cellClasses}" href="#" >${value.displayText}</a>`;
+		return `<a class="${cellClasses}" href="#" >${escape(value.displayText)}</a>`;
 	}
 	return `<span title="${valueToDisplay}" class="${cellClasses}">${valueToDisplay}</span>`;
 }

--- a/src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput.ts
+++ b/src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput.ts
@@ -13,6 +13,7 @@ import { getDataGridFormatter } from 'sql/workbench/services/dataGridProvider/br
 
 export interface ColumnDefinition extends Slick.Column<Slick.SlickData> {
 	name: string;
+	type: string;
 	filterable?: boolean;
 }
 
@@ -69,28 +70,27 @@ export class ResourceViewerInput extends EditorInput {
 		]);
 	}
 
-	private fetchColumns(): void {
-		this._dataGridProvider.getDataGridColumns(this._providerId).then(columns => {
-			this.columns = columns.map(col => {
-				return {
-					name: col.name,
-					field: col.field,
-					id: col.id,
-					formatter: getDataGridFormatter(col.type),
-					sortable: col.sortable ?? true,
-					filterable: col.filterable ?? true,
-					resizable: col.resizable ?? true,
-					tooltip: col.tooltip,
-					width: col.width
-				};
-			});
-		}).catch(err => onUnexpectedError(err));
+	private async fetchColumns(): Promise<void> {
+		const columns = await this._dataGridProvider.getDataGridColumns(this._providerId);
+		this.columns = columns.map(col => {
+			return {
+				name: col.name,
+				field: col.field,
+				id: col.id,
+				formatter: getDataGridFormatter(col.type),
+				sortable: col.sortable ?? true,
+				filterable: col.filterable ?? true,
+				resizable: col.resizable ?? true,
+				tooltip: col.tooltip,
+				width: col.width,
+				type: col.type
+			};
+		});
 	}
 
-	private fetchItems(): void {
-		this._dataGridProvider.getDataGridItems(this._providerId).then(items => {
-			this._data = items;
-			this._onDataChanged.fire();
-		}).catch(err => onUnexpectedError(err));
+	private async fetchItems(): Promise<void> {
+		const items = await this._dataGridProvider.getDataGridItems(this._providerId);
+		this._data = items;
+		this._onDataChanged.fire();
 	}
 }

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/resourceViewerTable';
-import * as vscode from 'vscode';
+import * as azdata from 'azdata';
 import { Table } from 'sql/base/browser/ui/table/table';
 import { attachTableStyler, attachButtonStyler } from 'sql/platform/theme/common/styler';
 import { RowSelectionModel } from 'sql/base/browser/ui/table/plugins/rowSelectionModel.plugin';
@@ -19,6 +19,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { isString } from 'vs/base/common/types';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { localize } from 'vs/nls';
+import { INotificationService } from 'vs/platform/notification/common/notification';
 
 export class ResourceViewerTable extends Disposable {
 
@@ -28,7 +29,8 @@ export class ResourceViewerTable extends Disposable {
 	constructor(parent: HTMLElement,
 		@IWorkbenchThemeService private _themeService: IWorkbenchThemeService,
 		@IOpenerService private _openerService: IOpenerService,
-		@ICommandService private _commandService: ICommandService) {
+		@ICommandService private _commandService: ICommandService,
+		@INotificationService private _notificationService: INotificationService) {
 		super();
 		let filterFn = (data: Array<Slick.SlickData>): Array<Slick.SlickData> => {
 			return data.filter(item => this.filter(item));
@@ -115,14 +117,14 @@ export class ResourceViewerTable extends Disposable {
 					try {
 						await this._openerService.open(value.linkOrCommand);
 					} catch (err) {
-						vscode.window.showErrorMessage(localize('resourceViewerTable.openError', "Error opening link : {0}", err));
+						this._notificationService.error(localize('resourceViewerTable.openError', "Error opening link : {0}", err.message ?? err));
 					}
 
 				} else {
 					try {
 						await this._commandService.executeCommand(value.linkOrCommand.id, ...(value.linkOrCommand.args ?? []));
 					} catch (err) {
-						vscode.window.showErrorMessage(localize('resourceViewerTable.commandError', "Error executing command '{0}' : {1}", value.linkOrCommand.id, err));
+						this._notificationService.error(localize('resourceViewerTable.commandError', "Error executing command '{0}' : {1}", value.linkOrCommand.id, err.message ?? err));
 					}
 				}
 			}

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/resourceViewerTable';
+import * as vscode from 'vscode';
 import { Table } from 'sql/base/browser/ui/table/table';
 import { attachTableStyler, attachButtonStyler } from 'sql/platform/theme/common/styler';
 import { RowSelectionModel } from 'sql/base/browser/ui/table/plugins/rowSelectionModel.plugin';
@@ -17,6 +18,7 @@ import { ITableMouseEvent } from 'sql/base/browser/ui/table/interfaces';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { isString } from 'vs/base/common/types';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+import { localize } from 'vs/nls';
 
 export class ResourceViewerTable extends Disposable {
 
@@ -110,9 +112,18 @@ export class ResourceViewerTable extends Disposable {
 			const value = row[column.field];
 			if (isHyperlinkCellValue(value)) {
 				if (isString(value.linkOrCommand)) {
-					await this._openerService.open(value.linkOrCommand);
+					try {
+						await this._openerService.open(value.linkOrCommand);
+					} catch (err) {
+						vscode.window.showErrorMessage(localize('resourceViewerTable.openError', "Error opening link : {0}", err));
+					}
+
 				} else {
-					await this._commandService.executeCommand(value.linkOrCommand.id, ...(value.linkOrCommand.args ?? []));
+					try {
+						await this._commandService.executeCommand(value.linkOrCommand.id, ...(value.linkOrCommand.args ?? []));
+					} catch (err) {
+						vscode.window.showErrorMessage(localize('resourceViewerTable.commandError', "Error executing command '{0}' : {1}", value.linkOrCommand.id, err));
+					}
 				}
 			}
 		}

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
@@ -9,17 +9,24 @@ import { attachTableStyler, attachButtonStyler } from 'sql/platform/theme/common
 import { RowSelectionModel } from 'sql/base/browser/ui/table/plugins/rowSelectionModel.plugin';
 
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
-import { slickGridDataItemColumnValueExtractor } from 'sql/base/browser/ui/table/formatters';
+import { isHyperlinkCellValue, slickGridDataItemColumnValueExtractor } from 'sql/base/browser/ui/table/formatters';
 import { HeaderFilter, CommandEventArgs, IExtendedColumn } from 'sql/base/browser/ui/table/plugins/headerFilter.plugin';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { TableDataView } from 'sql/base/browser/ui/table/tableDataView';
+import { ITableMouseEvent } from 'sql/base/browser/ui/table/interfaces';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { isString } from 'vs/base/common/types';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 
 export class ResourceViewerTable extends Disposable {
 
 	private _resourceViewerTable!: Table<Slick.SlickData>;
 	private _dataView: TableDataView<Slick.SlickData>;
 
-	constructor(parent: HTMLElement, @IWorkbenchThemeService private _themeService: IWorkbenchThemeService) {
+	constructor(parent: HTMLElement,
+		@IWorkbenchThemeService private _themeService: IWorkbenchThemeService,
+		@IOpenerService private _openerService: IOpenerService,
+		@ICommandService private _commandService: ICommandService) {
 		super();
 		let filterFn = (data: Array<Slick.SlickData>): Array<Slick.SlickData> => {
 			return data.filter(item => this.filter(item));
@@ -38,6 +45,8 @@ export class ResourceViewerTable extends Disposable {
 		let filterPlugin = new HeaderFilter<Slick.SlickData>();
 		this._register(attachButtonStyler(filterPlugin, this._themeService));
 		this._register(attachTableStyler(this._resourceViewerTable, this._themeService));
+		this._register(this._resourceViewerTable.onClick(this.onTableClick, this));
+
 		filterPlugin.onFilterApplied.subscribe(() => {
 			this._dataView.filter();
 			this._resourceViewerTable.grid.invalidate();
@@ -92,5 +101,20 @@ export class ResourceViewerTable extends Disposable {
 			}
 		}
 		return value;
+	}
+
+	private async onTableClick(event: ITableMouseEvent): Promise<void> {
+		const column = this._resourceViewerTable.columns[event.cell.cell];
+		if (column) {
+			const row = this._dataView.getItem(event.cell.row);
+			const value = row[column.field];
+			if (isHyperlinkCellValue(value)) {
+				if (isString(value.linkOrCommand)) {
+					await this._openerService.open(value.linkOrCommand);
+				} else {
+					await this._commandService.executeCommand(value.linkOrCommand.id, ...(value.linkOrCommand.args ?? []));
+				}
+			}
+		}
 	}
 }

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/resourceViewerTable';
-import * as azdata from 'azdata';
 import { Table } from 'sql/base/browser/ui/table/table';
 import { attachTableStyler, attachButtonStyler } from 'sql/platform/theme/common/styler';
 import { RowSelectionModel } from 'sql/base/browser/ui/table/plugins/rowSelectionModel.plugin';


### PR DESCRIPTION
Adds support for the hyperlink fields in a DataGrid table - this will support two types of values : 

1. string - a URL to open
1. ExecuteCommandInfo - a command to execute

Note that this initial implementation has the caller that creates the grid also needing to hook up the click handler which isn't great. This is how it's handled in the query editor grid and I didn't see an obvious way to attach the click handler directly to the link itself. I plan on investigating this further, but for now I wanted to move into working on another part that's more important so getting this in as it is now since it at least works. 