### PR TITLE
scoped refresh commands

### DIFF
--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -141,7 +141,12 @@
         "icon": "$(refresh)"
       },
       {
-        "command": "azure.resource.refresh",
+        "command": "azure.resource.azureview.refresh",
+        "title": "%azure.resource.refresh.title%",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "azure.resource.connectiondialog.refresh",
         "title": "%azure.resource.refresh.title%",
         "icon": "$(refresh)"
       },
@@ -209,7 +214,11 @@
           "when": "false"
         },
         {
-          "command": "azure.resource.refresh",
+          "command": "azure.resource.azureview.refresh",
+          "when": "false"
+        },
+        {
+          "command": "azure.resource.connectiondialog.refresh",
           "when": "false"
         },
         {
@@ -245,12 +254,12 @@
           "group": "azurecore"
         },
         {
-          "command": "azure.resource.refresh",
+          "command": "azure.resource.azureview.refresh",
           "when": "viewItem =~ /^azure\\.resource\\.itemType\\.(?:account|subscription|databaseContainer|databaseServerContainer)$/",
           "group": "inline"
         },
         {
-          "command": "azure.resource.refresh",
+          "command": "azure.resource.azureview.refresh",
           "when": "viewItem =~ /^azure\\.resource\\.itemType\\.(?:account|subscription|databaseContainer|databaseServerContainer)$/",
           "group": "azurecore"
         },
@@ -287,7 +296,7 @@
           "group": "navigation"
         },
         {
-          "command": "azure.resource.refresh",
+          "command": "azure.resource.connectiondialog.refresh",
           "when": "contextValue == azure.resource.itemType.account",
           "group": "navigation"
         },

--- a/extensions/azurecore/src/azureResource/commands.ts
+++ b/extensions/azurecore/src/azureResource/commands.ts
@@ -21,7 +21,8 @@ import { AzureAccount, Tenant } from '../account-provider/interfaces';
 import { FlatAccountTreeNode } from './tree/flatAccountTreeNode';
 import { ConnectionDialogTreeProvider } from './tree/connectionDialogTreeProvider';
 
-export function registerAzureResourceCommands(appContext: AppContext, trees: (AzureResourceTreeProvider | ConnectionDialogTreeProvider)[]): void {
+export function registerAzureResourceCommands(appContext: AppContext, azureViewTree: AzureResourceTreeProvider, connectionDialogTree: ConnectionDialogTreeProvider): void {
+	const trees = [azureViewTree, connectionDialogTree];
 	vscode.commands.registerCommand('azure.resource.startterminal', async (node?: TreeNode) => {
 		try {
 			const enablePreviewFeatures = vscode.workspace.getConfiguration('workbench').get('enablePreviewFeatures');
@@ -168,10 +169,12 @@ export function registerAzureResourceCommands(appContext: AppContext, trees: (Az
 		}
 	});
 
-	vscode.commands.registerCommand('azure.resource.refresh', async (node?: TreeNode) => {
-		for (const tree of trees) {
-			await tree.refresh(node, true);
-		}
+	vscode.commands.registerCommand('azure.resource.azureview.refresh', async (node?: TreeNode) => {
+		await azureViewTree.refresh(node, true);
+	});
+
+	vscode.commands.registerCommand('azure.resource.connectiondialog.refresh', async (node?: TreeNode) => {
+		await connectionDialogTree.refresh(node, true);
 	});
 
 	vscode.commands.registerCommand('azure.resource.signin', async (node?: TreeNode) => {

--- a/extensions/azurecore/src/extension.ts
+++ b/extensions/azurecore/src/extension.ts
@@ -89,7 +89,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<azurec
 	pushDisposable(vscode.window.registerTreeDataProvider('connectionDialog/azureResourceExplorer', connectionDialogTree));
 	pushDisposable(vscode.window.registerTreeDataProvider('azureResourceExplorer', azureResourceTree));
 	pushDisposable(vscode.workspace.onDidChangeConfiguration(e => onDidChangeConfiguration(e), this));
-	registerAzureResourceCommands(appContext, [azureResourceTree, connectionDialogTree]);
+	registerAzureResourceCommands(appContext, azureResourceTree, connectionDialogTree);
 	azdata.dataprotocol.registerDataGridProvider(new AzureDataGridProvider(appContext));
 	vscode.commands.registerCommand('azure.dataGrid.openInAzurePortal', async (item: azdata.DataGridItem) => {
 		const portalEndpoint = item.portalEndpoint;


### PR DESCRIPTION
the refresh command doesn't really meant to refresh both trees especially the node context menus. there is no real impact here since the tree component is doing no-op if the passed in node is not found, but we should fix it so that only the right tree gets the refresh request.