### PR TITLE
[Port] Fix env var names for Arc deployment

### DIFF
--- a/extensions/arc/notebooks/arcDeployment/deploy.arc.data.controller.ipynb
+++ b/extensions/arc/notebooks/arcDeployment/deploy.arc.data.controller.ipynb
@@ -135,7 +135,7 @@
                 "            sys.exit(f'Passwords do not match.')\n",
                 "\n",
                 "os.environ[\"SPN_CLIENT_ID\"] = sp_client_id\n",
-                "os.environ[\"SPN_CLIENT_TENANTID\"] = sp_client_tenantid\n",
+                "os.environ[\"SPN_TENANT_ID\"] = sp_tenant_id\n",
                 "if \"AZDATA_NB_VAR_SP_CLIENT_SECRET\" in os.environ:\n",
                 "    os.environ[\"SPN_CLIENT_SECRET\"] = os.environ[\"AZDATA_NB_VAR_SP_CLIENT_SECRET\"]\n",
                 "os.environ[\"SPN_AUTHORITY\"] = \"https://login.microsoftonline.com\""

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -311,7 +311,7 @@
                         {
                           "label": "%arc.data.controller.sptenantid%",
                           "description": "%arc.data.controller.sptenantid.description%",
-                          "variableName": "AZDATA_NB_VAR_SP_CLIENT_TENANTID",
+                          "variableName": "AZDATA_NB_VAR_SP_TENANT_ID",
                           "type": "text",
                           "required": true,
                           "defaultValue": "",

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -2,14 +2,14 @@
   "name": "arc",
   "displayName": "%arc.displayName%",
   "description": "%arc.description%",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
   "engines": {
     "vscode": "*",
-    "azdata": ">=1.23.0"
+    "azdata": ">=1.25.0"
   },
   "activationEvents": [
     "onCommand:arc.connectToController",


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13734

Port https://github.com/microsoft/azuredatastudio/commit/30289b4d14f354d7aec7e1d609042a61891f447b

This fixes an issue where the wrong environment variables were being used for the connected mode deployment causing it to fail.

Also bumped extension version to match new released version of the extension.