### PR TITLE
Fix ModelView container validation ordering

### DIFF
--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -308,7 +308,6 @@ export abstract class ContainerBase<T, TPropertyBag extends azdata.ComponentProp
 			if (event.eventType === ComponentEventType.validityChanged) {
 				this.validate();
 			}
-			component.validate();
 		}), true);
 		this._changeRef.detectChanges();
 		this.onItemsUpdated();

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -308,7 +308,7 @@ export abstract class ContainerBase<T, TPropertyBag extends azdata.ComponentProp
 			if (event.eventType === ComponentEventType.validityChanged) {
 				this.validate();
 			}
-		}), false);
+		}), true);
 		this._changeRef.detectChanges();
 		this.onItemsUpdated();
 		return;

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -308,6 +308,7 @@ export abstract class ContainerBase<T, TPropertyBag extends azdata.ComponentProp
 			if (event.eventType === ComponentEventType.validityChanged) {
 				this.validate();
 			}
+			component.validate();
 		}), true);
 		this._changeRef.detectChanges();
 		this.onItemsUpdated();


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13318

This was broken in https://github.com/microsoft/azuredatastudio/pull/13317

This changed when the event handler was hooked up - since it wasn't specified as an "initial" action that meant it was only ran after the other initial actions were done. For containers these initial actions include adding and defining child components - so now when the child component is created the event handler isn't hooked up yet and so the parts of the creation (such as setting properties) that triggered the validity update were done before that event handler was hooked up.

So the fix here is just to make the action to register the event handler for child components also an "initial" action so it gets set before the child components are created. 