### PR TITLE
fix the recent list

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -86,7 +86,7 @@ export default () => `
 								<div class="flex list-header-container">
 									<i class="icon-document themed-icon"></i>
 									<span class="list-header">${escape(localize('welcomePage.name', "Name"))}</span>
-									<span class="list-header-last-opened">${escape(localize('welcomePage.lastOpened', "Last Opened"))}</span>
+									<span class="list-header-last-opened">${escape(localize('welcomePage.location', "Location"))}</span>
 								</div>
 								<ul class="list">
 									<!-- Filled programmatically -->


### PR DESCRIPTION
1. looks like the recent workspace and folder never worked before, I've been working on the data-workspace feature and noticed errors in the console and the empty recent list
![image](https://user-images.githubusercontent.com/13777222/101843694-a12bb600-3aff-11eb-967c-d0bd5e2ec53f.png)

2. the last opened information is simply not available right now, it meant to use the folder or files last modified time, which I don't think is correct, not to mention the fullPath parameter is not set properly. so I am showing the location along with the name just like the old welcome page and the vscode welcome page.

the corresponding vscode welcome page code: https://github.com/microsoft/azuredatastudio/blob/main/src/vs/workbench/contrib/welcome/page/browser/welcomePage.ts#L377

Before:

![image](https://user-images.githubusercontent.com/13777222/101843740-b7397680-3aff-11eb-935b-969a59515d69.png)


After:
on Windows
![image](https://user-images.githubusercontent.com/13777222/101843763-c6202900-3aff-11eb-968b-246e53588e9d.png)

on Mac
![image](https://user-images.githubusercontent.com/13777222/101843849-f36cd700-3aff-11eb-8887-c1e1c5494dcb.png)

old welcome page:
![image](https://user-images.githubusercontent.com/13777222/101844609-b275c200-3b01-11eb-8f43-75dc97a3a588.png)

