### PR TITLE
Notebooks: Fix query results not displaying table rows

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/browser/sqlFuture.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/sqlFuture.test.ts
@@ -69,7 +69,7 @@ suite('SQL Future', function () {
 
 		queryRunner.setup(x => x.getQueryRows(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(subset));
 		sqlFuture.handleResultSet(resultSet);
-		await sqlFuture.queryAndConvertData(resultSet, 0);
+		await sqlFuture.handleDone();
 		sinon.assert.calledWith(handleSpy, expectedMsg);
 	});
 });

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -527,6 +527,12 @@ export class SQLFuture extends Disposable implements FutureInternal {
 			this._dataToSaveMap.set(key, data);
 			this._rowsMap.set(key, []);
 			this.sendIOPubMessage(data, set);
+			// When there is no streaming, the results are returned in one set and
+			// onResultSetUpdate is not called. Therefore we must call handleResultSetUpdate
+			// here to display all the rows.
+			if (set.rowCount > 0) {
+				this.handleResultSetUpdate(set);
+			}
 		}
 	}
 

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -527,10 +527,7 @@ export class SQLFuture extends Disposable implements FutureInternal {
 			this._dataToSaveMap.set(key, data);
 			this._rowsMap.set(key, []);
 			this.sendIOPubMessage(data, set);
-			// When there is no streaming, the results are returned in one set and
-			// onResultSetUpdate is not called. Therefore we must call handleResultSetUpdate
-			// here to display all the rows.
-			// Note: when there is streaming, set.rowCount === 0
+			// If rows are returned in the initial result set, make sure to convert and send to notebook
 			if (set.rowCount > 0) {
 				this.handleResultSetUpdate(set);
 			}

--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -530,6 +530,7 @@ export class SQLFuture extends Disposable implements FutureInternal {
 			// When there is no streaming, the results are returned in one set and
 			// onResultSetUpdate is not called. Therefore we must call handleResultSetUpdate
 			// here to display all the rows.
+			// Note: when there is streaming, set.rowCount === 0
 			if (set.rowCount > 0) {
 				this.handleResultSetUpdate(set);
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/13486 and fixes https://github.com/microsoft/azuredatastudio/issues/13433

Queries against PostgreSQL servers do not have result streaming support and the results are returned in one set.
The code changes ensure that all the rows are being displayed even when there is no streaming implemented.
