### PR TITLE
add right padding to notebook toolbar action item (#13640)

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.css
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.css
@@ -37,6 +37,9 @@
 	min-height: 21px;
 }
 
+.notebookEditor  .editor-toolbar .actions-container .action-item .notebook-button.masked-pseudo {
+	padding-right: 18px;
+}
 .notebookEditor .editor-toolbar .actions-container .action-item .notebook-button {
 	display: inline-block;
 	text-align: center;


### PR DESCRIPTION
* add right padding to action item

* remove extra line and add space

This PR fixes #13607
