### PR TITLE
append data functionality

### DIFF
--- a/extensions/dacpac/src/test/testContext.ts
+++ b/extensions/dacpac/src/test/testContext.ts
@@ -195,6 +195,7 @@ export function createViewContext(): ViewTestContext {
 		data: [] as any[][],
 		columns: [] as string[],
 		onRowSelected: onClick.event,
+		appendData: (data: any[][]) => undefined,
 	});
 
 	let loadingComponent: () => azdata.LoadingComponent = () => Object.assign({}, componentBase, {

--- a/extensions/sql-assessment/src/assessmentResultGrid.ts
+++ b/extensions/sql-assessment/src/assessmentResultGrid.ts
@@ -121,10 +121,7 @@ export class AssessmentResultGrid implements vscode.Disposable {
 		if (this.dataItems) {
 			this.dataItems.push(...asmtResult.items);
 		}
-
-		await this.table.updateProperties({
-			'data': this.dataItems.map(item => this.convertToDataView(item))
-		});
+		this.table.appendData(asmtResult.items.map(item => this.convertToDataView(item)));
 	}
 
 	private async showDetails(rowNumber: number) {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -803,4 +803,12 @@ declare module 'azdata' {
 		 */
 		headerFilter?: boolean,
 	}
+
+	export interface TableComponent {
+
+		/**
+		 * Append data to an exsiting table data.
+		 */
+		appendData(data: any[][]);
+	}
 }

--- a/src/sql/platform/dashboard/browser/interfaces.ts
+++ b/src/sql/platform/dashboard/browser/interfaces.ts
@@ -27,7 +27,8 @@ export enum ComponentEventType {
  * Actions that can be handled by ModelView components
  */
 export enum ModelViewAction {
-	SelectTab = 'selectTab'
+	SelectTab = 'selectTab',
+	AppendData = 'appendData'
 }
 
 /**

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1427,7 +1427,9 @@ class TableComponentWrapper extends ComponentWrapper implements azdata.TableComp
 		return emitter && emitter.event;
 	}
 
-
+	public appendData(v: any[][]): void {
+		this.doAction(ModelViewAction.AppendData, v);
+	}
 }
 
 class DropDownWrapper extends ComponentWrapper implements azdata.DropDownComponent {

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -181,7 +181,8 @@ export enum ModelComponentTypes {
 }
 
 export enum ModelViewAction {
-	SelectTab = 'selectTab'
+	SelectTab = 'selectTab',
+	AppendData = 'appendData'
 }
 
 export enum ColumnSizingMode {

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -497,8 +497,8 @@ export default class TableComponent extends ComponentBase<azdata.TableComponentP
 		}
 	}
 	private appendData(data: any[][]) {
-		this.data.push(...data);
 		this._tableData.push(TableComponent.transformData(data, this.columns));
+		this.data = this._tableData.getItems().map(dataObject => Object.values(dataObject));
 		this.layoutTable();
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -25,7 +25,7 @@ import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { slickGridDataItemColumnValueWithNoData, textFormatter } from 'sql/base/browser/ui/table/formatters';
 import { isUndefinedOrNull } from 'vs/base/common/types';
-import { IComponent, IComponentDescriptor, IModelStore, ComponentEventType } from 'sql/platform/dashboard/browser/interfaces';
+import { IComponent, IComponentDescriptor, IModelStore, ComponentEventType, ModelViewAction } from 'sql/platform/dashboard/browser/interfaces';
 import { convertSizeToNumber } from 'sql/base/browser/dom';
 import { ButtonColumn, ButtonClickEventArgs } from 'sql/base/browser/ui/table/plugins/buttonColumn.plugin';
 import { createIconCssClass } from 'sql/workbench/browser/modelComponents/iconUtils';
@@ -488,5 +488,17 @@ export default class TableComponent extends ComponentBase<azdata.TableComponentP
 
 	public get headerFilter(): boolean {
 		return this.getPropertyOrDefault<boolean>((props) => props.headerFilter, false);
+	}
+
+	public doAction(action: string, ...args: any[]): void {
+		switch (action) {
+			case ModelViewAction.AppendData:
+				this.appendData(args[0]);
+		}
+	}
+	private appendData(data: any[][]) {
+		this.data.push(...data);
+		this._tableData.push(TableComponent.transformData(data, this.columns));
+		this.layoutTable();
 	}
 }


### PR DESCRIPTION
Append data functionality to the table component.
The Sql-Assessment extension performs long-running server assessment and displays results as it gets returned from STS one-by-one during the execution process. This allows a user to see results right away and do not wait until the full assessment is completed. 
Existing table component methods allows to completely replace data source only. This leads to scrolling being re-set to the top of the table every time a new data chunk arrives. 

A new proposed function appends new data to the existing data source and doesn't force the table to re-set its data completely. 

