### PR TITLE
Remove button property setter causing exception

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -557,7 +557,6 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 	private addButton(label: string, onDidClick?: () => void, enabled?: boolean): void {
 		const container = DOM.append(this.bookNav.nativeElement, DOM.$('.dialog-message-button'));
 		let button = new Button(container);
-		button.icon = '';
 		button.label = label;
 		if (onDidClick) {
 			this._register(button.onDidClick(onDidClick));

--- a/src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour.ts
@@ -171,7 +171,6 @@ export class GuidedTour extends Disposable {
 			bodyTag.innerText = body;
 			stepText.innerText = `${step} of ${tourData.length}`;
 			let button = new Button(btnContainer);
-			button.icon = '';
 			button.label = btnText;
 			btnContainer.appendChild(stepText);
 			flexContainer.appendChild(img);


### PR DESCRIPTION
Addresses [13265](https://github.com/microsoft/azuredatastudio/issues/13265)

Setting the button's icon property with empty was causing the DOM exception.
`Uncaught (in promise) DOMException: Failed to execute 'add' on 'DOMTokenList': The token provided must not be empty`
