### PR TITLE
[Port] Use console.log for retry logging (#13722)

### DIFF
--- a/build/azure-pipelines/common/publish.ts
+++ b/build/azure-pipelines/common/publish.ts
@@ -259,7 +259,7 @@ async function retry<T>(fn: () => Promise<T>): Promise<T> {
 			if (!/ECONNRESET/.test(err.message)) {
 				throw err;
 			}
-			console.warn(`Caught error ${err} - ${run}/${RETRY_TIMES}`);
+			console.log(`Caught error ${err} - ${run}/${RETRY_TIMES}`);
 		}
 	}
 


### PR DESCRIPTION
Port a74119038f711b77dc12f290e42b97a02e83dc57

warn logs to stderr which is causing the build pipeline to fail

