### PR TITLE
Resource viewer cleanup

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -22,7 +22,7 @@
     "resourceViewResources": [
       {
         "id": "azure-resources",
-        "name": "Azure",
+        "name": "%azure.resource.view.title%",
         "icon": "./resources/azure.svg"
       }
     ],

--- a/extensions/azurecore/package.nls.json
+++ b/extensions/azurecore/package.nls.json
@@ -13,6 +13,7 @@
 	"azure.resource.startterminal.title": "Start Cloud Shell",
 	"azure.resource.connectsqlserver.title": "Connect",
 	"azure.resource.connectsqldb.title": "Add to Servers",
+	"azure.resource.view.title": "Azure (Preview)",
 	"azure.tenant.config.filter.description": "The list of tenant IDs to ignore when querying azure resources. Each element is a tenant id.",
 
 	"accounts.clearTokenCache": "Clear Azure Account Token Cache",

--- a/extensions/azurecore/src/azureDataGridProvider.ts
+++ b/extensions/azurecore/src/azureDataGridProvider.ts
@@ -48,7 +48,6 @@ export class AzureDataGridProvider implements azdata.DataGridProvider {
 								return <azdata.DataGridItem>{
 									id: item.id,
 									// Property values
-									nameLink: <azdata.DataGridHyperlinkInfo>{ displayText: item.name, linkOrCommand: 'https://microsoft.com' },
 									name: item.name,
 									resourceGroup: item.resourceGroup,
 									subscriptionId: item.subscriptionId,
@@ -75,7 +74,7 @@ export class AzureDataGridProvider implements azdata.DataGridProvider {
 	public async getDataGridColumns(): Promise<azdata.DataGridColumn[]> {
 		return [
 			{ id: 'icon', type: 'image', field: 'iconPath', name: '', width: 25, sortable: false, filterable: false, resizable: false, tooltip: loc.typeIcon },
-			{ id: 'name', type: 'hyperlink', field: 'nameLink', name: loc.name, width: 150 },
+			{ id: 'name', type: 'text', field: 'name', name: loc.name, width: 150 },
 			{ id: 'type', type: 'text', field: 'typeDisplayName', name: loc.resourceType, width: 150 },
 			{ id: 'type', type: 'text', field: 'resourceGroup', name: loc.resourceGroup, width: 150 },
 			{ id: 'location', type: 'text', field: 'locationDisplayName', name: loc.location, width: 150 },

--- a/extensions/azurecore/src/localizedConstants.ts
+++ b/extensions/azurecore/src/localizedConstants.ts
@@ -73,4 +73,4 @@ export const sqlServerArc = localize('azurecore.sqlServerArc', "SQL Server - Azu
 export const azureArcPostgresServer = localize('azurecore.azureArcPostgres', "Azure Arc enabled PostgreSQL Hyperscale");
 
 export const unableToOpenAzureLink = localize('azure.unableToOpenAzureLink', "Unable to open link, missing required values");
-export const azureResourcesGridTitle = localize('azure.azureResourcesGridTitle', "Azure Resources");
+export const azureResourcesGridTitle = localize('azure.azureResourcesGridTitle', "Azure Resources (Preview)");

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution.ts
@@ -22,6 +22,7 @@ import { Codicon } from 'vs/base/common/codicons';
 import { localize } from 'vs/nls';
 import { Extensions as ViewContainerExtensions, IViewsRegistry, IViewContainersRegistry, ViewContainerLocation } from 'vs/workbench/common/views';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IProductService } from 'vs/platform/product/common/productService';
 
 CommandsRegistry.registerCommand({
 	id: 'resourceViewer.openResourceViewer',
@@ -50,9 +51,10 @@ Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).regi
 
 class ResourceViewerContributor implements IWorkbenchContribution {
 	constructor(
-		@IConfigurationService readonly configurationService: IConfigurationService
+		@IConfigurationService readonly configurationService: IConfigurationService,
+		@IProductService readonly productService: IProductService
 	) {
-		if (configurationService.getValue('workbench.enablePreviewFeatures')) {
+		if (productService.quality !== 'stable' && productService.quality !== 'saw' && configurationService.getValue('workbench.enablePreviewFeatures')) {
 			registerResourceViewerContainer();
 		}
 	}

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution.ts
@@ -21,8 +21,6 @@ import { RESOURCE_VIEWER_VIEW_CONTAINER_ID, RESOURCE_VIEWER_VIEW_ID } from 'sql/
 import { Codicon } from 'vs/base/common/codicons';
 import { localize } from 'vs/nls';
 import { Extensions as ViewContainerExtensions, IViewsRegistry, IViewContainersRegistry, ViewContainerLocation } from 'vs/workbench/common/views';
-import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
-import { onUnexpectedError } from 'vs/base/common/errors';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 CommandsRegistry.registerCommand({

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution.ts
@@ -12,9 +12,18 @@ import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { ServicesAccessor, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IEditorService, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { isString } from 'vs/base/common/types';
-import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import { ResourceViewResourcesExtensionHandler } from 'sql/workbench/contrib/resourceViewer/common/resourceViewerViewExtensionPoint';
+import { ResourceViewerView } from 'sql/workbench/contrib/resourceViewer/browser/resourceViewerView';
+import { ResourceViewerViewlet } from 'sql/workbench/contrib/resourceViewer/browser/resourceViewerViewlet';
+import { RESOURCE_VIEWER_VIEW_CONTAINER_ID, RESOURCE_VIEWER_VIEW_ID } from 'sql/workbench/contrib/resourceViewer/common/resourceViewer';
+import { Codicon } from 'vs/base/common/codicons';
+import { localize } from 'vs/nls';
+import { Extensions as ViewContainerExtensions, IViewsRegistry, IViewContainersRegistry, ViewContainerLocation } from 'vs/workbench/common/views';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { onUnexpectedError } from 'vs/base/common/errors';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 CommandsRegistry.registerCommand({
 	id: 'resourceViewer.openResourceViewer',
@@ -41,39 +50,27 @@ Registry.as<IEditorRegistry>(EditorExtensions.Editors)
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(ResourceViewResourcesExtensionHandler, LifecyclePhase.Ready);
 
-// TODO: chgagnon disabling until the resource viewer is feature complete
-// class ResourceViewerContributor implements IWorkbenchContribution {
-// 	constructor(
-// 		@IExtensionService private readonly extensionService: IExtensionService
-// 	) {
-// 		this.checkForArc();
-// 	}
+class ResourceViewerContributor implements IWorkbenchContribution {
+	constructor(
+		@IConfigurationService readonly configurationService: IConfigurationService
+	) {
+		if (configurationService.getValue('workbench.enablePreviewFeatures')) {
+			registerResourceViewerContainer();
+		}
+	}
+}
 
-// 	private async checkForArc(): Promise<void> {
-// 		if (await this.extensionService.getExtension('Microsoft.arc')) {
-// 			registerResourceViewerContainer();
-// 		} else {
-// 			const disposable = this.extensionService.onDidChangeExtensions(async () => {
-// 				if (await this.extensionService.getExtension('Microsoft.arc')) {
-// 					registerResourceViewerContainer();
-// 					disposable.dispose();
-// 				}
-// 			});
-// 		}
-// 	}
-// }
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(ResourceViewerContributor, LifecyclePhase.Ready);
 
-// Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(ResourceViewerContributor, LifecyclePhase.Ready);
+function registerResourceViewerContainer() {
+	const viewContainer = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer({
+		id: RESOURCE_VIEWER_VIEW_CONTAINER_ID,
+		name: localize('resourceViewer', "Resource Viewer"),
+		ctorDescriptor: new SyncDescriptor(ResourceViewerViewlet),
+		icon: Codicon.database.classNames,
+		alwaysUseContainerInfo: true
+	}, ViewContainerLocation.Sidebar);
 
-// function registerResourceViewerContainer() {
-// 	const viewContainer = Registry.as<IViewContainersRegistry>(ViewExtensions.ViewContainersRegistry).registerViewContainer({
-// 		id: RESOURCE_VIEWER_VIEW_CONTAINER_ID,
-// 		name: localize('resourceViewer', "Resource Viewer"),
-// 		ctorDescriptor: new SyncDescriptor(ResourceViewerViewlet),
-// 		icon: Codicon.database.classNames,
-// 		alwaysUseContainerInfo: true
-// 	}, ViewContainerLocation.Sidebar);
-
-// 	const viewsRegistry = Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry);
-// 	viewsRegistry.registerViews([{ id: RESOURCE_VIEWER_VIEW_ID, name: localize('resourceViewer', "Resource Viewer"), containerIcon: Codicon.database.classNames, ctorDescriptor: new SyncDescriptor(ResourceViewerView), canToggleVisibility: false, canMoveView: false }], viewContainer);
-// }
+	const viewsRegistry = Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry);
+	viewsRegistry.registerViews([{ id: RESOURCE_VIEWER_VIEW_ID, name: localize('resourceViewer', "Resource Viewer"), containerIcon: Codicon.database.classNames, ctorDescriptor: new SyncDescriptor(ResourceViewerView), canToggleVisibility: false, canMoveView: false }], viewContainer);
+}

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerActions.ts
@@ -7,19 +7,6 @@ import { Action } from 'vs/base/common/actions';
 import * as nls from 'vs/nls';
 import { ResourceViewerInput } from 'sql/workbench/browser/editor/resourceViewer/resourceViewerInput';
 
-export class ResourceViewerEditColumns extends Action {
-	public static readonly ID = 'resourceViewer.editColumns';
-	public static readonly LABEL = nls.localize('resourceViewer.editColumns', "Edit Columns");
-
-	constructor() {
-		super(ResourceViewerEditColumns.ID, ResourceViewerEditColumns.LABEL, 'codicon edit');
-	}
-
-	public async run(input: ResourceViewerInput): Promise<void> {
-
-	}
-}
-
 export class ResourceViewerRefresh extends Action {
 	public static readonly ID = 'resourceViewer.refresh';
 	public static readonly LABEL = nls.localize('resourceViewer.refresh', "Refresh");

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerEditor.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerEditor.ts
@@ -17,7 +17,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ResourceViewerInput } from 'sql/workbench/browser/editor/resourceViewer/resourceViewerInput';
 import { ResourceViewerTable } from 'sql/workbench/contrib/resourceViewer/browser/resourceViewerTable';
 import { EditorPane } from 'vs/workbench/browser/parts/editor/editorPane';
-import { ResourceViewerEditColumns, ResourceViewerRefresh } from 'sql/workbench/contrib/resourceViewer/browser/resourceViewerActions';
+import { ResourceViewerRefresh } from 'sql/workbench/contrib/resourceViewer/browser/resourceViewerActions';
 import { IAction } from 'vs/base/common/actions';
 import { fillInActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { IMenuService, MenuId } from 'vs/platform/actions/common/actions';
@@ -67,10 +67,8 @@ export class ResourceViewerEditor extends EditorPane {
 		header.className = 'resource-viewer-header';
 		this._actionBar = this._register(new Taskbar(header));
 
-		const editColumnsAction = this._register(this._instantiationService.createInstance(ResourceViewerEditColumns));
 		const refreshAction = this._register(this._instantiationService.createInstance(ResourceViewerRefresh));
 		this._actionBar.setContent([
-			{ action: editColumnsAction },
 			{ action: refreshAction }
 		]);
 		return header;

--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewerView.ts
@@ -136,7 +136,7 @@ class TreeModel {
 	private readonly registry = Registry.as<ResourceViewerResourcesRegistry>(Extensions.ResourceViewerExtension);
 
 	getChildren(): ResourceType[] {
-		return this.registry.allResources.slice();
+		return this.registry.allResources.filter(resource => resource.id === 'azure-resources');
 	}
 }
 

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -65,7 +65,6 @@ export interface NotebookConfig {
 	remoteBookDownloadTimeout: number;
 	showAllKernels: boolean;
 	showCellStatusBar: boolean;
-	showNotebookConvertActions: boolean;
 	sqlStopOnError: boolean;
 	trustedBooks: Array<string>;
 	useExistingPython: boolean;


### PR DESCRIPTION
1. Show Resource Viewer when preview features enabled
1. Preview text in titles
1. Name column back to just text until there's an actual action to take on click
1. Remove "Edit Columns" button until that feature can be added
1. Only show azure-resources provider in view for now

(also cleaned up a var I missed when removing notebook convert settings)