### PR TITLE
Let child ModelView components control their enabled status by default

### DIFF
--- a/src/sql/workbench/browser/modelComponents/componentBase.ts
+++ b/src/sql/workbench/browser/modelComponents/componentBase.ts
@@ -354,7 +354,8 @@ export abstract class ContainerBase<T, TPropertyBag extends azdata.ComponentProp
 		super.setProperties(properties);
 		this.items.forEach(item => {
 			let component = this.modelStore.getComponent(item.descriptor.id);
-			if (component) {
+			// Let child components control their own enabled status if we don't have one specifically set
+			if (component && properties.enabled !== undefined) {
 				component.enabled = this.enabled;
 			}
 		});


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13511

It's possible this is going to affect other components which are relying on this behavior always applying - but in general I don't think this is the best approach for this anyways. One problem we have with setting the enabled state like this is that it's not guaranteed to hold since components can update their own enabled state at any point. 

But we can probably assume/rely on people setting the enabled state on either the parent container or the child components and not trying to do both in which case this should work fine. 

![Capture](https://user-images.githubusercontent.com/28519865/100009156-4f570200-2d83-11eb-93a7-827fc61e1a56.gif)

![Capture](https://user-images.githubusercontent.com/28519865/100009691-15d2c680-2d84-11eb-8679-5fe718261be7.gif)
