### PR TITLE
Adding additional parameter to data workspace provider API (#13570)

### DIFF
--- a/extensions/data-workspace/src/dataworkspace.d.ts
+++ b/extensions/data-workspace/src/dataworkspace.d.ts
@@ -55,8 +55,9 @@ declare module 'dataworkspace' {
 		 *
 		 * @param name Create a project
 		 * @param location the parent directory of the project
+		 * @param projectTypeId the identifier of the selected project type
 		 */
-		createProject(name: string, location: vscode.Uri): Promise<vscode.Uri>;
+		createProject(name: string, location: vscode.Uri, projectTypeId: string): Promise<vscode.Uri>;
 
 		/**
 		 * Gets the supported project types

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -174,7 +174,7 @@ export class WorkspaceService implements IWorkspaceService {
 	async createProject(name: string, location: vscode.Uri, projectTypeId: string): Promise<vscode.Uri> {
 		const provider = ProjectProviderRegistry.getProviderByProjectType(projectTypeId);
 		if (provider) {
-			const projectFile = await provider.createProject(name, location);
+			const projectFile = await provider.createProject(name, location, projectTypeId);
 			this.addProjectsToWorkspace([projectFile]);
 			this._onDidWorkspaceProjectsChange.fire();
 			return projectFile;

--- a/extensions/data-workspace/src/test/projectProviderRegistry.test.ts
+++ b/extensions/data-workspace/src/test/projectProviderRegistry.test.ts
@@ -29,7 +29,7 @@ export function createProjectProvider(projectTypes: IProjectType[]): IProjectPro
 		getProjectTreeDataProvider: (projectFile: vscode.Uri): Promise<vscode.TreeDataProvider<any>> => {
 			return Promise.resolve(treeDataProvider);
 		},
-		createProject: (name: string, location: vscode.Uri): Promise<vscode.Uri> => {
+		createProject: (name: string, location: vscode.Uri, projectTypeId: string): Promise<vscode.Uri> => {
 			return Promise.resolve(location);
 		}
 	};

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -58,7 +58,7 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	 * @param location the parent directory
 	 * @returns Uri of the newly created project file
 	 */
-	async createProject(name: string, location: vscode.Uri): Promise<vscode.Uri> {
+	async createProject(name: string, location: vscode.Uri, _: string): Promise<vscode.Uri> {
 		const projectFile = await this.projectController.createNewProject(name, location, true);
 		return vscode.Uri.file(projectFile);
 	}


### PR DESCRIPTION
Business justification port request: https://github.com/microsoft/azuredatastudio/issues/13575
Tech lead port request: https://github.com/microsoft/azuredatastudio/issues/13573

This change adds a missing parameter to the contract between the new Data Workspaces extension and implementing project extensions that specifies which template was selected in the New Project dialog, which is important if the extension registers multiple templates (as in the case for Database Projects).