### PR TITLE
Fix schema compare source and target components not starting with the correct width

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -247,6 +247,10 @@ export class SchemaCompareMainWindow {
 				});
 
 				await view.initializeModel(this.flexModel);
+
+				// set layout so that source and target components are set to the correct width based on the CSSStyles
+				this.sourceTargetFlexLayout.setLayout({});
+
 				resolve();
 			});
 		});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #13385. The schema compare source and target components started having the incorrect width after #13261, since the order of when layouts got set must've changed. The fix is to make sure the layout for the source and target flex container gets set after everything is initialized since the widths of the source and target components depend on the flex container they are in. 
