### PR TITLE
Fix filtering for resource viewer

### DIFF
--- a/extensions/azurecore/src/azureDataGridProvider.ts
+++ b/extensions/azurecore/src/azureDataGridProvider.ts
@@ -45,18 +45,17 @@ export class AzureDataGridProvider implements azdata.DataGridProvider {
 							.map(item => {
 								return <azdata.DataGridItem>{
 									id: item.id,
-									fieldValues: {
-										nameLink: <azdata.DataGridHyperlinkInfo>{ displayText: item.name, linkOrCommand: 'https://microsoft.com' },
-										name: item.name,
-										resourceGroup: item.resourceGroup,
-										subscriptionId: item.subscriptionId,
-										subscriptionName: subscriptions.find(subscription => subscription.id === item.subscriptionId)?.name ?? item.subscriptionId,
-										locationDisplayName: utils.getRegionDisplayName(item.location),
-										type: item.type,
-										typeDisplayName: utils.getResourceTypeDisplayName(item.type),
-										iconPath: utils.getResourceTypeIcon(this._appContext, item.type),
-										portalEndpoint: account.properties.providerSettings.settings.portalEndpoint
-									}
+									// Property values
+									nameLink: <azdata.DataGridHyperlinkInfo>{ displayText: item.name, linkOrCommand: 'https://microsoft.com' },
+									name: item.name,
+									resourceGroup: item.resourceGroup,
+									subscriptionId: item.subscriptionId,
+									subscriptionName: subscriptions.find(subscription => subscription.id === item.subscriptionId)?.name ?? item.subscriptionId,
+									locationDisplayName: utils.getRegionDisplayName(item.location),
+									type: item.type,
+									typeDisplayName: utils.getResourceTypeDisplayName(item.type),
+									iconPath: utils.getResourceTypeIcon(this._appContext, item.type),
+									portalEndpoint: account.properties.providerSettings.settings.portalEndpoint
 								};
 							});
 						items.push(...newItems);

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -92,11 +92,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 	registerAzureResourceCommands(appContext, [azureResourceTree, connectionDialogTree]);
 	azdata.dataprotocol.registerDataGridProvider(new AzureDataGridProvider(appContext));
 	vscode.commands.registerCommand('azure.dataGrid.openInAzurePortal', async (item: azdata.DataGridItem) => {
-		const portalEndpoint = item.fieldValues.portalEndpoint;
-		const subscriptionId = item.fieldValues.subscriptionId;
-		const resourceGroup = item.fieldValues.resourceGroup;
-		const type = item.fieldValues.type;
-		const name = item.fieldValues.name;
+		const portalEndpoint = item.portalEndpoint;
+		const subscriptionId = item.subscriptionId;
+		const resourceGroup = item.resourceGroup;
+		const type = item.type;
+		const name = item.name;
 		if (portalEndpoint && subscriptionId && resourceGroup && type && name) {
 			await vscode.env.openExternal(vscode.Uri.parse(`${portalEndpoint}/#resource/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/${type}/${name}`));
 		} else {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -238,7 +238,7 @@ declare module 'azdata' {
 		/**
 		 * The other properties that will be displayed in the grid columns
 		 */
-		fieldValues: { [key: string]: string | DataGridHyperlinkInfo }
+		[key: string]: string | DataGridHyperlinkInfo;
 	}
 
 	/**

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
@@ -52,7 +52,7 @@ export class ResourceViewerTable extends Disposable {
 			forceFitColumns: true
 		}));
 		this._resourceViewerTable.setSelectionModel(new RowSelectionModel());
-		let filterPlugin = new HeaderFilter<Slick.SlickData>();
+		let filterPlugin = new HeaderFilter<azdata.DataGridItem>();
 		this._register(attachButtonStyler(filterPlugin, this._themeService));
 		this._register(attachTableStyler(this._resourceViewerTable, this._themeService));
 		this._register(this._resourceViewerTable.onClick(this.onTableClick, this));
@@ -130,7 +130,7 @@ export class ResourceViewerTable extends Disposable {
 		const column = this._resourceViewerTable.columns[event.cell.cell] as ColumnDefinition;
 		if (column) {
 			const row = this._dataView.getItem(event.cell.row);
-			const value = row.fieldValues[column.field];
+			const value = row[column.field];
 			if (isHyperlinkCellValue(value)) {
 				if (isString(value.linkOrCommand)) {
 					try {
@@ -154,7 +154,7 @@ export class ResourceViewerTable extends Disposable {
  * Extracts the specified field into the expected object to be handled by SlickGrid and/or formatters as needed.
  */
 function dataGridColumnValueExtractor(value: azdata.DataGridItem, columnDef: ColumnDefinition): TextCellValue | HyperlinkCellValue {
-	const fieldValue = value.fieldValues[columnDef.field];
+	const fieldValue = value[columnDef.field];
 	if (columnDef.type === 'hyperlink') {
 		return fieldValue as HyperlinkCellValue;
 	} else {


### PR DESCRIPTION
The HeaderFilter plugin isn't set up to accept nested values like these were so I'm reverting that change. At some point it would probably be good to be able to pass in a "value getter" to the filter - but for now I don't actually need the properties to be in the nested object so reverting is the easiest way until we actually have a need for that kind of support. 