### PR TITLE
add workspace information to open existing dialog

### DIFF
--- a/extensions/data-workspace/src/dialogs/dialogBase.ts
+++ b/extensions/data-workspace/src/dialogs/dialogBase.ts
@@ -5,7 +5,8 @@
 
 import * as azdata from 'azdata';
 import * as vscode from 'vscode';
-import { OkButtonText } from '../common/constants';
+import * as path from 'path';
+import * as constants from '../common/constants';
 
 interface Deferred<T> {
 	resolve: (result: T | Promise<T>) => void;
@@ -17,10 +18,12 @@ export abstract class DialogBase {
 	protected _dialogObject: azdata.window.Dialog;
 	protected initDialogComplete: Deferred<void> | undefined;
 	protected initDialogPromise: Promise<void> = new Promise<void>((resolve, reject) => this.initDialogComplete = { resolve, reject });
+	protected workspaceFormComponent: azdata.FormComponent | undefined;
+	protected workspaceInputBox: azdata.InputBoxComponent | undefined;
 
 	constructor(dialogTitle: string, dialogName: string, dialogWidth: azdata.window.DialogWidth = 600) {
 		this._dialogObject = azdata.window.createModelViewDialog(dialogTitle, dialogName, dialogWidth);
-		this._dialogObject.okButton.label = OkButtonText;
+		this._dialogObject.okButton.label = constants.OkButtonText;
 		this.register(this._dialogObject.cancelButton.onClick(() => this.onCancelButtonClicked()));
 		this.register(this._dialogObject.okButton.onClick(() => this.onOkButtonClicked()));
 		this._dialogObject.registerCloseValidator(async () => {
@@ -73,5 +76,50 @@ export abstract class DialogBase {
 
 	protected createHorizontalContainer(view: azdata.ModelView, items: azdata.Component[]): azdata.FlexContainer {
 		return view.modelBuilder.flexContainer().withItems(items, { CSSStyles: { 'margin-right': '5px', 'margin-bottom': '10px' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
+	}
+
+	/**
+	 * Creates container with information on which workspace the project will be added to and where the workspace will be
+	 * created if no workspace is currently open
+	 * @param view
+	 */
+	protected createWorkspaceContainer(view: azdata.ModelView): azdata.FormComponent {
+		const workspaceDescription = view.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+			value: vscode.workspace.workspaceFile ? constants.AddProjectToCurrentWorkspace : constants.NewWorkspaceWillBeCreated,
+			CSSStyles: { 'margin-top': '3px', 'margin-bottom': '10px' }
+		}).component();
+
+		this.workspaceInputBox = view.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
+			ariaLabel: constants.WorkspaceLocationTitle,
+			width: constants.DefaultInputWidth,
+			enabled: false,
+			value: vscode.workspace.workspaceFile?.fsPath ?? '',
+			title: vscode.workspace.workspaceFile?.fsPath ?? '' // hovertext for if file path is too long to be seen in textbox
+		}).component();
+
+		const container = view.modelBuilder.flexContainer()
+			.withItems([workspaceDescription, this.workspaceInputBox])
+			.withLayout({ flexFlow: 'column' })
+			.component();
+
+		this.workspaceFormComponent = {
+			title: constants.Workspace,
+			component: container
+		};
+
+		return this.workspaceFormComponent;
+	}
+
+	/**
+	 * Update the workspace inputbox based on the passed in location and name if there isn't a workspace currently open
+	 * @param location
+	 * @param name
+	 */
+	protected updateWorkspaceInputbox(location: string, name: string): void {
+		if (!vscode.workspace.workspaceFile) {
+			const fileLocation = location && name ? path.join(location, `${name}.code-workspace`) : '';
+			this.workspaceInputBox!.value = fileLocation;
+			this.workspaceInputBox!.title = fileLocation;
+		}
 	}
 }


### PR DESCRIPTION
This PR fixes ##13444. Previously, only the new project dialog had the workspace information. Since it's common code for both dialogs, I moved a lot of the code to the dialogBase. 

The workspace that the project is being added to only shows if the project radio card is selected and goes away when the selection is changed to open a workspace:
![openExistingWorkspace](https://user-images.githubusercontent.com/31145923/99337597-6f446e00-2837-11eb-831b-35557d1beb00.gif)


