### PR TITLE
Notebooks: Improve Jupyter server start up time by making configure Jupyter steps synchronous

### DIFF
--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -143,11 +143,11 @@ export class PerFolderServerInstance implements IServerInstance {
 	}
 
 	private async configureJupyter(): Promise<void> {
-		await this.createInstanceFolders();
+		this.createInstanceFolders();
 		let resourcesFolder = path.join(this.options.install.extensionPath, 'resources', constants.jupyterConfigRootFolder);
-		await this.copyInstanceConfig(resourcesFolder);
-		await this.CopyCustomJs(resourcesFolder);
-		await this.copyKernelsToSystemJupyterDirs();
+		this.copyInstanceConfig(resourcesFolder);
+		this.CopyCustomJs(resourcesFolder);
+		this.copyKernelsToSystemJupyterDirs();
 	}
 
 	private async createInstanceFolders(): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Previously, the configureServer() step would sometimes take up to 3s on Windows even though it was just copying a couple of files over to a new folder. Removing await from the method calls has brought the time down to 1ms consistently for Mac and Windows. 

All the tests in serverInstance.test.ts are passing. I'll look into adding more testing if needed.
