### PR TITLE
bumping versions and using ComponentWithIcon props to set icon size

### DIFF
--- a/extensions/sql-assessment/package.json
+++ b/extensions/sql-assessment/package.json
@@ -2,7 +2,7 @@
   "name": "sql-assessment",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
@@ -10,7 +10,7 @@
   "aiKey": "AIF-37eefaf0-8022-4671-a3fb-64752724682e",
   "engines": {
     "vscode": "^1.25.0",
-    "azdata": ">=1.19.0"
+    "azdata": ">=1.24.0"
   },
   "activationEvents": [
     "onDashboardOpen"

--- a/extensions/sql-assessment/src/tabs/assessmentMainTab.ts
+++ b/extensions/sql-assessment/src/tabs/assessmentMainTab.ts
@@ -106,12 +106,18 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 				dark: this.extensionContext.asAbsolutePath('resources/dark/database.svg'),
 				light: this.extensionContext.asAbsolutePath('resources/light/database.svg')
 			};
+		const iconSize: number = 16;
 
 		const btnInvokeAssessment = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
-				label: this.invokeAssessmentLabel,
+				label: this.invokeAssessmentLabel
+			})
+			.withProperties<azdata.ComponentWithIconProperties>({
 				iconPath: targetIconPath,
-			}).component();
+				iconHeight: iconSize,
+				iconWidth: iconSize
+			})
+			.component();
 		const btnInvokeAssessmentLoading = view.modelBuilder.loadingComponent()
 			.withItem(btnInvokeAssessment)
 			.withProperties<azdata.LoadingComponentProperties>({
@@ -139,9 +145,14 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 
 		const btnGetAssessmentItems = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
-				label: this.getItemsLabel,
+				label: this.getItemsLabel
+			})
+			.withProperties<azdata.ComponentWithIconProperties>({
 				iconPath: targetIconPath,
-			}).component();
+				iconHeight: iconSize,
+				iconWidth: iconSize
+			})
+			.component();
 		const btnGetAssessmentItemsLoading = view.modelBuilder.loadingComponent()
 			.withItem(btnGetAssessmentItems)
 			.withProperties<azdata.LoadingComponentProperties>({
@@ -170,12 +181,17 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 		this.btnExportAsScript = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
 				label: localize('btnExportAsScript', "Export as script"),
+				enabled: false
+			})
+			.withProperties<azdata.ComponentWithIconProperties>({
 				iconPath: {
 					dark: this.extensionContext.asAbsolutePath('resources/dark/newquery_inverse.svg'),
 					light: this.extensionContext.asAbsolutePath('resources/light/newquery.svg')
 				},
-				enabled: false
-			}).component();
+				iconHeight: iconSize,
+				iconWidth: iconSize
+			})
+			.component();
 		this.toDispose.push(this.btnExportAsScript.onDidClick(async () => {
 			this.engine.generateAssessmentScript();
 		}));
@@ -183,12 +199,17 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 		this.btnHTMLExport = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
 				label: localize('btnGeneratehtmlreport', "Create HTML Report"),
+				enabled: false
+			})
+			.withProperties<azdata.ComponentWithIconProperties>({
 				iconPath: {
 					dark: this.extensionContext.asAbsolutePath('resources/dark/book_inverse.svg'),
 					light: this.extensionContext.asAbsolutePath('resources/light/book.svg')
 				},
-				enabled: false
-			}).component();
+				iconHeight: iconSize,
+				iconWidth: iconSize
+			})
+			.component();
 
 		this.toDispose.push(this.btnHTMLExport.onDidClick(async () => {
 			TelemetryReporter.sendActionEvent(SqlAssessmentTelemetryView, SqlTelemetryActions.CreateHTMLReport);
@@ -215,12 +236,17 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 
 		let btnViewSamples = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
-				label: localize('btnViewSamples', "View all rules and learn more on GitHub"),
+				label: localize('btnViewSamples', "View all rules and learn more on GitHub")
+			})
+			.withProperties<azdata.ComponentWithIconProperties>({
 				iconPath: {
 					dark: this.extensionContext.asAbsolutePath('resources/dark/configuredashboard_inverse.svg'),
 					light: this.extensionContext.asAbsolutePath('resources/light/configuredashboard.svg')
 				},
-			}).component();
+				iconHeight: iconSize,
+				iconWidth: iconSize
+			})
+			.component();
 
 		this.toDispose.push(btnViewSamples.onDidClick(() => {
 			TelemetryReporter.sendActionEvent(SqlAssessmentTelemetryView, SqlTelemetryActions.LearnMoreAssessmentLink);
@@ -229,12 +255,17 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 
 		let btnAPIDetails = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
-				label: LocalizedStrings.SECTION_TITLE_API,
+				label: LocalizedStrings.SECTION_TITLE_API
+			})
+			.withProperties<azdata.ComponentWithIconProperties>({
 				iconPath: {
 					dark: this.extensionContext.asAbsolutePath('resources/dark/status_info.svg'),
 					light: this.extensionContext.asAbsolutePath('resources/light/status_info.svg')
 				},
-			}).component();
+				iconHeight: iconSize,
+				iconWidth: iconSize
+			})
+			.component();
 		this.toDispose.push(btnAPIDetails.onDidClick(async () => {
 			let infoArray: azdata.PropertiesContainerItem[] = [];
 

--- a/extensions/sql-assessment/src/tabs/assessmentMainTab.ts
+++ b/extensions/sql-assessment/src/tabs/assessmentMainTab.ts
@@ -110,14 +110,11 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 
 		const btnInvokeAssessment = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
-				label: this.invokeAssessmentLabel
-			})
-			.withProperties<azdata.ComponentWithIconProperties>({
+				label: this.invokeAssessmentLabel,
 				iconPath: targetIconPath,
 				iconHeight: iconSize,
 				iconWidth: iconSize
-			})
-			.component();
+			}).component();
 		const btnInvokeAssessmentLoading = view.modelBuilder.loadingComponent()
 			.withItem(btnInvokeAssessment)
 			.withProperties<azdata.LoadingComponentProperties>({
@@ -145,14 +142,11 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 
 		const btnGetAssessmentItems = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
-				label: this.getItemsLabel
-			})
-			.withProperties<azdata.ComponentWithIconProperties>({
+				label: this.getItemsLabel,
 				iconPath: targetIconPath,
 				iconHeight: iconSize,
 				iconWidth: iconSize
-			})
-			.component();
+			}).component();
 		const btnGetAssessmentItemsLoading = view.modelBuilder.loadingComponent()
 			.withItem(btnGetAssessmentItems)
 			.withProperties<azdata.LoadingComponentProperties>({
@@ -181,17 +175,14 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 		this.btnExportAsScript = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
 				label: localize('btnExportAsScript', "Export as script"),
-				enabled: false
-			})
-			.withProperties<azdata.ComponentWithIconProperties>({
+				enabled: false,
 				iconPath: {
 					dark: this.extensionContext.asAbsolutePath('resources/dark/newquery_inverse.svg'),
 					light: this.extensionContext.asAbsolutePath('resources/light/newquery.svg')
 				},
 				iconHeight: iconSize,
 				iconWidth: iconSize
-			})
-			.component();
+			}).component();
 		this.toDispose.push(this.btnExportAsScript.onDidClick(async () => {
 			this.engine.generateAssessmentScript();
 		}));
@@ -199,17 +190,14 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 		this.btnHTMLExport = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
 				label: localize('btnGeneratehtmlreport', "Create HTML Report"),
-				enabled: false
-			})
-			.withProperties<azdata.ComponentWithIconProperties>({
+				enabled: false,
 				iconPath: {
 					dark: this.extensionContext.asAbsolutePath('resources/dark/book_inverse.svg'),
 					light: this.extensionContext.asAbsolutePath('resources/light/book.svg')
 				},
 				iconHeight: iconSize,
 				iconWidth: iconSize
-			})
-			.component();
+			}).component();
 
 		this.toDispose.push(this.btnHTMLExport.onDidClick(async () => {
 			TelemetryReporter.sendActionEvent(SqlAssessmentTelemetryView, SqlTelemetryActions.CreateHTMLReport);
@@ -236,17 +224,14 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 
 		let btnViewSamples = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
-				label: localize('btnViewSamples', "View all rules and learn more on GitHub")
-			})
-			.withProperties<azdata.ComponentWithIconProperties>({
+				label: localize('btnViewSamples', "View all rules and learn more on GitHub"),
 				iconPath: {
 					dark: this.extensionContext.asAbsolutePath('resources/dark/configuredashboard_inverse.svg'),
 					light: this.extensionContext.asAbsolutePath('resources/light/configuredashboard.svg')
 				},
 				iconHeight: iconSize,
 				iconWidth: iconSize
-			})
-			.component();
+			}).component();
 
 		this.toDispose.push(btnViewSamples.onDidClick(() => {
 			TelemetryReporter.sendActionEvent(SqlAssessmentTelemetryView, SqlTelemetryActions.LearnMoreAssessmentLink);
@@ -255,17 +240,14 @@ export class SqlAssessmentMainTab extends SqlAssessmentTab {
 
 		let btnAPIDetails = view.modelBuilder.button()
 			.withProperties<azdata.ButtonProperties>({
-				label: LocalizedStrings.SECTION_TITLE_API
-			})
-			.withProperties<azdata.ComponentWithIconProperties>({
+				label: LocalizedStrings.SECTION_TITLE_API,
 				iconPath: {
 					dark: this.extensionContext.asAbsolutePath('resources/dark/status_info.svg'),
 					light: this.extensionContext.asAbsolutePath('resources/light/status_info.svg')
 				},
 				iconHeight: iconSize,
 				iconWidth: iconSize
-			})
-			.component();
+			}).component();
 		this.toDispose.push(btnAPIDetails.onDidClick(async () => {
 			let infoArray: azdata.PropertiesContainerItem[] = [];
 


### PR DESCRIPTION
- extension versions 0.5.0 and minimal ADS core version - 1.24.0 - the one with icon column feature
- use iconWigth and iconHeight props to set toolbar icon size
