### PR TITLE
uncomment the hideContextMenu

### DIFF
--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -292,7 +292,7 @@ export class Dropdown extends Disposable implements IListVirtualDelegate<string>
 	}
 
 	private _hideList(): void {
-		//this.contextViewService.hideContextView();
+		this.contextViewService.hideContextView();
 		this._inputContainer.setAttribute('aria-expanded', 'false');
 	}
 


### PR DESCRIPTION
I was testing something together with the changes I made to address the comments and forgot to remove the comment before commit.
