### PR TITLE
Cleanup Resource Deployment ModelView

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -210,7 +210,6 @@
                           "type": "azure_account",
                           "required": true,
                           "subscriptionVariableName": "AZDATA_NB_VAR_ARC_SUBSCRIPTION",
-                          "displaySubscriptionVariableName": "AZDATA_NB_VAR_ARC_DISPLAY_SUBSCRIPTION",
                           "resourceGroupVariableName": "AZDATA_NB_VAR_ARC_RESOURCE_GROUP"
                         },
                         {
@@ -219,7 +218,6 @@
                           "defaultValue": "eastus",
                           "required": true,
                           "locationVariableName": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_LOCATION",
-                          "displayLocationVariableName": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_DISPLAY_LOCATION",
                           "locations": [
                             "australiaeast",
                             "centralus",
@@ -273,7 +271,7 @@
                           "defaultValue": "",
                           "enabled": {
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "%arc.data.controller.direct%"
+                            "value": "direct"
                           }
                         },
                         {
@@ -284,7 +282,7 @@
                           "defaultValue": "",
                           "enabled": {
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "%arc.data.controller.direct%"
+                            "value": "direct"
                           }
                         },
                         {
@@ -295,7 +293,7 @@
                           "defaultValue": "",
                           "enabled": {
                             "target": "AZDATA_NB_VAR_ARC_DATA_CONTROLLER_CONNECTIVITY_MODE",
-                            "value": "%arc.data.controller.direct%"
+                            "value": "direct"
                           }
                         }
                       ]
@@ -542,7 +540,7 @@
                           "label": "%arc.data.controller.summary.subscription%",
                           "type": "readonly_text",
                           "isEvaluated": true,
-                          "defaultValue": "$(AZDATA_NB_VAR_ARC_DISPLAY_SUBSCRIPTION)",
+                          "defaultValue": "$(AZDATA_NB_VAR_ARC_SUBSCRIPTION)",
                           "inputWidth": "600"
                         },
                         {
@@ -555,7 +553,7 @@
                           "label": "%arc.data.controller.summary.location%",
                           "type": "readonly_text",
                           "isEvaluated": true,
-                          "defaultValue": "$(AZDATA_NB_VAR_ARC_DATA_CONTROLLER_DISPLAY_LOCATION)"
+                          "defaultValue": "$(AZDATA_NB_VAR_ARC_DATA_CONTROLLER_LOCATION)"
                         }
                       ]
                     },

--- a/extensions/asde-deployment/package.json
+++ b/extensions/asde-deployment/package.json
@@ -296,7 +296,6 @@
                           "defaultValue": "westus",
                           "required": true,
                           "locationVariableName": "AZDATA_NB_VAR_ASDE_AZURE_LOCATION",
-                          "displayLocationVariableName": "AZDATA_NB_VAR_ASDE_AZURE_LOCATION_TEXT",
                           "locations": [
                             "australiaeast",
                             "australiasoutheast",

--- a/extensions/resource-deployment/src/interfaces.ts
+++ b/extensions/resource-deployment/src/interfaces.ts
@@ -316,7 +316,6 @@ export interface KubeClusterContextFieldInfo extends FieldInfo {
 	configFileVariableName?: string;
 }
 export interface AzureAccountFieldInfo extends AzureLocationsFieldInfo {
-	displaySubscriptionVariableName?: string;
 	subscriptionVariableName?: string;
 	resourceGroupVariableName?: string;
 	allowNewResourceGroup?: boolean;
@@ -326,7 +325,6 @@ export interface AzureAccountFieldInfo extends AzureLocationsFieldInfo {
 
 export interface AzureLocationsFieldInfo extends FieldInfo {
 	locationVariableName?: string;
-	displayLocationVariableName?: string;
 	locations?: string[]
 }
 

--- a/extensions/resource-deployment/src/ui/radioGroupLoadingComponentBuilder.ts
+++ b/extensions/resource-deployment/src/ui/radioGroupLoadingComponentBuilder.ts
@@ -49,8 +49,8 @@ export class RadioGroupLoadingComponentBuilder implements azdata.ComponentBuilde
 					: op as azdata.CategoryValue;
 				const radioOption = this._view!.modelBuilder.radioButton().withProperties<azdata.RadioButtonProperties>({
 					label: option.displayName,
+					value: option.name,
 					checked: option.displayName === defaultValue,
-					name: option.name,
 					enabled: instanceOfDynamicEnablementInfo(this._fieldInfo.enabled) ? false : this._fieldInfo.enabled // Dynamic enablement is initially set to false
 				}).component();
 				if (radioOption.checked) {
@@ -75,7 +75,11 @@ export class RadioGroupLoadingComponentBuilder implements azdata.ComponentBuilde
 	}
 
 	get value(): string | undefined {
-		return this._currentRadioOption?.label;
+		return this._currentRadioOption?.value || this._currentRadioOption?.label;
+	}
+
+	get displayValue(): string {
+		return this._currentRadioOption.label || '';
 	}
 
 	get checked(): azdata.RadioButtonComponent {


### PR DESCRIPTION
Doing some general cleanup : 

1. RadioGroupLoadingComponentBuilder was using the name property to store the value but this isn't correct, name should be used for grouping radio buttons together - not for storing the actual value (value should be used for that) https://www.w3schools.com/tags/att_input_type_radio.asp
1. As part of this the value for the dynamic enablement is now going to be the actual non-display value so updating that 
1. Removed the "displayName" values for the Azure sections. Instead implementing an optional getDisplayValue function for all inputs that will return the appropriate user-visible display name and then having the evaluated text use that. Currently evaluated text is only used for these kind of display scenarios so that should be safe - we can add support for embedding the actual value in later if that is needed

Summary page and generated notebook vars after change : 
![image](https://user-images.githubusercontent.com/28519865/99856798-a324d980-2b3e-11eb-9032-92224d33b09e.png)
![image](https://user-images.githubusercontent.com/28519865/99856858-c2bc0200-2b3e-11eb-825e-d799d93b2298.png)
