### PR TITLE
Add error logging when fetching account provider accounts

### DIFF
--- a/src/sql/platform/accounts/test/common/accountViewModel.test.ts
+++ b/src/sql/platform/accounts/test/common/accountViewModel.test.ts
@@ -11,6 +11,7 @@ import { AccountViewModel } from 'sql/platform/accounts/common/accountViewModel'
 import { AccountProviderAddedEventParams, UpdateAccountListEventParams } from 'sql/platform/accounts/common/eventTypes';
 import { TestAccountManagementService } from 'sql/platform/accounts/test/common/testAccountManagementService';
 import { EventVerifierSingle } from 'sql/base/test/common/event';
+import { NullLogService } from 'vs/platform/log/common/log';
 
 // SUITE STATE /////////////////////////////////////////////////////////////
 let mockAddProviderEmitter: Emitter<AccountProviderAddedEventParams>;
@@ -63,7 +64,7 @@ suite('Account Management Dialog ViewModel Tests', () => {
 	test('Construction - Events are properly defined', () => {
 		// If: I create an account viewmodel
 		let mockAccountManagementService = getMockAccountManagementService(false, false);
-		let vm = new AccountViewModel(mockAccountManagementService.object);
+		let vm = new AccountViewModel(mockAccountManagementService.object, new NullLogService());
 
 		// Then:
 		// ... All the events for the view models should be properly initialized
@@ -195,7 +196,7 @@ function getViewModel(
 	evRemove: EventVerifierSingle<azdata.AccountProviderMetadata>,
 	evUpdate: EventVerifierSingle<UpdateAccountListEventParams>
 ): AccountViewModel {
-	let vm = new AccountViewModel(ams);
+	let vm = new AccountViewModel(ams, new NullLogService());
 	vm.addProviderEvent(evAdd.eventHandler);
 	vm.removeProviderEvent(evRemove.eventHandler);
 	vm.updateAccountListEvent(evUpdate.eventHandler);

--- a/src/sql/workbench/contrib/accounts/test/browser/accountDialogController.test.ts
+++ b/src/sql/workbench/contrib/accounts/test/browser/accountDialogController.test.ts
@@ -14,6 +14,7 @@ import { TestErrorMessageService } from 'sql/platform/errorMessage/test/common/t
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { AccountListRenderer } from 'sql/workbench/services/accountManagement/browser/accountListRenderer';
 import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
+import { NullLogService } from 'vs/platform/log/common/log';
 
 // TESTS ///////////////////////////////////////////////////////////////////
 suite('Account Management Dialog Controller Tests', () => {
@@ -70,7 +71,7 @@ suite('Account Management Dialog Controller Tests', () => {
 
 function createInstantiationService(addAccountFailureEmitter?: Emitter<string>): InstantiationService {
 	// Create a mock account dialog view model
-	let accountViewModel = new AccountViewModel(new TestAccountManagementService());
+	let accountViewModel = new AccountViewModel(new TestAccountManagementService(), new NullLogService());
 	let mockAccountViewModel = TypeMoq.Mock.ofInstance(accountViewModel);
 	let mockEvent = new Emitter<any>();
 	mockAccountViewModel.setup(x => x.addProviderEvent).returns(() => mockEvent.event);


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/11260 - it's not clear where the issue is coming from but if it's here this would silently just be failing so adding logging to see if that helps track down what's happening. 