### PR TITLE
Fix error path for predict button on ML import

### DIFF
--- a/extensions/machine-learning/src/views/models/modelManagementController.ts
+++ b/extensions/machine-learning/src/views/models/modelManagementController.ts
@@ -85,7 +85,7 @@ export class ModelManagementController extends ControllerBase {
 
 		// Open view
 		//
-		await view.open();
+		view.open();
 		await view.refresh();
 		return view;
 	}
@@ -120,7 +120,7 @@ export class ModelManagementController extends ControllerBase {
 			await view.refresh();
 			return view;
 		} else {
-			this._apiWrapper.showErrorMessage(constants.onnxNotSupportedError);
+			apiWrapper.showErrorMessage(constants.onnxNotSupportedError);
 			return undefined;
 		}
 	}


### PR DESCRIPTION
Noticed this while fixing the table - clicking the button on an unsupported server was doing nothing and displaying this error in the console 

`[15636:1124/144543.693:INFO:CONSOLE(44)] "TypeError: Cannot read property '_apiWrapper' of undefined`

The reason here is that all these functions are being called through executeAction https://github.com/microsoft/azuredatastudio/blob/main/extensions%2Fmachine-learning%2Fsrc%2Fviews%2FcontrollerBase.ts#L25, but that is causing it to lose the this context.

TBH what I think a better pattern to use here is to wrap the function call in a lambda instead : 

`await this.executeAction(view, PredictWizardEventName, args, () => this.predictModel(models, undefined, this, this._apiWrapper, this._root));`

which doesn't have this problem so is a lot safer and easier to understand (and would also allow the removal of most of the parameters which are just class members)

But anyways this fixes the issue so not going to go in and refactor - just something to think about in the future. 

Also removed a useless await - open doesn't return a Promise. 