### PR TITLE
Update typings/namings

### DIFF
--- a/extensions/azurecore/src/azureResource/azure-resource.d.ts
+++ b/extensions/azurecore/src/azureResource/azure-resource.d.ts
@@ -6,7 +6,6 @@
 declare module 'azureResource' {
 	import { TreeDataProvider } from 'vscode';
 	import { DataProvider, Account, TreeItem } from 'azdata';
-	import { FileShareItem, ListContainerItem } from '@azure/arm-storage/esm/models';
 	export namespace azureResource {
 
 		export const enum AzureResourceType {
@@ -77,10 +76,8 @@ declare module 'azureResource' {
 			fullName: string;
 			defaultDatabaseName: string;
 		}
-		export interface BlobContainer extends ListContainerItem {
-		}
+		export interface BlobContainer extends AzureResource { }
 
-		export interface FileShare extends FileShareItem {
-		}
+		export interface FileShare extends AzureResource { }
 	}
 }

--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -363,7 +363,7 @@ export async function makeHttpGetRequest(account: azdata.Account, subscription: 
 }
 
 export async function getBlobContainers(account: azdata.Account, subscription: azureResource.AzureResourceSubscription, storageAccounts: azureResource.AzureGraphResource, ignoreErrors: boolean): Promise<GetBlobContainersResult> {
-	let result: GetBlobContainersResult = { blobContainer: undefined, errors: [] };
+	let result: GetBlobContainersResult = { blobContainers: undefined, errors: [] };
 
 	if (!account?.properties?.tenants || !Array.isArray(account.properties.tenants)) {
 		const error = new Error(invalidAzureAccount);
@@ -407,7 +407,7 @@ export async function getBlobContainers(account: azdata.Account, subscription: a
 
 	try {
 		const client = new StorageManagementClient(<any>credential, subscription.id);
-		result.blobContainer = await client.blobContainers.list(storageAccounts.resourceGroup, storageAccounts.name);
+		result.blobContainers = await client.blobContainers.list(storageAccounts.resourceGroup, storageAccounts.name);
 	} catch (err) {
 		console.error(err);
 		if (!ignoreErrors) {

--- a/extensions/azurecore/src/azureResource/utils.ts
+++ b/extensions/azurecore/src/azureResource/utils.ts
@@ -407,7 +407,14 @@ export async function getBlobContainers(account: azdata.Account, subscription: a
 
 	try {
 		const client = new StorageManagementClient(<any>credential, subscription.id);
-		result.blobContainers = await client.blobContainers.list(storageAccounts.resourceGroup, storageAccounts.name);
+		result.blobContainers = (await client.blobContainers.list(storageAccounts.resourceGroup, storageAccounts.name)).map(blobContainer => {
+			return {
+				...blobContainer,
+				id: blobContainer.id ?? '',
+				name: blobContainer.name ?? '',
+				subscription: subscription
+			};
+		});
 	} catch (err) {
 		console.error(err);
 		if (!ignoreErrors) {
@@ -463,7 +470,14 @@ export async function getFileShares(account: azdata.Account, subscription: azure
 
 	try {
 		const client = new StorageManagementClient(<any>credential, subscription.id);
-		result.fileShares = await client.fileShares.list(storageAccounts.resourceGroup, storageAccounts.name);
+		result.fileShares = (await client.fileShares.list(storageAccounts.resourceGroup, storageAccounts.name)).map(fileShare => {
+			return {
+				...fileShare,
+				id: fileShare.id ?? '',
+				name: fileShare.name ?? '',
+				subscription: subscription
+			};
+		});
 	} catch (err) {
 		console.error(err);
 		if (!ignoreErrors) {

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -6,7 +6,6 @@
 declare module 'azurecore' {
 	import * as azdata from 'azdata';
 	import { azureResource } from 'azureResource';
-	import { BlobContainersListResponse, FileSharesListResponse } from '@azure/arm-storage/esm/models';
 
 	/**
 	 * Covers defining what the azurecore extension exports to other extensions
@@ -93,8 +92,8 @@ declare module 'azurecore' {
 	export type GetSqlServersResult = {resources: azureResource.AzureGraphResource[], errors: Error[]};
 	export type GetSqlVMServersResult = {resources: azureResource.AzureGraphResource[], errors: Error[]};
 	export type GetStorageAccountResult = {resources: azureResource.AzureGraphResource[], errors: Error[]};
-	export type GetBlobContainersResult = {blobContainer: BlobContainersListResponse | undefined, errors: Error[]};
-	export type GetFileSharesResult = {fileShares: FileSharesListResponse | undefined, errors: Error[]};
+	export type GetBlobContainersResult = {blobContainers: azureResource.BlobContainer[] | undefined, errors: Error[]};
+	export type GetFileSharesResult = {fileShares: azureResource.FileShare[] | undefined, errors: Error[]};
 
 	export type ResourceQueryResult<T extends azureResource.AzureGraphResource> = { resources: T[], errors: Error[] };
 	export type HttpGetRequestResult = { response: any, errors: Error[] };

--- a/extensions/sql-migration/src/api/azure.ts
+++ b/extensions/sql-migration/src/api/azure.ts
@@ -78,7 +78,7 @@ export async function getFileShares(account: azdata.Account, subscription: Subsc
 export async function getBlobContainers(account: azdata.Account, subscription: Subscription, storageAccount: StorageAccount): Promise<azureResource.BlobContainer[]> {
 	const api = await getAzureCoreAPI();
 	let result = await api.getBlobContainers(account, subscription, storageAccount, true);
-	let blobContainers = result.blobContainer;
+	let blobContainers = result.blobContainers;
 	sortResourceArrayByName(blobContainers!);
 	return blobContainers!;
 }

--- a/extensions/sql-migration/src/wizard/databaseBackupPage.ts
+++ b/extensions/sql-migration/src/wizard/databaseBackupPage.ts
@@ -664,10 +664,10 @@ export class DatabaseBackupPage extends MigrationWizardPage {
 		if (!storageAccountId.length) {
 			this.setEmptyDropdownPlaceHolder(this._blobContainerBlobDropdown, constants.NO_BLOBCONTAINERS_FOUND);
 		} else {
-			const blobContainer = await getBlobContainers(this.migrationStateModel.azureAccount, this._subscriptionMap.get(this._blob.subscriptionId)!, this._storageAccountMap.get(storageAccountId)!);
-			if (blobContainer && blobContainer.length) {
-				this._blobContainerBlobDropdown.values = blobContainer.map(f => <azdata.CategoryValue>{ name: f.id, displayName: f.name });
-				this._blob.containerId = blobContainer[0].id!;
+			const blobContainers = await getBlobContainers(this.migrationStateModel.azureAccount, this._subscriptionMap.get(this._blob.subscriptionId)!, this._storageAccountMap.get(storageAccountId)!);
+			if (blobContainers && blobContainers.length) {
+				this._blobContainerBlobDropdown.values = blobContainers.map(f => <azdata.CategoryValue>{ name: f.id, displayName: f.name });
+				this._blob.containerId = blobContainers[0].id!;
 			} else {
 				this.setEmptyDropdownPlaceHolder(this._blobContainerBlobDropdown, constants.NO_BLOBCONTAINERS_FOUND);
 			}


### PR DESCRIPTION
This doesn't seem to fix the test failure unfortunately - but it's good clean up. We shouldn't be having types from other packages in our typings definitions since the calling extensions may not necessarily have those types available. 