### PR TITLE
Use progress notification for azdata install/updates

### DIFF
--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -239,52 +239,60 @@ export async function findAzdata(): Promise<IAzdataTool> {
  * runs the commands to install azdata, downloading the installation package if needed
  */
 export async function installAzdata(): Promise<void> {
-	const statusDisposable = vscode.window.setStatusBarMessage(loc.installingAzdata);
 	Logger.show();
 	Logger.log(loc.installingAzdata);
-	try {
-		switch (process.platform) {
-			case 'win32':
-				await downloadAndInstallAzdataWin32();
-				break;
-			case 'darwin':
-				await installAzdataDarwin();
-				break;
-			case 'linux':
-				await installAzdataLinux();
-				break;
-			default:
-				throw new Error(loc.platformUnsupported(process.platform));
+	await vscode.window.withProgress(
+		{
+			location: vscode.ProgressLocation.Notification,
+			title: loc.installingAzdata,
+			cancellable: false
+		},
+		async (_progress, _token): Promise<void> => {
+			switch (process.platform) {
+				case 'win32':
+					await downloadAndInstallAzdataWin32();
+					break;
+				case 'darwin':
+					await installAzdataDarwin();
+					break;
+				case 'linux':
+					await installAzdataLinux();
+					break;
+				default:
+					throw new Error(loc.platformUnsupported(process.platform));
+			}
 		}
-	} finally {
-		statusDisposable.dispose();
-	}
+	);
 }
 
 /**
  * Updates the azdata using os appropriate method
  */
 export async function updateAzdata(): Promise<void> {
-	const statusDisposable = vscode.window.setStatusBarMessage(loc.updatingAzdata);
 	Logger.show();
 	Logger.log(loc.updatingAzdata);
-	try {
-		switch (process.platform) {
-			case 'win32':
-				await downloadAndInstallAzdataWin32();
-				break;
-			case 'darwin':
-				await updateAzdataDarwin();
-				break;
-			case 'linux':
-				await installAzdataLinux();
-				break;
-			default:
-				throw new Error(loc.platformUnsupported(process.platform));
+	await vscode.window.withProgress(
+		{
+			location: vscode.ProgressLocation.Notification,
+			title: loc.updatingAzdata,
+			cancellable: false
+		},
+		async (_progress, _token): Promise<void> => {
+			switch (process.platform) {
+				case 'win32':
+					await downloadAndInstallAzdataWin32();
+					break;
+				case 'darwin':
+					await updateAzdataDarwin();
+					break;
+				case 'linux':
+					await installAzdataLinux();
+					break;
+				default:
+					throw new Error(loc.platformUnsupported(process.platform));
+			}
 		}
-	} finally {
-		statusDisposable.dispose();
-	}
+	);
 }
 
 /**


### PR DESCRIPTION
The progress notification makes it clearer about the status of the install - the status bar item was too easy to miss.

![image](https://user-images.githubusercontent.com/28519865/98866684-2e58ed80-2422-11eb-85d1-2224d0c8e502.png)

![image](https://user-images.githubusercontent.com/28519865/98868644-5007a400-2425-11eb-82e2-8a382643a50b.png)
