### PR TITLE
Change server group look

### DIFF
--- a/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
@@ -40,8 +40,8 @@
 }
 
 .server-explorer-viewlet .server-group {
-	height: 38px;
-	line-height: 38px;
+	height: 23px;
+	line-height: 23px;
 	color: #ffffff;
 }
 
@@ -94,6 +94,16 @@
 	padding-top: 3px;
 	padding-bottom: 3px;
 	overflow: hidden;
+}
+
+/* OE server group */
+.monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group,
+.monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group > .server-group {
+	padding-left: 5px;
+}
+
+.monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group {
+	padding-right: 20px;
 }
 
 /* OE and connection label */
@@ -159,16 +169,6 @@
 .monaco-list .connection-tile .connection-status-badge.disconnected {
 	border: 0.12rem solid rgba(208, 46, 0, 100%);
 	background: rgba(255, 255, 255, 80%);
-}
-
-.monaco-tree .monaco-tree-rows.show-twisties > .monaco-tree-row.expanded.has-children > .content.server-group:before,
-.monaco-list .monaco-list-rows.show-twisties > .monaco-list-row.expanded.has-children > .content.server-group:before {
-	background: url('expanded-dark.svg') 50% 50% no-repeat;
-}
-
-.monaco-tree .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children > .content.server-group:before,
-.monaco-list .monaco-list-rows.show-twisties > .monaco-list-row.has-children > .content.server-group:before {
-	background: url('collapsed-dark.svg') 50% 50% no-repeat;
 }
 
 /* Add connection button */

--- a/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
@@ -100,12 +100,19 @@
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group,
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group > .server-group {
 	padding-left: 5px;
+	overflow: hidden;
 }
 
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group {
-	padding-right: 20px;
+	padding-right: 5px;
 	padding-top: 5px;
 }
+
+.monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group > .server-group > .name {
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
+
 
 /* OE and connection label */
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content > .connection-tile > .label,

--- a/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
@@ -105,7 +105,6 @@
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group {
 	padding-right: 20px;
 	padding-top: 5px;
-	padding-bottom: 5px;
 }
 
 /* OE and connection label */

--- a/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
@@ -105,6 +105,7 @@
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group {
 	padding-right: 20px;
 	padding-top: 2px;
+	padding-bottom: 2px;
 }
 
 /* OE and connection label */

--- a/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
@@ -100,7 +100,6 @@
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group,
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group > .server-group {
 	padding-left: 5px;
-	overflow: hidden;
 }
 
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group {

--- a/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
@@ -104,6 +104,7 @@
 
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group {
 	padding-right: 20px;
+	padding-top: 2px;
 }
 
 /* OE and connection label */

--- a/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
@@ -104,8 +104,8 @@
 
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content.server-group {
 	padding-right: 20px;
-	padding-top: 2px;
-	padding-bottom: 2px;
+	padding-top: 5px;
+	padding-bottom: 5px;
 }
 
 /* OE and connection label */

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
@@ -45,7 +45,7 @@ export interface IObjectExplorerTemplateData {
 export class ServerTreeRenderer implements IRenderer {
 
 	public static CONNECTION_HEIGHT = 23;
-	public static CONNECTION_GROUP_HEIGHT = 23;
+	public static CONNECTION_GROUP_HEIGHT = 33;
 	public static CONNECTION_TEMPLATE_ID = 'connectionProfile';
 	public static CONNECTION_GROUP_TEMPLATE_ID = 'connectionProfileGroup';
 	public static OBJECTEXPLORER_HEIGHT = 23;

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
@@ -45,7 +45,7 @@ export interface IObjectExplorerTemplateData {
 export class ServerTreeRenderer implements IRenderer {
 
 	public static CONNECTION_HEIGHT = 23;
-	public static CONNECTION_GROUP_HEIGHT = 38;
+	public static CONNECTION_GROUP_HEIGHT = 23;
 	public static CONNECTION_TEMPLATE_ID = 'connectionProfile';
 	public static CONNECTION_GROUP_TEMPLATE_ID = 'connectionProfileGroup';
 	public static OBJECTEXPLORER_HEIGHT = 23;
@@ -231,14 +231,17 @@ export class ServerTreeRenderer implements IRenderer {
 	}
 
 	private renderConnectionProfileGroup(connectionProfileGroup: ConnectionProfileGroup, templateData: IConnectionProfileGroupTemplateData): void {
-
+		// add expanded class to rowElement to show expanding arrow
 		let rowElement = this.findParentElement(templateData.root, 'monaco-tree-row');
-		if (rowElement) {
+		rowElement.classList.add('expanded');
+
+		let groupElement = this.findParentElement(templateData.root, 'server-group');
+		if (groupElement) {
 			if (connectionProfileGroup.color) {
-				rowElement.style.background = connectionProfileGroup.color;
+				groupElement.style.background = connectionProfileGroup.color;
 			} else {
 				// If the group doesn't contain specific color, assign the default color
-				rowElement.style.background = DefaultServerGroupColor;
+				groupElement.style.background = DefaultServerGroupColor;
 			}
 		}
 		if (connectionProfileGroup.description && (connectionProfileGroup.description !== '')) {

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeRenderer.ts
@@ -231,10 +231,6 @@ export class ServerTreeRenderer implements IRenderer {
 	}
 
 	private renderConnectionProfileGroup(connectionProfileGroup: ConnectionProfileGroup, templateData: IConnectionProfileGroupTemplateData): void {
-		// add expanded class to rowElement to show expanding arrow
-		let rowElement = this.findParentElement(templateData.root, 'monaco-tree-row');
-		rowElement.classList.add('expanded');
-
 		let groupElement = this.findParentElement(templateData.root, 'server-group');
 		if (groupElement) {
 			if (connectionProfileGroup.color) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/12959

Changes the new server group look based on the review. This is just for server group and fixing the accessibility issue. The changing of colors in the dialog will be done separately in another PR.

![Screen Shot 2020-12-01 at 3 40 07 PM](https://user-images.githubusercontent.com/6411451/100809940-30441a00-33ec-11eb-8a74-8cec412c714f.png)

Changes -
- [x] Decreased height of server group row to match the server rows
- [x] Truncate width from sides for server group to show highlight/selection
- [x] Remove custom collapse/expand icons for groups and use default ones like the server ones.

Follow up:
Do we want to show an expand arrow for empty groups? Current behavior doesn't show any expand arrow for an empty group, however vscode shows one for empty folders. 

![Screen Shot 2020-12-01 at 3 40 39 PM](https://user-images.githubusercontent.com/6411451/100811290-27087c80-33ef-11eb-9588-dec1227e6667.png)
