### PR TITLE
Remove resultSet from IDisplayResult metadata

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -4737,10 +4737,6 @@ declare module 'azdata' {
 			 * This is dynamic and is controlled by kernels, so cannot be more specific
 			 */
 			data: { [key: string]: any };
-			/**
-			 * Optional metadata, also a mime bundle
-			 */
-			metadata?: {};
 		}
 		export interface IDisplayData extends IDisplayResult {
 			output_type: 'display_data';

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -4740,9 +4740,7 @@ declare module 'azdata' {
 			/**
 			 * Optional metadata, also a mime bundle
 			 */
-			metadata?: {
-				resultSet?: ResultSetSummary;
-			};
+			metadata?: {};
 		}
 		export interface IDisplayData extends IDisplayResult {
 			output_type: 'display_data';


### PR DESCRIPTION
This PR fixes this issue in azdata:

node_modules/azdata/azdata.d.ts:4734:20 - error TS2430: Interface 'IDisplayResult' incorrectly extends interface 'ICellOutput'.
  Types of property 'metadata' are incompatible.
    Type '{ resultSet?: ResultSetSummary; }' has no properties in common with type 'ICellOutputMetadata'.
4734:    export interface IDisplayResult extends ICellOutput {

which was caused by my grid streaming changes: https://github.com/microsoft/azuredatastudio/blame/32a6385fefab8f75902dfbe4ca92fdde2836a5c6/src/sql/azdata.d.ts#L4744

The resultSet property did not need to be added in IDisplayResult, only in ICellOutputMetadata. I checked that the only places we are accessing metadata is through the metadata field in ICellOutput https://github.com/microsoft/azuredatastudio/blob/2b4986c82728c3afac3ac424e6da45f1e94ceca4/src%2Fsql%2Fazdata.d.ts#L4706