### PR TITLE
Log active element when notebook smoke test fails

### DIFF
--- a/test/automation/src/code.ts
+++ b/test/automation/src/code.ts
@@ -332,7 +332,7 @@ export class Code {
 	// {{SQL CARBON EDIT}}
 	async isActiveElement(selector: string): Promise<boolean> {
 		const windowId = await this.getActiveWindowId();
-		return this.driver.isActiveElement(windowId, selector);
+		return await this.driver.isActiveElement(windowId, selector);
 	}
 
 	async waitForTitle(fn: (title: string) => boolean): Promise<void> {

--- a/test/automation/src/code.ts
+++ b/test/automation/src/code.ts
@@ -329,12 +329,6 @@ export class Code {
 		await poll(() => this.driver.isActiveElement(windowId, selector), r => r, `is active element '${selector}'`, retryCount);
 	}
 
-	// {{SQL CARBON EDIT}}
-	async isActiveElement(selector: string): Promise<boolean> {
-		const windowId = await this.getActiveWindowId();
-		return await this.driver.isActiveElement(windowId, selector);
-	}
-
 	async waitForTitle(fn: (title: string) => boolean): Promise<void> {
 		const windowId = await this.getActiveWindowId();
 		await poll(() => this.driver.getTitle(windowId), fn, `get title`);

--- a/test/automation/src/code.ts
+++ b/test/automation/src/code.ts
@@ -329,6 +329,12 @@ export class Code {
 		await poll(() => this.driver.isActiveElement(windowId, selector), r => r, `is active element '${selector}'`, retryCount);
 	}
 
+	// {{SQL CARBON EDIT}}
+	async isActiveElement(selector: string): Promise<boolean> {
+		const windowId = await this.getActiveWindowId();
+		return this.driver.isActiveElement(windowId, selector);
+	}
+
 	async waitForTitle(fn: (title: string) => boolean): Promise<void> {
 		const windowId = await this.getActiveWindowId();
 		await poll(() => this.driver.getTitle(windowId), fn, `get title`);

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -22,6 +22,9 @@ export class Notebook {
 	async openFile(fileName: string): Promise<void> {
 		await this.quickAccess.openQuickAccess(fileName);
 		await this.quickInput.waitForQuickInputElements(names => names[0] === fileName);
+		this.code.isActiveElement('.quick-input-widget .quick-input-box').catch(e => {
+			this.code.logger.log(e);
+		});
 		await this.code.dispatchKeybinding('enter');
 		await this.editors.waitForActiveTab(fileName);
 		await this.code.waitForElement('.notebookEditor');

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -22,7 +22,7 @@ export class Notebook {
 	async openFile(fileName: string): Promise<void> {
 		await this.quickAccess.openQuickAccess(fileName);
 		await this.quickInput.waitForQuickInputElements(names => names[0] === fileName);
-		await this.code.isActiveElement('.quick-input-widget .quick-input-box input');
+		await this.code.waitForActiveElement('.quick-input-widget .quick-input-box input');
 		await this.code.dispatchKeybinding('enter');
 		await this.editors.waitForActiveTab(fileName);
 		await this.code.waitForElement('.notebookEditor');

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -22,7 +22,7 @@ export class Notebook {
 	async openFile(fileName: string): Promise<void> {
 		await this.quickAccess.openQuickAccess(fileName);
 		await this.quickInput.waitForQuickInputElements(names => names[0] === fileName);
-		this.code.isActiveElement('.quick-input-widget .quick-input-box').catch(e => {
+		this.code.isActiveElement('.quick-input-widget .quick-input-box input').catch(e => {
 			this.code.logger.log(e);
 		});
 		await this.code.dispatchKeybinding('enter');

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -22,9 +22,7 @@ export class Notebook {
 	async openFile(fileName: string): Promise<void> {
 		await this.quickAccess.openQuickAccess(fileName);
 		await this.quickInput.waitForQuickInputElements(names => names[0] === fileName);
-		this.code.isActiveElement('.quick-input-widget .quick-input-box input').catch(e => {
-			this.code.logger.log(e);
-		});
+		await this.code.isActiveElement('.quick-input-widget .quick-input-box input');
 		await this.code.dispatchKeybinding('enter');
 		await this.editors.waitForActiveTab(fileName);
 		await this.code.waitForElement('.notebookEditor');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

A notebook smoke test has failed to open a file a couple of times in the past. One theory is that there is something taking the focus away from the quick input element right before the 'enter' step. This PR adds active element information to the logs if the quick input element is not in focus. 