### PR TITLE
Enables streaming job validation, minor bugfix

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -7,7 +7,7 @@
   "preview": true,
   "engines": {
     "vscode": "^1.30.1",
-    "azdata": ">=1.22.0"
+    "azdata": ">=1.24.0"
   },
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/sqlDatabaseProjects.png",

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -352,6 +352,11 @@
           "group": "4_dbProjects_addDatabaseReference"
         },
         {
+          "command": "sqlDatabaseProjects.validateExternalStreamingJob",
+          "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.file.externalStreamingJob",
+          "group": "5_dbProjects_streamingJob"
+        },
+        {
           "command": "sqlDatabaseProjects.exclude",
           "when": "view =~ /^(sqlDatabaseProjectsView|dataworkspace.views.main)$/ && viewItem == databaseProject.itemType.folder || viewItem =~ /^databaseProject.itemType.file/",
           "group": "9_dbProjectsLast@1"

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -298,6 +298,7 @@ export class Project {
 		const attributes = new Map<string, string>();
 
 		if (itemType === templates.externalStreamingJob) {
+			fileEntry.sqlObjectType = constants.ExternalStreamingJob;
 			attributes.set(constants.Type, constants.ExternalStreamingJob);
 		}
 


### PR DESCRIPTION
Fixes #13233 by correctly tagging the in-memory object at creation time; previously only got tagged when loaded from sqlproj
Fixes #13234 by re-enabling the validation menu item now that SqlToolsService is updated