### PR TITLE
Fix issue with pasting results in Teams

### DIFF
--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -157,15 +157,16 @@ export class CopyQueryWithResultsKeyboardAction extends Action {
 				let resultSummary = queryRunner.batchSets[0].resultSetSummaries[i];
 				let result = await queryRunner.getQueryRows(0, resultSummary.rowCount, resultSummary.batchId, resultSummary.id);
 				let tableHeaders = resultSummary.columnInfo.map((col, i) => (col.columnName));
-				let htmlTableHeaders = resultSummary.columnInfo.map((col, i) => (`<th style="border:solid black 1.0pt; whiteSpace:nowrap">${escape(col.columnName)}</th>`));
+				let htmlTableHeaders = resultSummary.columnInfo.map((col, i) => (`<td style="border:1.0px solid black;padding:3pt;font-size:9pt;font-weight: bold;">${escape(col.columnName)}</td>`));
 				let copyString = '\n';
-				let htmlCopyString = '<tr>';
+				let htmlCopyString = '';
 
 				for (let rowEntry of result.rows) {
+					htmlCopyString = htmlCopyString + '<tr>';
 					for (let colIdx = 0; colIdx < rowEntry.length; colIdx++) {
 						let value = rowEntry[colIdx].displayValue;
 						copyString = `${copyString}${value}\t`;
-						htmlCopyString = `${htmlCopyString}<td style="border:solid black 1.0pt;white-space:nowrap">${escape(value)}</td>`;
+						htmlCopyString = `${htmlCopyString}<td style="border:1.0px solid black;padding:3pt;font-size:9pt;">${escape(value)}</td>`;
 					}
 					// Removes the tab seperator from the end of a row
 					copyString = copyString.slice(0, -1 * '\t'.length) + '\n';

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -157,7 +157,7 @@ export class CopyQueryWithResultsKeyboardAction extends Action {
 				let resultSummary = queryRunner.batchSets[0].resultSetSummaries[i];
 				let result = await queryRunner.getQueryRows(0, resultSummary.rowCount, resultSummary.batchId, resultSummary.id);
 				let tableHeaders = resultSummary.columnInfo.map((col, i) => (col.columnName));
-				let htmlTableHeaders = resultSummary.columnInfo.map((col, i) => (`<td style="border:1.0px solid black;padding:3pt;font-size:9pt;font-weight: bold;">${escape(col.columnName)}</td>`));
+				let htmlTableHeaders = `<thead><tr style="background-color:DarkGray">${resultSummary.columnInfo.map((col, i) => (`<th style="border:1.0px solid black;padding:3pt;font-size:9pt;font-weight: bold;">${escape(col.columnName)}</th>`)).join('')}</tr></thead>`;
 				let copyString = '\n';
 				let htmlCopyString = '';
 
@@ -176,7 +176,7 @@ export class CopyQueryWithResultsKeyboardAction extends Action {
 				allResults = `${allResults}${tableHeaders.join('\t')}${copyString}\n`;
 				allHtmlResults = `${allHtmlResults}<div><br/><br/>
 				<table cellPadding="5" cellSpacing="1" style="border:1;border-color:Black;font-family:Segoe UI;font-size:12px;border-collapse:collapse">
-				<tr style="background-color:DarkGray">${htmlTableHeaders.join('')}</tr>${htmlCopyString}
+				${htmlTableHeaders}${htmlCopyString}
 				</table></div>`;
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
Fixes issue with pasting query and results in Teams as well as in ADS notebooks.

Teams issue: This was happening due to missing tr tag at the start of every row from 2nd row in the table.
![image](https://user-images.githubusercontent.com/11342435/101199016-2b17e280-3619-11eb-9556-56d296616015.png)

Notebooks issue: Pasting it in text cell wasnt actually showing the markdown string and if user clicks away from the cell, it disappears. This was weirdly happening because of th tags. In Kusto explorer, they use the td tags even for header and it works fine, so I am using the same.
![image](https://user-images.githubusercontent.com/11342435/101199324-8fd33d00-3619-11eb-9d45-f30bf9606d47.png)
