### PR TITLE
Increase yarn timeout when installing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,10 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: '2.x'
-    - run: yarn --frozen-lockfile
+    # Increase timeout to get around latency issues when fetching certain packages
+    - run: |
+        yarn config set network-timeout 300000
+        yarn --frozen-lockfile
       name: Install Dependencies
     - run: yarn electron
       name: Download Electron
@@ -115,7 +118,10 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 10
-    - run: yarn --frozen-lockfile
+    # Increase timeout to get around latency issues when fetching certain packages
+    - run: |
+        yarn config set network-timeout 300000
+        yarn --frozen-lockfile
       name: Install Dependencies
     - run: yarn electron x64
       name: Download Electron

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,10 @@ jobs:
       with:
         node-version: 10
     # TODO: cache node modules
-    - run: yarn --frozen-lockfile
+    # Increase timeout to get around latency issues when fetching certain packages
+    - run: |
+        yarn config set network-timeout 300000
+        yarn --frozen-lockfile
       name: Install Dependencies
     - run: yarn electron x64
       name: Download Electron


### PR DESCRIPTION
Been seeing a lot of failures similar to this lately in CI builds (where we aren't currently caching packages) :

https://github.com/microsoft/azuredatastudio/pull/13330/checks?check_run_id=1382218824

```
Tue, 10 Nov 2020 21:47:37 GMT
yarn install v1.22.5
Tue, 10 Nov 2020 21:47:37 GMT
$ node build/npm/preinstall.js
Tue, 10 Nov 2020 21:47:38 GMT
[1/4] Resolving packages...
Tue, 10 Nov 2020 21:47:39 GMT
[2/4] Fetching packages...
Tue, 10 Nov 2020 21:48:56 GMT
info There appears to be trouble with your network connection. Retrying...
Tue, 10 Nov 2020 21:49:06 GMT
info There appears to be trouble with your network connection. Retrying...
Tue, 10 Nov 2020 21:49:30 GMT
info There appears to be trouble with your network connection. Retrying...
Tue, 10 Nov 2020 21:49:39 GMT
info There appears to be trouble with your network connection. Retrying...
Tue, 10 Nov 2020 21:50:04 GMT
info There appears to be trouble with your network connection. Retrying...
Tue, 10 Nov 2020 21:50:13 GMT
info There appears to be trouble with your network connection. Retrying...
Tue, 10 Nov 2020 21:50:38 GMT
info There appears to be trouble with your network connection. Retrying...
Tue, 10 Nov 2020 21:51:12 GMT
error An unexpected error occurred: "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.0.tgz: ESOCKETTIMEDOUT".
Tue, 10 Nov 2020 21:51:12 GMT
info If you think this is a bug, please open a bug report with the information provided in "/Users/runner/work/azuredatastudio/azuredatastudio/yarn-error.log".
Tue, 10 Nov 2020 21:51:12 GMT
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

One of the suggested workarounds is to increase the default timeout per https://github.com/yarnpkg/yarn/issues/6115 so trying that to see if it helps. 