### PR TITLE
Ignore built notebook component files

### DIFF
--- a/extensions/azurehybridtoolkit/.gitignore
+++ b/extensions/azurehybridtoolkit/.gitignore
@@ -1,0 +1,1 @@
+notebooks/hybridbook/Components/**/obj


### PR DESCRIPTION
@smartguest How are these even generated? I just had them show up randomly in my repo without opening the Notebook or anything. Are users expected to have some c# compiler installed or anything to properly generate these?

And then taking a quick look through the files what is all this supposed to be doing? There's some weird stuff like hardcoded paths : https://github.com/microsoft/azuredatastudio/blob/main/extensions/azurehybridtoolkit/notebooks/hybridbook/Components/ADP/SqlPackageWrapper/Program.cs#L13