### PR TITLE
Add missing get and set in extHostModelView for title and validationErrorMessage

### DIFF
--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -973,6 +973,13 @@ class InputBoxWrapper extends ComponentWrapper implements azdata.InputBoxCompone
 		this.setProperty('placeHolder', v);
 	}
 
+	public get title(): string {
+		return this.properties['title'];
+	}
+	public set title(v: string) {
+		this.setProperty('title', v);
+	}
+
 	public get rows(): number {
 		return this.properties['rows'];
 	}
@@ -1020,6 +1027,13 @@ class InputBoxWrapper extends ComponentWrapper implements azdata.InputBoxCompone
 	}
 	public set stopEnterPropagation(v: boolean) {
 		this.setProperty('stopEnterPropagation', v);
+	}
+
+	public get validationErrorMessage(): string {
+		return this.properties['validationErrorMessage'];
+	}
+	public set validationErrorMessage(v: string) {
+		this.setProperty('validationErrorMessage', v);
 	}
 
 	public get onTextChanged(): vscode.Event<any> {


### PR DESCRIPTION
Missed updating this file in #8909 and #13084 so only 
`projectFilePathTextBox.updateProperty('title', this._projectFile)` 
worked, but 
`projectFilePathTextbox.title = this._projectFile` 
wasn't working (and same for validationErrorMessage)
