### PR TITLE
Fix notebook unordered grid values after papermill execution

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -61,7 +61,7 @@ export class GridOutputComponent extends AngularDisposable implements IMimeCompo
 
 	constructor(
 		@Inject(IInstantiationService) private instantiationService: IInstantiationService,
-		@Inject(IThemeService) private readonly themeService: IThemeService,
+		@Inject(IThemeService) private readonly themeService: IThemeService
 	) {
 		super();
 	}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -126,7 +126,7 @@ export class GridOutputComponent extends AngularDisposable implements IMimeCompo
 				columnNames.push(i.name);
 			}
 			// Checks to see if data source is ordered properly based on schema
-			if (source.schema.fields[0].name !== Object.keys(source.data[0])[0]) {
+			if (columnNames !== Object.keys(source.data[0])) {
 				// Order each row based on the schema
 				for (let row of source.data) {
 					let reorderedData = {};

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -120,16 +120,14 @@ export class GridOutputComponent extends AngularDisposable implements IMimeCompo
 		if (!this._table) {
 			let source = <IDataResource><any>this._bundleOptions.data[this.mimeType];
 			let columnNames: Array<string> = [];
-			let columnIndex = [];
 			let rowIndex = 0;
-			// Get schema list
+			// Get schema list of grid
 			for (let i of source.schema.fields) {
 				columnNames.push(i.name);
-				columnIndex.push(source.schema.fields.indexOf(i));
 			}
-			// Checks to see if data source is ordered properly based on schema'
-			// SQL notebooks does not use columnName as key (instead uses indices)
-			// so we need to add condition for SQL notebooks to not be reordered
+			// Check to see if data source is ordered properly based on schema
+			// SQL notebooks do not use columnName as key (instead uses indices)
+			// So we add a condition for SQL notebooks to not be reordered
 			if (source.data.length > 0) {
 				if (columnNames !== Object.keys(source.data[0]) && Object.keys(source.data[0])[0] !== '0') {
 					// Order each row based on the schema

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -160,18 +160,18 @@ function reorderGridData(source: IDataResource): void {
 			// SQL notebooks do not use columnName as key (instead use indices)
 			// Indicies indicate the row is ordered properly
 			// We must check the data to know if it is in index form
-			let isValidOrder = false;
+			let notIndexOrder = false;
 			for (let index = 0; index < rowKeys.length - 1; index++) {
 				// Index form (all numbers, start at 0 and increase by 1)
 				let value = Number(rowKeys[index]);
 				if (isNaN(value) || value !== index) {
 					// break if key is not a number or in index form
-					isValidOrder = true;
+					notIndexOrder = true;
 					break;
 				}
 			}
 			// Only reorder data that is not in index form
-			if (isValidOrder) {
+			if (notIndexOrder) {
 				source.data.forEach((row, index) => {
 					// Order each row based on the schema
 					let reorderedData = {};

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -119,6 +119,24 @@ export class GridOutputComponent extends AngularDisposable implements IMimeCompo
 		}
 		if (!this._table) {
 			let source = <IDataResource><any>this._bundleOptions.data[this.mimeType];
+			let columnNames: Array<string> = [];
+			let index = 0;
+			// Get schema list
+			for (let i of source.schema.fields) {
+				columnNames.push(i.name);
+			}
+			// Checks to see if data source is ordered properly based on schema
+			if (source.schema.fields[0].name !== Object.keys(source.data[0])[0]) {
+				// Order each row based on the schema
+				for (let row of source.data) {
+					let reorderedData = {};
+					for (let key of columnNames) {
+						reorderedData[key] = row[key];
+					}
+					index = source.data.indexOf(row);
+					source.data[index] = reorderedData;
+				}
+			}
 			let state = new GridTableState(0, 0);
 			this._table = this.instantiationService.createInstance(DataResourceTable, source, this.cellModel, this.cellOutput, state);
 			let outputElement = <HTMLElement>this.output.nativeElement;

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -160,18 +160,18 @@ function reorderGridData(source: IDataResource): void {
 			// SQL notebooks do not use columnName as key (instead use indices)
 			// Indicies indicate the row is ordered properly
 			// We must check the data to know if it is in index form
-			let notIndexOrder = false;
+			let notIndexOrderKeys = false;
 			for (let index = 0; index < rowKeys.length - 1; index++) {
 				// Index form (all numbers, start at 0 and increase by 1)
 				let value = Number(rowKeys[index]);
 				if (isNaN(value) || value !== index) {
 					// break if key is not a number or in index form
-					notIndexOrder = true;
+					notIndexOrderKeys = true;
 					break;
 				}
 			}
 			// Only reorder data that is not in index form
-			if (notIndexOrder) {
+			if (notIndexOrderKeys) {
 				source.data.forEach((row, index) => {
 					// Order each row based on the schema
 					let reorderedData = {};

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -120,23 +120,30 @@ export class GridOutputComponent extends AngularDisposable implements IMimeCompo
 		if (!this._table) {
 			let source = <IDataResource><any>this._bundleOptions.data[this.mimeType];
 			let columnNames: Array<string> = [];
-			let index = 0;
+			let columnIndex = [];
+			let rowIndex = 0;
 			// Get schema list
 			for (let i of source.schema.fields) {
 				columnNames.push(i.name);
+				columnIndex.push(source.schema.fields.indexOf(i));
 			}
-			// Checks to see if data source is ordered properly based on schema
-			if (columnNames !== Object.keys(source.data[0])) {
-				// Order each row based on the schema
-				for (let row of source.data) {
-					let reorderedData = {};
-					for (let key of columnNames) {
-						reorderedData[key] = row[key];
+			// Checks to see if data source is ordered properly based on schema'
+			// SQL notebooks does not use columnName as key (instead uses indices)
+			// so we need to add condition for SQL notebooks to not be reordered
+			if (source.data.length > 0) {
+				if (columnNames !== Object.keys(source.data[0]) && Object.keys(source.data[0])[0] !== '0') {
+					// Order each row based on the schema
+					for (let row of source.data) {
+						let reorderedData = {};
+						for (let key of columnNames) {
+							reorderedData[key] = row[key];
+						}
+						rowIndex = source.data.indexOf(row);
+						source.data[rowIndex] = reorderedData;
 					}
-					index = source.data.indexOf(row);
-					source.data[index] = reorderedData;
 				}
 			}
+
 			let state = new GridTableState(0, 0);
 			this._table = this.instantiationService.createInstance(DataResourceTable, source, this.cellModel, this.cellOutput, state);
 			let outputElement = <HTMLElement>this.output.nativeElement;

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -162,7 +162,7 @@ export class GridOutputComponent extends AngularDisposable implements IMimeCompo
 					let currentIndex = typeof Number(index);
 					let nextIndex = typeof Number(rowKeys[currentIndex + 1]);
 					if (currentIndex === 'number' && rowKeys[nextIndex] < (rowKeys.length - 1)) {
-						//check to see if next element is number (confirm table is already ordered)
+						// Check to see if next element is number (confirms table is already ordered)
 						if (!(nextIndex === 'number')) {
 							this._notificationService.error(localize('orderFailed', "Not able to have mix of numbers and string column names"));
 						}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -148,7 +148,6 @@ export class GridOutputComponent extends AngularDisposable implements IMimeCompo
 }
 
 function reorderGridData(source: IDataResource): void {
-	let rowIndex = 0;
 	// Get Column Names list from the data resource schema
 	const columnNames: string[] = source.schema.fields.map(field => field.name);
 	if (source.data.length > 0) {
@@ -163,29 +162,28 @@ function reorderGridData(source: IDataResource): void {
 			// We check the data to know if it is in index form or string form
 			for (let rowKey in rowKeys) {
 				// Check to see if first row keys are in index format (numbers)
-				let currentIndex = typeof Number(rowKeys[rowKey]);
-				let nextIndex = typeof Number(rowKeys[rowKey + 1]);
+				let currentIndex = Number(rowKeys[rowKey]);
+				let nextIndex = Number(rowKeys[rowKey]) + 1;
 				// We are only testing to make sure that the entire row is in index format
 				// We assume that index format data keys are in order based on the data resource schema
 				// Edge case: If the index format is out of order, then we would not have the ability to match
 				// random indexes with the column names list
-				if (currentIndex === 'number' && rowKeys[rowKey + 1] < (rowKeys.length - 1)) {
+				if (typeof currentIndex === 'number' && !Number.isNaN(currentIndex)) {
 					// Check to see if next element is number (confirms table is already ordered and in index format)
-					if (!(nextIndex === 'number')) {
+					if (!(typeof nextIndex === 'number' && nextIndex !== NaN)) {
 						// There should not be mix of numbers and strings as row keys
 						return;
 					}
 					// Only reorder data in form of strings (as index ordered tables are already ordered)
-				} else if (typeof (rowKey) === 'string') {
+				} else {
 					// Order each row based on the schema
-					for (let row of source.data) {
+					source.data.forEach((row, index) => {
 						let reorderedData = {};
 						for (let key of columnNames) {
 							reorderedData[key] = row[key];
 						}
-						rowIndex = source.data.indexOf(row);
-						source.data[rowIndex] = reorderedData;
-					}
+						source.data[index] = reorderedData;
+					});
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses issue: #13304

We will only change the grid data if we notice that the schema for the first row is not in order. If it is then we order each row based on the schema.

**Updated grid view after papermill execution (same column values 👍 )**:
![image](https://user-images.githubusercontent.com/23587151/100840524-a2901b00-343b-11eb-8b0f-674127909023.png)

