### PR TITLE
Changing Editable dropdown focus to dropdown arrow instead of editText on pressing escape from dropdown options

### DIFF
--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -209,7 +209,7 @@ export class Dropdown extends Disposable {
 		});
 
 		this._controller.onDropdownEscape(() => {
-			(this._inputContainer.getElementsByClassName('action-label codicon dropdown-arrow')[0] as HTMLElement).focus();
+			(this._inputContainer.getElementsByTagName('a')[0] as HTMLElement).focus();
 			this.contextViewService.hideContextView();
 		});
 

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -209,7 +209,7 @@ export class Dropdown extends Disposable {
 		});
 
 		this._controller.onDropdownEscape(() => {
-			this._input.focus();
+			(this._inputContainer.getElementsByClassName('action-label codicon dropdown-arrow')[0] as HTMLElement).focus();
 			this.contextViewService.hideContextView();
 		});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #12980 

I am getting the element by tag name to perform this action. Should I change to getElementsByClassName?

Editable dropdown html for reference

```
<div class="dropdown-input" style="width: 100%;">
	<div class="monaco-inputbox idle"
		style="background-color: rgb(33, 33, 33); color: rgb(255, 255, 254); border-width: 1px; border-style: solid; border-color: rgb(136, 136, 136);">
		<div class="wrapper"><input class="input" autocorrect="off" autocapitalize="off" spellcheck="false" type="text"
				wrap="off" title="" style="padding-right: 22px; background-color: inherit; color: rgb(255, 255, 254);">
		</div>
		<div class="monaco-action-bar animated">
			<ul class="actions-container" role="toolbar">
				<li class="action-item" role="presentation"><a class="action-label codicon dropdown-arrow" role="button"
						tabindex="0"></a></li>
			</ul>
		</div>
	</div>
</div>
```