### PR TITLE
onComplete -> onLeave for toolsAndEulaPage

### DIFF
--- a/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
@@ -6,7 +6,7 @@
 import * as azdata from 'azdata';
 import { EOL } from 'os';
 import * as nls from 'vscode-nls';
-import { AgreementInfo, DeploymentProvider, ITool, ResourceType, ResourceTypeOptionValue, ToolStatus } from '../interfaces';
+import { AgreementInfo, DeploymentProvider, ITool, ResourceType, ResourceTypeOptionValue, ToolRequirementInfo, ToolStatus } from '../interfaces';
 import { createFlexContainer } from './modelViewUtils';
 import * as loc from '../localizedConstants';
 import { IToolsService } from '../services/toolsService';
@@ -358,9 +358,9 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 
 
 	/**
- *
- * @param enable - if true the UiControls are set to be enabled, if not they are set to be disabled.
- */
+	 *
+	 * @param enable - if true the UiControls are set to be enabled, if not they are set to be disabled.
+	 */
 	private setUiControlsEnabled(enable: boolean): void {
 		this._agreementContainer.enabled = enable;
 		this._optionsContainer.enabled = enable;
@@ -368,8 +368,7 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 		// select and install tools buttons are controlled separately
 	}
 
-
-	protected async onComplete(): Promise<void> {
+	public async onLeave(): Promise<void> {
 		this.toolsService.toolsForCurrentProvider = this._tools;
 	}
 
@@ -388,7 +387,7 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 		return this._eulaValidationSucceeded;
 	}
 
-	private get toolRequirements() {
+	private get toolRequirements(): ToolRequirementInfo[] {
 		return this.wizard.provider.requiredTools;
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Before notebook generation the toolsForCurrentProvider in toolsService need to be set by the toolsAndEulaPage. It was doing it in an onComplete method that is not called from anywhere. Changed the method to onLeave so that this value gets set when toolsAndEulaPage has exited.

This PR fixes #13365
