### PR TITLE
Add Azure account initialization logging

### DIFF
--- a/extensions/azurecore/src/account-provider/azureAccountProvider.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProvider.ts
@@ -88,6 +88,7 @@ export class AzureAccountProvider implements azdata.AccountProvider, vscode.Disp
 
 	private async _initialize(storedAccounts: azdata.Account[]): Promise<azdata.Account[]> {
 		const accounts: azdata.Account[] = [];
+		console.log(`Initializing stored accounts ${JSON.stringify(accounts)}`);
 		for (let account of storedAccounts) {
 			const azureAuth = this.getAuthMethod(account);
 			if (!azureAuth) {

--- a/src/sql/platform/accounts/common/accountStore.ts
+++ b/src/sql/platform/accounts/common/accountStore.ts
@@ -206,7 +206,7 @@ export default class AccountStore implements IAccountStore {
 		if (!accounts) {
 			accounts = [];
 		}
-
+		this.logService.debug(`Read accounts from memento ${JSON.stringify(accounts)}`);
 		// Make a deep copy of the account list to ensure that the memento list isn't obliterated
 		accounts = deepClone(accounts);
 


### PR DESCRIPTION
Adding some more logging to help try to track down https://github.com/microsoft/azuredatastudio/issues/11260

User was seeing this error on startup so it looks like something might be wrong with the memento retrieval. 
```
/C:/Users/a/AppData/Local/Programs/Azure Data Studio - Insiders/resources/app/out/vs/workbench/workbench.desktop.main.js:2315   ERR e is not iterable: TypeError: e is not iterable
	at p._initialize (c:\Users\a\AppData\Local\Programs\Azure Data Studio - Insiders\resources\app\extensions\azurecore\dist\extension.js:166:32362)
	at p.initialize (c:\Users\a\AppData\Local\Programs\Azure Data Studio - Insiders\resources\app\extensions\azurecore\dist\extension.js:166:32302)
	at c:\Users\a\AppData\Local\Programs\Azure Data Studio - Insiders\resources\app\out\vs\workbench\services\extensions\node\extensionHostProcess.js:693:948
	at a._withProvider (c:\Users\a\AppData\Local\Programs\Azure Data Studio - Insiders\resources\app\out\vs\workbench\services\extensions\node\extensionHostProcess.js:696:200)
```