### PR TITLE
Table with no headings gets corrupted when editing 

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/turndownPluginGfm.ts
+++ b/src/sql/workbench/contrib/notebook/browser/turndownPluginGfm.ts
@@ -99,14 +99,14 @@ rules['table'] = {
 		// Ensure there are no blank lines
 		content = content.replace('\n\n', '\n');
 		// if the headings are empty, add border line and headings to keep table format
-		if(node.tHead.innerText === '') {
+		if (node.tHead.innerText === '') {
 			let emptyHeader = '\n\n|';
 			let border = '\n|';
 			for (let i = 0; i < node.rows[0].childNodes.length; i++) {
-				emptyHeader += ' |';
+				emptyHeader += '  |';
 				border += ' --- |'
 			}
-			return emptyHeader + border + content + '\n\n' ;
+			return emptyHeader + border + content + '\n\n';
 		}
 		return '\n\n' + content + '\n\n';
 	}

--- a/src/sql/workbench/contrib/notebook/browser/turndownPluginGfm.ts
+++ b/src/sql/workbench/contrib/notebook/browser/turndownPluginGfm.ts
@@ -119,7 +119,7 @@ rules['tableSection'] = {
 	}
 };
 
-// A tr is a heading row if
+// A tr is a heading row if:
 // - the parent is a THEAD
 // - or if its the first child of the TABLE or the first TBODY (possibly
 //   following a blank THEAD)

--- a/src/sql/workbench/contrib/notebook/browser/turndownPluginGfm.ts
+++ b/src/sql/workbench/contrib/notebook/browser/turndownPluginGfm.ts
@@ -95,10 +95,19 @@ rules['table'] = {
 	filter: function (node) {
 		return node.nodeName === 'TABLE' && isHeadingRow(node.rows[0]);
 	},
-
-	replacement: function (content) {
+	replacement: function (content, node) {
 		// Ensure there are no blank lines
 		content = content.replace('\n\n', '\n');
+		// if the headings are empty, add border line and headings to keep table format
+		if(node.tHead.innerText === '') {
+			let emptyHeader = '\n\n|';
+			let border = '\n|';
+			for (let i = 0; i < node.rows[0].childNodes.length; i++) {
+				emptyHeader += ' |';
+				border += ' --- |'
+			}
+			return emptyHeader + border + content + '\n\n' ;
+		}
 		return '\n\n' + content + '\n\n';
 	}
 };
@@ -110,7 +119,7 @@ rules['tableSection'] = {
 	}
 };
 
-// A tr is a heading row if:
+// A tr is a heading row if
 // - the parent is a THEAD
 // - or if its the first child of the TABLE or the first TBODY (possibly
 //   following a blank THEAD)

--- a/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
@@ -152,4 +152,19 @@ suite('HTML Markdown Converter', function (): void {
 		htmlString = '<ol><li>Test<ol><li>Test2</li></ol><li>Test3</li></ol>';
 		assert.equal(htmlMarkdownConverter.convert(htmlString), `1. Test\n    1. Test2\n2. Test3`, 'Basic ordered item test failed');
 	});
+
+	test('Should transform table with no header', () => {
+		htmlString = '<table>\n<thead>\n<tr>\n<th></th>\n<th></th>\n<th></th>\n</tr>\n</thead>\n<tbody><tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n</tbody></table>\n';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `|  |  |  |\n| --- | --- | --- |\n| test | test | test |\n| test | test | test |\n| test | test | test |\n| test | test | test |`, 'Table with no header failed');
+	});
+
+	test('Should transform table with missing headings', () => {
+		htmlString = '<table>\n<thead>\n<tr>\n<th>Test</th>\n<th></th>\n<th></th>\n</tr>\n</thead>\n<tbody><tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n</tbody></table>\n';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `| Test |  |  |\n| --- | --- | --- |\n| test | test | test |\n| test | test | test |\n| test | test | test |\n| test | test | test |`, 'Table with missing headings failed');
+	});
+
+	test('Should transform table with header', () => {
+		htmlString = '<table>\n<thead>\n<tr>\n<th>Test</th>\n<th>Test</th>\n<th>Test</th>\n</tr>\n</thead>\n<tbody><tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n</tbody></table>\n';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `| Test | Test | Test |\n| --- | --- | --- |\n| test | test | test |\n| test | test | test |\n| test | test | test |\n| test | test | test |`, 'Table with header failed');
+	});
 });


### PR DESCRIPTION
Addresses [13289](https://github.com/microsoft/azuredatastudio/issues/13289)

If we have a table with no headings and update the cell in rich text mode, then the border line and headings are removed and the table gets corrupted. To fix the issue, I check if the head of the table is empty and add the empty headings and the border line before the table's content.
