### PR TITLE
show folder icon for some tree nodes

### DIFF
--- a/src/sql/workbench/services/connection/browser/media/connectionBrowseTab.css
+++ b/src/sql/workbench/services/connection/browser/media/connectionBrowseTab.css
@@ -37,3 +37,13 @@
 	padding-right: 12px;
 	padding-left: 0px;
 }
+
+.connection-dialog .browse-tree-element {
+	height: 100%;
+	display: flex;
+	align-items: center;
+}
+
+.connection-dialog .browse-tree-element .icon {
+	margin-right: 5px;
+}


### PR DESCRIPTION
requested by UX team.

show folder icon for the following nodes:  'Saved Connections', 'Azure' and connection group nodes. 
refactor the tree item renders since the majority of the code can be reused by different node types. since the connection group node is going to be different from the one in OE, I am using the common renderer for it now, I can switch back to the common one when we would like to have the same UX for it.

![image](https://user-images.githubusercontent.com/13777222/97758448-1eedb200-1abc-11eb-8944-47ebb1d98dfc.png)
