### PR TITLE
Remove prose from notebooks default package list

### DIFF
--- a/extensions/notebook/src/integrationTest/notebookIntegration.test.ts
+++ b/extensions/notebook/src/integrationTest/notebookIntegration.test.ts
@@ -60,7 +60,7 @@ describe('Notebook Extension Python Installation', function () {
 		console.log('Uninstalling existing pip dependencies');
 		let install = jupyterController.jupyterInstallation;
 		let pythonExe = JupyterServerInstallation.getPythonExePath(pythonInstallDir, false);
-		let command = `"${pythonExe}" -m pip uninstall -y jupyter pandas sparkmagic prose-codeaccelerator`;
+		let command = `"${pythonExe}" -m pip uninstall -y jupyter pandas sparkmagic`;
 		await executeStreamedCommand(command, { env: install.execOptions.env }, install.outputChannel);
 		console.log('Uninstalling existing pip dependencies is done');
 

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -120,9 +120,6 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 			}, {
 				name: 'pandas',
 				version: '0.24.2'
-			}, {
-				name: 'prose-codeaccelerator',
-				version: '1.3.0'
 			}];
 		this._requiredKernelPackages.set(constants.pysparkDisplayName, sparkPackages);
 		this._requiredKernelPackages.set(constants.sparkScalaDisplayName, sparkPackages);
@@ -526,7 +523,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 
 		let versionSpecifier = useMinVersion ? '>=' : '==';
 		let packagesStr = packages.map(pkg => `"${pkg.name}${versionSpecifier}${pkg.version}"`).join(' ');
-		let cmd = `"${this.pythonExecutable}" -m pip install --user ${packagesStr} --extra-index-url https://prose-python-packages.azurewebsites.net`;
+		let cmd = `"${this.pythonExecutable}" -m pip install --user ${packagesStr}`;
 		return this.executeStreamedCommand(cmd);
 	}
 

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -339,16 +339,6 @@ export class PerFolderServerInstance implements IServerInstance {
 		// Note: Get env from the install since it gets used elsewhere
 		let env = this.getEnvWithConfigPaths(install.execOptions.env);
 
-		// 'MSHOST_TELEMETRY_ENABLED' and 'MSHOST_ENVIRONMENT' environment variables are set
-		// for telemetry purposes used by PROSE in the process where the Jupyter kernel runs
-		if (vscode.workspace.getConfiguration('telemetry').get<boolean>('enableTelemetry', true)) {
-			env['MSHOST_TELEMETRY_ENABLED'] = true;
-		} else {
-			env['MSHOST_TELEMETRY_ENABLED'] = false;
-		}
-
-		env['MSHOST_ENVIRONMENT'] = 'ADSClient-' + vscode.version;
-
 		// Start the notebook process
 		let options: SpawnOptions = {
 			shell: true,

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -246,9 +246,6 @@ describe('Jupyter Server Installation', function () {
 		}, {
 			name: 'pandas',
 			version: '0.24.2'
-		}, {
-			name: 'prose-codeaccelerator',
-			version: '1.3.0'
 		}];
 		let packages = installation.getRequiredPackagesForKernel(pysparkDisplayName);
 		should(packages).be.deepEqual(expectedPackages, "Unexpected packages for PySpark kernel.");


### PR DESCRIPTION
The PROSE python package is no longer being maintained, and we've been asked by the PROSE team to stop shipping the package by default. The team would like to take down their static page that hosts this package as well in the future (exact date TBD).

Because of these two factors, we need to remove the package from the list of packages that we install by default.