### PR TITLE
Remove hardcoded colors for HDFS access dialog

### DIFF
--- a/extensions/mssql/src/hdfs/ui/hdfsManageAccessDialog.ts
+++ b/extensions/mssql/src/hdfs/ui/hdfsManageAccessDialog.ts
@@ -348,7 +348,6 @@ export class ManageAccessDialog {
 			width: width,
 			headerCssStyles: {
 				'border': 'none',
-				'background-color': '#FFFFFF',
 				'padding': '0px',
 				...cssStyles.permissionsTableHeaderCss
 			},


### PR DESCRIPTION
Current look in dark mode : 

![image](https://user-images.githubusercontent.com/28519865/98174093-2096eb80-1ea9-11eb-975c-1ac54e6703e4.png)

Fixed in dark mode : 

![image](https://user-images.githubusercontent.com/28519865/98174043-0826d100-1ea9-11eb-8b59-410a72efad0b.png)

Fixed in light mode : 

![image](https://user-images.githubusercontent.com/28519865/98174074-15dc5680-1ea9-11eb-811b-7e39abf827fb.png)
