### PR TITLE
fix the extra large icon issue

### DIFF
--- a/src/sql/base/browser/dom.ts
+++ b/src/sql/base/browser/dom.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { endsWith } from 'vs/base/common/strings';
 import * as types from 'vs/base/common/types';
 
 export function isHidden(element: HTMLElement): boolean {
@@ -22,21 +21,22 @@ export function convertSize(size: number | string | undefined, defaultValue?: st
 		return defaultValue;
 	}
 	let convertedSize: string = size ? size.toString() : defaultValue;
-	if (!endsWith(convertedSize.toLowerCase(), 'px') && !endsWith(convertedSize.toLowerCase(), '%')) {
+	convertedSize = convertedSize.toLowerCase();
+	if (!convertedSize.endsWith('px') && !convertedSize.endsWith('%')) {
 		convertedSize = convertedSize + 'px';
 	}
 	return convertedSize;
 }
 
 /**
- * Converts a size value into its number representation. Supports px, em and unspecified units. 
+ * Converts a size value into its number representation. Supports px, em and unspecified units.
  * @param size The size value to convert
  */
 export function convertSizeToNumber(size: number | string | undefined): number {
 	if (size && typeof (size) === 'string') {
-		if (endsWith(size.toLowerCase(), 'px')) {
+		if (size.toLowerCase().endsWith('px')) {
 			return +size.replace('px', '');
-		} else if (endsWith(size.toLowerCase(), 'em')) {
+		} else if (size.toLowerCase().endsWith('em')) {
 			return +size.replace('em', '') * 11;
 		}
 	} else if (!size) {

--- a/src/sql/workbench/browser/modelComponents/button.component.ts
+++ b/src/sql/workbench/browser/modelComponents/button.component.ts
@@ -187,6 +187,14 @@ export default class ButtonComponent extends ComponentWithIconBase<azdata.Button
 		}
 	}
 
+	protected get defaultIconHeight(): number {
+		return 15;
+	}
+
+	protected get defaultIconWidth(): number {
+		return 15;
+	}
+
 	// CSS-bound properties
 
 	private get label(): string {

--- a/src/sql/workbench/browser/modelComponents/componentWithIconBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentWithIconBase.ts
@@ -42,12 +42,20 @@ export abstract class ComponentWithIconBase<T extends azdata.ComponentWithIconPr
 		}
 	}
 
+	protected get defaultIconWidth(): number {
+		return 50;
+	}
+
+	protected get defaultIconHeight(): number {
+		return 50;
+	}
+
 	public getIconWidth(): string {
-		return convertSize(this.iconWidth, '40px');
+		return convertSize(this.iconWidth, `${this.defaultIconWidth}px`);
 	}
 
 	public getIconHeight(): string {
-		return convertSize(this.iconHeight, '40px');
+		return convertSize(this.iconHeight, `${this.defaultIconHeight}px`);
 	}
 
 	public get iconPath(): string | URI | { light: string | URI; dark: string | URI } {
@@ -55,11 +63,11 @@ export abstract class ComponentWithIconBase<T extends azdata.ComponentWithIconPr
 	}
 
 	public get iconHeight(): number | string {
-		return this.getPropertyOrDefault<number | string>((props) => props.iconHeight, '50px');
+		return this.getPropertyOrDefault<number | string>((props) => props.iconHeight, this.defaultIconHeight);
 	}
 
 	public get iconWidth(): number | string {
-		return this.getPropertyOrDefault<number | string>((props) => props.iconWidth, '50px');
+		return this.getPropertyOrDefault<number | string>((props) => props.iconWidth, this.defaultIconWidth);
 	}
 
 	public get title(): string {

--- a/src/sql/workbench/browser/modelComponents/media/toolbarLayout.css
+++ b/src/sql/workbench/browser/modelComponents/media/toolbarLayout.css
@@ -51,17 +51,17 @@
 }
 
 .modelview-toolbar-container .modelview-toolbar-component modelview-button .monaco-text-button.icon {
-	padding-left: 19px;
-	background-size: 15px;
+	padding-left: 19px !important;
+	background-size: 15px !important;
 	margin-right: 0.3em;
 }
 
 /* Vertical button handling */
 .modelview-toolbar-container.toolbar-vertical  .modelview-toolbar-component modelview-button .monaco-text-button.icon {
-	padding: 20px 16px 20px 16px;
-	background-size: 20px;
+	padding: 20px 16px 20px 16px !important;
+	background-size: 20px !important;
 	margin-right: 0.3em;
-	background-position: 50% 50%;
+	background-position: 50% 50% !important;
 
 }
 


### PR DESCRIPTION
This PR fixes #13521

introduced by https://github.com/microsoft/azuredatastudio/pull/13514

for toolbar, we would like a consistent sizing for all buttons, overwriting the sizing in toolbar container's CSS.
for normal buttons, I am providing a proper default size.

before:


![image](https://user-images.githubusercontent.com/13777222/100005942-98588780-2d7e-11eb-9230-a419129954aa.png)

![image](https://user-images.githubusercontent.com/13777222/100006005-aefede80-2d7e-11eb-89c2-5e3cf7e3e39d.png)

after:

![image](https://user-images.githubusercontent.com/13777222/100006557-83c8bf00-2d7f-11eb-8fca-47e8e1b506f8.png)

![image](https://user-images.githubusercontent.com/13777222/100006578-8deabd80-2d7f-11eb-8310-3fd0f25f8931.png)

