### PR TITLE
Server Reports extension: fix for start and stop xevent sessions

### DIFF
--- a/samples/serverReports/package.json
+++ b/samples/serverReports/package.json
@@ -48,7 +48,7 @@
       },
       {
         "command": "tempdb.pauseEvent",
-        "title": "Pause",
+        "title": "Toggle Auto Refresh",
         "icon": {
           "light": "./out/src/media/insights.svg",
           "dark": "./out/src/media/insights_inverse.svg"
@@ -387,7 +387,8 @@
   "dependencies": {
     "fs-extra": "^8.1.0",
     "handlebars": "^4.5.3",
-    "openurl": "^1.1.1"
+    "openurl": "^1.1.1",
+    "vscode-nls": "^5.0.0"
   },
   "devDependencies": {
     "azdata": "^1.0.0",

--- a/samples/serverReports/src/constants.ts
+++ b/samples/serverReports/src/constants.ts
@@ -4,6 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
+import * as nls from 'vscode-nls';
+const localize = nls.loadMessageBundle();
+
+// TempDB Messages
+export const XEventsFailed = localize('XEventsFailed', 'XEvents operation failed.');
+export const XEventsStarted = localize('XEventsStarted', 'XEvents sessions started for PageContention and ObjectContention.');
+export const XEventsNotSupported = localize('XEventsNotSupported', 'XEvents sessions not supported.');
+export const XEventsStopped = localize('XEventsStopped', 'XEvents sessions PageContention and ObjectContention removed.');
 // CONFIG VALUES ///////////////////////////////////////////////////////////
 export const extensionConfigSectionName = 'server-reports';
 export const configLogDebugInfo = 'logDebugInfo';

--- a/samples/serverReports/src/controllers/mainController.ts
+++ b/samples/serverReports/src/controllers/mainController.ts
@@ -11,7 +11,6 @@ import ControllerBase from './controllerBase';
 import { promises } from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as openurl from 'openurl';
 
 
 /**
@@ -38,7 +37,7 @@ export default class MainController extends ControllerBase {
 	}
 
 	private openurl(link: string): void {
-		openurl.open(link);
+		vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(link));
 	}
 
 	private async onExecute(connection: azdata.IConnectionProfile, fileName: string): Promise<void> {

--- a/samples/serverReports/src/sql/startEvent.sql
+++ b/samples/serverReports/src/sql/startEvent.sql
@@ -1,6 +1,4 @@
 --Starts the XEvents sessions and creates the functions needed to find object id and give name to the page types
-use tempdb
-
 BEGIN TRY
 IF NOT EXISTS (SELECT * FROM sys.dm_xe_sessions  WHERE name = 'PageContention')
     BEGIN
@@ -8,7 +6,7 @@ IF NOT EXISTS (SELECT * FROM sys.dm_xe_sessions  WHERE name = 'PageContention')
         ADD EVENT latch_suspend_end(
             WHERE class = 28
             AND (page_type_id = 8
-            OR page_type_id = 9 
+            OR page_type_id = 9
             OR page_type_id = 11))
         ADD TARGET package0.histogram(SET slots=16, filtering_event_name=N'latch_suspend_end', source=N'page_type_id', source_type=(0))
         ALTER EVENT SESSION [PageContention] ON SERVER
@@ -24,9 +22,11 @@ IF NOT EXISTS (SELECT * FROM sys.dm_xe_sessions  WHERE name = 'ObjectContention'
         ALTER EVENT SESSION [ObjectContention] ON SERVER
         STATE =  START
     END
+SELECT 0 AS RESULTCODE, 'XEvent sessions started for PageContention and ObjectContention' AS RESULTMSG
 END TRY
 BEGIN CATCH
     PRINT 'XEvent fields not supported'
+    SELECT 1 AS RESULTCODE, 'XEvent sessions not supported' AS RESULTMSG
 END CATCH
 GO
 
@@ -38,7 +38,7 @@ CREATE FUNCTION [dbo].[isSystemTable] (@alloc bigint)
 RETURNS bigint
 
 AS BEGIN
-    
+
     DECLARE @index BIGINT;
     DECLARE @objId BIGINT;
 
@@ -47,7 +47,7 @@ AS BEGIN
             CONVERT (FLOAT, @alloc)
                 * (1 / POWER (2.0, 48))
         );
-    SELECT @objId = 
+    SELECT @objId =
         CONVERT (BIGINT,
             CONVERT (FLOAT, @alloc - (@index * CONVERT (BIGINT, POWER (2.0, 48))))
                 * (1 / POWER (2.0, 16))
@@ -55,9 +55,9 @@ AS BEGIN
 
     IF (@objId > 0 AND @objId <= 100 AND @index <= 255)
         return @objId
-    
+
     return 0
-    
+
     END
 GO
 
@@ -74,7 +74,7 @@ AS BEGIN
     ELSE IF @pageTypeId = 9
         return 'SGAM_PAGE'
     ELSE IF @pageTypeId = 11
-        return 'PFS_PAGE'    
+        return 'PFS_PAGE'
     return ''
     END
 GO

--- a/samples/serverReports/src/sql/startEvent.sql
+++ b/samples/serverReports/src/sql/startEvent.sql
@@ -22,11 +22,11 @@ IF NOT EXISTS (SELECT * FROM sys.dm_xe_sessions  WHERE name = 'ObjectContention'
         ALTER EVENT SESSION [ObjectContention] ON SERVER
         STATE =  START
     END
-SELECT 0 AS RESULTCODE, 'XEvent sessions started for PageContention and ObjectContention' AS RESULTMSG
+SELECT 0 AS RESULTCODE
 END TRY
 BEGIN CATCH
     PRINT 'XEvent fields not supported'
-    SELECT 1 AS RESULTCODE, 'XEvent sessions not supported' AS RESULTMSG
+    SELECT 1 AS RESULTCODE
 END CATCH
 GO
 

--- a/samples/serverReports/src/sql/stopEvent.sql
+++ b/samples/serverReports/src/sql/stopEvent.sql
@@ -1,4 +1,4 @@
 --Stops the XEvent Sessions
 DROP EVENT SESSION [PageContention] ON SERVER
 DROP EVENT SESSION [ObjectContention] ON SERVER
-SELECT 0 AS RESULTCODE, 'XEvent sessions PageContention and ObjectContention removed' AS RESULTMSG
+SELECT 0 AS RESULTCODE

--- a/samples/serverReports/src/sql/stopEvent.sql
+++ b/samples/serverReports/src/sql/stopEvent.sql
@@ -1,3 +1,4 @@
 --Stops the XEvent Sessions
 DROP EVENT SESSION [PageContention] ON SERVER
 DROP EVENT SESSION [ObjectContention] ON SERVER
+SELECT 0 AS RESULTCODE, 'XEvent sessions PageContention and ObjectContention removed' AS RESULTMSG

--- a/samples/serverReports/yarn.lock
+++ b/samples/serverReports/yarn.lock
@@ -3973,6 +3973,11 @@ vsce@1.36.2:
     yauzl "^2.3.1"
     yazl "^2.2.2"
 
+vscode-nls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
+  integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
+
 vscode-test@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/vscode-test/-/vscode-test-0.1.5.tgz#250534f90e78d37a84419a00f9bd15341e1a4f8f"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Before: "Server Reports" extension v0.2.2, TempDB tab is unable to start/stop XEvent sessions.  Task triggers query files to open into file windows instead of query windows, leading to some odd behaviors. (user is unable to close editor without closing application)


![serverreports-broken](https://user-images.githubusercontent.com/12227241/100527353-a8110b00-3186-11eb-95c1-be6956c21edc.gif)


After: TempDB tab start/stop XEvent sessions tasks are run in the background with a queryprovider.
![serverreports-background](https://user-images.githubusercontent.com/12227241/100527424-3c7b6d80-3187-11eb-9c3e-fbf75fbd4ca4.gif)

![image](https://user-images.githubusercontent.com/12227241/100527648-f32c1d80-3188-11eb-8436-6b648f4970b6.png)


Changes:
- queries startEvent.sql and stopEvent.sql return a query result indicating success/error from try/catch
- tempdb tab tasks utilize a query provider to execute the queries instead of requiring further user interaction
- contention help link utilizes vscode.open instead of 'openurl' module to provide user with open/copy/cancel dialog
