### PR TITLE
Parameterization - Fix injected multiple parameter cell

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -356,7 +356,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						*/
 						if (cellModel.isInjectedParameter) {
 							cellModel.source = cellModel.source.slice(1);
-							cellModel.source = '# Injected-Parameters\n' + cellModel.source;
+							cellModel.source = ['# Injected-Parameters\n'].concat(cellModel.source);
 						}
 						this.trackMarkdownTelemetry(<nb.ICellContents>c, cellModel);
 						return cellModel;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #13128

The previous functionality was treating the cell source as a string instead of a string array. So now I concat a new string array with the '# Injected-Parameters' comment properly so that we keep the cellModel.source as a string array (which will not include commas to separate the content).
