### PR TITLE
Attempt to Colorize Code Cells from Notebook Contents

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -266,7 +266,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		}));
 
 		this.layout();
-		this.updateLanguageMode();
+		// this.updateLanguageMode();
 		if (this._cellModel.isCollapsed) {
 			this.onCellCollapse(true);
 		}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -266,7 +266,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		}));
 
 		this.layout();
-		// this.updateLanguageMode();
+
 		if (this._cellModel.isCollapsed) {
 			this.onCellCollapse(true);
 		}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.component.ts
@@ -266,7 +266,7 @@ export class CodeComponent extends CellView implements OnInit, OnChanges {
 		}));
 
 		this.layout();
-
+		this.updateLanguageMode();
 		if (this._cellModel.isCollapsed) {
 			this.onCellCollapse(true);
 		}

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -336,6 +336,11 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			this._cells = [];
 			if (contents) {
 				this._defaultLanguageInfo = contents.metadata?.language_info;
+				// If language info was serialized in the notebook, attempt to use that to decrease time
+				// required until colorization occurs
+				if (this._defaultLanguageInfo) {
+					this.updateLanguageInfo(this._defaultLanguageInfo);
+				}
 				this._savedKernelInfo = this.getSavedKernelInfo(contents);
 				this._savedConnectionName = this.getSavedConnectionName(contents);
 				if (contents.metadata) {


### PR DESCRIPTION
Fixes #13472.

We currently wait until a notebook kernel is loaded before trying to set an editor's language, but this means that code cells won't have a language associated with them until the kernel is finished loading (which may be many seconds, depending on whether a Jupyter server needs to be started or not). This means that users will see un-colorized editors.

This change sets the language info based on what was serialized in a notebook previously (if it exists). Note that we're still checking for language info when the kernel is loaded; this change merely tries to optimize for the case when language info was present in the notebook previously.

![ColorizeFaster](https://user-images.githubusercontent.com/40371649/99566582-f1d94480-2981-11eb-9692-d5c3c0cbf554.gif)

