### PR TITLE
Fix ModelView logging error

### DIFF
--- a/src/sql/workbench/browser/modelComponents/groupContainer.component.ts
+++ b/src/sql/workbench/browser/modelComponents/groupContainer.component.ts
@@ -48,7 +48,6 @@ export default class GroupContainer extends ContainerBase<GroupLayout, GroupCont
 		@Inject(forwardRef(() => ElementRef)) el: ElementRef,
 		@Inject(ILogService) logService: ILogService) {
 		super(changeRef, el, logService);
-		this.collapsed = false;
 	}
 
 	ngAfterViewInit(): void {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13405

The issue here is that we were updating a property in the constructor before the object was fully instantiated - this caused it to fire off a bunch of other stuff including the validation logic and so the descriptor was still undefined when it ran those functions.

Doing this is pretty dangerous in general - setting properties causes all sorts of side effects and so doing it before it's fully instantiated is highly likely to cause issues elsewhere.

I debated adding an undefined check to the logging calls for safety but given the previous sentence I would rather keep this as it is and clearly break things when that happens instead of silently ignoring it. 

It might not be the worst idea to actually throw an exception when we try to do things like set properties before it's done being initialized, but I want to think about that a bit more before trying to do something bigger like that.

Collapsed is already defaulting to false so setting it in the constructor isn't necessary.