### PR TITLE
sqlAsmt: restore focus after grid append command

### DIFF
--- a/extensions/sql-assessment/src/assessmentResultGrid.ts
+++ b/extensions/sql-assessment/src/assessmentResultGrid.ts
@@ -161,7 +161,6 @@ export class AssessmentResultGrid implements vscode.Disposable {
 			this.dataItems.push(...filteredValues);
 		}
 		this.table.appendData(filteredValues.map(item => this.convertToDataView(item)));
-		this.table.focus();
 	}
 
 	private async showDetails(rowNumber: number) {

--- a/extensions/sql-assessment/src/assessmentResultGrid.ts
+++ b/extensions/sql-assessment/src/assessmentResultGrid.ts
@@ -161,6 +161,7 @@ export class AssessmentResultGrid implements vscode.Disposable {
 			this.dataItems.push(...filteredValues);
 		}
 		this.table.appendData(filteredValues.map(item => this.convertToDataView(item)));
+		this.table.focus();
 	}
 
 	private async showDetails(rowNumber: number) {

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -533,14 +533,18 @@ export default class TableComponent extends ComponentBase<azdata.TableComponentP
 
 	private appendData(data: any[][]) {
 		const tableHasFocus = isAncestor(document.activeElement, <HTMLElement>this._inputContainer.nativeElement);
-		const wasFocused = tableHasFocus && this._table.grid.getDataLength() > 0 && this._table.grid.getActiveCell();
+		const currentActiveCell = this._table.grid.getActiveCell();
+		const wasFocused = tableHasFocus && this._table.grid.getDataLength() > 0 && currentActiveCell;
 
 		this._tableData.push(this.transformData(data, this.columns));
 		this.data = this._tableData.getItems().map(dataObject => Object.values(dataObject));
 		this.layoutTable();
 
 		if (wasFocused) {
-			this.focus();
+			if (!this._table.grid.getActiveCell()) {
+				this._table.grid.setActiveCell(currentActiveCell.row, currentActiveCell.cell);
+			}
+			this._table.grid.getActiveCellNode().focus();
 		}
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/table.component.ts
+++ b/src/sql/workbench/browser/modelComponents/table.component.ts
@@ -17,7 +17,7 @@ import { Table } from 'sql/base/browser/ui/table/table';
 import { TableDataView } from 'sql/base/browser/ui/table/tableDataView';
 import { attachTableStyler, attachButtonStyler } from 'sql/platform/theme/common/styler';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
-import { getContentHeight, getContentWidth, Dimension } from 'vs/base/browser/dom';
+import { getContentHeight, getContentWidth, Dimension, isAncestor } from 'vs/base/browser/dom';
 import { RowSelectionModel } from 'sql/base/browser/ui/table/plugins/rowSelectionModel.plugin';
 import { CheckboxSelectColumn, ICheckboxCellActionEventArgs } from 'sql/base/browser/ui/table/plugins/checkboxSelectColumn.plugin';
 import { Emitter, Event as vsEvent } from 'vs/base/common/event';
@@ -530,10 +530,18 @@ export default class TableComponent extends ComponentBase<azdata.TableComponentP
 				this.appendData(args[0]);
 		}
 	}
+
 	private appendData(data: any[][]) {
+		const tableHasFocus = isAncestor(document.activeElement, <HTMLElement>this._inputContainer.nativeElement);
+		const wasFocused = tableHasFocus && this._table.grid.getDataLength() > 0 && this._table.grid.getActiveCell();
+
 		this._tableData.push(this.transformData(data, this.columns));
 		this.data = this._tableData.getItems().map(dataObject => Object.values(dataObject));
 		this.layoutTable();
+
+		if (wasFocused) {
+			this.focus();
+		}
 	}
 }
 


### PR DESCRIPTION
The focus gets lost each time new data gets appended to the table. This became an issue if a user is using keyboard for navigation through grid rows.
The fix is to restore this focus so a user can keep navigating by grid rows with keyboard keyup/keydown buttons.
