### PR TITLE
Update arc to 0.6.1

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3257,14 +3257,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.6.0",
-							"lastUpdated": "10/29/2020",
+							"version": "0.6.1",
+							"lastUpdated": "11/2/2020",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-0.6.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/arc/arc-0.6.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -3290,7 +3290,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.22.0"
+									"value": ">=1.23.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",


### PR DESCRIPTION
This is actually reverting back to the 0.5.1 code due to regression found for stable only - hence why insiders is staying at 0.6.0 for now (the issue doesn't occur there)