### PR TITLE
updates copy

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -148,7 +148,7 @@ export default () => `
 			</div>
 			<div class="ads-homepage-section content extensions">
 				<div class="flex flex-j-between">
-					<h2>Extend your data studio</h2>
+					<h2>Extensions</h2>
 					<a role="button" class="link-show-all flex ads-welcome-page-link" href="command:workbench.view.extensions">${escape(localize('welcomePage.showAll', "Show All"))} <span class="icon-arrow-right"></span></a>
 				</div>
 				<div class="row ads-grid grip-gap-50">

--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -148,7 +148,7 @@ export default () => `
 			</div>
 			<div class="ads-homepage-section content extensions">
 				<div class="flex flex-j-between">
-					<h2>Extensions</h2>
+					<h2>${escape(localize('welcomePage.extensions', "Extensions"))}</h2>
 					<a role="button" class="link-show-all flex ads-welcome-page-link" href="command:workbench.view.extensions">${escape(localize('welcomePage.showAll', "Show All"))} <span class="icon-arrow-right"></span></a>
 				</div>
 				<div class="row ads-grid grip-gap-50">


### PR DESCRIPTION
This PR updates copy based on PM direction. It changes the header on the welcome page for the extensions section from "Extend your data studio" to "Extensions".