### PR TITLE
WYSIWYG fix list nesting

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -114,17 +114,17 @@ export class HTMLMarkdownConverter {
 					.replace(/\n/gm, '\n    '); // indent
 				let prefix = options.bulletListMarker + ' ';
 				let parent = node.parentNode;
+				let nestedCount = 0;
 				if (parent.nodeName === 'OL') {
 					let start = parent.getAttribute('start');
 					let index = Array.prototype.indexOf.call(parent.children, node);
 					prefix = (start ? Number(start) + index : index + 1) + '. ';
 				} else if (parent.nodeName === 'UL') {
-					let count = 0;
 					while (parent?.nodeName === 'UL') {
-						count++;
+						nestedCount++;
 						parent = parent?.parentNode;
 					}
-					prefix = ('    '.repeat(count - 1)) + '- ';
+					prefix = ('    '.repeat(nestedCount - 1)) + options.bulletListMarker + ' ';
 				}
 				return (
 					prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '')

--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -105,6 +105,32 @@ export class HTMLMarkdownConverter {
 				return `[${node.innerText}](${node.href})`;
 			}
 		});
+		this.turndownService.addRule('listItem', {
+			filter: 'li',
+			replacement: function (content, node, options) {
+				content = content
+					.replace(/^\n+/, '') // remove leading newlines
+					.replace(/\n+$/, '\n') // replace trailing newlines with just a single one
+					.replace(/\n/gm, '\n    '); // indent
+				let prefix = options.bulletListMarker + ' ';
+				let parent = node.parentNode;
+				if (parent.nodeName === 'OL') {
+					let start = parent.getAttribute('start');
+					let index = Array.prototype.indexOf.call(parent.children, node);
+					prefix = (start ? Number(start) + index : index + 1) + '. ';
+				} else if (parent.nodeName === 'UL') {
+					let count = 0;
+					while (parent?.nodeName === 'UL') {
+						count++;
+						parent = parent?.parentNode;
+					}
+					prefix = ('    '.repeat(count - 1)) + '- ';
+				}
+				return (
+					prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '')
+				);
+			}
+		});
 	}
 }
 

--- a/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
@@ -138,4 +138,12 @@ suite('HTML Markdown Converter', function (): void {
 		htmlString = '<a href="http://www.microsoft.com/images/msft.png">msft</a>';
 		assert.equal(htmlMarkdownConverter.convert(htmlString), '[msft](http://www.microsoft.com/images/msft.png)', 'Basic http link test failed');
 	});
+	test('Should transform <li> tags', () => {
+		htmlString = '<ul><li>Test</li></ul>';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `- Test`, 'Basic unordered list test failed');
+		htmlString = '<ul><li>Test</li><li>Test2</li></ul>';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `- Test\n- Test2`, 'Basic unordered 2 item list test failed');
+		htmlString = '<ul><li>Test</li><ul><li>Test2</li></ul><li>Test3</li></ul>';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `- Test\n\n    - Test2\n\n- Test3`, 'Nested item list test failed');
+	});
 });

--- a/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
@@ -143,7 +143,13 @@ suite('HTML Markdown Converter', function (): void {
 		assert.equal(htmlMarkdownConverter.convert(htmlString), `- Test`, 'Basic unordered list test failed');
 		htmlString = '<ul><li>Test</li><li>Test2</li></ul>';
 		assert.equal(htmlMarkdownConverter.convert(htmlString), `- Test\n- Test2`, 'Basic unordered 2 item list test failed');
-		htmlString = '<ul><li>Test</li><ul><li>Test2</li></ul><li>Test3</li></ul>';
-		assert.equal(htmlMarkdownConverter.convert(htmlString), `- Test\n\n    - Test2\n\n- Test3`, 'Nested item list test failed');
+		htmlString = '<ul><li>Test<ul><li>Test2</li></ul><li>Test3</li></ul>';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `- Test\n    - Test2\n- Test3`, 'Nested item list test failed');
+		htmlString = '<ol><li>Test</li></ol>';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `1. Test`, 'Basic ordered item test failed');
+		htmlString = '<ol><li>Test</li><li>Test2</li></ol>';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `1. Test\n2. Test2`, 'Basic ordered item test failed');
+		htmlString = '<ol><li>Test<ol><li>Test2</li></ol><li>Test3</li></ol>';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `1. Test\n    1. Test2\n2. Test3`, 'Basic ordered item test failed');
 	});
 });


### PR DESCRIPTION
Fixes #12842. Turndown doesn't like nested lists and there's some discussion here: https://github.com/domchristie/turndown/issues/272.

If we generate the HTML from that issue from the contentEditable attribute set to true, then we should display it as users would expect 😄 

Based on https://github.com/domchristie/turndown/blob/8ba04467c5fd73f58a1b49f68a66266f30fa202b/src/commonmark-rules.js#L61. Just added a few lines there to see how many levels deep the list item should be indented.