### PR TITLE
Disable the upgradeExistingDatabases radio button if databases don't exist.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,5 +76,6 @@
 	"[typescript]": {
 		"editor.defaultFormatter": "vscode.typescript-language-features"
 	},
-	"typescript.tsc.autoDetect": "off"
+	"typescript.tsc.autoDetect": "off",
+	"debug.javascript.usePreview": false
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #12356.

I have added a function to the file deployConfigPage.ts, which changes the enabled status of the radio buttons based on whether databases exist or not. If the databases don't exist, the radio button for upgrade existing databases is disabled and the new databases radio button is checked as default. Else, the upgrade existing databases option is checked as default.
