### PR TITLE
make the tree theme aware and remove group color

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
+++ b/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
@@ -134,7 +134,7 @@ export class ConnectionBrowserView extends Disposable implements IPanelView {
 			new ProviderElementRenderer(),
 			this.instantiationService.createInstance(TreeItemRenderer, this.treeLabels),
 			this.instantiationService.createInstance(ConnectionProfileRenderer, true),
-			this.instantiationService.createInstance(ConnectionProfileGroupRenderer),
+			this.instantiationService.createInstance(ConnectionProfileGroupRenderer, { showColor: false }),
 			this.instantiationService.createInstance(TreeNodeRenderer),
 			new SavedConnectionsNodeRenderer()
 		];
@@ -214,6 +214,10 @@ export class ConnectionBrowserView extends Disposable implements IPanelView {
 		// it will be displayed as 'loading...', this event will be fired when a connection's provider becomes available.
 		this._register(this.capabilitiesService.onCapabilitiesRegistered(() => {
 			this.updateSavedConnectionsNode();
+		}));
+
+		this._register(this.themeService.onDidColorThemeChange(() => {
+			this.refresh();
 		}));
 	}
 
@@ -411,7 +415,7 @@ class DataSource implements IAsyncDataSource<TreeModel, TreeElement> {
 		} else if (element instanceof ConnectionProfile) {
 			return false;
 		} else if (element instanceof ConnectionProfileGroup) {
-			return element.hasChildren();
+			return true;
 		} else if (element instanceof TreeNode) {
 			return element.children.length > 0;
 		} else if (element instanceof SavedConnectionNode) {

--- a/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
+++ b/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
@@ -216,8 +216,8 @@ export class ConnectionBrowserView extends Disposable implements IPanelView {
 			this.updateSavedConnectionsNode();
 		}));
 
-		this._register(this.themeService.onDidColorThemeChange(() => {
-			this.refresh();
+		this._register(this.themeService.onDidColorThemeChange(async () => {
+			await this.refresh();
 		}));
 	}
 

--- a/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/asyncServerTreeRenderer.ts
@@ -26,12 +26,17 @@ import { withNullAsUndefined } from 'vs/base/common/types';
 
 const DefaultConnectionIconClass = 'server-page';
 
+export interface ConnectionProfileGroupDisplayOptions {
+	showColor: boolean;
+}
+
 class ConnectionProfileGroupTemplate extends Disposable {
 	private _root: HTMLElement;
 	private _nameContainer: HTMLElement;
 
 	constructor(
-		container: HTMLElement
+		container: HTMLElement,
+		private _option: ConnectionProfileGroupDisplayOptions
 	) {
 		super();
 		container.parentElement!.classList.add('server-group');
@@ -42,7 +47,7 @@ class ConnectionProfileGroupTemplate extends Disposable {
 
 	set(element: ConnectionProfileGroup) {
 		let rowElement = findParentElement(this._root, 'monaco-list-row');
-		if (rowElement) {
+		if (this._option.showColor && rowElement) {
 			rowElement.style.color = element.textColor;
 			if (element.color) {
 				rowElement.style.background = element.color;
@@ -63,10 +68,11 @@ export class ConnectionProfileGroupRenderer implements ITreeRenderer<ConnectionP
 
 	readonly templateId: string = ServerTreeRenderer.CONNECTION_GROUP_TEMPLATE_ID;
 
-	constructor(@IInstantiationService private readonly _instantiationService: IInstantiationService) { }
+	constructor(private _options: ConnectionProfileGroupDisplayOptions,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService) { }
 
 	renderTemplate(container: HTMLElement): ConnectionProfileGroupTemplate {
-		return this._instantiationService.createInstance(ConnectionProfileGroupTemplate, container);
+		return this._instantiationService.createInstance(ConnectionProfileGroupTemplate, container, this._options);
 	}
 	renderElement(node: ITreeNode<ConnectionProfileGroup, FuzzyScore>, index: number, template: ConnectionProfileGroupTemplate): void {
 		template.set(node.element);

--- a/src/sql/workbench/services/objectExplorer/browser/treeCreationUtils.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/treeCreationUtils.ts
@@ -33,7 +33,7 @@ export class TreeCreationUtils {
 	public static createConnectionTree(treeContainer: HTMLElement, instantiationService: IInstantiationService, configurationService: IConfigurationService, ariaLabel: string, useController?: IController): Tree | AsyncServerTree {
 		if (useAsyncServerTree(configurationService)) {
 			const dataSource = instantiationService.createInstance(AsyncRecentConnectionTreeDataSource);
-			const connectionProfileGroupRender = instantiationService.createInstance(ConnectionProfileGroupRenderer);
+			const connectionProfileGroupRender = instantiationService.createInstance(ConnectionProfileGroupRenderer, { showColor: true });
 			const connectionProfileRenderer = instantiationService.createInstance(ConnectionProfileRenderer, true);
 			const treeNodeRenderer = instantiationService.createInstance(TreeNodeRenderer);
 			const dnd = instantiationService.createInstance(AsyncRecentConnectionsDragAndDrop);
@@ -88,7 +88,7 @@ export class TreeCreationUtils {
 
 		if (useAsyncServerTree(configurationService)) {
 			const dataSource = instantiationService.createInstance(AsyncServerTreeDataSource);
-			const connectionProfileGroupRender = instantiationService.createInstance(ConnectionProfileGroupRenderer);
+			const connectionProfileGroupRender = instantiationService.createInstance(ConnectionProfileGroupRenderer, { showColor: true });
 			const connectionProfileRenderer = instantiationService.createInstance(ConnectionProfileRenderer, false);
 			const treeNodeRenderer = instantiationService.createInstance(TreeNodeRenderer);
 			const dnd = instantiationService.createInstance(AsyncServerTreeDragAndDrop);


### PR DESCRIPTION
1. Currently the tree is not theme aware, the event is hooked up in this PR

![image](https://user-images.githubusercontent.com/13777222/97645950-8dbf0280-1a0b-11eb-97d7-59c8f5910935.png)
![image](https://user-images.githubusercontent.com/13777222/97645961-9b748800-1a0b-11eb-878c-f9321956305e.png)

2. We discussed in today's sync up and agreed on not showing color
3. show the expander for group regardless to make it clear it is a container.

![image](https://user-images.githubusercontent.com/13777222/97645974-a6c7b380-1a0b-11eb-97b5-324d6ed376a3.png)
