### PR TITLE
Fix schema compare database dropdown not starting with values

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -526,6 +526,8 @@ export class SchemaCompareDialog {
 		}
 
 		currentDropdown.loading = false;
+
+		await this.populateDatabaseDropdown((currentDropdown.value as ConnectionDropdownValue).connection, isTarget);
 	}
 
 	protected async getServerValues(isTarget: boolean): Promise<{ connection: azdata.connection.ConnectionProfile, displayName: string, name: string }[]> {


### PR DESCRIPTION
Forgot to push my changes with this line before merging https://github.com/microsoft/azuredatastudio/pull/13189. This fixes the target dropdown starting with no values until the server is selected.