### PR TITLE
Only show resource viewer on insiders and dev (#13238)

### DIFF
--- a/src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution.ts
+++ b/src/sql/workbench/contrib/resourceViewer/browser/resourceViewer.contribution.ts
@@ -54,7 +54,8 @@ class ResourceViewerContributor implements IWorkbenchContribution {
 		@IConfigurationService readonly configurationService: IConfigurationService,
 		@IProductService readonly productService: IProductService
 	) {
-		if (productService.quality !== 'stable' && productService.quality !== 'saw' && configurationService.getValue('workbench.enablePreviewFeatures')) {
+		// Only show for insiders and dev
+		if (['insiders', ''].includes(productService.quality ?? '') && configurationService.getValue('workbench.enablePreviewFeatures')) {
 			registerResourceViewerContainer();
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13237

(cherry picked from commit fd8f88db4b4d22a6b9810fd7349369884973f650)

The Resource Viewer is going to be in insiders for the time being - this is hiding it for the RC builds. 
