### PR TITLE
Removed Web App connection strings. 

### DIFF
--- a/extensions/arc/src/ui/dashboards/miaa/miaaConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaConnectionStringsPage.ts
@@ -91,8 +91,7 @@ export class MiaaConnectionStringsPage extends DashboardPage {
 $serverName = "${externalEndpoint.ip},${externalEndpoint.port}";
 $conn = sqlsrv_connect($serverName, $connectionInfo);`),
 			new InputKeyValue(this.modelView.modelBuilder, 'Python', `dbname='master' user='${username}' host='${externalEndpoint.ip}' password='{your_password_here}' port='${externalEndpoint.port}' sslmode='true'`),
-			new InputKeyValue(this.modelView.modelBuilder, 'Ruby', `host=${externalEndpoint.ip}; user=${username} password={your_password_here} port=${externalEndpoint.port} sslmode=require`),
-			new InputKeyValue(this.modelView.modelBuilder, 'Web App', `Database=master; Data Source=${externalEndpoint.ip}; User Id=${username}; Password={your_password_here}`)
+			new InputKeyValue(this.modelView.modelBuilder, 'Ruby', `host=${externalEndpoint.ip}; user=${username} password={your_password_here} port=${externalEndpoint.port} sslmode=require`)
 		];
 	}
 

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -202,7 +202,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		}).component();
 
 		this.disposables.push(
-			this.workerBox!.onTextChanged(() => {
+			this.workerBox.onTextChanged(() => {
 				if (!(this.handleOnTextChanged(this.workerBox!))) {
 					this.saveArgs.workers = undefined;
 				} else {
@@ -219,7 +219,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		}).component();
 
 		this.disposables.push(
-			this.coresLimitBox!.onTextChanged(() => {
+			this.coresLimitBox.onTextChanged(() => {
 				if (!(this.handleOnTextChanged(this.coresLimitBox!))) {
 					this.saveArgs.coresLimit = undefined;
 				} else {
@@ -236,7 +236,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		}).component();
 
 		this.disposables.push(
-			this.coresRequestBox!.onTextChanged(() => {
+			this.coresRequestBox.onTextChanged(() => {
 				if (!(this.handleOnTextChanged(this.coresRequestBox!))) {
 					this.saveArgs.coresRequest = undefined;
 				} else {
@@ -253,7 +253,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		}).component();
 
 		this.disposables.push(
-			this.memoryLimitBox!.onTextChanged(() => {
+			this.memoryLimitBox.onTextChanged(() => {
 				if (!(this.handleOnTextChanged(this.memoryLimitBox!))) {
 					this.saveArgs.memoryLimit = undefined;
 				} else {
@@ -270,7 +270,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		}).component();
 
 		this.disposables.push(
-			this.memoryRequestBox!.onTextChanged(() => {
+			this.memoryRequestBox.onTextChanged(() => {
 				if (!(this.handleOnTextChanged(this.memoryRequestBox!))) {
 					this.saveArgs.memoryRequest = undefined;
 				} else {

--- a/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
@@ -82,8 +82,7 @@ export class PostgresConnectionStringsPage extends DashboardPage {
 			new InputKeyValue(this.modelView.modelBuilder, 'PHP', `host=${endpoint.ip} port=${endpoint.port} dbname=postgres user=postgres password={your_password_here} sslmode=require`),
 			new InputKeyValue(this.modelView.modelBuilder, 'psql', `psql "host=${endpoint.ip} port=${endpoint.port} dbname=postgres user=postgres password={your_password_here} sslmode=require"`),
 			new InputKeyValue(this.modelView.modelBuilder, 'Python', `dbname='postgres' user='postgres' host='${endpoint.ip}' password='{your_password_here}' port='${endpoint.port}' sslmode='true'`),
-			new InputKeyValue(this.modelView.modelBuilder, 'Ruby', `host=${endpoint.ip}; dbname=postgres user=postgres password={your_password_here} port=${endpoint.port} sslmode=require`),
-			new InputKeyValue(this.modelView.modelBuilder, 'Web App', `Database=postgres; Data Source=${endpoint.ip}; User Id=postgres; Password={your_password_here}`)
+			new InputKeyValue(this.modelView.modelBuilder, 'Ruby', `host=${endpoint.ip}; dbname=postgres user=postgres password={your_password_here} port=${endpoint.port} sslmode=require`)
 		];
 	}
 


### PR DESCRIPTION
This PR fixes #13151 

Most of apps using Orcas do not really use the web app connection string property setting from app service, so this will follow the removal of the string like in Flexible and Single server on portal. 

<img width="612" alt="connectremove" src="https://user-images.githubusercontent.com/69922333/98609778-f8d9c600-22a2-11eb-9e23-c1128c2e2e83.PNG">
