### PR TITLE
Fixes for NotebookUtils Tests Reliability

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -328,7 +328,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		if (shouldReveal || this._bookViewer?.visible) {
 			bookItem = notebookPath ? await this.findAndExpandParentNode(notebookPath) : undefined;
 			// Select + focus item in viewlet if books viewlet is already open, or if we pass in variable
-			if (bookItem?.contextValue !== 'pinnedNotebook') {
+			if (bookItem?.contextValue && bookItem.contextValue !== 'pinnedNotebook') {
 				// Note: 3 is the maximum number of levels that the vscode APIs let you expand to
 				await this._bookViewer.reveal(bookItem, { select: true, focus: true, expand: true });
 			}

--- a/extensions/notebook/src/test/common/notebookUtils.test.ts
+++ b/extensions/notebook/src/test/common/notebookUtils.test.ts
@@ -20,12 +20,16 @@ describe('notebookUtils Tests', function (): void {
 	let notebookUtils: NotebookUtils = new NotebookUtils();
 	let showErrorMessageSpy: sinon.SinonSpy;
 
-	beforeEach(function(): void {
+	beforeEach(function (): void {
 		showErrorMessageSpy = sinon.spy(vscode.window, 'showErrorMessage');
 	});
 
-	afterEach(function(): void {
+	afterEach(function (): void {
 		sinon.restore();
+	});
+
+	this.beforeAll(async function (): Promise<void> {
+		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
 	});
 
 	this.afterAll(async function (): Promise<void> {
@@ -109,7 +113,7 @@ describe('notebookUtils Tests', function (): void {
 			sinon.replaceGetter(azdata.nb, 'activeNotebookEditor', () => undefined);
 			await notebookUtils.clearActiveCellOutput();
 			should(showErrorMessageSpy.calledOnce).be.true('showErrorMessage should be called exactly once');
-});
+		});
 
 		it('does not show error when notebook visible', async function (): Promise<void> {
 			let mockNotebookEditor = TypeMoq.Mock.ofType<azdata.nb.NotebookEditor>();


### PR DESCRIPTION
Last night we had one notebooks extension unit test failure during one of the canary runs. Many of the tests failed with this message:

```AssertionError: There should be not any open Notebook documents```

Before running the notebookutils test suite, we weren't actually ensuring that all editors were closed, while the first line of the newNotebook test suite has the following assert:
`should(azdata.nb.notebookDocuments.length).equal(0, 'There should be not any open Notebook documents');
`

Fixed this by ensuring that we're closing all open editors in a new `beforeAll()` method.

In addition, there was an exception being thrown in bookTreeView when bookItem was undefined and we called `this._bookViewer.reveal()`. Doing a simple check removes these exceptions.