### PR TITLE
Notebooks: Add unit test for data conversion in SQLFuture

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/browser/sqlFuture.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/sqlFuture.test.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { nb } from 'azdata';
+import * as sinon from 'sinon';
+import * as TypeMoq from 'typemoq';
+import { TestConfigurationService } from 'sql/platform/connection/test/common/testConfigurationService';
+import { SQLFuture } from 'sql/workbench/services/notebook/browser/sql/sqlSessionManager';
+import { ResultSetSubset, ResultSetSummary } from 'sql/workbench/services/query/common/query';
+import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
+import { NullLogService } from 'vs/platform/log/common/log';
+
+suite('SQL Future', function () {
+	let sqlFuture: SQLFuture;
+	let queryRunner: TypeMoq.Mock<QueryRunner>;
+
+	suiteSetup(async () => {
+		let configurationService = new TestConfigurationService();
+		let logService = new NullLogService();
+		queryRunner = TypeMoq.Mock.ofType(QueryRunner);
+		sqlFuture = new SQLFuture(queryRunner.object, undefined, configurationService, logService);
+	});
+
+	test('Rows returned from SQL Tools Service are correctly converted to data resource and html', async function (): Promise<void> {
+		const resultSet: ResultSetSummary = {
+			batchId: 0,
+			columnInfo: [{ columnName: 'col1' }, { columnName: 'col2' }],
+			complete: true,
+			id: 0,
+			rowCount: 2
+		};
+		const subset: ResultSetSubset = {
+			rowCount: 2,
+			rows: [[{ displayValue: '1' }, { displayValue: '2' }], [{ displayValue: '3' }, { displayValue: '4' }]]
+		};
+		const expectedData = {
+			'application/vnd.dataresource+json': {
+				data: [{ 0: '1', 1: '2' }, { 0: '3', 1: '4' }],
+				schema: { fields: [{ name: 'col1' }, { name: 'col2' }] }
+			},
+			'text/html': ['<table>', '<tr><th>col1</th><th>col2</th></tr>', '<tr><td>1</td><td>2</td></tr>', '<tr><td>3</td><td>4</td></tr>', '</table>']
+		};
+		const expectedMsg: nb.IIOPubMessage = {
+			channel: 'iopub',
+			type: 'iopub',
+			header: <nb.IHeader>{
+				msg_id: undefined,
+				msg_type: 'execute_result'
+			},
+			content: <nb.IExecuteResult>{
+				output_type: 'execute_result',
+				metadata: {
+					resultSet: resultSet
+				},
+				execution_count: this._executionCount,
+				data: expectedData
+			},
+			metadata: undefined,
+			parent_header: undefined
+		};
+
+		let handler: nb.MessageHandler<nb.IIOPubMessage> = {
+			handle: (msg: nb.IIOPubMessage) => { }
+		};
+		let handleSpy = sinon.spy(handler, 'handle');
+		sqlFuture.setIOPubHandler(handler);
+
+		queryRunner.setup(x => x.getQueryRows(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(subset));
+		sqlFuture.handleResultSet(resultSet);
+		await sqlFuture.queryAndConvertData(resultSet, 0);
+		sinon.assert.calledWith(handleSpy, expectedMsg);
+	});
+});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds a unit test for the data conversion logic (converting the grid rows returned from SQL Tools Service to data resource and html) in SQLFuture class.
