### PR TITLE
Fix declarative table display issues with ML ext

### DIFF
--- a/extensions/machine-learning/src/views/externalLanguages/languagesTable.ts
+++ b/extensions/machine-learning/src/views/externalLanguages/languagesTable.ts
@@ -100,7 +100,7 @@ export class LanguagesTable extends LanguageViewBase {
 		let languages: mssql.ExternalLanguage[] | undefined;
 
 		languages = await this.listLanguages();
-		let tableData: any[][] = [];
+		let tableData: azdata.DeclarativeTableCellValue[][] = [];
 
 		if (languages) {
 
@@ -113,10 +113,10 @@ export class LanguagesTable extends LanguageViewBase {
 			});
 		}
 
-		this._table.data = tableData;
+		this._table.dataValues = tableData;
 	}
 
-	private createTableRow(language: mssql.ExternalLanguage, content: mssql.ExternalLanguageContent): any[] {
+	private createTableRow(language: mssql.ExternalLanguage, content: mssql.ExternalLanguageContent): azdata.DeclarativeTableCellValue[] {
 		if (this._modelBuilder) {
 			let dropLanguageButton = this._modelBuilder.button().withProperties({
 				label: '',
@@ -153,7 +153,7 @@ export class LanguagesTable extends LanguageViewBase {
 					newLang: false
 				});
 			});
-			return [language.name, content.platform, language.createdDate, dropLanguageButton, editLanguageButton];
+			return [{ value: language.name }, { value: content.platform || '' }, { value: language.createdDate || '' }, { value: dropLanguageButton }, { value: editLanguageButton }];
 		}
 
 		return [];

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -419,7 +419,7 @@ declare module 'azdata' {
 	}
 
 	export interface DeclarativeTableCellValue {
-		value: string | number | boolean;
+		value: string | number | boolean | Component;
 		ariaLabel?: string;
 		style?: CssStyles
 	}

--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
@@ -280,7 +280,17 @@ export default class DeclarativeTableComponent extends ContainerBase<any, azdata
 			this.data?.forEach(row => {
 				for (let i = 0; i < row.length; i++) {
 					if (this.isComponent(i)) {
-						this.addToContainer(this.getItemDescriptor(row[i].value as string), undefined);
+						const itemDescriptor = this.getItemDescriptor(row[i].value as string);
+						if (itemDescriptor) {
+							this.addToContainer(itemDescriptor, {});
+						} else {
+							// This should ideally never happen but it's possible for a race condition to happen when adding/removing components quickly where
+							// the child component is unregistered after it is defined because a component is only unregistered when it's destroyed by Angular
+							// which can take a while and we don't wait on that to happen currently.
+							// While this happening isn't desirable it typically doesn't have a huge impact since the component will still be displayed properly in
+							// most cases
+							this.logService.warn(`Could not find ItemDescriptor for component ${row[i].value} when adding to DeclarativeTable ${this.descriptor.id}`);
+						}
 					}
 				}
 			});

--- a/src/sql/workbench/browser/modelComponents/modelStore.ts
+++ b/src/sql/workbench/browser/modelComponents/modelStore.ts
@@ -7,6 +7,7 @@ import { Deferred } from 'sql/base/common/promise';
 import { entries } from 'sql/base/common/collections';
 import { IComponentDescriptor, IModelStore, IComponent } from 'sql/platform/dashboard/browser/interfaces';
 import { onUnexpectedError } from 'vs/base/common/errors';
+import { ILogService } from 'vs/platform/log/common/log';
 
 class ComponentDescriptor implements IComponentDescriptor {
 	constructor(public readonly id: string, public readonly type: string) {
@@ -22,7 +23,7 @@ export class ModelStore implements IModelStore {
 	private _componentMappings: { [x: string]: IComponent } = {};
 	private _componentActions: { [x: string]: { initial: ModelStoreAction<any>[], actions: Deferred<IComponent> } } = {};
 	private _validationCallbacks: ((componentId: string) => Thenable<boolean>)[] = [];
-	constructor() {
+	constructor(private _logService: ILogService) {
 	}
 
 	public createComponentDescriptor(type: string, id: string): IComponentDescriptor {
@@ -36,12 +37,14 @@ export class ModelStore implements IModelStore {
 	}
 
 	registerComponent(component: IComponent): void {
+		this._logService.debug(`Registering component ${component.descriptor.id}`);
 		let id = component.descriptor.id;
 		this._componentMappings[id] = component;
 		this.runPendingActions(id, component);
 	}
 
 	unregisterComponent(component: IComponent): void {
+		this._logService.debug(`Unregistering component ${component.descriptor.id}`);
 		let id = component.descriptor.id;
 		this._componentMappings[id] = undefined;
 		this._componentActions[id] = undefined;

--- a/src/sql/workbench/test/electron-browser/modalComponents/componentBase.test.ts
+++ b/src/sql/workbench/test/electron-browser/modalComponents/componentBase.test.ts
@@ -60,7 +60,7 @@ suite('ComponentBase Tests', () => {
 	let modelStore: IModelStore;
 
 	setup(() => {
-		modelStore = new ModelStore();
+		modelStore = new ModelStore(new NullLogService());
 		testComponent = new TestComponent(modelStore, 'testComponent');
 		testComponent2 = new TestComponent(modelStore, 'testComponent2');
 		testContainer = new TestContainer(modelStore, 'testContainer');


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13476

Unfortunately this isn't fixing the root issue.

From my investigation what seems to be happening here is that the ML dialog is set up so that when it loads it "refreshes" the page it will remove all components and then add them back (based on current settings and such).

This is causing a race condition though - 

1. Root container for table is removed
1. This causes Angular to detect this and go through and start removing and destroying child components in the background
1. The table data is loaded and we set the table component data - this adds the components to the table which creates them in the ModelStore
1. The table component is re-added by the extension
1. Angular eventually gets down to removing the actual table component itself from the calls started in step 1, which then removes its children (the components added in the previous step)
1. Now we're left in an inconsistent state because the components aren't registered but we expect them to always be

Fixing this is going to be a pretty hefty amount of work though since we'd have to redo the entire lifecycle process of components to ensure that they're added and removed in the correct order and we wait for all previous actions to finish before starting the next one.

And so for the time being this fix seems to be enough to get us around the issue and given how the table is used here shouldn't be a problem - the click handlers still work as expected.

Note I also updated the table to use the new dataValues property since data is deprecated - this also gets us typing for the values which is handy. Had to add Component to list of supported values though which is supported so should have been there from the start. 

![image](https://user-images.githubusercontent.com/28519865/100038716-0ae65900-2db9-11eb-9623-54bbdaf92901.png)
