### PR TITLE
Disabling validation, changing template for Streaming Jobs

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -352,11 +352,6 @@
           "group": "4_dbProjects_addDatabaseReference"
         },
         {
-          "command": "sqlDatabaseProjects.validateExternalStreamingJob",
-          "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.file.externalStreamingJob",
-          "group": "5_dbProjects_streamingJob"
-        },
-        {
           "command": "sqlDatabaseProjects.exclude",
           "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/",
           "group": "9_dbProjectsLast@1"

--- a/extensions/sql-database-projects/resources/templates/newTsqlExternalStreamingJobTemplate.sql
+++ b/extensions/sql-database-projects/resources/templates/newTsqlExternalStreamingJobTemplate.sql
@@ -1,7 +1,10 @@
+-- External Streaming Jobs have dependencies on External Streams.
+-- You will need to separately create External Streams in order to
+-- successfully deploy this script.  For more information, see:
+-- https://docs.microsoft.com/en-us/azure/azure-sql-edge/create-stream-analytics-job
+
 EXEC sys.sp_create_streaming_job @NAME = '@@OBJECT_NAME@@', @STATEMENT = 'INSERT INTO SqlOutputStream SELECT
     timeCreated,
-    machine.temperature as machine_temperature,
-    machine.pressure as machine_pressure,
-    ambient.temperature as ambient_temperature,
-    ambient.humidity as ambient_humidity
+    streamColumn1 as column1,
+    streamColumn2 as column2
 FROM EdgeHubInputStream'


### PR DESCRIPTION
* Fixes #13245: Updating the template to make the names of the sample columns more generic and add information about its dependencies
* Disabling Streaming Job validation until the dependent code in Tools Service is present in drops, issue #13234