### PR TITLE
Compute and Storage Page, progress notification waits for model to be refreshed before saying instance has been updated. 

### DIFF
--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -153,12 +153,10 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 							title: loc.updatingInstance(this._postgresModel.info.name),
 							cancellable: false
 						},
-						(_progress, _token) => {
-							return this._azdataApi.azdata.arc.postgres.server.edit(
-								this._postgresModel.info.name, this.saveArgs).then(
-									async () => {
-										await this._postgresModel.refresh();
-									});
+						async (_progress, _token): Promise<void> => {
+							await this._azdataApi.azdata.arc.postgres.server.edit(
+								this._postgresModel.info.name, this.saveArgs);
+							await this._postgresModel.refresh();
 						}
 					);
 

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -155,11 +155,12 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 						},
 						(_progress, _token) => {
 							return this._azdataApi.azdata.arc.postgres.server.edit(
-								this._postgresModel.info.name, this.saveArgs);
+								this._postgresModel.info.name, this.saveArgs).then(
+									async () => {
+										await this._postgresModel.refresh();
+									});
 						}
 					);
-
-					this._postgresModel.refresh();
 
 					vscode.window.showInformationMessage(loc.instanceUpdated(this._postgresModel.info.name));
 


### PR DESCRIPTION
The progress popup waits for instance to be edited and model has been refreshed before closing out and showing update notification.