### PR TITLE
Add Import UI to Data-workspace Ellipsis

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -152,6 +152,13 @@
       }
     ],
     "menus": {
+      "view/title": [
+        {
+          "command": "sqlDatabaseProjects.createProjectFromDatabase",
+          "when": "view == dataworkspace.views.main",
+          "group": "secondary"
+        }
+      ],
       "commandPalette": [
         {
           "command": "sqlDatabaseProjects.newScript",


### PR DESCRIPTION
With this PR, "Create Project From Database" can be called from within data-workspace extension from the ellipsis (...).

On clicking the 3dots, a new option is added for create project from database.
![image](https://user-images.githubusercontent.com/57200045/100175570-84e31480-2e83-11eb-880a-e51d52dc323c.png)

And this opens the import UI.
![image](https://user-images.githubusercontent.com/57200045/100175680-b956d080-2e83-11eb-9d67-5e1189a2865c.png)
