### PR TITLE
Fix Loading component removal

### DIFF
--- a/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
+++ b/src/sql/workbench/browser/modelComponents/loadingComponent.component.ts
@@ -95,6 +95,11 @@ export default class LoadingComponent extends ComponentBase<azdata.LoadingCompon
 		this.layout();
 	}
 
+	public removeFromContainer(_componentDescriptor: IComponentDescriptor): void {
+		this._component = undefined;
+		this.layout();
+	}
+
 	public getStatusText(): string {
 		return this.loading ? this.loadingText : this.loadingCompletedText;
 	}

--- a/src/sql/workbench/browser/modelComponents/viewBase.ts
+++ b/src/sql/workbench/browser/modelComponents/viewBase.ts
@@ -88,6 +88,10 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 	clearContainer(componentId: string): void {
 		this.logService.debug(`Queuing action to clear component ${componentId}`);
 		this.queueAction(componentId, (component) => {
+			if (!component.clearContainer) {
+				this.logService.warn(`Trying to clear container ${componentId} but does not implement clearContainer!`);
+				return;
+			}
 			this.logService.debug(`Clearing component ${componentId}`);
 			component.clearContainer();
 		});
@@ -97,6 +101,10 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 		this.logService.debug(`Queueing action to add component ${itemConfig.componentShape.id} to container ${containerId}`);
 		// Do not return the promise as this should be non-blocking
 		this.queueAction(containerId, (component) => {
+			if (!component.addToContainer) {
+				this.logService.warn(`Container ${containerId} is trying to add component ${itemConfig.componentShape.id} but does not implement addToContainer!`);
+				return;
+			}
 			this.logService.debug(`Adding component ${itemConfig.componentShape.id} to container ${containerId}`);
 			let childDescriptor = this.defineComponent(itemConfig.componentShape);
 			component.addToContainer(childDescriptor, itemConfig.config, index);
@@ -107,6 +115,10 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 		this.logService.debug(`Queueing action to remove component ${itemConfig.componentShape.id} from container ${containerId}`);
 		let childDescriptor = this.modelStore.getComponentDescriptor(itemConfig.componentShape.id);
 		this.queueAction(containerId, (component) => {
+			if (!component.removeFromContainer) {
+				this.logService.warn(`Container ${containerId} is trying to remove component ${itemConfig.componentShape.id} but does not implement removeFromContainer!`);
+				return;
+			}
 			this.logService.debug(`Removing component ${itemConfig.componentShape.id} from container ${containerId}`);
 			component.removeFromContainer(childDescriptor);
 			this.removeComponent(itemConfig.componentShape);


### PR DESCRIPTION
Discovered while investigating https://github.com/microsoft/azuredatastudio/issues/13476

Loading component is a bit weird - it uses container functionality like addItem which means that on the core side it has itemConfigs.

But then we have logic that assumes if a component has itemConfigs that it also implements removeFromContainer which it doesn't because it just extends from ComponentBase.

For now I'm just implementing removeFromContainer here - this shouldn't be a normal case and is more of a side effect of LoadingComponent being a pretty weird component itself. But to be safe I also guarded against addToContainer, removeFromContainer and clearContainer not being set to prevent this from happening again in the future.