### PR TITLE
Always upload build artifacts + logs during product build

### DIFF
--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -156,6 +156,7 @@ steps:
       tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/logs-linux-x64.tar.gz adsuser*
     displayName: Archive Logs
     continueOnError: true
+    condition: succeededOrFailed()
 
   - script: |
       set -e
@@ -229,6 +230,7 @@ steps:
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
+    condition: succeededOrFailed()
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'


### PR DESCRIPTION
We were only uploading the artifacts when all previous steps succeeded which meant if a test failure happened we wouldn't get the logs.

I could have made it so we only upload the logs (other artifacts are ignored) but it doesn't seem to be a bad thing to always upload the artifacts even for a failed build - the build will still fail so won't cause other pipeline tasks to run unexpectedly. 