### PR TITLE
Adding External Streaming Job I/O validation

### DIFF
--- a/extensions/dacpac/src/test/testDacFxService.ts
+++ b/extensions/dacpac/src/test/testDacFxService.ts
@@ -10,8 +10,9 @@ export const deployOperationId = 'deploy dacpac';
 export const extractOperationId = 'extract dacpac';
 export const exportOperationId = 'export bacpac';
 export const importOperationId = 'import bacpac';
-export const generateScript = 'genenrate script';
-export const generateDeployPlan = 'genenrate deploy plan';
+export const generateScript = 'generate script';
+export const generateDeployPlan = 'generate deploy plan';
+export const validateStreamingJob = 'validate streaming job';
 
 export class DacFxTestService implements mssql.IDacFxService {
 	dacfxResult: mssql.DacFxResult = {
@@ -143,5 +144,13 @@ export class DacFxTestService implements mssql.IDacFxService {
 		};
 
 		return Promise.resolve(optionsResult);
+	}
+	validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<mssql.ValidateStreamingJobResult> {
+		this.dacfxResult.operationId = validateStreamingJob;
+		const streamingJobValidationResult: mssql.ValidateStreamingJobResult = {
+			success: true,
+			errorMessage: ''
+		};
+		return Promise.resolve(streamingJobValidationResult);
 	}
 }

--- a/extensions/dacpac/src/test/testDacFxService.ts
+++ b/extensions/dacpac/src/test/testDacFxService.ts
@@ -23,31 +23,31 @@ export class DacFxTestService implements mssql.IDacFxService {
 	constructor() {
 	}
 
-	exportBacpac(databaseName: string, packageFilePath: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.DacFxResult> {
+	exportBacpac(databaseName: string, packageFilePath: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Promise<mssql.DacFxResult> {
 		this.dacfxResult.operationId = exportOperationId;
 		return Promise.resolve(this.dacfxResult);
 	}
-	importBacpac(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.DacFxResult> {
+	importBacpac(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Promise<mssql.DacFxResult> {
 		this.dacfxResult.operationId = importOperationId;
 		return Promise.resolve(this.dacfxResult);
 	}
-	extractDacpac(databaseName: string, packageFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.DacFxResult> {
+	extractDacpac(databaseName: string, packageFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Promise<mssql.DacFxResult> {
 		this.dacfxResult.operationId = extractOperationId;
 		return Promise.resolve(this.dacfxResult);
 	}
-	importDatabaseProject(databaseName: string, targetFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, extractTarget: mssql.ExtractTarget, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.DacFxResult> {
+	importDatabaseProject(databaseName: string, targetFilePath: string, applicationName: string, applicationVersion: string, ownerUri: string, extractTarget: mssql.ExtractTarget, taskExecutionMode: azdata.TaskExecutionMode): Promise<mssql.DacFxResult> {
 		this.dacfxResult.operationId = importOperationId;
 		return Promise.resolve(this.dacfxResult);
 	}
-	deployDacpac(packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode, sqlCommandVariableValues?: Record<string, string>): Thenable<mssql.DacFxResult> {
+	deployDacpac(packageFilePath: string, databaseName: string, upgradeExisting: boolean, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode, sqlCommandVariableValues?: Record<string, string>): Promise<mssql.DacFxResult> {
 		this.dacfxResult.operationId = deployOperationId;
 		return Promise.resolve(this.dacfxResult);
 	}
-	generateDeployScript(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode, sqlCommandVariableValues?: Record<string, string>): Thenable<mssql.DacFxResult> {
+	generateDeployScript(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode, sqlCommandVariableValues?: Record<string, string>): Promise<mssql.DacFxResult> {
 		this.dacfxResult.operationId = generateScript;
 		return Promise.resolve(this.dacfxResult);
 	}
-	generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<mssql.GenerateDeployPlanResult> {
+	generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Promise<mssql.GenerateDeployPlanResult> {
 		this.dacfxResult.operationId = generateDeployPlan;
 		const deployPlan: mssql.GenerateDeployPlanResult = {
 			operationId: generateDeployPlan,
@@ -57,7 +57,7 @@ export class DacFxTestService implements mssql.IDacFxService {
 		};
 		return Promise.resolve(deployPlan);
 	}
-	getOptionsFromProfile(profilePath: string): Thenable<mssql.DacFxOptionsResult> {
+	getOptionsFromProfile(profilePath: string): Promise<mssql.DacFxOptionsResult> {
 		const optionsResult: mssql.DacFxOptionsResult = {
 			success: true,
 			errorMessage: '',
@@ -145,7 +145,7 @@ export class DacFxTestService implements mssql.IDacFxService {
 
 		return Promise.resolve(optionsResult);
 	}
-	validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<mssql.ValidateStreamingJobResult> {
+	validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Promise<mssql.ValidateStreamingJobResult> {
 		this.dacfxResult.operationId = validateStreamingJob;
 		const streamingJobValidationResult: mssql.ValidateStreamingJobResult = {
 			success: true,

--- a/extensions/mssql/src/contracts.ts
+++ b/extensions/mssql/src/contracts.ts
@@ -476,6 +476,12 @@ export interface GenerateDeployPlanParams {
 export interface GetOptionsFromProfileParams {
 	profilePath: string;
 }
+
+export interface ValidateStreamingJobParams {
+	packageFilePath: string,
+	createStreamingJobTsql: string
+}
+
 export namespace ExportRequest {
 	export const type = new RequestType<ExportParams, mssql.DacFxResult, void, void>('dacfx/export');
 }
@@ -503,7 +509,12 @@ export namespace GenerateDeployPlanRequest {
 export namespace GetOptionsFromProfileRequest {
 	export const type = new RequestType<GetOptionsFromProfileParams, mssql.DacFxOptionsResult, void, void>('dacfx/getOptionsFromProfile');
 }
-// ------------------------------- < DacFx > ------------------------------------
+
+export namespace ValidateStreamingJobRequest {
+	export const type = new RequestType<ValidateStreamingJobParams, mssql.ValidateStreamingJobResult, void, void>('dacfx/validateStreamingJob');
+}
+
+// ------------------------------- </ DacFx > ------------------------------------
 
 // ------------------------------- <CMS> ----------------------------------------
 

--- a/extensions/mssql/src/dacfx/dacFxService.ts
+++ b/extensions/mssql/src/dacfx/dacFxService.ts
@@ -119,4 +119,15 @@ export class DacFxService implements mssql.IDacFxService {
 			}
 		);
 	}
+
+	public validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<mssql.ValidateStreamingJobResult> {
+		const params: contracts.ValidateStreamingJobParams = { packageFilePath: packageFilePath, createStreamingJobTsql: createStreamingJobTsql };
+		return this.client.sendRequest(contracts.ValidateStreamingJobRequest.type, params).then(
+			undefined,
+			e => {
+				this.client.logFailedRequest(contracts.ValidateStreamingJobRequest.type, e);
+				return Promise.resolve(undefined);
+			}
+		);
+	}
 }

--- a/extensions/mssql/src/mssql.d.ts
+++ b/extensions/mssql/src/mssql.d.ts
@@ -339,6 +339,7 @@ export interface IDacFxService {
 	generateDeployScript(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode, sqlCommandVariableValues?: Record<string, string>, deploymentOptions?: DeploymentOptions): Thenable<DacFxResult>;
 	generateDeployPlan(packageFilePath: string, databaseName: string, ownerUri: string, taskExecutionMode: azdata.TaskExecutionMode): Thenable<GenerateDeployPlanResult>;
 	getOptionsFromProfile(profilePath: string): Thenable<DacFxOptionsResult>;
+	validateStreamingJob(packageFilePath: string, createStreamingJobTsql: string): Thenable<ValidateStreamingJobResult>;
 }
 
 export interface DacFxResult extends azdata.ResultStatus {
@@ -351,6 +352,9 @@ export interface GenerateDeployPlanResult extends DacFxResult {
 
 export interface DacFxOptionsResult extends azdata.ResultStatus {
 	deploymentOptions: DeploymentOptions;
+}
+
+export interface ValidateStreamingJobResult extends azdata.ResultStatus {
 }
 
 export interface ExportParams {

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -96,6 +96,11 @@
         "category": "%sqlDatabaseProjects.displayName%"
       },
       {
+        "command": "sqlDatabaseProjects.newExternalStreamingJob",
+        "title": "%sqlDatabaseProjects.newExternalStreamingJob%",
+        "category": "%sqlDatabaseProjects.displayName%"
+      },
+      {
         "command": "sqlDatabaseProjects.newStoredProcedure",
         "title": "%sqlDatabaseProjects.newStoredProcedure%",
         "category": "%sqlDatabaseProjects.displayName%"
@@ -197,6 +202,10 @@
         },
         {
           "command": "sqlDatabaseProjects.newView",
+          "when": "false"
+        },
+        {
+          "command": "sqlDatabaseProjects.newExternalStreamingJob",
           "when": "false"
         },
         {
@@ -307,6 +316,11 @@
           "command": "sqlDatabaseProjects.newStoredProcedure",
           "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.project || viewItem == databaseProject.itemType.folder",
           "group": "3_dbProjects_newItem@3"
+        },
+        {
+          "command": "sqlDatabaseProjects.newExternalStreamingJob",
+          "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.project || viewItem == databaseProject.itemType.folder",
+          "group": "3_dbProjects_newItem@4"
         },
         {
           "command": "sqlDatabaseProjects.newScript",

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -157,6 +157,11 @@
         "category": "%sqlDatabaseProjects.displayName%"
       },
       {
+        "command": "sqlDatabaseProjects.validateExternalStreamingJob",
+        "title": "%sqlDatabaseProjects.validateExternalStreamingJob%",
+        "category": "%sqlDatabaseProjects.displayName%"
+      },
+      {
         "command": "sqlDatabaseProjects.openContainingFolder",
         "title": "%sqlDatabaseProjects.openContainingFolder%",
         "category": "%sqlDatabaseProjects.displayName%"
@@ -341,6 +346,11 @@
           "command": "sqlDatabaseProjects.addDatabaseReference",
           "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.referencesRoot",
           "group": "4_dbProjects_addDatabaseReference"
+        },
+        {
+          "command": "sqlDatabaseProjects.validateExternalStreamingJob",
+          "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.externalStreamingJob",
+          "group": "5_dbProjects_streamingJob"
         },
         {
           "command": "sqlDatabaseProjects.exclude",

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -349,17 +349,17 @@
         },
         {
           "command": "sqlDatabaseProjects.validateExternalStreamingJob",
-          "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.externalStreamingJob",
+          "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.file.externalStreamingJob",
           "group": "5_dbProjects_streamingJob"
         },
         {
           "command": "sqlDatabaseProjects.exclude",
-          "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.folder || viewItem == databaseProject.itemType.file",
+          "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/",
           "group": "9_dbProjectsLast@1"
         },
         {
           "command": "sqlDatabaseProjects.delete",
-          "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.folder || viewItem == databaseProject.itemType.file || viewItem == databaseProject.itemType.reference",
+          "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/ || viewItem == databaseProject.itemType.reference",
           "group": "9_dbProjectsLast@2"
         },
         {

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -253,6 +253,10 @@
           "when": "false"
         },
         {
+          "command": "sqlDatabaseProjects.validateExternalStreamingJob",
+          "when": "false"
+        },
+        {
           "command": "sqlDatabaseProjects.openContainingFolder",
           "when": "false"
         },

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -13,6 +13,7 @@
 	"sqlDatabaseProjects.schemaCompare": "Schema Compare",
 	"sqlDatabaseProjects.delete": "Delete",
 	"sqlDatabaseProjects.exclude": "Exclude from project",
+	"sqlDatabaseProjects.validateExternalStreamingJob": "Validate External Streaming Job",
 
 	"sqlDatabaseProjects.newScript": "Add Script",
 	"sqlDatabaseProjects.newPreDeploymentScript": "Add Pre-Deployment Script",
@@ -20,6 +21,7 @@
 	"sqlDatabaseProjects.newTable": "Add Table",
 	"sqlDatabaseProjects.newView": "Add View",
 	"sqlDatabaseProjects.newStoredProcedure": "Add Stored Procedure",
+	"sqlDatabaseProjects.newExternalStreamingJob": "Add External Streaming Job",
 	"sqlDatabaseProjects.newItem": "Add Item...",
 	"sqlDatabaseProjects.newFolder": "Add Folder",
 

--- a/extensions/sql-database-projects/resources/templates/newTsqlExternalStreamingJobTemplate.sql
+++ b/extensions/sql-database-projects/resources/templates/newTsqlExternalStreamingJobTemplate.sql
@@ -1,0 +1,7 @@
+EXEC sys.sp_create_streaming_job @NAME = '@@OBJECT_NAME@@', @STATEMENT = 'INSERT INTO SqlOutputStream SELECT
+    timeCreated,
+    machine.temperature as machine_temperature,
+    machine.pressure as machine_pressure,
+    ambient.temperature as ambient_temperature,
+    ambient.humidity as ambient_humidity
+FROM EdgeHubInputStream'

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -149,6 +149,7 @@ export const ousiderFolderPath = localize('outsideFolderPath', "Items with absol
 export const parentTreeItemUnknown = localize('parentTreeItemUnknown', "Cannot access parent of provided tree item");
 export const prePostDeployCount = localize('prePostDeployCount', "To successfully build, update the project to have one pre-deployment script and/or one post-deployment script");
 export const invalidProjectReload = localize('invalidProjectReload', "Cannot access provided database project. Only valid, open database projects can be reloaded.");
+export const externalStreamingJobValidationPassed = localize('externalStreamingJobValidationPassed', "Validation of external streaming job passed.");
 export function projectAlreadyOpened(path: string) { return localize('projectAlreadyOpened', "Project '{0}' is already opened.", path); }
 export function projectAlreadyExists(name: string, path: string) { return localize('projectAlreadyExists', "A project named {0} already exists in {1}.", name, path); }
 export function noFileExist(fileName: string) { return localize('noFileExist', "File {0} doesn't exist", fileName); }
@@ -224,6 +225,7 @@ export const True = 'True';
 export const False = 'False';
 export const Private = 'Private';
 export const ProjectGuid = 'ProjectGuid';
+export const Type = 'Type';
 
 // SqlProj File targets
 export const NetCoreTargets = '$(NETCoreTargetsPath)\\Microsoft.Data.Tools.Schema.SqlTasks.targets';
@@ -271,7 +273,7 @@ export enum DatabaseProjectItemType {
 	project = 'databaseProject.itemType.project',
 	folder = 'databaseProject.itemType.folder',
 	file = 'databaseProject.itemType.file',
-	externalStreamingJob = 'databaseProject.itemType.externalStreamingJob',
+	externalStreamingJob = 'databaseProject.itemType.file.externalStreamingJob',
 	referencesRoot = 'databaseProject.itemType.referencesRoot',
 	reference = 'databaseProject.itemType.reference',
 	dataSourceRoot = 'databaseProject.itemType.dataSourceRoot',

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -184,6 +184,7 @@ export const scriptFriendlyName = localize('scriptFriendlyName', "Script");
 export const tableFriendlyName = localize('tableFriendlyName', "Table");
 export const viewFriendlyName = localize('viewFriendlyName', "View");
 export const storedProcedureFriendlyName = localize('storedProcedureFriendlyName', "Stored Procedure");
+export const externalStreamingJobFriendlyName = localize('externalStreamingJobFriendlyName', "External Streaming Job");
 export const preDeployScriptFriendlyName = localize('preDeployScriptFriendlyName', "Script.PreDeployment");
 export const postDeployScriptFriendlyName = localize('postDeployScriptFriendlyName', "Script.PostDeployment");
 
@@ -270,6 +271,7 @@ export enum DatabaseProjectItemType {
 	project = 'databaseProject.itemType.project',
 	folder = 'databaseProject.itemType.folder',
 	file = 'databaseProject.itemType.file',
+	externalStreamingJob = 'databaseProject.itemType.externalStreamingJob',
 	referencesRoot = 'databaseProject.itemType.referencesRoot',
 	reference = 'databaseProject.itemType.reference',
 	dataSourceRoot = 'databaseProject.itemType.dataSourceRoot',

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -226,6 +226,7 @@ export const False = 'False';
 export const Private = 'Private';
 export const ProjectGuid = 'ProjectGuid';
 export const Type = 'Type';
+export const ExternalStreamingJob: string = 'ExternalStreamingJob';
 
 // SqlProj File targets
 export const NetCoreTargets = '$(NETCoreTargetsPath)\\Microsoft.Data.Tools.Schema.SqlTasks.targets';

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -70,6 +70,7 @@ export default class MainController implements vscode.Disposable {
 		vscode.commands.registerCommand('sqlDatabaseProjects.newTable', async (node: BaseProjectTreeItem) => { await this.projectsController.addItemPromptFromNode(node, templates.table); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.newView', async (node: BaseProjectTreeItem) => { await this.projectsController.addItemPromptFromNode(node, templates.view); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.newStoredProcedure', async (node: BaseProjectTreeItem) => { await this.projectsController.addItemPromptFromNode(node, templates.storedProcedure); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.newExternalStreamingJob', async (node: BaseProjectTreeItem) => { await this.projectsController.addItemPromptFromNode(node, templates.externalStreamingJob); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.newItem', async (node: BaseProjectTreeItem) => { await this.projectsController.addItemPromptFromNode(node); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.newFolder', async (node: BaseProjectTreeItem) => { await this.projectsController.addFolderPrompt(node); });
 

--- a/extensions/sql-database-projects/src/controllers/mainController.ts
+++ b/extensions/sql-database-projects/src/controllers/mainController.ts
@@ -16,7 +16,7 @@ import { ProjectsController } from './projectController';
 import { BaseProjectTreeItem } from '../models/tree/baseTreeItem';
 import { NetCoreTool } from '../tools/netcoreTool';
 import { Project } from '../models/project';
-import { FileNode, FolderNode } from '../models/tree/fileFolderTreeItem';
+import { ExternalStreamingJobFileNode, FileNode, FolderNode } from '../models/tree/fileFolderTreeItem';
 import { IconPathHelper } from '../common/iconHelper';
 import { IProjectProvider } from 'dataworkspace';
 import { SqlDatabaseProjectProvider } from '../projectProvider/projectProvider';
@@ -80,6 +80,7 @@ export default class MainController implements vscode.Disposable {
 		vscode.commands.registerCommand('sqlDatabaseProjects.delete', async (node: BaseProjectTreeItem) => { await this.projectsController.delete(node); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.exclude', async (node: FileNode | FolderNode) => { await this.projectsController.exclude(node); });
 		vscode.commands.registerCommand('sqlDatabaseProjects.changeTargetPlatform', async (node: BaseProjectTreeItem) => { await this.projectsController.changeTargetPlatform(node); });
+		vscode.commands.registerCommand('sqlDatabaseProjects.validateExternalStreamingJob', async (node: ExternalStreamingJobFileNode) => { await this.projectsController.validateExternalStreamingJob(node); });
 
 		IconPathHelper.setExtensionContext(this.extensionContext);
 

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -298,7 +298,7 @@ export class Project {
 		const attributes = new Map<string, string>();
 
 		if (itemType === templates.externalStreamingJob) {
-			attributes.set(constants.Type, itemType);
+			attributes.set(constants.Type, constants.ExternalStreamingJob);
 		}
 
 		await this.addToProjFile(fileEntry, xmlTag, attributes);
@@ -490,6 +490,7 @@ export class Project {
 		if (!outputItemGroup) {
 			outputItemGroup = this.projFileXmlDoc.createElement(constants.ItemGroup);
 			this.projFileXmlDoc.documentElement.appendChild(outputItemGroup);
+
 			if (prePostScriptExist) {
 				prePostScriptExist.scriptExist = false;
 			}
@@ -504,6 +505,7 @@ export class Project {
 		if (xmlTag === constants.PreDeploy || xmlTag === constants.PostDeploy) {
 			let prePostScriptExist = { scriptExist: true };
 			itemGroup = this.findOrCreateItemGroup(xmlTag, prePostScriptExist);
+
 			if (prePostScriptExist.scriptExist === true) {
 				window.showInformationMessage(constants.deployScriptExists(xmlTag));
 				xmlTag = constants.None;	// Add only one pre-deploy and post-deploy script. All additional ones get added in the same item group with None tag
@@ -515,13 +517,13 @@ export class Project {
 
 		const newFileNode = this.projFileXmlDoc.createElement(xmlTag);
 
+		newFileNode.setAttribute(constants.Include, utils.convertSlashesForSqlProj(path));
+
 		if (attributes) {
 			for (const key of attributes.keys()) {
 				newFileNode.setAttribute(key, attributes.get(key));
 			}
 		}
-
-		newFileNode.setAttribute(constants.Include, utils.convertSlashesForSqlProj(path));
 
 		itemGroup.appendChild(newFileNode);
 	}
@@ -548,12 +550,14 @@ export class Project {
 	private removeNode(includeString: string, nodes: any): boolean {
 		for (let i = 0; i < nodes.length; i++) {
 			const parent = nodes[i].parentNode;
+
 			if (nodes[i].getAttribute(constants.Include) === utils.convertSlashesForSqlProj(includeString)) {
 				parent.removeChild(nodes[i]);
 
 				// delete ItemGroup if this was the only entry
 				// only want element nodes, not text nodes
 				const otherChildren = Array.from(parent.childNodes).filter((c: any) => c.childNodes);
+
 				if (otherChildren.length === 0) {
 					parent.parentNode.removeChild(parent);
 				}

--- a/extensions/sql-database-projects/src/models/tree/fileFolderTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/fileFolderTreeItem.ts
@@ -71,6 +71,15 @@ export class FileNode extends BaseProjectTreeItem {
 	}
 }
 
+export class ExternalStreamingJobFileNode extends FileNode {
+	public get treeItem(): vscode.TreeItem {
+		const treeItem = super.treeItem;
+		treeItem.contextValue = DatabaseProjectItemType.externalStreamingJob;
+
+		return treeItem;
+	}
+}
+
 /**
  * Compares two folder/file tree nodes so that folders come before files, then alphabetically
  * @param a a folder or file tree node

--- a/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
@@ -11,7 +11,7 @@ import * as fileTree from './fileFolderTreeItem';
 import { Project, EntryType, FileProjectEntry } from '../project';
 import * as utils from '../../common/utils';
 import { DatabaseReferencesTreeItem } from './databaseReferencesTreeItem';
-import { DatabaseProjectItemType, RelativeOuterPath } from '../../common/constants';
+import { DatabaseProjectItemType, RelativeOuterPath, ExternalStreamingJob } from '../../common/constants';
 import { IconPathHelper } from '../../common/iconHelper';
 
 /**
@@ -76,7 +76,7 @@ export class ProjectRootTreeItem extends BaseProjectTreeItem {
 
 			switch (entry.type) {
 				case EntryType.File:
-					if (entry.sqlObjectType === 'externalStreamingJob') {
+					if (entry.sqlObjectType === ExternalStreamingJob) {
 						newNode = new fileTree.ExternalStreamingJobFileNode(entry.fsUri, parentNode);
 					}
 					else {

--- a/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
+++ b/extensions/sql-database-projects/src/models/tree/projectTreeItem.ts
@@ -76,7 +76,13 @@ export class ProjectRootTreeItem extends BaseProjectTreeItem {
 
 			switch (entry.type) {
 				case EntryType.File:
-					newNode = new fileTree.FileNode(entry.fsUri, parentNode);
+					if (entry.sqlObjectType === 'externalStreamingJob') {
+						newNode = new fileTree.ExternalStreamingJobFileNode(entry.fsUri, parentNode);
+					}
+					else {
+						newNode = new fileTree.FileNode(entry.fsUri, parentNode);
+					}
+
 					break;
 				case EntryType.Folder:
 					newNode = new fileTree.FolderNode(entry.fsUri, parentNode);

--- a/extensions/sql-database-projects/src/templates/templates.ts
+++ b/extensions/sql-database-projects/src/templates/templates.ts
@@ -15,6 +15,8 @@ export const script: string = 'script';
 export const table: string = 'table';
 export const view: string = 'view';
 export const storedProcedure: string = 'storedProcedure';
+export const externalStreamingJob: string = 'externalStreamingJob';
+
 export const folder: string = 'folder';
 export const preDeployScript: string = 'preDeployScript';
 export const postDeployScript: string = 'postDeployScript';
@@ -49,7 +51,8 @@ export async function loadTemplates(templateFolderPath: string) {
 		loadObjectTypeInfo(view, constants.viewFriendlyName, templateFolderPath, 'newTsqlViewTemplate.sql'),
 		loadObjectTypeInfo(storedProcedure, constants.storedProcedureFriendlyName, templateFolderPath, 'newTsqlStoredProcedureTemplate.sql'),
 		loadObjectTypeInfo(preDeployScript, constants.preDeployScriptFriendlyName, templateFolderPath, 'newTsqlPreDeployScriptTemplate.sql'),
-		loadObjectTypeInfo(postDeployScript, constants.postDeployScriptFriendlyName, templateFolderPath, 'newTsqlPostDeployScriptTemplate.sql')
+		loadObjectTypeInfo(postDeployScript, constants.postDeployScriptFriendlyName, templateFolderPath, 'newTsqlPostDeployScriptTemplate.sql'),
+		loadObjectTypeInfo(externalStreamingJob, constants.externalStreamingJobFriendlyName, templateFolderPath, 'newTsqlexternalStreamingJobTemplate.sql')
 	]);
 
 	for (const scriptType of scriptTypes) {

--- a/extensions/sql-database-projects/src/templates/templates.ts
+++ b/extensions/sql-database-projects/src/templates/templates.ts
@@ -52,7 +52,7 @@ export async function loadTemplates(templateFolderPath: string) {
 		loadObjectTypeInfo(storedProcedure, constants.storedProcedureFriendlyName, templateFolderPath, 'newTsqlStoredProcedureTemplate.sql'),
 		loadObjectTypeInfo(preDeployScript, constants.preDeployScriptFriendlyName, templateFolderPath, 'newTsqlPreDeployScriptTemplate.sql'),
 		loadObjectTypeInfo(postDeployScript, constants.postDeployScriptFriendlyName, templateFolderPath, 'newTsqlPostDeployScriptTemplate.sql'),
-		loadObjectTypeInfo(externalStreamingJob, constants.externalStreamingJobFriendlyName, templateFolderPath, 'newTsqlexternalStreamingJobTemplate.sql')
+		loadObjectTypeInfo(externalStreamingJob, constants.externalStreamingJobFriendlyName, templateFolderPath, 'newTsqlExternalStreamingJobTemplate.sql')
 	]);
 
 	for (const scriptType of scriptTypes) {

--- a/extensions/sql-database-projects/src/test/baselines/openSqlProjectBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSqlProjectBaseline.xml
@@ -75,6 +75,9 @@
     <Build Include="Views\User\Profile.sql" />
   </ItemGroup>
   <ItemGroup>
+    <Build Include="MyExternalStreamingJob.sql" Type="ExternalStreamingJob" />
+  </ItemGroup>
+  <ItemGroup>
     <SqlCmdVariable Include="ProdDatabaseName">
       <DefaultValue>MyProdDatabase</DefaultValue>
       <Value>$(SqlCmdVar__1)</Value>

--- a/extensions/sql-database-projects/src/test/baselines/openSqlProjectWithAdditionalSqlCmdVariablesBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSqlProjectWithAdditionalSqlCmdVariablesBaseline.xml
@@ -75,6 +75,9 @@
     <Build Include="Views\User\Profile.sql"/>
   </ItemGroup>
   <ItemGroup>
+    <Build Include="MyExternalStreamingJob.sql" Type="ExternalStreamingJob"/>
+  </ItemGroup>
+  <ItemGroup>
     <SqlCmdVariable Include="BackupDatabaseName">
       <DefaultValue>MyBackupDatabase</DefaultValue>
       <Value>$(SqlCmdVar__2)</Value>

--- a/extensions/sql-database-projects/src/test/projectController.test.ts
+++ b/extensions/sql-database-projects/src/test/projectController.test.ts
@@ -85,7 +85,7 @@ describe('ProjectsController', function (): void {
 
 				const project = await projController.openProject(vscode.Uri.file(sqlProjPath));
 
-				should(project.files.length).equal(9); // detailed sqlproj tests in their own test file
+				should(project.files.length).equal(10); // detailed sqlproj tests in their own test file
 				should(project.dataSources.length).equal(3); // detailed datasources tests in their own test file
 			});
 

--- a/extensions/sql-database-projects/src/test/templates.test.ts
+++ b/extensions/sql-database-projects/src/test/templates.test.ts
@@ -23,7 +23,7 @@ describe('Templates: loading templates from disk', function (): void {
 
 		// check expected counts
 
-		const numScriptObjectTypes = 6;
+		const numScriptObjectTypes = 7;
 
 		should(templates.projectScriptTypes().length).equal(numScriptObjectTypes);
 		should(Object.keys(templates.projectScriptTypes()).length).equal(numScriptObjectTypes);

--- a/extensions/sql-database-projects/src/test/testContext.ts
+++ b/extensions/sql-database-projects/src/test/testContext.ts
@@ -115,6 +115,7 @@ export class MockDacFxService implements mssql.IDacFxService {
 	public generateDeployScript(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode, ______?: Record<string, string>): Thenable<mssql.DacFxResult> { return Promise.resolve(mockDacFxResult); }
 	public generateDeployPlan(_: string, __: string, ___: string, ____: azdata.TaskExecutionMode): Thenable<mssql.GenerateDeployPlanResult> { return Promise.resolve(mockDacFxResult); }
 	public getOptionsFromProfile(_: string): Thenable<mssql.DacFxOptionsResult> { return Promise.resolve(mockDacFxOptionsResult); }
+	public validateStreamingJob(_: string, __: string): Thenable<mssql.ValidateStreamingJobResult> { return Promise.resolve(mockDacFxResult); }
 }
 
 export function createContext(): TestContext {


### PR DESCRIPTION
Reconstruction of https://github.com/microsoft/azuredatastudio/pull/13148

This PR adds basic sqlproj and UX support for External Streaming Jobs and validation. The validation will use the model from the most recently built dacpac, or build a new one if there isn't one in the output folder.

