### PR TITLE
Run initial modelview actions first

### DIFF
--- a/extensions/sql-database-projects/src/test/dialogs/addDatabaseReferenceDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/addDatabaseReferenceDialog.test.ts
@@ -31,8 +31,6 @@ describe('Add Database Reference Dialog', () => {
 
 		should(dialog.dialog.okButton.enabled).equal(true, 'Ok button should be enabled since initial type of systemDb has default values filled');
 		should(dialog.currentReferenceType).equal(ReferenceType.systemDb);
-		dialog.tryEnableAddReferenceButton();
-		should(dialog.dialog.okButton.enabled).equal(true, 'Ok button should be enabled because there is a default value in the database name textbox');
 
 		// empty db name textbox
 		dialog.databaseNameTextbox!.value = '';

--- a/extensions/sql-database-projects/src/test/dialogs/addDatabaseReferenceDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/addDatabaseReferenceDialog.test.ts
@@ -29,7 +29,7 @@ describe('Add Database Reference Dialog', () => {
 		const dialog = new AddDatabaseReferenceDialog(project);
 		await dialog.openDialog();
 
-		should(dialog.dialog.okButton.enabled).equal(false);
+		should(dialog.dialog.okButton.enabled).equal(true, 'Ok button should be enabled since initial type of systemDb has default values filled');
 		should(dialog.currentReferenceType).equal(ReferenceType.systemDb);
 		dialog.tryEnableAddReferenceButton();
 		should(dialog.dialog.okButton.enabled).equal(true, 'Ok button should be enabled because there is a default value in the database name textbox');

--- a/src/sql/platform/dashboard/browser/interfaces.ts
+++ b/src/sql/platform/dashboard/browser/interfaces.ts
@@ -69,7 +69,7 @@ export interface IModelStore {
 	 * @param componentId unique identifier of the component
 	 * @param action some action to perform
 	 */
-	eventuallyRunOnComponent<T>(componentId: string, action: (component: IComponent) => T): Promise<T>;
+	eventuallyRunOnComponent<T>(componentId: string, action: (component: IComponent) => T, initial: boolean): void;
 	/**
 	 * Register a callback that will validate components when given a component ID
 	 */

--- a/src/sql/platform/model/browser/modelViewService.ts
+++ b/src/sql/platform/model/browser/modelViewService.ts
@@ -35,12 +35,12 @@ export interface IModelView extends IView {
 	clearContainer(componentId: string): void;
 	addToContainer(containerId: string, item: IItemConfig, index?: number): void;
 	removeFromContainer(containerId: string, item: IItemConfig): void;
-	setLayout(componentId: string, layout: any): void;
+	setLayout(componentId: string, layout: any, initial?: boolean): void;
 	setItemLayout(componentId: string, item: IItemConfig): void;
 	setProperties(componentId: string, properties: { [key: string]: any }, initial?: boolean): void;
 	setDataProvider(handle: number, componentId: string, context: any): void;
 	refreshDataProvider(componentId: string, item: any): void;
-	registerEvent(componentId: string): void;
+	registerEvent(componentId: string, initial?: boolean): void;
 	onEvent: Event<IModelViewEventArgs>;
 	validate(componentId: string): Thenable<boolean>;
 	readonly onDestroy: Event<void>;

--- a/src/sql/platform/model/browser/modelViewService.ts
+++ b/src/sql/platform/model/browser/modelViewService.ts
@@ -37,7 +37,7 @@ export interface IModelView extends IView {
 	removeFromContainer(containerId: string, item: IItemConfig): void;
 	setLayout(componentId: string, layout: any): void;
 	setItemLayout(componentId: string, item: IItemConfig): void;
-	setProperties(componentId: string, properties: { [key: string]: any }): void;
+	setProperties(componentId: string, properties: { [key: string]: any }, initial?: boolean): void;
 	setDataProvider(handle: number, componentId: string, context: any): void;
 	refreshDataProvider(componentId: string, item: any): void;
 	registerEvent(componentId: string): void;

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -308,7 +308,7 @@ export abstract class ContainerBase<T, TPropertyBag extends azdata.ComponentProp
 			if (event.eventType === ComponentEventType.validityChanged) {
 				this.validate();
 			}
-		}));
+		}), false);
 		this._changeRef.detectChanges();
 		this.onItemsUpdated();
 		return;

--- a/src/sql/workbench/browser/modelComponents/modelStore.ts
+++ b/src/sql/workbench/browser/modelComponents/modelStore.ts
@@ -6,6 +6,7 @@
 import { Deferred } from 'sql/base/common/promise';
 import { entries } from 'sql/base/common/collections';
 import { IComponentDescriptor, IModelStore, IComponent } from 'sql/platform/dashboard/browser/interfaces';
+import { onUnexpectedError } from 'vs/base/common/errors';
 
 class ComponentDescriptor implements IComponentDescriptor {
 	constructor(public readonly id: string, public readonly type: string) {
@@ -102,7 +103,7 @@ export class ModelStore implements IModelStore {
 
 	/**
 	 * Runs the set of pending actions for a given component. This will run the initial setup actions
-	 * first and then run all the other actions afterwards. 
+	 * first and then run all the other actions afterwards.
 	 * @param componentId The ID of the component to run the currently pending actions for
 	 * @param component The component object to run the actions against
 	 */
@@ -115,7 +116,7 @@ export class ModelStore implements IModelStore {
 				resolve();
 			}).then(() => {
 				promiseTracker.actions.resolve(component);
-			});
+			}).catch(onUnexpectedError);
 			this._componentActions[componentId] = undefined;
 		}
 	}

--- a/src/sql/workbench/browser/modelComponents/viewBase.ts
+++ b/src/sql/workbench/browser/modelComponents/viewBase.ts
@@ -104,7 +104,7 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 		if (!layout) {
 			return;
 		}
-		this.queueAction(componentId, (component) => component.setLayout(layout));
+		this.queueAction(componentId, (component) => component.setLayout(layout), initial);
 	}
 
 	setItemLayout(containerId: string, itemConfig: IItemConfig): void {


### PR DESCRIPTION
Fix for https://github.com/microsoft/azuredatastudio/issues/13134

The root issue causing this is that when we queue up actions we do so through promise chaining, which doesn't guarantee order of execution when the root Promise is resolved. This problem is made even worse by the actions never waiting to "complete" - i.e. actions such as setting properties are usually async but the actual action function call is never awaited. 

I've experimented around with completely serializing the actions but in the past I've always hit some weird issues - and so for this fix I just scoped it down to at least gather up the small set of "initial" actions (which are the ones queued. 

I plan to keep poking at this and moving it towards a much more deterministic state but in my testing this solves the immediate problem listed above and so in the interest of trying to keep these scoped so as not to break everything I'm sticking with this fix for now.