### PR TITLE
Adding backup/restore back for pgsql db and restore for server in dashboard

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/databaseDashboardPage.contribution.ts
@@ -98,8 +98,8 @@ export const databaseDashboardSettingSchema: IJSONSchema = {
 				'tasks-widget': [
 					'newQuery',
 					'mssqlCluster.task.newNotebook',
-					{ name: 'backup', when: 'connectionProvider == \'MSSQL\' && !mssql:iscloud && mssql:engineedition != 11' },
-					{ name: 'restore', when: 'connectionProvider == \'MSSQL\' && !mssql:iscloud && mssql:engineedition != 11' }
+					{ name: 'backup', when: 'connectionProvider == \'MSSQL\' && !mssql:iscloud && mssql:engineedition != 11 || connectionProvider == \'PGSQL\'' },
+					{ name: 'restore', when: 'connectionProvider == \'MSSQL\' && !mssql:iscloud && mssql:engineedition != 11 || connectionProvider == \'PGSQL\'' }
 				]
 			}
 		},

--- a/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/pages/serverDashboardPage.contribution.ts
@@ -77,7 +77,10 @@ const defaultVal = [
 	{
 		name: 'Tasks',
 		widget: {
-			'tasks-widget': ['newQuery', 'mssqlCluster.task.newNotebook', { name: 'restore', when: 'connectionProvider == \'MSSQL\' && !mssql:iscloud && mssql:engineedition != 11' }]
+			'tasks-widget': [
+				'newQuery',
+				'mssqlCluster.task.newNotebook',
+				{ name: 'restore', when: 'connectionProvider == \'MSSQL\' && !mssql:iscloud && mssql:engineedition != 11 || connectionProvider == \'PGSQL\'' }]
 		},
 		gridItemConfig: {
 			sizex: 1,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #12974

Backup restore button got hidden for PGSQL due to explicit check for MSSQL only - adding PGSQL back.  Thanks @kisantia for help.