### PR TITLE
[Port] Added Loading to Compute&Storage and Connection Strings Pages

### DIFF
--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -159,12 +159,10 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 							title: loc.updatingInstance(this._postgresModel.info.name),
 							cancellable: false
 						},
-						(_progress, _token) => {
-							return this._azdataApi.azdata.arc.postgres.server.edit(
-								this._postgresModel.info.name, this.saveArgs).then(
-									async () => {
-										await this._postgresModel.refresh();
-									});
+						async (_progress, _token): Promise<void> => {
+							await this._azdataApi.azdata.arc.postgres.server.edit(
+								this._postgresModel.info.name, this.saveArgs);
+							await this._postgresModel.refresh();
 						}
 					);
 

--- a/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
@@ -50,7 +50,7 @@ export class PostgresConnectionStringsPage extends DashboardPage {
 
 		const link = this.modelView.modelBuilder.hyperlink().withProperties<azdata.HyperlinkComponentProperties>({
 			label: loc.learnAboutPostgresClients,
-			url: 'https://docs.microsoft.com/azure/postgresql/concepts-connection-libraries',
+			url: 'https://docs.microsoft.com/azure/azure-arc/data/get-connection-endpoints-and-connection-strings-postgres-hyperscale',
 		}).component();
 
 		const infoAndLink = this.modelView.modelBuilder.flexContainer().withLayout({ flexWrap: 'wrap' }).component();

--- a/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
@@ -11,6 +11,7 @@ import { DashboardPage } from '../../components/dashboardPage';
 import { PostgresModel } from '../../../models/postgresModel';
 
 export class PostgresConnectionStringsPage extends DashboardPage {
+	private dataLoading!: azdata.LoadingComponent;
 	private keyValueContainer?: KeyValueContainer;
 
 	constructor(protected modelView: azdata.ModelView, private _postgresModel: PostgresModel) {
@@ -60,6 +61,18 @@ export class PostgresConnectionStringsPage extends DashboardPage {
 		this.keyValueContainer = new KeyValueContainer(this.modelView.modelBuilder, this.getConnectionStrings());
 		this.disposables.push(this.keyValueContainer);
 		content.addItem(this.keyValueContainer.container);
+
+		if (!this._postgresModel.configLastUpdated) {
+			this.keyValueContainer?.container.updateCssStyles({ display: 'none' });
+		}
+
+		this.dataLoading = this.modelView.modelBuilder.loadingComponent()
+			.withProperties<azdata.LoadingComponentProperties>({
+				loading: !this._postgresModel.configLastUpdated
+			}).component();
+
+		content.addItem(this.dataLoading, { CSSStyles: cssStyles.text });
+
 		this.initialized = true;
 		return root;
 	}
@@ -88,6 +101,9 @@ export class PostgresConnectionStringsPage extends DashboardPage {
 	}
 
 	private handleServiceUpdated() {
+		this.dataLoading!.loading = false;
+		this.dataLoading!.updateCssStyles({ display: 'none' });
 		this.keyValueContainer?.refresh(this.getConnectionStrings());
+		this.keyValueContainer?.container.updateCssStyles({ display: 'initial' });
 	}
 }

--- a/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
@@ -17,6 +17,11 @@ export class PostgresConnectionStringsPage extends DashboardPage {
 	constructor(protected modelView: azdata.ModelView, private _postgresModel: PostgresModel) {
 		super(modelView);
 
+		this.dataLoading = this.modelView.modelBuilder.loadingComponent()
+			.withProperties<azdata.LoadingComponentProperties>({
+				loading: !this._postgresModel.configLastUpdated
+			}).component();
+
 		this.disposables.push(this._postgresModel.onConfigUpdated(
 			() => this.eventuallyRunOnInitialized(() => this.handleServiceUpdated())));
 	}
@@ -62,15 +67,6 @@ export class PostgresConnectionStringsPage extends DashboardPage {
 		this.disposables.push(this.keyValueContainer);
 		content.addItem(this.keyValueContainer.container);
 
-		if (!this._postgresModel.configLastUpdated) {
-			this.keyValueContainer?.container.updateCssStyles({ display: 'none' });
-		}
-
-		this.dataLoading = this.modelView.modelBuilder.loadingComponent()
-			.withProperties<azdata.LoadingComponentProperties>({
-				loading: !this._postgresModel.configLastUpdated
-			}).component();
-
 		content.addItem(this.dataLoading, { CSSStyles: cssStyles.text });
 
 		this.initialized = true;
@@ -104,6 +100,5 @@ export class PostgresConnectionStringsPage extends DashboardPage {
 		this.dataLoading!.loading = false;
 		this.dataLoading!.updateCssStyles({ display: 'none' });
 		this.keyValueContainer?.refresh(this.getConnectionStrings());
-		this.keyValueContainer?.container.updateCssStyles({ display: 'initial' });
 	}
 }

--- a/extensions/arc/src/ui/dashboards/postgres/postgresDashboard.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresDashboard.ts
@@ -14,7 +14,6 @@ import { Dashboard } from '../../components/dashboard';
 import { PostgresDiagnoseAndSolveProblemsPage } from './postgresDiagnoseAndSolveProblemsPage';
 import { PostgresSupportRequestPage } from './postgresSupportRequestPage';
 import { PostgresComputeAndStoragePage } from './postgresComputeAndStoragePage';
-import { PostgresPropertiesPage } from './postgresPropertiesPage';
 
 export class PostgresDashboard extends Dashboard {
 	constructor(private _context: vscode.ExtensionContext, private _controllerModel: ControllerModel, private _postgresModel: PostgresModel) {
@@ -33,7 +32,8 @@ export class PostgresDashboard extends Dashboard {
 		const overviewPage = new PostgresOverviewPage(modelView, this._controllerModel, this._postgresModel);
 		const connectionStringsPage = new PostgresConnectionStringsPage(modelView, this._postgresModel);
 		const computeAndStoragePage = new PostgresComputeAndStoragePage(modelView, this._postgresModel);
-		const propertiesPage = new PostgresPropertiesPage(modelView, this._controllerModel, this._postgresModel);
+		// TODO: Removed properties page while investigating bug where refreshed values don't appear in UI
+		// const propertiesPage = new PostgresPropertiesPage(modelView, this._controllerModel, this._postgresModel);
 		const diagnoseAndSolveProblemsPage = new PostgresDiagnoseAndSolveProblemsPage(modelView, this._context, this._postgresModel);
 		const supportRequestPage = new PostgresSupportRequestPage(modelView, this._controllerModel, this._postgresModel);
 
@@ -43,8 +43,7 @@ export class PostgresDashboard extends Dashboard {
 				title: loc.settings,
 				tabs: [
 					connectionStringsPage.tab,
-					computeAndStoragePage.tab,
-					propertiesPage.tab
+					computeAndStoragePage.tab
 				]
 			},
 			{

--- a/extensions/arc/src/ui/dashboards/postgres/postgresDashboard.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresDashboard.ts
@@ -14,6 +14,7 @@ import { Dashboard } from '../../components/dashboard';
 import { PostgresDiagnoseAndSolveProblemsPage } from './postgresDiagnoseAndSolveProblemsPage';
 import { PostgresSupportRequestPage } from './postgresSupportRequestPage';
 import { PostgresComputeAndStoragePage } from './postgresComputeAndStoragePage';
+import { PostgresPropertiesPage } from './postgresPropertiesPage';
 
 export class PostgresDashboard extends Dashboard {
 	constructor(private _context: vscode.ExtensionContext, private _controllerModel: ControllerModel, private _postgresModel: PostgresModel) {
@@ -32,8 +33,7 @@ export class PostgresDashboard extends Dashboard {
 		const overviewPage = new PostgresOverviewPage(modelView, this._controllerModel, this._postgresModel);
 		const connectionStringsPage = new PostgresConnectionStringsPage(modelView, this._postgresModel);
 		const computeAndStoragePage = new PostgresComputeAndStoragePage(modelView, this._postgresModel);
-		// TODO: Removed properties page while investigating bug where refreshed values don't appear in UI
-		// const propertiesPage = new PostgresPropertiesPage(modelView, this._controllerModel, this._postgresModel);
+		const propertiesPage = new PostgresPropertiesPage(modelView, this._controllerModel, this._postgresModel);
 		const diagnoseAndSolveProblemsPage = new PostgresDiagnoseAndSolveProblemsPage(modelView, this._context, this._postgresModel);
 		const supportRequestPage = new PostgresSupportRequestPage(modelView, this._controllerModel, this._postgresModel);
 
@@ -43,7 +43,8 @@ export class PostgresDashboard extends Dashboard {
 				title: loc.settings,
 				tabs: [
 					connectionStringsPage.tab,
-					computeAndStoragePage.tab
+					computeAndStoragePage.tab,
+					propertiesPage.tab
 				]
 			},
 			{

--- a/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
@@ -7,10 +7,11 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as loc from '../../../localizedConstants';
 import { IconPathHelper, cssStyles } from '../../../constants';
-import { KeyValueContainer, KeyValue, InputKeyValue, TextKeyValue } from '../../components/keyValueContainer';
+import { KeyValueContainer, KeyValue, InputKeyValue, TextKeyValue, LinkKeyValue } from '../../components/keyValueContainer';
 import { DashboardPage } from '../../components/dashboardPage';
 import { ControllerModel } from '../../../models/controllerModel';
 import { PostgresModel } from '../../../models/postgresModel';
+import { ControllerDashboard } from '../controller/controllerDashboard';
 
 export class PostgresPropertiesPage extends DashboardPage {
 	private loading?: azdata.LoadingComponent;
@@ -93,12 +94,13 @@ export class PostgresPropertiesPage extends DashboardPage {
 	private getProperties(): KeyValue[] {
 		const endpoint = this._postgresModel.endpoint;
 		const status = this._postgresModel.config?.status;
+		const controllerDashboard = new ControllerDashboard(this._controllerModel);
 
 		return [
 			new InputKeyValue(this.modelView.modelBuilder, loc.coordinatorEndpoint, endpoint ? `postgresql://postgres@${endpoint.ip}:${endpoint.port}` : ''),
 			new InputKeyValue(this.modelView.modelBuilder, loc.postgresAdminUsername, 'postgres'),
 			new TextKeyValue(this.modelView.modelBuilder, loc.status, status ? `${status.state} (${status.readyPods} ${loc.podsReady})` : loc.unknown),
-			// TODO: Make this a LinkKeyValue that opens the controller dashboard
+			new LinkKeyValue(this.modelView.modelBuilder, loc.dataController, this._controllerModel.controllerConfig?.metadata.namespace ?? '', () => controllerDashboard.showDashboard()),
 			new TextKeyValue(this.modelView.modelBuilder, loc.dataController, this._controllerModel.controllerConfig?.metadata.namespace ?? ''),
 			new TextKeyValue(this.modelView.modelBuilder, loc.nodeConfiguration, this._postgresModel.scaleConfiguration ?? ''),
 			new TextKeyValue(this.modelView.modelBuilder, loc.postgresVersion, this._postgresModel.engineVersion ?? ''),


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13262

(Workaround for https://github.com/microsoft/azuredatastudio/issues/13134)

This adds loading indicators to the Compute&Storage and Connection Strings pages when the config is waiting for data to be present. 

<img width="400" alt="loadingstring" src="https://user-images.githubusercontent.com/69922333/98177524-a74ec700-1eaf-11eb-9061-7ec3280c5724.PNG">

Also...
TODO in Properties page was completed so that LinkKeyValue takes user to controller dashboard. (not currently shown on ADS)