### PR TITLE
Update sqlcmd table to use dataValues instead of deprecated data

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -460,8 +460,7 @@ export class PublishDatabaseDialog {
 
 			const data = this.convertSqlCmdVarsToTableFormat(this.sqlCmdVars!);
 			(<azdata.DeclarativeTableComponent>this.sqlCmdVariablesTable)!.updateProperties({
-				dataValues: data,
-				data: [] // data is deprecated, but the table gets updated incorrectly if this isn't set to an empty array
+				dataValues: data
 			});
 
 			this.tryEnableGenerateScriptAndOkButtons();
@@ -569,8 +568,7 @@ export class PublishDatabaseDialog {
 
 				const data = this.convertSqlCmdVarsToTableFormat(this.getSqlCmdVariablesForPublish());
 				await (<azdata.DeclarativeTableComponent>this.sqlCmdVariablesTable).updateProperties({
-					dataValues: data,
-					data: [] // data is deprecated, but the table gets updated incorrectly if this isn't set to an empty array
+					dataValues: data
 				});
 
 				if (Object.keys(result.sqlCmdVariables).length) {

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -569,7 +569,8 @@ export class PublishDatabaseDialog {
 
 				const data = this.convertSqlCmdVarsToTableFormat(this.getSqlCmdVariablesForPublish());
 				await (<azdata.DeclarativeTableComponent>this.sqlCmdVariablesTable).updateProperties({
-					data: data
+					dataValues: data,
+					data: [] // data is deprecated, but the table gets updated incorrectly if this isn't set to an empty array
 				});
 
 				if (Object.keys(result.sqlCmdVariables).length) {

--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
@@ -139,7 +139,13 @@ export default class DeclarativeTableComponent extends ContainerBase<any, azdata
 
 	private onCellDataChanged(newValue: string | number | boolean | any, rowIdx: number, colIdx: number): void {
 		this.data[rowIdx][colIdx].value = newValue;
-		this.setPropertyFromUI<any[][]>((props, value) => props.data = value, this.data);
+
+		if (this.properties.data) {
+			this.setPropertyFromUI<any[][]>((props, value) => props.data = value, this.data);
+		} else {
+			this.setPropertyFromUI<any[][]>((props, value) => props.dataValues = value, this.data);
+		}
+
 		let newCellData: azdata.TableCell = {
 			row: rowIdx,
 			column: colIdx,


### PR DESCRIPTION
Missed updating this in #12782. Sqlcmdvars were showing up like this after changing a cell value, then loading the values from a publish profile because data is deprecated for DeclarativeTableComponent:
![image](https://user-images.githubusercontent.com/31145923/97501497-97266d00-192e-11eb-9423-3f03687d47ca.png)

