### PR TITLE
Fix wizard page name and step getting announced when pages are added and removed

### DIFF
--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -138,13 +138,13 @@ export class WizardModal extends Modal {
 		this._wizard.onPageAdded(page => {
 			this.registerPage(page);
 			this.updatePageNumbers();
-			this.showPage(this._wizard.currentPage, false).catch(err => onUnexpectedError(err));
+			this.showPage(this._wizard.currentPage, false, false, false).catch(err => onUnexpectedError(err));
 		});
 		this._wizard.onPageRemoved(page => {
 			let dialogPane = this._dialogPanes.get(page);
 			this._dialogPanes.delete(page);
 			this.updatePageNumbers();
-			this.showPage(this._wizard.currentPage, false).catch(err => onUnexpectedError(err));
+			this.showPage(this._wizard.currentPage, false, false, false).catch(err => onUnexpectedError(err));
 			dialogPane.dispose();
 		});
 		this.updatePageNumbers();
@@ -173,7 +173,7 @@ export class WizardModal extends Modal {
 		page.onUpdate(() => this.setButtonsForPage(this._wizard.currentPage));
 	}
 
-	public async showPage(index: number, validate: boolean = true, focus: boolean = false): Promise<void> {
+	public async showPage(index: number, validate: boolean = true, focus: boolean = false, readHeader: boolean = true): Promise<void> {
 		let pageToShow = this._wizard.pages[index];
 		if (!pageToShow) {
 			this.done(validate).catch(err => onUnexpectedError(err));
@@ -194,7 +194,7 @@ export class WizardModal extends Modal {
 			}
 		});
 
-		if (dialogPaneToShow) {
+		if (dialogPaneToShow && readHeader) {
 			status(`${dialogPaneToShow.pageNumberDisplayText} ${dialogPaneToShow.title}`);
 		}
 		this.setButtonsForPage(index);


### PR DESCRIPTION
This PR fixes #12983. The dacpac wizard adds and removes pages based on the selected radio button, so the page step and name were getting announced every time a different radio button was selected.
