### PR TITLE
Change PG Dashboard page back to using original loading components

### DIFF
--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -118,10 +118,13 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		computeInfoAndLinks.addItem(infoComputeStorage_p6, { CSSStyles: { 'margin-right': '5px' } });
 		content.addItem(computeInfoAndLinks, { CSSStyles: { 'min-height': '30px' } });
 
-
+		content.addItem(this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+			value: loc.workerNodes,
+			CSSStyles: { ...cssStyles.title, 'margin-top': '25px' }
+		}).component());
 
 		this.workerContainer = this.modelView.modelBuilder.divContainer().component();
-		this.handleServiceUpdated();
+		this.workerContainer.addItems(this.createUserInputSection(), { CSSStyles: { 'min-height': '30px' } });
 		content.addItem(this.workerContainer, { CSSStyles: { 'min-height': '30px' } });
 
 		this.initialized = true;
@@ -140,12 +143,6 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		this.disposables.push(
 			this.saveButton.onDidClick(async () => {
 				this.saveButton!.enabled = false;
-				this.discardButton!.enabled = false;
-				this.workerBox!.value = '';
-				this.coresRequestBox!.value = '';
-				this.coresLimitBox!.value = '';
-				this.memoryRequestBox!.value = '';
-				this.memoryLimitBox!.value = '';
 				try {
 					await vscode.window.withProgress(
 						{
@@ -161,6 +158,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 					);
 
 					vscode.window.showInformationMessage(loc.instanceUpdated(this._postgresModel.info.name));
+
+					this.discardButton!.enabled = false;
 
 				} catch (error) {
 					vscode.window.showErrorMessage(loc.instanceUpdateFailed(this._postgresModel.info.name, error));
@@ -198,7 +197,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		this.workerBox = this.modelView.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
 			readOnly: false,
 			validationErrorMessage: loc.workerValidationErrorMessage,
-			inputType: 'number'
+			inputType: 'number',
+			placeHolder: loc.loading
 		}).component();
 
 		this.disposables.push(
@@ -215,7 +215,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			readOnly: false,
 			min: 1,
 			validationErrorMessage: loc.coresValidationErrorMessage,
-			inputType: 'number'
+			inputType: 'number',
+			placeHolder: loc.loading
 		}).component();
 
 		this.disposables.push(
@@ -232,7 +233,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			readOnly: false,
 			min: 1,
 			validationErrorMessage: loc.coresValidationErrorMessage,
-			inputType: 'number'
+			inputType: 'number',
+			placeHolder: loc.loading
 		}).component();
 
 		this.disposables.push(
@@ -249,7 +251,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			readOnly: false,
 			min: 0.25,
 			validationErrorMessage: loc.memoryLimitValidationErrorMessage,
-			inputType: 'number'
+			inputType: 'number',
+			placeHolder: loc.loading
 		}).component();
 
 		this.disposables.push(
@@ -266,7 +269,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			readOnly: false,
 			min: 0.25,
 			validationErrorMessage: loc.memoryRequestValidationErrorMessage,
-			inputType: 'number'
+			inputType: 'number',
+			placeHolder: loc.loading
 		}).component();
 
 		this.disposables.push(
@@ -279,6 +283,24 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			})
 		);
 
+	}
+
+	private createUserInputSection(): azdata.Component[] {
+		if (this._postgresModel.configLastUpdated) {
+			this.editWorkerNodeCount();
+			this.editCores();
+			this.editMemory();
+		}
+
+		return [
+			this.createWorkerNodesSectionContainer(),
+			this.createCoresMemorySection(),
+			this.createConfigurationSectionContainer(loc.coresRequest, this.coresRequestBox!),
+			this.createConfigurationSectionContainer(loc.coresLimit, this.coresLimitBox!),
+			this.createConfigurationSectionContainer(loc.memoryRequest, this.memoryRequestBox!),
+			this.createConfigurationSectionContainer(loc.memoryLimit, this.memoryLimitBox!)
+
+		];
 	}
 
 	private createWorkerNodesSectionContainer(): azdata.FlexContainer {
@@ -460,30 +482,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 	}
 
 	private handleServiceUpdated() {
-		if (this._postgresModel.configLastUpdated) {
-			this.editWorkerNodeCount();
-			this.editCores();
-			this.editMemory();
-
-			// Workaround https://github.com/microsoft/azuredatastudio/issues/13134
-			// by only adding these once the model has data. After the bug is fixed,
-			// use loading indicators instead of keeping the page blank.
-			if (this.workerContainer?.items.length === 0) {
-				this.workerContainer.addItem(this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
-					value: loc.workerNodes,
-					CSSStyles: { ...cssStyles.title, 'margin-top': '25px' }
-				}).component());
-
-				this.workerContainer.addItems([
-					this.createWorkerNodesSectionContainer(),
-					this.createCoresMemorySection(),
-					this.createConfigurationSectionContainer(loc.coresRequest, this.coresRequestBox!),
-					this.createConfigurationSectionContainer(loc.coresLimit, this.coresLimitBox!),
-					this.createConfigurationSectionContainer(loc.memoryRequest, this.memoryRequestBox!),
-					this.createConfigurationSectionContainer(loc.memoryLimit, this.memoryLimitBox!)
-
-				]);
-			}
-		}
+		this.editWorkerNodeCount();
+		this.editCores();
+		this.editMemory();
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13134

Reverts the temporary changes made to the Compute+Storage page for the loading components. The actual fix was done in other PRs - this is just moving the page back to using the original loading components. 

Visiting tab only after changes have already been made (originally what was broken):
![Capture](https://user-images.githubusercontent.com/28519865/98753070-5ee44d00-2378-11eb-8eb1-d2cbb3496547.gif)

Visiting tab immediately and then having components updated afterwards:
![Capture](https://user-images.githubusercontent.com/28519865/98753208-aa96f680-2378-11eb-852e-5ac5f1a7a62d.gif)
