### PR TITLE
enable the outline for active tab header

### DIFF
--- a/src/sql/base/browser/ui/panel/panel.ts
+++ b/src/sql/base/browser/ui/panel/panel.ts
@@ -337,10 +337,6 @@ export class TabbedPanel extends Disposable {
 				color: ${styles.titleActiveForeground};
 				border-bottom-color: ${styles.titleActiveBorder};
 				border-bottom-width: 2px;
-			}
-
-			.tabbedPanel > .title .tabList .tab-header.active {
-				outline: none;
 			}`);
 		}
 


### PR DESCRIPTION
 while testing the browse connection feature, I noticed that there is no focus indicator when the connection dialog's tab header is getting focused. when the tab header is getting focused it will focus on the active tab header, but the css rule being removed in this PR is setting the outline to be hidden.

**Before**

look the same with or without focus

![image](https://user-images.githubusercontent.com/13777222/99136202-8afe0900-25d8-11eb-8daa-fc404a7d8c42.png)


**After**
with focus:
![image](https://user-images.githubusercontent.com/13777222/99136166-5e49f180-25d8-11eb-9a87-48439153a8e8.png)

without focus:
![image](https://user-images.githubusercontent.com/13777222/99136181-6e61d100-25d8-11eb-9222-fd880d3ac40c.png)
