### PR TITLE
Fix WYSIWYG text + image paste

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -101,10 +101,11 @@ export class HTMLMarkdownConverter {
 				const notebookFolder = this.notebookUri ? path.join(path.dirname(this.notebookUri.fsPath), path.sep) : '';
 				let relativePath = findPathRelativeToContent(notebookFolder, notebookLink);
 				node.innerText = escapeAngleBrackets(node.innerText);
+				content = escapeAngleBrackets(content);
 				if (relativePath) {
 					return `[${node.innerText}](${relativePath})`;
 				}
-				return `[${node.innerText}](${node.href})`;
+				return `[${content}](${node.href})`;
 			}
 		});
 		this.turndownService.addRule('listItem', {
@@ -137,14 +138,22 @@ export class HTMLMarkdownConverter {
 		this.turndownService.addRule('p', {
 			filter: 'p',
 			replacement: function (content, node) {
+				let isAnchorElement: boolean = false;
 				node.childNodes.forEach(c => {
 					if (c.nodeType === Node.TEXT_NODE) {
 						c.nodeValue = escapeAngleBrackets(c.textContent);
 					} else if (c.nodeType === Node.ELEMENT_NODE) {
 						c.innerText = escapeAngleBrackets(c.textContent);
+						if (c.nodeName === 'A') {
+							isAnchorElement = true;
+						}
 					}
 				});
-				return '\n\n' + node.innerHTML.replace(/&lt;/gi, '<').replace(/&gt;/gi, '>').replace(/&nbsp;/gi, '') + '\n\n';
+				if (isAnchorElement) {
+					return content;
+				} else {
+					return '\n\n' + node.innerHTML.replace(/&lt;/gi, '<').replace(/&gt;/gi, '>').replace(/&nbsp;/gi, '') + '\n\n';
+				}
 			}
 		});
 		this.turndownService.addRule('heading', {

--- a/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
@@ -137,6 +137,8 @@ suite('HTML Markdown Converter', function (): void {
 		assert.equal(htmlMarkdownConverter.convert(htmlString), '[msft](https://www.microsoft.com/images/msft.png)', 'Basic https link test failed');
 		htmlString = '<a href="http://www.microsoft.com/images/msft.png">msft</a>';
 		assert.equal(htmlMarkdownConverter.convert(htmlString), '[msft](http://www.microsoft.com/images/msft.png)', 'Basic http link test failed');
+		htmlString = 'Test <a href="http://www.microsoft.com/images/msft.png">msft</a>';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), 'Test [msft](http://www.microsoft.com/images/msft.png)', 'Basic http link + text test failed');
 	});
 
 	test('Should transform <li> tags', () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #13454.

It fixes when a user copied both Text and images, and we now convert the image link properly (similar to how we did it in the October release of ADS). 