### PR TITLE
Adding custom focus outline-offset for checkboxes

### DIFF
--- a/src/sql/base/browser/ui/checkbox/checkbox.ts
+++ b/src/sql/base/browser/ui/checkbox/checkbox.ts
@@ -66,11 +66,6 @@ export class Checkbox extends Widget {
 			this.onChange(opts.onChange);
 		}
 
-		this._el.addEventListener('focus', () => {
-			this._el.style.outlineColor = '#E47609';
-			this._el.style.outlineWidth = '2px';
-		});
-
 		container.appendChild(this._el);
 		container.appendChild(this._label);
 	}

--- a/src/sql/base/browser/ui/checkbox/checkbox.ts
+++ b/src/sql/base/browser/ui/checkbox/checkbox.ts
@@ -66,6 +66,11 @@ export class Checkbox extends Widget {
 			this.onChange(opts.onChange);
 		}
 
+		this._el.addEventListener('focus', () => {
+			this._el.style.outlineColor = '#E47609';
+			this._el.style.outlineWidth = '2px';
+		});
+
 		container.appendChild(this._el);
 		container.appendChild(this._label);
 	}

--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -220,6 +220,10 @@ body.web {
 	opacity: 1 !important;
 }
 
+.monaco-workbench input[type="checkbox"]:focus {
+	outline-offset: 2px;
+}
+
 .monaco-workbench [tabindex="0"]:active,
 .monaco-workbench [tabindex="-1"]:active,
 .monaco-workbench select:active,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->



This PR fixes #12979 

Light:
![image](https://user-images.githubusercontent.com/6816294/98304050-12fa6800-1f74-11eb-9f5a-3d00c2a09332.png)

Dark:
![image](https://user-images.githubusercontent.com/6816294/98304083-24437480-1f74-11eb-94a9-4cd20dd019fd.png)

I am taking over this change from vscode to ads. 