### PR TITLE
Update tools service to .61

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.59",
+	"version": "3.0.0-release.61",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",


### PR DESCRIPTION
Main change since last Tools Service version:
* Updating DacFx dependency to take a couple bug fixes, namely for a bug that prevents applying a schema compare result to a database, if that result includes Edge/Streaming objects. (Fixes https://github.com/microsoft/azuredatastudio/issues/13246)