### PR TITLE
Prevent Table from Disappearing due to exception when looking for tHead

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/turndownPluginGfm.ts
+++ b/src/sql/workbench/contrib/notebook/browser/turndownPluginGfm.ts
@@ -99,12 +99,12 @@ rules['table'] = {
 		// Ensure there are no blank lines
 		content = content.replace('\n\n', '\n');
 		// if the headings are empty, add border line and headings to keep table format
-		if (node.tHead.innerText === '') {
+		if (node.tHead?.innerText === '') {
 			let emptyHeader = '\n\n|';
 			let border = '\n|';
 			for (let i = 0; i < node.rows[0].childNodes.length; i++) {
 				emptyHeader += '  |';
-				border += ' --- |'
+				border += ' --- |';
 			}
 			return emptyHeader + border + content + '\n\n';
 		}

--- a/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
@@ -208,6 +208,12 @@ suite('HTML Markdown Converter', function (): void {
 		htmlString = '<table>\n<thead>\n<tr>\n<th>Test</th>\n<th>Test</th>\n<th>Test</th>\n</tr>\n</thead>\n<tbody><tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n</tbody></table>\n';
 		assert.equal(htmlMarkdownConverter.convert(htmlString), `| Test | Test | Test |\n| --- | --- | --- |\n| test | test | test |\n| test | test | test |\n| test | test | test |\n| test | test | test |`, 'Table with header failed');
 	});
+
+	test('Should transform table with no thead', () => {
+		htmlString = '<table>\n<tr>\n<th>Test</th>\n<th>Test</th>\n<th>Test</th>\n</tr>\n<tbody><tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n<tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n</tbody></table>\n';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `| Test | Test | Test |\n| --- | --- | --- |\n| test | test | test |\n| test | test | test |\n| test | test | test |\n| test | test | test |`, 'Table with no thead failed');
+	});
+
 	test('Should transform <b> and <strong> tags', () => {
 		htmlString = '<b>test string</b>';
 		assert.equal(htmlMarkdownConverter.convert(htmlString), '**test string**', 'Basic bold test failed');


### PR DESCRIPTION
Addresses #13681 

Prevent exception when tHead doesn't exist at the table node. That's a specific error case, so being more defensive.