### PR TITLE
Update a few strings in projects

### DIFF
--- a/extensions/data-workspace/package.nls.json
+++ b/extensions/data-workspace/package.nls.json
@@ -6,8 +6,8 @@
 	"new-command": "New",
 	"refresh-workspace-command": "Refresh",
 	"remove-project-command": "Remove Project",
-	"projects-view-no-workspace-content": "[Create new](command:projects.new)\n[Open existing](command:projects.openExisting)\n",
-	"projects-view-no-project-content": "No projects found in current workspace.\n[Create new](command:projects.new)\n[Open existing](command:projects.openExisting)\n",
+	"projects-view-no-workspace-content": "No workspace open, create new or open existing to get started.\n[Create new](command:projects.new)\n[Open existing](command:projects.openExisting)\nTo learn more about SQL Database projects [read our docs](https://aka.ms/azuredatastudio-sqlprojects)",
+	"projects-view-no-project-content": "No projects found in current workspace.\n[Create new](command:projects.new)\n[Open existing](command:projects.openExisting)\nTo learn more about SQL Database projects [read our docs](https://aka.ms/azuredatastudio-sqlprojects).\n",
 	"open-existing-command": "Open existing",
 	"projects.defaultProjectSaveLocation": "Full path to folder where new projects are saved by default."
 }

--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -31,7 +31,7 @@ export const TypeTitle = localize('dataworkspace.Type', "Type");
 export const ProjectNameTitle = localize('dataworkspace.projectNameTitle', "Name");
 export const ProjectNamePlaceholder = localize('dataworkspace.projectNamePlaceholder', "Enter project name");
 export const ProjectLocationTitle = localize('dataworkspace.projectLocationTitle', "Location");
-export const ProjectLocationPlaceholder = localize('dataworkspace.projectLocationPlaceholder', "Enter project location");
+export const ProjectLocationPlaceholder = localize('dataworkspace.projectLocationPlaceholder', "Select location to create project");
 export const AddProjectToCurrentWorkspace = localize('dataworkspace.AddProjectToCurrentWorkspace', "This project will be added to the current workspace.");
 export const NewWorkspaceWillBeCreated = localize('dataworkspace.NewWorkspaceWillBeCreated', "A new workspace will be created for this project.");
 export const WorkspaceLocationTitle = localize('dataworkspace.workspaceLocationTitle', "Workspace location");
@@ -45,8 +45,8 @@ export const WorkspaceFileNotExistError = (workspaceFilePath: string): string =>
 export const Project = localize('dataworkspace.project', "Project");
 export const Workspace = localize('dataworkspace.workspace', "Workspace");
 export const LocationSelectorTitle = localize('dataworkspace.locationSelectorTitle', "Location");
-export const ProjectFilePlaceholder = localize('dataworkspace.projectFilePlaceholder', "Enter project location");
-export const WorkspacePlaceholder = localize('dataworkspace.workspacePlaceholder', "Enter workspace location");
+export const ProjectFilePlaceholder = localize('dataworkspace.projectFilePlaceholder', "Select project (.sqlproj) file");
+export const WorkspacePlaceholder = localize('dataworkspace.workspacePlaceholder', "Select workspace (.code-workspace) file");
 export const WorkspaceFileExtension = 'code-workspace';
 
 // Workspace settings for saving new projects


### PR DESCRIPTION
Updating a few strings with suggestions from Drew. Since we only have one project type right now, it should be fine to have .sqlproj specific strings, but we’ll need to remember to update those in the future when more project types are added.

![Screen Shot 2020-11-18 at 10 21 44 AM](https://user-images.githubusercontent.com/31145923/99604757-11d92a00-29bb-11eb-816a-38ce08a8de45.png)
![Screen Shot 2020-11-18 at 10 22 26 AM](https://user-images.githubusercontent.com/31145923/99604760-130a5700-29bb-11eb-808d-0dc2ff8919c6.png)

![Screen Shot 2020-11-18 at 10 59 15 AM](https://user-images.githubusercontent.com/31145923/99604791-2289a000-29bb-11eb-89e3-c3d35684ccac.png)
![Screen Shot 2020-11-18 at 10 59 26 AM](https://user-images.githubusercontent.com/31145923/99604801-287f8100-29bb-11eb-96a1-53e9efd5f648.png)

