### PR TITLE
Ensure trusted action is always enabled

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -369,8 +369,8 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	}
 
 	private updateToolbarComponents() {
+		this._trustedAction.enabled = true;
 		if (this.model.trustedMode) {
-			this._trustedAction.enabled = true;
 			this._trustedAction.trusted = true;
 		}
 	}


### PR DESCRIPTION
Fixes #13172.

We disable the action until the model is done loading, but there was a change a few months back that only re-enabled the trusted action if the notebook was trusted.

This action should always be clickable (i.e. enabled).