### PR TITLE
Add --force to azdata arc postgres server delete

### DIFF
--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -95,7 +95,7 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 		postgres: {
 			server: {
 				delete: (name: string): Promise<azdataExt.AzdataOutput<void>> => {
-					return this.executeCommand<void>(['arc', 'postgres', 'server', 'delete', '-n', name]);
+					return this.executeCommand<void>(['arc', 'postgres', 'server', 'delete', '-n', name, '--force']);
 				},
 				list: (): Promise<azdataExt.AzdataOutput<azdataExt.PostgresServerListResult[]>> => {
 					return this.executeCommand<azdataExt.PostgresServerListResult[]>(['arc', 'postgres', 'server', 'list']);


### PR DESCRIPTION
The azdata CLI recently added a confirmation prompt when deleting Postgres.  But when running azdata outside of a terminal you can't respond to the prompt.  So add the --force argument to skip the prompt.  Azure Data Studio already has it's own confirmation dialog anyway.