### PR TITLE
Added engine version argument to edit command. 

### DIFF
--- a/extensions/arc/src/test/mocks/fakeAzdataApi.ts
+++ b/extensions/arc/src/test/mocks/fakeAzdataApi.ts
@@ -49,6 +49,7 @@ export class FakeAzdataApi implements azdataExt.IAzdataApi {
 							replaceEngineSettings?: boolean,
 							workers?: number
 						},
+						_engineVersion?: string,
 						_additionalEnvVars?: { [key: string]: string }): Promise<azdataExt.AzdataOutput<void>> { throw new Error('Method not implemented.'); }
 				}
 			},

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -159,7 +159,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 								await this._azdataApi.azdata.arc.postgres.server.edit(
 									this._postgresModel.info.name,
 									this.saveArgs,
-									this._postgresModel.engineVersion!);
+									this._postgresModel.engineVersion);
 							} catch (err) {
 								// If an error occurs while editing the instance then re-enable the save button since
 								// the edit wasn't successfully applied

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -157,7 +157,9 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 						async (_progress, _token): Promise<void> => {
 							try {
 								await this._azdataApi.azdata.arc.postgres.server.edit(
-									this._postgresModel.info.name, this.saveArgs);
+									this._postgresModel.info.name,
+									this.saveArgs,
+									this._postgresModel.engineVersion!);
 							} catch (err) {
 								// If an error occurs while editing the instance then re-enable the save button since
 								// the edit wasn't successfully applied

--- a/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
@@ -157,6 +157,7 @@ export class PostgresOverviewPage extends DashboardPage {
 								adminPassword: true,
 								noWait: true
 							},
+							this._postgresModel.engineVersion,
 							{ 'AZDATA_PASSWORD': password });
 						vscode.window.showInformationMessage(loc.passwordReset);
 					}

--- a/extensions/azdata/src/api.ts
+++ b/extensions/azdata/src/api.ts
@@ -102,10 +102,11 @@ export function getAzdataApi(localAzdataDiscovered: Promise<IAzdataTool | undefi
 							replaceEngineSettings?: boolean;
 							workers?: number;
 						},
+						engineVersion?: string,
 						additionalEnvVars?: { [key: string]: string; }) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.postgres.server.edit(name, args, additionalEnvVars);
+						return azdataToolService.localAzdata.arc.postgres.server.edit(name, args, engineVersion, additionalEnvVars);
 					}
 				}
 			},

--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -118,6 +118,7 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 						replaceEngineSettings?: boolean,
 						workers?: number
 					},
+					engineVersion?: string,
 					additionalEnvVars?: { [key: string]: string }): Promise<azdataExt.AzdataOutput<void>> => {
 					const argsArray = ['arc', 'postgres', 'server', 'edit', '-n', name];
 					if (args.adminPassword) { argsArray.push('--admin-password'); }
@@ -131,6 +132,7 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 					if (args.port) { argsArray.push('--port', args.port.toString()); }
 					if (args.replaceEngineSettings) { argsArray.push('--replace-engine-settings'); }
 					if (args.workers) { argsArray.push('--workers', args.workers.toString()); }
+					if (engineVersion) { argsArray.push('--engine-version', engineVersion); }
 					return this.executeCommand<void>(argsArray, additionalEnvVars);
 				}
 			}

--- a/extensions/azdata/src/typings/azdata-ext.d.ts
+++ b/extensions/azdata/src/typings/azdata-ext.d.ts
@@ -262,6 +262,7 @@ declare module 'azdata-ext' {
 							replaceEngineSettings?: boolean,
 							workers?: number
 						},
+						engineVersion?: string,
 						additionalEnvVars?: { [key: string]: string }): Promise<AzdataOutput<void>>
 				}
 			},


### PR DESCRIPTION
This PR fixes #13609 

When pressing save, edit command takes engine version to add as an azdata argument. 