### PR TITLE
restore focus on escape

### DIFF
--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -99,6 +99,8 @@ export class Dropdown extends Disposable {
 	public onFocus: Event<void> = this._onFocus.event;
 	private readonly _widthControlElement: HTMLElement;
 
+	private _focusRestoreTarget: HTMLElement;
+
 	constructor(
 		container: HTMLElement,
 		private readonly contextViewService: IContextViewProvider,
@@ -209,8 +211,10 @@ export class Dropdown extends Disposable {
 		});
 
 		this._controller.onDropdownEscape(() => {
-			this._input.focus();
 			this.contextViewService.hideContextView();
+			setTimeout(() => {
+				this._focusRestoreTarget?.focus();
+			}, 0);
 		});
 
 		this._input.onDidChange(e => {
@@ -235,6 +239,7 @@ export class Dropdown extends Disposable {
 
 	private _showList(): void {
 		if (this._input.isEnabled()) {
+			this._focusRestoreTarget = document.activeElement as HTMLElement;
 			this._onFocus.fire();
 			this._filter.filterString = '';
 			this.contextViewService.showContextView({

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -82,7 +82,6 @@ export class Dropdown extends Disposable {
 	private _input: InputBox;
 	private _tree: ITree;
 	private _options: IDropdownOptions;
-	private _toggleAction: ToggleDropdownAction;
 	private _dataSource = new DropdownDataSource();
 	private _filter = new DropdownFilter();
 	private _renderer = new DropdownRenderer();
@@ -348,7 +347,6 @@ export class Dropdown extends Disposable {
 
 	public set enabled(val: boolean) {
 		this._input.setEnabled(val);
-		this._toggleAction.enabled = val;
 	}
 
 	public get enabled(): boolean {

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -130,7 +130,7 @@ export class Dropdown extends Disposable {
 		// in the text box - we already have tooltips for each item in the dropdown itself.
 		this._input.inputElement.title = '';
 
-		this._input.inputElement.setAttribute('role', 'combobox');
+		this._inputContainer.setAttribute('role', 'combobox');
 
 		this._register(DOM.addDisposableListener(this._input.inputElement, DOM.EventType.CLICK, () => {
 			this._showList();
@@ -155,14 +155,14 @@ export class Dropdown extends Disposable {
 					if (this._treeContainer.parentElement) {
 						this._input.validate();
 						this._onBlur.fire();
-						this.contextViewService.hideContextView();
+						this._hideList();
 						e.stopPropagation();
 					}
 					break;
 				case KeyCode.Tab:
 					this._input.validate();
 					this._onBlur.fire();
-					this.contextViewService.hideContextView();
+					this._hideList();
 					e.stopPropagation();
 					break;
 				case KeyCode.DownArrow:
@@ -198,11 +198,11 @@ export class Dropdown extends Disposable {
 			this.value = e.value;
 			this._onValueChange.fire(e.value);
 			this._input.focus();
-			this.contextViewService.hideContextView();
+			this._hideList();
 		});
 
 		this._controller.onDropdownEscape(() => {
-			this.contextViewService.hideContextView();
+			this._hideList();
 			// have to put this in the setTimeout to make sure the focus can be set properly when the context menu is opened by pressing the DownArrow key
 			setTimeout(() => {
 				this._input.focus();
@@ -221,7 +221,7 @@ export class Dropdown extends Disposable {
 		});
 
 		this.onBlur(() => {
-			this.contextViewService.hideContextView();
+			this._hideList();
 			this._input.validate();
 		});
 
@@ -231,6 +231,7 @@ export class Dropdown extends Disposable {
 
 	private _showList(): void {
 		if (this._input.isEnabled()) {
+			this._inputContainer.setAttribute('aria-expanded', 'true');
 			this._onFocus.fire();
 			this._filter.filterString = '';
 			this.contextViewService.showContextView({
@@ -246,8 +247,13 @@ export class Dropdown extends Disposable {
 						}
 					};
 				}
-			});
+			}, this._inputContainer);
 		}
+	}
+
+	private _hideList(): void {
+		this.contextViewService.hideContextView();
+		this._inputContainer.setAttribute('aria-expanded', 'false');
 	}
 
 	private _layoutTree(): void {
@@ -316,7 +322,7 @@ export class Dropdown extends Disposable {
 
 	public blur() {
 		this._input.blur();
-		this.contextViewService.hideContextView();
+		this._hideList();
 	}
 
 	style(style: IListStyles & IInputBoxStyles & IDropdownStyles) {

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -5,7 +5,6 @@
 
 import 'vs/css!./media/dropdownList';
 
-import { ToggleDropdownAction } from './actions';
 import { DropdownDataSource, DropdownFilter, DropdownModel, DropdownRenderer, DropdownController } from './dropdownTree';
 
 import { IContextViewProvider } from 'vs/base/browser/ui/contextview/contextview';

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -121,6 +121,8 @@ export class Dropdown extends Disposable {
 		this._treeContainer = DOM.$('.dropdown-tree');
 
 		this._toggleAction = new ToggleDropdownAction(() => {
+			// Move the focus to input focus so that when we close the context menu by press escaping
+			// the focus stays on the input box, this is behavior of a regular select box.
 			this._input.focus();
 			this._showList();
 			this._tree.domFocus();

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -213,6 +213,7 @@ export class Dropdown extends Disposable {
 
 		this._controller.onDropdownEscape(() => {
 			this.contextViewService.hideContextView();
+			// have to put this in the setTimeout to make sure the focus can be set properly when the context menu is opened by pressing the DownArrow key
 			setTimeout(() => {
 				this._focusRestoreTarget?.focus();
 			}, 0);

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -121,6 +121,7 @@ export class Dropdown extends Disposable {
 		this._treeContainer = DOM.$('.dropdown-tree');
 
 		this._toggleAction = new ToggleDropdownAction(() => {
+			this._input.focus();
 			this._showList();
 			this._tree.domFocus();
 			this._tree.focusFirst();


### PR DESCRIPTION
This PR fixes #12980

there are 4 ways to invoke the dropdown list and the expected focus behavior when escape is pressed to close the dropdown list

click inside the textbox -> focus should go back to textbox
press down arrow key when textbox is being focused -> focus should go back to text box
click on the dropdown arrow when focus is not within the control: -> focus should go back to textbox (similar to native select control)
focus on the dropdown arrow and invoke it -> focus should go back to the dropdown arrow
the fix is to capture the focused element before showing the list and restore focus to it when escape is pressed.