### PR TITLE
fix for history reload upon target change and filter out unsupported …

### DIFF
--- a/extensions/sql-assessment/src/assessmentResultGrid.ts
+++ b/extensions/sql-assessment/src/assessmentResultGrid.ts
@@ -162,13 +162,6 @@ export class AssessmentResultGrid implements vscode.Disposable {
 
 	private async showDetails(rowNumber: number) {
 		const selectedRowValues = this.table.data[rowNumber];
-<<<<<<< HEAD
-		const asmtResultItem = this.dataItems.find(item =>
-			item.targetName === selectedRowValues[this.targetColOrder]
-			&& item.checkId === selectedRowValues[this.checkIdColOrder]
-			&& item.message === selectedRowValues[this.messageColOrder]
-		);
-=======
 		const asmtResultItem = this.asmtType === AssessmentType.InvokeAssessment
 			? this.dataItems.find(item =>
 				item.targetName === selectedRowValues[this.targetColOrder]
@@ -177,7 +170,6 @@ export class AssessmentResultGrid implements vscode.Disposable {
 			: this.dataItems.find(item =>
 				item.targetName === selectedRowValues[this.targetColOrder]
 				&& item.checkId === selectedRowValues[this.checkIdColOrder]);
->>>>>>> 8b8c4067c... fix for history reload upon target change and filter out unsupported asmt messages
 
 		if (!asmtResultItem) {
 			return;

--- a/extensions/sql-assessment/src/assessmentResultGrid.ts
+++ b/extensions/sql-assessment/src/assessmentResultGrid.ts
@@ -123,7 +123,7 @@ export class AssessmentResultGrid implements vscode.Disposable {
 		this.asmtType = method;
 		this.dataItems = this.filterOutNotSupportedKind(asmtResult.items);
 		await this.table.updateProperties({
-			'data': this.filterOutNotSupportedKind(asmtResult.items).map(item => this.convertToDataView(item))
+			'data': this.dataItems.map(item => this.convertToDataView(item))
 		});
 		this.rootContainer.setLayout({
 			flexFlow: 'column',
@@ -145,6 +145,8 @@ export class AssessmentResultGrid implements vscode.Disposable {
 		});
 	}
 
+	// we need to filter out warnings and error results since we don't have an appropriate way of displaying such messages.
+	// have to redone this once required functionality will be added to the core.
 	private filterOutNotSupportedKind(items: azdata.SqlAssessmentResultItem[]): azdata.SqlAssessmentResultItem[] {
 		if (this.asmtType === AssessmentType.AvailableRules) {
 			return items;
@@ -154,10 +156,11 @@ export class AssessmentResultGrid implements vscode.Disposable {
 	}
 
 	public async appendResult(asmtResult: azdata.SqlAssessmentResult): Promise<void> {
+		let filteredValues = this.filterOutNotSupportedKind(asmtResult.items);
 		if (this.dataItems) {
-			this.dataItems.push(...this.filterOutNotSupportedKind(asmtResult.items));
+			this.dataItems.push(...filteredValues);
 		}
-		this.table.appendData(this.filterOutNotSupportedKind(asmtResult.items).map(item => this.convertToDataView(item)));
+		this.table.appendData(filteredValues.map(item => this.convertToDataView(item)));
 	}
 
 	private async showDetails(rowNumber: number) {

--- a/extensions/sql-assessment/src/assessmentResultGrid.ts
+++ b/extensions/sql-assessment/src/assessmentResultGrid.ts
@@ -121,9 +121,9 @@ export class AssessmentResultGrid implements vscode.Disposable {
 
 	public async displayResult(asmtResult: azdata.SqlAssessmentResult, method: AssessmentType) {
 		this.asmtType = method;
-		this.dataItems = asmtResult.items;
+		this.dataItems = this.filterOutNotSupportedKind(asmtResult.items);
 		await this.table.updateProperties({
-			'data': asmtResult.items.map(item => this.convertToDataView(item))
+			'data': this.filterOutNotSupportedKind(asmtResult.items).map(item => this.convertToDataView(item))
 		});
 		this.rootContainer.setLayout({
 			flexFlow: 'column',
@@ -145,20 +145,39 @@ export class AssessmentResultGrid implements vscode.Disposable {
 		});
 	}
 
+	private filterOutNotSupportedKind(items: azdata.SqlAssessmentResultItem[]): azdata.SqlAssessmentResultItem[] {
+		if (this.asmtType === AssessmentType.AvailableRules) {
+			return items;
+		}
+
+		return items.filter(i => i.kind === azdata.sqlAssessment.SqlAssessmentResultItemKind.RealResult);
+	}
+
 	public async appendResult(asmtResult: azdata.SqlAssessmentResult): Promise<void> {
 		if (this.dataItems) {
-			this.dataItems.push(...asmtResult.items);
+			this.dataItems.push(...this.filterOutNotSupportedKind(asmtResult.items));
 		}
-		this.table.appendData(asmtResult.items.map(item => this.convertToDataView(item)));
+		this.table.appendData(this.filterOutNotSupportedKind(asmtResult.items).map(item => this.convertToDataView(item)));
 	}
 
 	private async showDetails(rowNumber: number) {
 		const selectedRowValues = this.table.data[rowNumber];
+<<<<<<< HEAD
 		const asmtResultItem = this.dataItems.find(item =>
 			item.targetName === selectedRowValues[this.targetColOrder]
 			&& item.checkId === selectedRowValues[this.checkIdColOrder]
 			&& item.message === selectedRowValues[this.messageColOrder]
 		);
+=======
+		const asmtResultItem = this.asmtType === AssessmentType.InvokeAssessment
+			? this.dataItems.find(item =>
+				item.targetName === selectedRowValues[this.targetColOrder]
+				&& item.checkId === selectedRowValues[this.checkIdColOrder]
+				&& item.message === selectedRowValues[this.messageColOrder])
+			: this.dataItems.find(item =>
+				item.targetName === selectedRowValues[this.targetColOrder]
+				&& item.checkId === selectedRowValues[this.checkIdColOrder]);
+>>>>>>> 8b8c4067c... fix for history reload upon target change and filter out unsupported asmt messages
 
 		if (!asmtResultItem) {
 			return;

--- a/extensions/sql-assessment/src/engine.ts
+++ b/extensions/sql-assessment/src/engine.ts
@@ -32,7 +32,7 @@ export class AssessmentEngine {
 	private connectionUri: string = '';
 	private connectionProfile!: azdata.connection.ConnectionProfile;
 	private lastInvokedResults!: SqlAssessmentResultInfo;
-	private historicalRecords!: SqlAssessmentRecord[];
+	private historicalRecords!: SqlAssessmentRecord[] | undefined;
 
 
 	constructor(service: mssql.ISqlAssessmentService) {
@@ -56,6 +56,7 @@ export class AssessmentEngine {
 	public async initialize(connectionId: string) {
 		this.connectionUri = await azdata.connection.getUriForConnection(connectionId);
 		this.connectionProfile = await azdata.connection.getCurrentConnection();
+		this.historicalRecords = undefined;
 	}
 
 	public async performAssessment(asmtType: AssessmentType, onResult: OnResultCallback): Promise<void> {
@@ -99,7 +100,7 @@ export class AssessmentEngine {
 			await this.loadHistory();
 		}
 
-		return this.historicalRecords;
+		return this.historicalRecords ?? [];
 	}
 
 	private async loadHistory(): Promise<void> {

--- a/extensions/sql-assessment/src/maincontroller.ts
+++ b/extensions/sql-assessment/src/maincontroller.ts
@@ -31,7 +31,6 @@ export default class MainController {
 	}
 
 	public async activate(): Promise<boolean> {
-
 		this.sqlAssessment = ((await vscode.extensions.getExtension(mssql.extension.name)?.activate() as mssql.IExtension)).sqlAssessment;
 		this.engine = new AssessmentEngine(this.sqlAssessment);
 		this.registerModelViewProvider();


### PR DESCRIPTION
1. History has to be re-loaded upon assessment target change.
2. Assessment results may contain Warnings and Errors. In order to display these properly, we need to add some formatting functionality like font and background colors for the core tableComponent. This will be introduced in the next release. Thus, we have to filter unsupported messages for now.
