### PR TITLE
Add test for dynamic enablement

### DIFF
--- a/extensions/resource-deployment/src/test/stubs.ts
+++ b/extensions/resource-deployment/src/test/stubs.ts
@@ -3,8 +3,11 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as azdata from 'azdata';
+import * as vscode from 'vscode';
 import * as events from 'events';
 import * as cp from 'promisify-child-process';
+import * as TypeMoq from 'typemoq';
 import { Readable } from 'stream';
 
 export class TestChildProcessPromise<T> implements cp.ChildProcessPromise {
@@ -102,4 +105,118 @@ export class TestChildProcessPromise<T> implements cp.ChildProcessPromise {
 	listenerCount(type: string | symbol): number {
 		throw new Error('Method not implemented.');
 	}
+}
+
+export type MockComponentAndComponentBuilder<C, B> = {
+	component: C,
+	builder: TypeMoq.IMock<B>
+};
+
+export function createModelViewMock(): {
+	modelBuilder: TypeMoq.IMock<azdata.ModelBuilder>,
+	modelView: TypeMoq.IMock<azdata.ModelView>
+} {
+	const mockModelView = TypeMoq.Mock.ofType<azdata.ModelView>();
+	const mockModelBuilder = TypeMoq.Mock.ofType<azdata.ModelBuilder>();
+	const mockTextBuilder = createMockComponentBuilder<azdata.TextComponent>();
+	const mockGroupContainerBuilder = createMockContainerBuilder<azdata.GroupContainer>();
+	const mockFormContainerBuilder = createMockFormContainerBuilder();
+	mockModelBuilder.setup(b => b.text()).returns(() => mockTextBuilder.builder.object);
+	mockModelBuilder.setup(b => b.groupContainer()).returns(() => mockGroupContainerBuilder.builder.object);
+	mockModelBuilder.setup(b => b.formContainer()).returns(() => mockFormContainerBuilder.object);
+	mockModelView.setup(mv => mv.modelBuilder).returns(() => mockModelBuilder.object);
+	return {
+		modelBuilder: mockModelBuilder,
+		modelView: mockModelView
+	};
+}
+
+export function createMockComponentBuilder<C extends azdata.Component, B extends azdata.ComponentBuilder<C, any> = azdata.ComponentBuilder<C, any>>(component?: C): MockComponentAndComponentBuilder<C, B> {
+	const mockComponentBuilder = TypeMoq.Mock.ofType<B>();
+	// Create a mocked dynamic component if we don't have a stub instance to use.
+	// Note that we don't use ofInstance here for the component because there's some limitations around properties that I was
+	// hitting preventing me from easily using TypeMoq. Passing in the stub instance lets users control the object being stubbed - which means
+	// they can use things like sinon to then override specific functions if desired.
+	if (!component) {
+		const mockComponent = TypeMoq.Mock.ofType<C>();
+		// Need to setup then for when a dynamic mocked object is resolved otherwise the test will hang : https://github.com/florinn/typemoq/issues/66
+		mockComponent.setup((x: any) => x.then).returns(() => undefined);
+		component = mockComponent.object;
+	}
+	// For now just have these be passthrough - can hook up additional functionality later if needed
+	mockComponentBuilder.setup(b => b.withProperties(TypeMoq.It.isAny())).returns(() => mockComponentBuilder.object);
+	mockComponentBuilder.setup(b => b.withValidation(TypeMoq.It.isAny())).returns(() => mockComponentBuilder.object);
+	mockComponentBuilder.setup(b => b.component()).returns(() => component! /*mockComponent.object*/);
+	return {
+		component: component!,
+		builder: mockComponentBuilder
+	};
+}
+
+export function createMockContainerBuilder<C extends azdata.Container<any, any>, B extends azdata.ContainerBuilder<C, any, any, any> = azdata.ContainerBuilder<C, any, any, any>>(): MockComponentAndComponentBuilder<C, B> {
+	const mockContainerBuilder = createMockComponentBuilder<C, B>();
+	// For now just have these be passthrough - can hook up additional functionality later if needed
+	mockContainerBuilder.builder.setup(b => b.withItems(TypeMoq.It.isAny(), undefined)).returns(() => mockContainerBuilder.builder.object);
+	mockContainerBuilder.builder.setup(b => b.withLayout(TypeMoq.It.isAny())).returns(() => mockContainerBuilder.builder.object);
+	return mockContainerBuilder;
+}
+
+export function createMockFormContainerBuilder(): TypeMoq.IMock<azdata.FormBuilder> {
+	const mockContainerBuilder = createMockContainerBuilder<azdata.FormContainer, azdata.FormBuilder>();
+	mockContainerBuilder.builder.setup(b => b.withFormItems(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => mockContainerBuilder.builder.object);
+	return mockContainerBuilder.builder;
+}
+
+export class StubInputBox implements azdata.InputBoxComponent {
+	readonly id = 'input-box';
+	public enabled: boolean = false;
+
+	onTextChanged: vscode.Event<any> = undefined!;
+	onEnterKeyPressed: vscode.Event<string> = undefined!;
+
+	updateProperties(properties: { [key: string]: any }): Thenable<void> { throw new Error('Not implemented'); }
+
+	updateProperty(key: string, value: any): Thenable<void> { throw new Error('Not implemented'); }
+
+	updateCssStyles(cssStyles: { [key: string]: string }): Thenable<void> { throw new Error('Not implemented'); }
+
+	readonly onValidityChanged: vscode.Event<boolean> = undefined!;
+
+	readonly valid: boolean = true;
+
+	validate(): Thenable<boolean> { throw new Error('Not implemented'); }
+
+	focus(): Thenable<void> { return Promise.resolve(); }
+}
+
+export class StubCheckbox implements azdata.CheckBoxComponent {
+	private _onChanged = new vscode.EventEmitter<void>();
+	private _checked = false;
+
+	readonly id = 'stub-checkbox';
+	public enabled: boolean = false;
+
+	get checked(): boolean {
+		return this._checked;
+	}
+	set checked(value: boolean) {
+		this._checked = value;
+		this._onChanged.fire();
+	}
+
+	onChanged: vscode.Event<any> = this._onChanged.event;
+
+	updateProperties(properties: { [key: string]: any }): Thenable<void> { throw new Error('Not implemented'); }
+
+	updateProperty(key: string, value: any): Thenable<void> { throw new Error('Not implemented'); }
+
+	updateCssStyles(cssStyles: { [key: string]: string }): Thenable<void> { throw new Error('Not implemented'); }
+
+	readonly onValidityChanged: vscode.Event<boolean> = undefined!;
+
+	readonly valid: boolean = true;
+
+	validate(): Thenable<boolean> { throw new Error('Not implemented'); }
+
+	focus(): Thenable<void> { return Promise.resolve(); }
 }

--- a/extensions/resource-deployment/src/test/ui/validation/modelViewUtils.test.ts
+++ b/extensions/resource-deployment/src/test/ui/validation/modelViewUtils.test.ts
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from 'azdata';
+import 'mocha';
+import * as vscode from 'vscode';
+import * as TypeMoq from 'typemoq';
+import { initializeWizardPage, InputComponent, InputComponentInfo, Validator, WizardPageContext } from '../../../ui/modelViewUtils';
+import { FieldType } from '../../../interfaces';
+import { IToolsService } from '../../../services/toolsService';
+import { Deferred } from '../../utils';
+import { createMockComponentBuilder, createModelViewMock as createMockModelView, StubCheckbox, StubInputBox } from '../../stubs';
+import * as should from 'should';
+import * as sinon from 'sinon';
+
+
+describe('WizardPage', () => {
+	let mockModelBuilder: TypeMoq.IMock<azdata.ModelBuilder>;
+	let testWizardPage: WizardPageContext;
+	let contentRegistered: Deferred<void>;
+
+	before(function () {
+		contentRegistered = new Deferred<void>();
+		const mockWizardPage = TypeMoq.Mock.ofType<azdata.window.WizardPage>();
+		const mockModelView = createMockModelView();
+		mockModelBuilder = mockModelView.modelBuilder;
+		mockWizardPage.setup(p => p.registerContent(TypeMoq.It.isAny())).callback(async (handler: (view: azdata.ModelView) => Thenable<void>) => {
+			await handler(mockModelView.modelView.object);
+			contentRegistered.resolve();
+		});
+		const mockWizard = TypeMoq.Mock.ofType<azdata.window.Wizard>();
+		const mockToolsService = TypeMoq.Mock.ofType<IToolsService>();
+		testWizardPage = {
+			page: mockWizardPage.object,
+			container: mockWizard.object,
+			wizardInfo: {
+				title: 'TestWizard',
+				pages: [],
+				doneAction: {}
+			},
+			pageInfo: {
+				title: 'TestWizardPage',
+				sections: [
+					{
+						fields: [
+							{
+								label: 'Field1',
+								type: FieldType.Checkbox
+							},
+							{
+								label: 'Field2',
+								type: FieldType.Text,
+								enabled: {
+									target: 'Field1',
+									value: 'true'
+								}
+							}
+						]
+					}
+				]
+			},
+			inputComponents: {},
+			onNewDisposableCreated: (_disposable: vscode.Disposable): void => { },
+			onNewInputComponentCreated: (
+				name: string,
+				inputComponentInfo: InputComponentInfo<InputComponent>
+			): void => {
+				testWizardPage.inputComponents[name] = inputComponentInfo;
+			},
+			onNewValidatorCreated: (_validator: Validator): void => { },
+			toolsService: mockToolsService.object
+		};
+	});
+
+	it('dynamic enablement', async function (): Promise<void> {
+		const stubCheckbox = new StubCheckbox();
+		const mockCheckboxBuilder = createMockComponentBuilder<azdata.CheckBoxComponent>(stubCheckbox);
+		const stubInputBox = new StubInputBox();
+		// Stub out the enabled property so we can hook into when that's set to ensure we wait for the state to be updated
+		// before continuing the test
+		let enabled = false;
+		sinon.stub(stubInputBox, 'enabled').set(v => {
+			enabled = v;
+			enabledDeferred.resolve();
+		});
+		sinon.stub(stubInputBox, 'enabled').get(() => {
+			return enabled;
+		});
+		const mockInputBoxBuilder = createMockComponentBuilder<azdata.InputBoxComponent>(stubInputBox);
+		// Used to ensure that we wait until the enabled state is updated for our mocked components before continuing
+		let enabledDeferred = new Deferred();
+		mockModelBuilder.setup(b => b.checkBox()).returns(() => mockCheckboxBuilder.builder.object);
+		mockModelBuilder.setup(b => b.inputBox()).returns(() => mockInputBoxBuilder.builder.object);
+
+		initializeWizardPage(testWizardPage);
+		await contentRegistered.promise;
+		await enabledDeferred.promise;
+		console.log(stubInputBox.enabled);
+		should(stubInputBox.enabled).be.false('Input box should be disabled by default');
+		enabledDeferred = new Deferred();
+		stubCheckbox.checked = true;
+		// Now wait for the enabled state to be updated again
+		await enabledDeferred.promise;
+		should(stubInputBox.enabled).be.true('Input box should be enabled after target component value updated');
+	});
+});


### PR DESCRIPTION
Tried to use TypeMoq fully but ran into some issues with the dynamic mocks (mocks without a constructor/instance) and the property getters/setters. Sinon is a lot easier to use for this stuff so ended up doing a mixed approach where the boilerplate stuff for the builders and view were done with TypeMoq and then the actual components that the code interacts with had stub instances created as needed. 

I intend to use this stuff as a baseline for a common ModelView test framework that all extensions can use so general comments are appreciated. That'll be done in a follow up task once I get more feedback on the design and approach. 