### PR TITLE
Fix extension install version check

### DIFF
--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -161,8 +161,11 @@ export class ExtensionManagementService extends Disposable implements IExtension
 			const identifier = { id: getGalleryExtensionId(manifest.publisher, manifest.name) };
 			// let operation: InstallOperation = InstallOperation.Install; {{ SQL CARBON EDIT }}
 			// {{ SQL CARBON EDIT }}
-			if (manifest.engines && ((manifest.engines.vscode && !isEngineValid(manifest.engines.vscode, product.vscodeVersion)) || (manifest.engines.azdata && !isEngineValid(manifest.engines.azdata, product.version)))) {
-				throw new Error(nls.localize('incompatible', "Unable to install extension '{0}' as it is not compatible with VS Code '{1}'.", identifier.id, product.version));
+			if (manifest.engines?.vscode && !isEngineValid(manifest.engines.vscode, product.vscodeVersion)) {
+				throw new Error(nls.localize('incompatible', "Unable to install extension '{0}' as it is not compatible with the current VS Code engine version '{1}'.", identifier.id, product.vscodeVersion));
+			}
+			if (manifest.engines?.azdata && !isEngineValid(manifest.engines.azdata, product.version)) {
+				throw new Error(nls.localize('incompatibleAzdata', "Unable to install extension '{0}' as it is not compatible with Azure Data Studio '{1}'.", identifier.id, product.version));
 			}
 
 			const identifierWithVersion = new ExtensionIdentifierWithVersion(identifier, manifest.version);


### PR DESCRIPTION
Closes https://github.com/microsoft/azuredatastudio/issues/13430

We were doing both engine version checks in the same check and then using the wrong version when displaying the error to the user. Splitting them out to make it clear which version isn't compatible. 