### PR TITLE
Upload user dir from test runs

### DIFF
--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -144,21 +144,6 @@ steps:
   displayName: Run remote integration tests (Electron)
   condition: and(succeeded(), eq(variables['VSCODE_ARCH'], 'x64'), eq(variables['VSCODE_STEP_ON_IT'], 'false'))
 
-- script: |
-    set -e
-    mkdir -p $(Build.ArtifactStagingDirectory)/logs/linux-x64
-    cd ~/.config/azuredatastudio
-    tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/logs-linux-x64.tar.gz logs
-  displayName: Archive Logs
-  continueOnError: true
-
-- task: PublishPipelineArtifact@0
-  inputs:
-    artifactName: logs-linux-x64.tar.gz
-    targetPath: $(Build.ArtifactStagingDirectory)/logs/linux-x64
-  displayName: Publish Logs
-  continueOnError: true
-
 - task: PublishPipelineArtifact@0
   inputs:
     artifactName: 'crash-dump-linux-$(VSCODE_ARCH)'

--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -144,6 +144,21 @@ steps:
   displayName: Run remote integration tests (Electron)
   condition: and(succeeded(), eq(variables['VSCODE_ARCH'], 'x64'), eq(variables['VSCODE_STEP_ON_IT'], 'false'))
 
+- script: |
+    set -e
+    mkdir -p $(Build.ArtifactStagingDirectory)/logs/linux-x64
+    cd ~/.config/azuredatastudio
+    tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/logs-linux-x64.tar.gz logs
+  displayName: Archive Logs
+  continueOnError: true
+
+- task: PublishPipelineArtifact@0
+  inputs:
+    artifactName: logs-linux-x64.tar.gz
+    targetPath: $(Build.ArtifactStagingDirectory)/logs/linux-x64
+  displayName: Publish Logs
+  continueOnError: true
+
 - task: PublishPipelineArtifact@0
   inputs:
     artifactName: 'crash-dump-linux-$(VSCODE_ARCH)'

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -150,6 +150,21 @@ steps:
 
   - script: |
       set -e
+      mkdir -p $(Build.ArtifactStagingDirectory)/logs/linux-x64
+      cd ~/.config/azuredatastudio
+      tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/logs-linux-x64.tar.gz logs
+    displayName: Archive Logs
+    continueOnError: true
+
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: logs-linux-x64.tar.gz
+      targetPath: $(Build.ArtifactStagingDirectory)/logs/linux-x64
+    displayName: Publish Logs
+    continueOnError: true
+
+  - script: |
+      set -e
       yarn gulp vscode-linux-x64-build-deb
     displayName: Build Deb
 

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -157,12 +157,6 @@ steps:
     displayName: Archive Logs
     continueOnError: true
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      artifactName: logs
-    displayName: Publish Logs
-    continueOnError: true
-
   - script: |
       set -e
       yarn gulp vscode-linux-x64-build-deb

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -136,8 +136,8 @@ steps:
         INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
         DISPLAY=:10 node ./scripts/test-extensions-unit.js ${{ extension }}
         NO_CLEANUP=1
-        VSCODEUSERDATAROOT=$TMPDIR/adsuser
-        displayName: 'Run ${{ extension }} Stable Extension Unit Tests'
+        VSCODEUSERDATAROOT="$TMPDIR/adsuser"
+      displayName: 'Run ${{ extension }} Stable Extension Unit Tests'
       condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
   - script: |

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -134,9 +134,9 @@ steps:
         APP_ROOT=$(agent.builddirectory)/azuredatastudio-linux-x64
         APP_NAME=$(node -p "require(\"$APP_ROOT/resources/app/product.json\").applicationName")
         INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
-        DISPLAY=:10 node ./scripts/test-extensions-unit.js ${{ extension }}
         NO_CLEANUP=1
         VSCODEUSERDATAROOT="$TMPDIR/adsuser"
+        DISPLAY=:10 node ./scripts/test-extensions-unit.js ${{ extension }}
       displayName: 'Run ${{ extension }} Stable Extension Unit Tests'
       condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -135,7 +135,6 @@ steps:
         APP_NAME=$(node -p "require(\"$APP_ROOT/resources/app/product.json\").applicationName")
         export INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
         export NO_CLEANUP=1
-        export VSCODEUSERDATAROOT="$TMPDIR/adsuser"
         DISPLAY=:10 node ./scripts/test-extensions-unit.js ${{ extension }}
       displayName: 'Run ${{ extension }} Stable Extension Unit Tests'
       condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -152,8 +152,8 @@ steps:
   - script: |
       set -e
       mkdir -p $(Build.ArtifactStagingDirectory)/logs/linux-x64
-      cd $TMPDIR
-      tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/logs-linux-x64.tar.gz adsuser
+      cd /tmp
+      tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/logs-linux-x64.tar.gz adsuser*
     displayName: Archive Logs
     continueOnError: true
 

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -158,10 +158,9 @@ steps:
     displayName: Archive Logs
     continueOnError: true
 
-  - task: PublishPipelineArtifact@0
+  - task: PublishBuildArtifacts@1
     inputs:
-      artifactName: logs-linux-x64.tar.gz
-      targetPath: $(Build.ArtifactStagingDirectory)/logs/linux-x64
+      artifactName: logs
     displayName: Publish Logs
     continueOnError: true
 

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -135,7 +135,9 @@ steps:
         APP_NAME=$(node -p "require(\"$APP_ROOT/resources/app/product.json\").applicationName")
         INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
         DISPLAY=:10 node ./scripts/test-extensions-unit.js ${{ extension }}
-      displayName: 'Run ${{ extension }} Stable Extension Unit Tests'
+        NO_CLEANUP=1
+        VSCODEUSERDATAROOT=$TMPDIR/adsuser
+        displayName: 'Run ${{ extension }} Stable Extension Unit Tests'
       condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
   - script: |
@@ -151,8 +153,8 @@ steps:
   - script: |
       set -e
       mkdir -p $(Build.ArtifactStagingDirectory)/logs/linux-x64
-      cd ~/.config/azuredatastudio
-      tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/logs-linux-x64.tar.gz logs
+      cd $TMPDIR
+      tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/logs-linux-x64.tar.gz adsuser
     displayName: Archive Logs
     continueOnError: true
 

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -133,9 +133,9 @@ steps:
         set -e
         APP_ROOT=$(agent.builddirectory)/azuredatastudio-linux-x64
         APP_NAME=$(node -p "require(\"$APP_ROOT/resources/app/product.json\").applicationName")
-        INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
-        NO_CLEANUP=1
-        VSCODEUSERDATAROOT="$TMPDIR/adsuser"
+        export INTEGRATION_TEST_ELECTRON_PATH="$APP_ROOT/$APP_NAME" \
+        export NO_CLEANUP=1
+        export VSCODEUSERDATAROOT="$TMPDIR/adsuser"
         DISPLAY=:10 node ./scripts/test-extensions-unit.js ${{ extension }}
       displayName: 'Run ${{ extension }} Stable Extension Unit Tests'
       condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))

--- a/scripts/test-extensions-unit.bat
+++ b/scripts/test-extensions-unit.bat
@@ -117,8 +117,10 @@ if "%RUN_DBPROJECT_TESTS%" == "true" (
 
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-rmdir /s /q %VSCODEUSERDATADIR%
-rmdir /s /q %VSCODEEXTENSIONSDIR%
+if "%NO_CLEANUP%"=="" (
+	rmdir /s /q %VSCODEUSERDATADIR%
+	rmdir /s /q %VSCODEEXTENSIONSDIR%
+)
 
 popd
 

--- a/scripts/test-extensions-unit.js
+++ b/scripts/test-extensions-unit.js
@@ -38,7 +38,12 @@ let argv = require('yargs')
 let VSCODEUSERDATADIR;
 
 if (process.env.VSCODEUSERDATAROOT) {
-	VSCODEUSERDATADIR = path.join(process.env.VSCODEUSERDATAROOT, tmp.tmpNameSync({ prefix: 'adsuser' }));
+	console.log(`root : ${process.env.VSCODEUSERDATAROOT}`);
+	let tmpName = tmp.tmpNameSync({ prefix: 'adsuser' });
+	console.log(`tmpname : ${tmpName}`);
+
+	VSCODEUSERDATADIR = path.join(process.env.VSCODEUSERDATAROOT, );
+	console.log(`data dir : ${VSCODEUSERDATADIR}`);
 } else {
 	VSCODEUSERDATADIR = tmp.dirSync({ prefix: 'adsuser' }).name;
 }

--- a/scripts/test-extensions-unit.js
+++ b/scripts/test-extensions-unit.js
@@ -35,8 +35,8 @@ let argv = require('yargs')
 
 // set up environment
 
-const VSCODEUSERDATADIR = tmp.dirSync({ dir: '/tmp/adsuser', prefix: 'adsuser' }).name;
-const VSCODEEXTENSIONSDIR = tmp.dirSync({ dir: '/tmp/adsext', prefix: 'adsext' }).name;
+const VSCODEUSERDATADIR = tmp.dirSync({ prefix: 'adsuser' }).name;
+const VSCODEEXTENSIONSDIR = tmp.dirSync({ prefix: 'adsext' }).name;
 
 console.log(VSCODEUSERDATADIR);
 console.log(VSCODEEXTENSIONSDIR);

--- a/scripts/test-extensions-unit.js
+++ b/scripts/test-extensions-unit.js
@@ -35,7 +35,13 @@ let argv = require('yargs')
 
 // set up environment
 
-const VSCODEUSERDATADIR = tmp.dirSync({ prefix: 'adsuser' }).name;
+let VSCODEUSERDATADIR;
+
+if (process.env.VSCODEUSERDATAROOT) {
+	VSCODEUSERDATADIR = path.join(process.env.VSCODEUSERDATAROOT, tmp.tmpNameSync({ prefix: 'adsuser' }));
+} else {
+	VSCODEUSERDATADIR = tmp.dirSync({ prefix: 'adsuser' }).name;
+}
 const VSCODEEXTENSIONSDIR = tmp.dirSync({ prefix: 'adsext' }).name;
 
 console.log(VSCODEUSERDATADIR);
@@ -74,5 +80,7 @@ for (const ext of argv.extensions) {
 
 // clean up
 
-fs.remove(VSCODEUSERDATADIR, { recursive: true }).catch(console.error);
-fs.remove(VSCODEEXTENSIONSDIR, { recursive: true }).catch(console.error);
+if (!process.env.NO_CLEANUP) {
+	fs.remove(VSCODEUSERDATADIR, { recursive: true }).catch(console.error);
+	fs.remove(VSCODEEXTENSIONSDIR, { recursive: true }).catch(console.error);
+}

--- a/scripts/test-extensions-unit.js
+++ b/scripts/test-extensions-unit.js
@@ -35,19 +35,8 @@ let argv = require('yargs')
 
 // set up environment
 
-let VSCODEUSERDATADIR;
-
-if (process.env.VSCODEUSERDATAROOT) {
-	console.log(`root : ${process.env.VSCODEUSERDATAROOT}`);
-	let tmpName = tmp.tmpNameSync({ prefix: 'adsuser' });
-	console.log(`tmpname : ${tmpName}`);
-
-	VSCODEUSERDATADIR = path.join(process.env.VSCODEUSERDATAROOT, );
-	console.log(`data dir : ${VSCODEUSERDATADIR}`);
-} else {
-	VSCODEUSERDATADIR = tmp.dirSync({ prefix: 'adsuser' }).name;
-}
-const VSCODEEXTENSIONSDIR = tmp.dirSync({ prefix: 'adsext' }).name;
+const VSCODEUSERDATADIR = tmp.dirSync({ dir: '/tmp/adsuser', prefix: 'adsuser' }).name;
+const VSCODEEXTENSIONSDIR = tmp.dirSync({ dir: '/tmp/adsext', prefix: 'adsext' }).name;
 
 console.log(VSCODEUSERDATADIR);
 console.log(VSCODEEXTENSIONSDIR);

--- a/scripts/test-extensions-unit.js
+++ b/scripts/test-extensions-unit.js
@@ -33,14 +33,6 @@ let argv = require('yargs')
 	.default('extensions', extensionList)
 	.strict().help().wrap(null).version(false).argv;
 
-// set up environment
-
-const VSCODEUSERDATADIR = tmp.dirSync({ prefix: 'adsuser' }).name;
-const VSCODEEXTENSIONSDIR = tmp.dirSync({ prefix: 'adsext' }).name;
-
-console.log(`VSCODEUSERDATADIR : ${VSCODEUSERDATADIR}`);
-console.log(`VSCODEEXTENSIONSDIR : ${VSCODEEXTENSIONSDIR}`);
-
 if (!process.env.INTEGRATION_TEST_ELECTRON_PATH) {
 	process.env.INTEGRATION_TEST_ELECTRON_PATH = path.join(__dirname, '..', 'scripts', os.platform() === 'win32' ? 'code.bat' : 'code.sh');
 	console.log('Running unit tests out of sources.');
@@ -66,6 +58,14 @@ for (const ext of argv.extensions) {
 	console.log('*'.repeat(ext.length + 23));
 	console.log(`*** starting ${ext} tests ***`);
 	console.log('*'.repeat(ext.length + 23));
+
+	// set up environment
+
+	const VSCODEUSERDATADIR = tmp.dirSync({ prefix: `adsuser_${ext}` }).name;
+	const VSCODEEXTENSIONSDIR = tmp.dirSync({ prefix: `adsext_${ext}` }).name;
+
+	console.log(`VSCODEUSERDATADIR : ${VSCODEUSERDATADIR}`);
+	console.log(`VSCODEEXTENSIONSDIR : ${VSCODEEXTENSIONSDIR}`);
 
 	const command = `${process.env.INTEGRATION_TEST_ELECTRON_PATH} --no-sandbox --extensionDevelopmentPath=${path.join(__dirname, '..', 'extensions', ext)} --extensionTestsPath=${path.join(__dirname, '..', 'extensions', ext, 'out', 'test')} --user-data-dir=${VSCODEUSERDATADIR} --extensions-dir=${VSCODEEXTENSIONSDIR} --remote-debugging-port=9222 --disable-telemetry --disable-crash-reporter --disable-updates --nogpu`;
 	console.log(`Command used: ${command}`);

--- a/scripts/test-extensions-unit.js
+++ b/scripts/test-extensions-unit.js
@@ -38,8 +38,8 @@ let argv = require('yargs')
 const VSCODEUSERDATADIR = tmp.dirSync({ prefix: 'adsuser' }).name;
 const VSCODEEXTENSIONSDIR = tmp.dirSync({ prefix: 'adsext' }).name;
 
-console.log(VSCODEUSERDATADIR);
-console.log(VSCODEEXTENSIONSDIR);
+console.log(`VSCODEUSERDATADIR : ${VSCODEUSERDATADIR}`);
+console.log(`VSCODEEXTENSIONSDIR : ${VSCODEEXTENSIONSDIR}`);
 
 if (!process.env.INTEGRATION_TEST_ELECTRON_PATH) {
 	process.env.INTEGRATION_TEST_ELECTRON_PATH = path.join(__dirname, '..', 'scripts', os.platform() === 'win32' ? 'code.bat' : 'code.sh');

--- a/scripts/test-extensions-unit.sh
+++ b/scripts/test-extensions-unit.sh
@@ -111,5 +111,7 @@ if [[ "$RUN_DBPROJECT_TESTS" == "true" ]]; then
 	"$INTEGRATION_TEST_ELECTRON_PATH" $LINUX_NO_SANDBOX --extensionDevelopmentPath=$ROOT/extensions/sql-database-projects --extensionTestsPath=$ROOT/extensions/sql-database-projects/out/test --user-data-dir=$VSCODEUSERDATADIR --extensions-dir=$VSCODEEXTDIR --disable-telemetry --disable-crash-reporter --disable-updates --nogpu
 fi
 
-rm -r $VSCODEUSERDATADIR
-rm -r $VSCODEEXTDIR
+if [[ "$NO_CLEANUP" == "" ]]; then
+	rm -r $VSCODEUSERDATADIR
+	rm -r $VSCODEEXTDIR
+fi


### PR DESCRIPTION
Uploads the user data directories generated during test runs as build artifacts to help with test failure debugging.

See https://mssqltools.visualstudio.com/_apis/resources/Containers/2586338/drop?itemPath=drop%2Flogs%2Flinux-x64%2Flogs-linux-x64.tar.gz for an example of the generated archive. 

Also added the names to the temp user data dirs we create for the test runs to easily tell which run the logs came from. Only did this for the JS script on purpose since we don't really use the others anymore and that functionality isn't needed there currently.