### PR TITLE
Notebooks: Check for clientSession before checking isInErrorState

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -338,7 +338,7 @@ export class KernelsDropdown extends SelectBox {
 				}
 				this.setOptions(kernels, index);
 			}
-		} else if (this.model.clientSession.isInErrorState) {
+		} else if (this.model.clientSession?.isInErrorState) {
 			kernels.unshift(noKernelName);
 			this.setOptions(kernels, 0);
 		}
@@ -402,7 +402,7 @@ export class AttachToDropdown extends SelectBox {
 		let kernelDisplayName: string = this.getKernelDisplayName();
 		if (kernelDisplayName) {
 			this.loadAttachToDropdown(this.model, kernelDisplayName, showSelectConnection);
-		} else if (this.model.clientSession.isInErrorState) {
+		} else if (this.model.clientSession?.isInErrorState) {
 			this.setOptions([localize('noContextAvailable', "None")], 0);
 		}
 	}


### PR DESCRIPTION
Turned on exceptions and found that we were throwing in notebookActions because we were checking a property on the clientSession before checking that clientSession existed at all.

Followed where the nearest `catch` block is, and it doesn't look like this has any adverse effects (and prevents other code from being executed).

