### PR TITLE
Fix ModelView container child layout issues

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -157,7 +157,8 @@ export class SchemaCompareMainWindow {
 
 				this.sourceName = getEndpointName(this.sourceEndpointInfo);
 				this.targetName = ' ';
-				this.sourceNameComponent = view.modelBuilder.table().withProperties({
+				this.sourceNameComponent = view.modelBuilder.table().withProperties<azdata.TableComponentProperties>({
+					data: [],
 					columns: [
 						{
 							value: this.sourceName,
@@ -167,7 +168,8 @@ export class SchemaCompareMainWindow {
 					]
 				}).component();
 
-				this.targetNameComponent = view.modelBuilder.table().withProperties({
+				this.targetNameComponent = view.modelBuilder.table().withProperties<azdata.TableComponentProperties>({
+					data: [],
 					columns: [
 						{
 							value: this.targetName,

--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -361,12 +361,12 @@ export abstract class ContainerBase<T, TPropertyBag extends azdata.ComponentProp
 	}
 
 	public layout(): void {
+		super.layout();
 		if (this._componentWrappers) {
 			this._componentWrappers.forEach(wrapper => {
 				wrapper.layout();
 			});
 		}
-		super.layout();
 	}
 
 	abstract setLayout(layout: any): void;


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13385

I'm not super confident that this won't have any side-effects but it fixes the immediate issues and I went through a bunch of other dialogs and didn't notice anything weird layout wise.

Laying out the child components before the container meant that child components which depended on layout properties of the parent (such as width) weren't having that set correctly when their layout was done. This could cause issues such as the one described in the bug - this is only happening in a few special cases though because we call layout from so many different places that most other things either don't have the specific layout dependencies or are having that called after the parent container is fully done with its layout.

![Capture](https://user-images.githubusercontent.com/28519865/99130775-233ec280-25c6-11eb-847b-3a13d0001ca4.gif)
