### PR TITLE
Changed hyperlink found on PG ConnectionString Page

### DIFF
--- a/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
@@ -49,7 +49,7 @@ export class PostgresConnectionStringsPage extends DashboardPage {
 
 		const link = this.modelView.modelBuilder.hyperlink().withProperties<azdata.HyperlinkComponentProperties>({
 			label: loc.learnAboutPostgresClients,
-			url: 'https://docs.microsoft.com/azure/postgresql/concepts-connection-libraries',
+			url: 'https://docs.microsoft.com/azure/azure-arc/data/get-connection-endpoints-and-connection-strings-postgres-hyperscale',
 		}).component();
 
 		const infoAndLink = this.modelView.modelBuilder.flexContainer().withLayout({ flexWrap: 'wrap' }).component();


### PR DESCRIPTION
The hyperlink in Connection Strings page has been corrected to point to https://docs.microsoft.com/en-us/azure/azure-arc/data/get-connection-endpoints-and-connection-strings-postgres-hyperscale.