### PR TITLE
Un-skip and fix a few of the db projects tests

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -179,12 +179,11 @@ export class PublishDatabaseDialog {
 	}
 
 	public async publishClick(): Promise<void> {
-		const sqlCmdVars = this.getSqlCmdVariablesForPublish();
 		const settings: IPublishSettings = {
 			databaseName: this.getTargetDatabaseName(),
 			upgradeExisting: true,
 			connectionUri: await this.getConnectionUri(),
-			sqlCmdVariables: sqlCmdVars,
+			sqlCmdVariables: this.getSqlCmdVariablesForPublish(),
 			deploymentOptions: await this.getDeploymentOptions()
 		};
 
@@ -212,7 +211,7 @@ export class PublishDatabaseDialog {
 		this.dispose();
 	}
 
-	private async getDeploymentOptions(): Promise<DeploymentOptions> {
+	public async getDeploymentOptions(): Promise<DeploymentOptions> {
 		// eventually, database options will be configurable in this dialog
 		// but for now, just send the default DacFx deployment options if no options were loaded from a publish profile
 		if (!this.deploymentOptions) {
@@ -230,7 +229,7 @@ export class PublishDatabaseDialog {
 		return this.deploymentOptions;
 	}
 
-	private getSqlCmdVariablesForPublish(): Record<string, string> {
+	public getSqlCmdVariablesForPublish(): Record<string, string> {
 		// get SQLCMD variables from table
 		let sqlCmdVariables = { ...this.sqlCmdVars };
 		return sqlCmdVariables;

--- a/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/publishDatabaseDialog.test.ts
@@ -17,8 +17,9 @@ import { Project } from '../../models/project';
 import { ProjectsController } from '../../controllers/projectController';
 import { IPublishSettings, IGenerateScriptSettings } from '../../models/IPublishSettings';
 import { emptySqlDatabaseProjectTypeId } from '../../common/constants';
+import { mockDacFxOptionsResult } from '../testContext';
 
-describe.skip('Publish Database Dialog', () => {
+describe('Publish Database Dialog', () => {
 	before(async function (): Promise<void> {
 		await templates.loadTemplates(path.join(__dirname, '..', '..', '..', 'resources', 'templates'));
 		await baselines.loadBaselines();
@@ -64,6 +65,8 @@ describe.skip('Publish Database Dialog', () => {
 		const dialog = TypeMoq.Mock.ofType(PublishDatabaseDialog, undefined, undefined, proj);
 		dialog.setup(x => x.getConnectionUri()).returns(() => { return Promise.resolve('Mock|Connection|Uri'); });
 		dialog.setup(x => x.getTargetDatabaseName()).returns(() => 'MockDatabaseName');
+		dialog.setup(x => x.getSqlCmdVariablesForPublish()).returns(() => proj.sqlCmdVariables);
+		dialog.setup(x => x.getDeploymentOptions()).returns(() => { return Promise.resolve(mockDacFxOptionsResult.deploymentOptions); });
 		dialog.callBase = true;
 
 		let profile: IPublishSettings | IGenerateScriptSettings | undefined;
@@ -75,7 +78,8 @@ describe.skip('Publish Database Dialog', () => {
 			sqlCmdVariables: {
 				'ProdDatabaseName': 'MyProdDatabase',
 				'BackupDatabaseName': 'MyBackupDatabase'
-			}
+			},
+			deploymentOptions: mockDacFxOptionsResult.deploymentOptions
 		};
 
 		dialog.object.publish = (_, prof) => { profile = prof; };
@@ -89,7 +93,8 @@ describe.skip('Publish Database Dialog', () => {
 			sqlCmdVariables: {
 				'ProdDatabaseName': 'MyProdDatabase',
 				'BackupDatabaseName': 'MyBackupDatabase'
-			}
+			},
+			deploymentOptions: mockDacFxOptionsResult.deploymentOptions
 		};
 
 		dialog.object.generateScript = (_, prof) => { profile = prof; };

--- a/extensions/sql-database-projects/src/test/netCoreTool.test.ts
+++ b/extensions/sql-database-projects/src/test/netCoreTool.test.ts
@@ -15,26 +15,28 @@ import { isNullOrUndefined } from 'util';
 import { generateTestFolderPath } from './testUtils';
 
 describe('NetCoreTool: Net core tests', function (): void {
+	afterEach(function (): void {
+		sinon.restore();
+	});
 
 	it('Should override dotnet default value with settings', async function (): Promise<void> {
 		try {
 			// update settings and validate
 			await vscode.workspace.getConfiguration(DBProjectConfigurationKey).update(NetCoreInstallLocationKey, 'test value path', true);
 			const netcoreTool = new NetCoreTool();
-			sinon.stub(netcoreTool, 'showInstallDialog').returns(<any>Promise.resolve());
+			sinon.stub(netcoreTool, 'showInstallDialog').returns(Promise.resolve());
 			should(netcoreTool.netcoreInstallLocation).equal('test value path'); // the path in settings should be taken
 			should(await netcoreTool.findOrInstallNetCore()).equal(false); // dotnet can not be present at dummy path in settings
 		}
 		finally {
 			// clean again
 			await vscode.workspace.getConfiguration(DBProjectConfigurationKey).update(NetCoreInstallLocationKey, '', true);
-			sinon.restore();
 		}
 	});
 
 	it('Should find right dotnet default paths', async function (): Promise<void> {
 		const netcoreTool = new NetCoreTool();
-		sinon.stub(netcoreTool, 'showInstallDialog').returns(<any>Promise.resolve());
+		sinon.stub(netcoreTool, 'showInstallDialog').returns(Promise.resolve());
 		await netcoreTool.findOrInstallNetCore();
 
 		if (os.platform() === 'win32') {
@@ -48,7 +50,6 @@ describe('NetCoreTool: Net core tests', function (): void {
 			let result = isNullOrUndefined(netcoreTool.netcoreInstallLocation) || netcoreTool.netcoreInstallLocation.toLowerCase().startsWith(NextCoreNonWindowsDefaultPath);
 			should(result).true('dotnet is either not present or in /usr/local/share by default');
 		}
-		sinon.restore();
 	});
 
 	it('should run a command successfully', async function (): Promise<void> {

--- a/extensions/sql-database-projects/src/test/projectTree.test.ts
+++ b/extensions/sql-database-projects/src/test/projectTree.test.ts
@@ -115,7 +115,7 @@ describe('Project Tree tests', function (): void {
 	});
 
 	it('Should be able to parse and include relative paths outside project folder', function (): void {
-		const root = os.platform() === 'win32' ? 'Z:\\Level1\\Level2\\' : '/Root/Level1/Level2';
+		const root = os.platform() === 'win32' ? 'Z:\\Level1\\Level2\\' : '/Root/Level1/Level2/';
 		const proj = new Project(vscode.Uri.file(`${root}TestProj.sqlproj`).fsPath);
 
 		// nested entries before explicit top-level folder entry

--- a/extensions/sql-database-projects/src/test/projectTree.test.ts
+++ b/extensions/sql-database-projects/src/test/projectTree.test.ts
@@ -13,7 +13,7 @@ import { FolderNode, FileNode, sortFileFolderNodes } from '../models/tree/fileFo
 import { ProjectRootTreeItem } from '../models/tree/projectTreeItem';
 import { DatabaseProjectItemType } from '../common/constants';
 
-describe.skip('Project Tree tests', function (): void {
+describe('Project Tree tests', function (): void {
 	it('Should correctly order tree nodes by type, then by name', function (): void {
 		const root = os.platform() === 'win32' ? 'Z:\\' : '/';
 
@@ -68,26 +68,24 @@ describe.skip('Project Tree tests', function (): void {
 
 		const tree = new ProjectRootTreeItem(proj);
 		should(tree.children.map(x => x.uri.path)).deepEqual([
-			'/TestProj.sqlproj/Data Sources',
-			'/TestProj.sqlproj/Database References',
-			'/TestProj.sqlproj/duplicateFolder',
-			'/TestProj.sqlproj/someFolder',
-			'/TestProj.sqlproj/duplicate.sql']);
+			'/TestProj/Database References',
+			'/TestProj/duplicateFolder',
+			'/TestProj/someFolder',
+			'/TestProj/duplicate.sql']);
 
-		should(tree.children.find(x => x.uri.path === '/TestProj.sqlproj/someFolder')?.children.map(y => y.uri.path)).deepEqual([
-			'/TestProj.sqlproj/someFolder/aNestedFolder',
-			'/TestProj.sqlproj/someFolder/bNestedFolder',
-			'/TestProj.sqlproj/someFolder/aNestedTest.sql',
-			'/TestProj.sqlproj/someFolder/bNestedTest.sql']);
+		should(tree.children.find(x => x.uri.path === '/TestProj/someFolder')?.children.map(y => y.uri.path)).deepEqual([
+			'/TestProj/someFolder/aNestedFolder',
+			'/TestProj/someFolder/bNestedFolder',
+			'/TestProj/someFolder/aNestedTest.sql',
+			'/TestProj/someFolder/bNestedTest.sql']);
 
 		should(tree.children.map(x => x.treeItem.contextValue)).deepEqual([
-			DatabaseProjectItemType.dataSourceRoot,
 			DatabaseProjectItemType.referencesRoot,
 			DatabaseProjectItemType.folder,
 			DatabaseProjectItemType.folder,
 			DatabaseProjectItemType.file]);
 
-		should(tree.children.find(x => x.uri.path === '/TestProj.sqlproj/someFolder')?.children.map(y => y.treeItem.contextValue)).deepEqual([
+		should(tree.children.find(x => x.uri.path === '/TestProj/someFolder')?.children.map(y => y.treeItem.contextValue)).deepEqual([
 			DatabaseProjectItemType.folder,
 			DatabaseProjectItemType.folder,
 			DatabaseProjectItemType.file,
@@ -106,12 +104,11 @@ describe.skip('Project Tree tests', function (): void {
 
 		const tree = new ProjectRootTreeItem(proj);
 		should(tree.children.map(x => x.uri.path)).deepEqual([
-			'/TestProj.sqlproj/Data Sources',
-			'/TestProj.sqlproj/Database References',
-			'/TestProj.sqlproj/someFolder1']);
+			'/TestProj/Database References',
+			'/TestProj/someFolder1']);
 
 		// Why are we only matching names - https://github.com/microsoft/azuredatastudio/issues/11026
-		should(tree.children.find(x => x.uri.path === '/TestProj.sqlproj/someFolder1')?.children.map(y => path.basename(y.uri.path))).deepEqual([
+		should(tree.children.find(x => x.uri.path === '/TestProj/someFolder1')?.children.map(y => path.basename(y.uri.path))).deepEqual([
 			'MyNestedFolder1',
 			'MyNestedFolder2',
 			'MyFile2.sql']);
@@ -129,9 +126,8 @@ describe.skip('Project Tree tests', function (): void {
 
 		const tree = new ProjectRootTreeItem(proj);
 		should(tree.children.map(x => x.uri.path)).deepEqual([
-			'/TestProj.sqlproj/Data Sources',
-			'/TestProj.sqlproj/Database References',
-			'/TestProj.sqlproj/MyFile1.sql',
-			'/TestProj.sqlproj/MyFile2.sql']);
+			'/TestProj/Database References',
+			'/TestProj/MyFile1.sql',
+			'/TestProj/MyFile2.sql']);
 	});
 });

--- a/extensions/sql-database-projects/src/test/utils.test.ts
+++ b/extensions/sql-database-projects/src/test/utils.test.ts
@@ -22,7 +22,7 @@ describe('Tests to verify utils functions', function (): void {
 		should(await exists(path.join(testFolderPath, 'folder4', 'file2.sql'))).equal(false);
 	});
 
-	it.skip('Should get correct relative paths of files/folders', async () => {
+	it('Should get correct relative paths of files/folders', async () => {
 		const root = os.platform() === 'win32' ? 'Z:\\' : '/';
 		let projectUri = Uri.file(path.join(root, 'project', 'folder', 'project.sqlproj'));
 		let fileUri = Uri.file(path.join(root, 'project', 'folder', 'file.sql'));

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -42,7 +42,7 @@ export class NetCoreTool {
 		return true;
 	}
 
-	private async showInstallDialog(): Promise<void> {
+	public async showInstallDialog(): Promise<void> {
 		let result = await vscode.window.showInformationMessage(NetCoreInstallationConfirmation, UpdateNetCoreLocation, InstallNetCore);
 		if (result === UpdateNetCoreLocation) {
 			//open settings
@@ -96,7 +96,7 @@ export class NetCoreTool {
 			NetCoreTool._outputChannel.appendLine(`\t[ ${options.commandTitle} ]`);
 		}
 
-		if (!this.findOrInstallNetCore()) {
+		if (!(await this.findOrInstallNetCore())) {
 			throw new Error(NetCoreInstallationConfirmation);
 		}
 


### PR DESCRIPTION
This PR adds the skipped tests back that were commented out to resolve the curious case of test failures, a few months back.
A few of those tests weren't updated as the product code changed. Fixed those.

As of now, there are 2tests that are still in skipped state- dataSource related tests (product code doesn't support data sources for now) and one createProjectFromDatabase UI test (renderer crash error).