### PR TITLE
Expose inputbox title so hover text can be set

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -531,6 +531,10 @@ declare module 'azdata' {
 	export interface InputBoxProperties extends ComponentProperties {
 		validationErrorMessage?: string;
 		readOnly?: boolean;
+		/**
+		* This title will show when hovered over
+		*/
+		title?: string;
 	}
 
 	export interface CheckBoxProperties {

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -229,6 +229,7 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 		input.setAriaLabel(this.ariaLabel);
 		input.setPlaceHolder(this.placeHolder);
 		input.setEnabled(this.enabled);
+		input.inputElement.title = this.title;
 		this.layoutInputBox();
 		if (this.multiline) {
 			if (isNumber(this.rows)) {
@@ -267,6 +268,14 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 
 	public set placeHolder(newValue: string) {
 		this.setPropertyFromUI<string>((props, value) => props.placeHolder = value, newValue);
+	}
+
+	public get title(): string {
+		return this.getPropertyOrDefault<string>((props) => props.title, '');
+	}
+
+	public set title(newValue: string) {
+		this.setPropertyFromUI<string>((props, value) => props.title = value, newValue);
 	}
 
 	public set columns(newValue: number) {

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -229,7 +229,6 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 		input.setAriaLabel(this.ariaLabel);
 		input.setPlaceHolder(this.placeHolder);
 		input.setEnabled(this.enabled);
-		input.inputElement.title = this.title;
 		this.layoutInputBox();
 		if (this.multiline) {
 			if (isNumber(this.rows)) {
@@ -246,6 +245,11 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 
 		input.inputElement.required = this.required;
 		input.inputElement.readOnly = this.readOnly;
+
+		// only update title if there's a value, otherwise title gets set to placeholder above
+		if (this.title) {
+			input.inputElement.title = this.title;
+		}
 	}
 
 	// CSS-bound properties


### PR DESCRIPTION
This lets the input box title get set, which is the text that that shows when it's hovered over. I'm adding this so that if the string is longer than the length of the inputbox, the hover text can show the full string. 