### PR TITLE
Fixed the stray validation error message in Resource Deployment wizard

### DIFF
--- a/extensions/resource-deployment/src/localizedConstants.ts
+++ b/extensions/resource-deployment/src/localizedConstants.ts
@@ -7,7 +7,7 @@ import { EOL } from 'os';
 import * as nls from 'vscode-nls';
 import { getErrorMessage } from './common/utils';
 import { ResourceTypeCategories } from './constants';
-import { FieldType, OptionsType } from './interfaces';
+import { FieldType, ITool, OptionsType } from './interfaces';
 const localize = nls.loadMessageBundle();
 
 export const account = localize('azure.account', "Azure Account");
@@ -81,3 +81,7 @@ export const discoverPathOrAdditionalInformationText = localize('resourceDeploym
 export const requiredToolsText = localize('resourceDeployment.requiredTools', "Required tools");
 export const installToolsText = localize('resourceDeployment.InstallTools', "Install tools");
 export const optionsText = localize('resourceDeployment.Options', "Options");
+
+export function getToolInstallingMessage(tool: ITool): string {
+	return localize('deploymentDialog.InstallingTool', "Required tool '{0}' [ {1} ] is being installed now.", tool.displayName, tool.homePage);
+}

--- a/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
@@ -122,13 +122,6 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 				columns: [toolColumn, descriptionColumn, installStatusColumn, versionColumn, minVersionColumn, installedPathColumn],
 				width: tableWidth,
 				ariaLabel: loc.requiredToolsText
-			}).withValidation((component) => {
-				for (let i = 0; i < this._tools.length; i++) {
-					if (this._tools[i].status !== ToolStatus.Installed) {
-						return false;
-					}
-				}
-				return true;
 			}).component();
 
 			const toolsTableWrapper = view.modelBuilder.divContainer().withLayout({ width: tableWidth }).component();
@@ -387,6 +380,7 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 	private setUiControlsEnabled(enable: boolean): void {
 		this._agreementContainer.enabled = enable;
 		this._optionsContainer.enabled = enable;
+		this.wizard.wizardObject.cancelButton.enabled = enable;
 	}
 
 	public async onLeave(): Promise<void> {

--- a/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
@@ -31,7 +31,6 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 	private _tools: ITool[] = [];
 	private _eulaValidationSucceeded: boolean = false;
 	private _isInitialized = false;
-	private _isDoneButtonEnabled = false;
 	private _resourceType: ResourceType;
 
 	public set resourceProvider(provider: DeploymentProvider) {
@@ -58,14 +57,28 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 				return false; // we return false so that the workflow does not proceed and user gets to either click acceptEulaAndSelect again or cancel
 			}
 
-			if (!this._isDoneButtonEnabled) {
-				this.wizard.wizardObject.message = {
-					text: localize('deploymentDialog.FailedToolsInstallation', "Some tools were still not discovered. Please make sure that they are installed, running and discoverable"),
-					level: azdata.window.MessageLevel.Error
-				};
-				return false;
+			for (let i = 0; i < this._tools.length; i++) {
+				switch (this._tools[i].status) {
+					case ToolStatus.Installing:
+						this.wizard.wizardObject.message = {
+							text: loc.getToolInstallingMessage(this._tools[i]),
+							level: azdata.window.MessageLevel.Information
+						};
+						return false;
+					case ToolStatus.Installed:
+						continue;
+					default:
+						this.wizard.wizardObject.message = {
+							text: localize('deploymentDialog.FailedToolsInstallation', "Some tools were still not discovered. Please make sure that they are installed, running and discoverable"),
+							level: azdata.window.MessageLevel.Error
+						};
+						return false;
+				}
 			}
 
+			this.wizard.wizardObject.message = {
+				text: ''
+			};
 			return true;
 		});
 	}
@@ -109,6 +122,13 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 				columns: [toolColumn, descriptionColumn, installStatusColumn, versionColumn, minVersionColumn, installedPathColumn],
 				width: tableWidth,
 				ariaLabel: loc.requiredToolsText
+			}).withValidation((component) => {
+				for (let i = 0; i < this._tools.length; i++) {
+					if (this._tools[i].status !== ToolStatus.Installed) {
+						return false;
+					}
+				}
+				return true;
 			}).component();
 
 			const toolsTableWrapper = view.modelBuilder.divContainer().withLayout({ width: tableWidth }).component();
@@ -293,6 +313,7 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 		this._installationInProgress = true;
 		let tool: ITool;
 		try {
+			this.enableDoneButton(false);
 			const toolRequirements = this.toolRequirements;
 			let toolsNotInstalled: ITool[] = [];
 			for (let i: number = 0; i < toolRequirements.length; i++) {
@@ -302,7 +323,7 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 					// Update the informational message
 					this.wizard.wizardObject.message = {
 						level: azdata.window.MessageLevel.Information,
-						text: localize('deploymentDialog.InstallingTool', "Required tool '{0}' [ {1} ] is being installed now.", tool.displayName, tool.homePage)
+						text: loc.getToolInstallingMessage(tool)
 					};
 					await this._tools[i].install();
 					if (tool.status === ToolStatus.Installed && toolReq.version && !tool.isSameOrNewerThan(toolReq.version)) {
@@ -313,7 +334,9 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 						);
 					}
 				} else {
-					toolsNotInstalled.push(tool);
+					if (this._tools[i].status !== ToolStatus.Installed) {
+						toolsNotInstalled.push(tool);
+					}
 				}
 			}
 			// Update the informational message
@@ -364,8 +387,6 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 	private setUiControlsEnabled(enable: boolean): void {
 		this._agreementContainer.enabled = enable;
 		this._optionsContainer.enabled = enable;
-		this.wizard.wizardObject.cancelButton.enabled = enable;
-		// select and install tools buttons are controlled separately
 	}
 
 	public async onLeave(): Promise<void> {
@@ -503,7 +524,6 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 	}
 
 	private enableDoneButton(enable: boolean) {
-		this._isDoneButtonEnabled = enable;
 		this.wizard.wizardObject.doneButton.enabled = enable;
 		this.wizard.wizardObject.nextButton.enabled = enable;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #13679 and fixes #13719 

I have already extensively tested this change locally and I found 1 bug: Table 'withValidation' does not work. @Charles-Gagnon  what can be a potential fix for this issue?  

@ranasaria and @Charles-Gagnon, 
Please run this branch locally to see if it has fixed all the other edge cases. If not then please report the issues to this PR.


Initial State when a tool is not installed: (@Charles-Gagnon, @ranasaria   shouldn't this be an error message?)
![image](https://user-images.githubusercontent.com/6816294/101750530-fcb85e00-3a83-11eb-817d-624aa98fc324.png)

If you click next without installing the tool:
![image](https://user-images.githubusercontent.com/6816294/101750608-1b1e5980-3a84-11eb-9a5e-ae1fec6f1a82.png)

If you click install button:
![image](https://user-images.githubusercontent.com/6816294/101750770-502aac00-3a84-11eb-8bd1-7ae757170e04.png)

Once the tool installed: 
![image](https://user-images.githubusercontent.com/6816294/101750777-56b92380-3a84-11eb-9773-4f265e6367e7.png)

When you click the next button: 
![image](https://user-images.githubusercontent.com/6816294/101750929-86682b80-3a84-11eb-8234-366bc069d1de.png)
