### PR TITLE
fix icon size issue

### DIFF
--- a/src/sql/workbench/browser/modelComponents/button.component.ts
+++ b/src/sql/workbench/browser/modelComponents/button.component.ts
@@ -124,15 +124,14 @@ export default class ButtonComponent extends ComponentWithIconBase<azdata.Button
 		if (this._currentButtonType !== this.buttonType) {
 			this.initButton();
 		}
-		if (this._infoButtonContainer) {
-			let button = this._button as InfoButton;
-			button.buttonMaxHeight = this.properties.height;
-			button.buttonMaxWidth = this.properties.width;
-			button.description = this.properties.description;
-			button.iconClass = createIconCssClass(this.properties.iconPath);
-			button.iconHeight = this.properties.iconHeight;
-			button.iconWidth = this.properties.iconWidth;
-			button.title = this.properties.title;
+		if (this._button instanceof InfoButton) {
+			this._button.buttonMaxHeight = this.properties.height;
+			this._button.buttonMaxWidth = this.properties.width;
+			this._button.description = this.properties.description;
+			this._button.iconClass = createIconCssClass(this.properties.iconPath);
+			this._button.iconHeight = this.properties.iconHeight;
+			this._button.iconWidth = this.properties.iconWidth;
+			this._button.title = this.properties.title;
 		} else {
 			this._button.enabled = this.enabled;
 			this._button.label = this.label;
@@ -154,6 +153,12 @@ export default class ButtonComponent extends ComponentWithIconBase<azdata.Button
 			if (this.height) {
 				this._button.setHeight(convertSize(this.height.toString()));
 			}
+
+			if (this.iconPath) {
+				this._button.element.style.backgroundSize = `${this.getIconWidth()} ${this.getIconHeight()}`;
+				this._button.element.style.paddingLeft = this.getIconWidth();
+			}
+
 		}
 
 		this.updateIcon();


### PR DESCRIPTION
migration workstream needs to use button image, I noticed the button with image relies on the original size of the image and the iconWidth/iconHeight properties are not being respected.

before:

![image](https://user-images.githubusercontent.com/13777222/99863577-a5456300-2b53-11eb-85c5-0eb72453e6a5.png)

after:

![image](https://user-images.githubusercontent.com/13777222/99863743-6bc12780-2b54-11eb-9057-f9bf3827a6ef.png)


code used for demo purpose:
```TypeScript
view.modelBuilder.button().withProperties<azdata.ButtonProperties>({
				label: this.NewStepButtonString,
				title: this.NewStepButtonString,
				width: 140,
				iconPath: {
					light: 'C:\\git\\azuredatastudio\\extensions\\agent\\resources\\light\\open_notebook.svg',
					dark: 'C:\\git\\azuredatastudio\\extensions\\agent\\resources\\dark\\open_notebook_inverse.svg'
				},
				iconWidth: 16,
				iconHeight: 16
			}).component();
```
