### PR TITLE
Add title property for data grid providers

### DIFF
--- a/extensions/azurecore/src/azureDataGridProvider.ts
+++ b/extensions/azurecore/src/azureDataGridProvider.ts
@@ -28,6 +28,8 @@ export class AzureDataGridProvider implements azdata.DataGridProvider {
 	constructor(private _appContext: AppContext) { }
 
 	public providerId = constants.dataGridProviderId;
+	public title = loc.azureResourcesGridTitle;
+
 	public async getDataGridItems() {
 		const accounts = await azdata.accounts.getAllAccounts();
 		const items: any[] = [];

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -73,3 +73,4 @@ export const sqlServerArc = localize('azurecore.sqlServerArc', "SQL Server - Azu
 export const azureArcPostgresServer = localize('azurecore.azureArcPostgres', "Azure Arc enabled PostgreSQL Hyperscale");
 
 export const unableToOpenAzureLink = localize('azure.unableToOpenAzureLink', "Unable to open link, missing required values");
+export const azureResourcesGridTitle = localize('azure.azureResourcesGridTitle', "Azure Resources");

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -253,6 +253,11 @@ declare module 'azdata' {
 		 * Gets the list of data grid columns for this provider
 		 */
 		getDataGridColumns(): Thenable<DataGridColumn[]>;
+
+		/**
+		 * The user visible string to use for the title of the grid
+		 */
+		title: string;
 	}
 
 	export interface HyperlinkComponent {

--- a/src/sql/workbench/api/common/extHostDataProtocol.ts
+++ b/src/sql/workbench/api/common/extHostDataProtocol.ts
@@ -174,7 +174,7 @@ export class ExtHostDataProtocol extends ExtHostDataProtocolShape {
 	}
 	$registerDataGridProvider(provider: azdata.DataGridProvider): vscode.Disposable {
 		let rt = this.registerProvider(provider, DataProviderType.DataGridProvider);
-		this._proxy.$registerDataGridProvider(provider.providerId, provider.handle);
+		this._proxy.$registerDataGridProvider(provider.providerId, provider.title, provider.handle);
 		return rt;
 	}
 	$registerCapabilitiesServiceProvider(provider: azdata.CapabilitiesProvider): vscode.Disposable {

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -583,7 +583,7 @@ export interface MainThreadDataProtocolShape extends IDisposable {
 	$registerAgentServicesProvider(providerId: string, handle: number): Promise<any>;
 	$registerSerializationProvider(providerId: string, handle: number): Promise<any>;
 	$registerSqlAssessmentServicesProvider(providerId: string, handle: number): Promise<any>;
-	$registerDataGridProvider(providerId: string, handle: number): void;
+	$registerDataGridProvider(providerId: string, title: string, handle: number): void;
 	$unregisterProvider(handle: number): Promise<any>;
 	$onConnectionComplete(handle: number, connectionInfoSummary: azdata.ConnectionInfoSummary): void;
 	$onIntelliSenseCacheComplete(handle: number, connectionUri: string): void;

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerEditor.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerEditor.ts
@@ -94,6 +94,8 @@ export class ResourceViewerEditor extends EditorPane {
 	async setInput(input: ResourceViewerInput, options: EditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
 		await super.setInput(input, options, context, token);
 
+		this._resourceViewerTable.title = input.title;
+
 		this._inputDisposables.clear();
 
 		input.plugins.forEach(plugin => {

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts
@@ -52,6 +52,7 @@ export class ResourceViewerTable extends Disposable {
 			dataItemColumnValueExtractor: dataGridColumnValueExtractor,
 			forceFitColumns: true
 		}));
+
 		this._resourceViewerTable.setSelectionModel(new RowSelectionModel());
 		let filterPlugin = new HeaderFilter<azdata.DataGridItem>();
 		this._register(attachButtonStyler(filterPlugin, this._themeService));
@@ -98,6 +99,10 @@ export class ResourceViewerTable extends Disposable {
 
 	public set loading(isLoading: boolean) {
 		this._loadingSpinnerPlugin.loading = isLoading;
+	}
+
+	public set title(title: string) {
+		this._resourceViewerTable.setTableTitle(title);
 	}
 
 	public registerPlugin(plugin: Slick.Plugin<azdata.DataGridItem>): void {

--- a/src/sql/workbench/services/dataGridProvider/browser/dataGridProviderService.ts
+++ b/src/sql/workbench/services/dataGridProvider/browser/dataGridProviderService.ts
@@ -4,19 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azdata from 'azdata';
-import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
-import { IDataGridProviderService } from 'sql/workbench/services/dataGridProvider/common/dataGridProviderService';
+import { DataGridProvider, IDataGridProviderService } from 'sql/workbench/services/dataGridProvider/common/dataGridProviderService';
 import { invalidProvider } from 'sql/base/common/errors';
-import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 
 export class DataGridProviderService implements IDataGridProviderService {
 
 	public _serviceBrand: undefined;
 	private _providers = new Map<string, azdata.DataGridProvider>();
-
-	constructor(
-		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
-	) { }
 
 	/**
 	 * Register a data grid provider
@@ -32,26 +26,10 @@ export class DataGridProviderService implements IDataGridProviderService {
 		this._providers.delete(providerId);
 	}
 
-	public async getDataGridItems(providerId: string): Promise<azdata.DataGridItem[]> {
+	public getDataGridProvider(providerId: string): DataGridProvider {
 		const provider = this._providers.get(providerId);
 		if (provider) {
-			this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.GetDataGridItems)
-				.withAdditionalProperties({
-					provider: providerId
-				}).send();
-			return provider.getDataGridItems();
-		}
-		throw invalidProvider(providerId);
-	}
-
-	public async getDataGridColumns(providerId: string): Promise<azdata.DataGridColumn[]> {
-		const provider = this._providers.get(providerId);
-		if (provider) {
-			this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.GetDataGridColumns)
-				.withAdditionalProperties({
-					provider: providerId
-				}).send();
-			return provider.getDataGridColumns();
+			return provider;
 		}
 		throw invalidProvider(providerId);
 	}

--- a/src/sql/workbench/services/dataGridProvider/common/dataGridProviderService.ts
+++ b/src/sql/workbench/services/dataGridProvider/common/dataGridProviderService.ts
@@ -9,6 +9,8 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 export const SERVICE_ID = 'dataGridProviderService';
 export const IDataGridProviderService = createDecorator<IDataGridProviderService>(SERVICE_ID);
 
+export interface DataGridProvider extends azdata.DataGridProvider { }
+
 export interface IDataGridProviderService {
 	_serviceBrand: undefined;
 
@@ -23,12 +25,9 @@ export interface IDataGridProviderService {
 	unregisterProvider(providerId: string): void;
 
 	/**
-	 * Gets a list of data grid items from the specified provider
+	 * Gets a registered data grid provider, throwing if none are registered with the specified ID
+	 * @param providerId The id of the registered provider
 	 */
-	getDataGridItems(providerId: string): Promise<azdata.DataGridItem[]>;
+	getDataGridProvider(providerId: string): DataGridProvider;
 
-	/**
-	* Gets a list of data grid columns from the specified provider
-	*/
-	getDataGridColumns(providerId: string): Promise<azdata.DataGridColumn[]>;
 }


### PR DESCRIPTION
Title used for editor title and aria title of the grid component.

Also did a slight refactoring of the data grid provider service to just expose getting the provider object itself instead of having to have a separate function for every property/function to query on the providers. 

![image](https://user-images.githubusercontent.com/28519865/97745941-d4ae0600-1aa6-11eb-9ecd-87af6da20642.png)

![image](https://user-images.githubusercontent.com/28519865/97746210-2fdff880-1aa7-11eb-9c66-b561d446e84f.png)
