### PR TITLE
Use correct Azure graph endpoint & cleanup

### DIFF
--- a/extensions/azurecore/src/account-provider/interfaces.ts
+++ b/extensions/azurecore/src/account-provider/interfaces.ts
@@ -75,6 +75,11 @@ interface Settings {
 	graphResource?: Resource;
 
 	/**
+	 * Information that describes the MS graph resource
+	 */
+	msGraphResource?: Resource;
+
+	/**
 	 * Information that describes the Azure resource management resource
 	 */
 	armResource?: Resource;

--- a/extensions/azurecore/src/account-provider/providerSettings.ts
+++ b/extensions/azurecore/src/account-provider/providerSettings.ts
@@ -9,6 +9,17 @@ import { AzureResource } from 'azdata';
 
 const localize = nls.loadMessageBundle();
 
+const enum SettingIds {
+	marm = 'marm',
+	graph = 'graph',
+	msgraph = 'msgraph',
+	arm = 'arm',
+	sql = 'sql',
+	ossrdbms = 'ossrdbms',
+	vault = 'vault',
+	ado = 'ado'
+}
+
 const publicAzureSettings: ProviderSettings = {
 	configKey: 'enablePublicCloud',
 	metadata: {
@@ -18,37 +29,42 @@ const publicAzureSettings: ProviderSettings = {
 			host: 'https://login.microsoftonline.com/',
 			clientId: 'a69788c6-1d43-44ed-9ca3-b83e194da255',
 			microsoftResource: {
-				id: 'marm',
+				id: SettingIds.marm,
 				endpoint: 'https://management.core.windows.net/',
 				azureResourceId: AzureResource.MicrosoftResourceManagement
 			},
 			graphResource: {
-				id: 'graph',
-				endpoint: 'https://graph.microsoft.com',
+				id: SettingIds.graph,
+				endpoint: 'https://graph.windows.net',
 				azureResourceId: AzureResource.Graph
 			},
+			msGraphResource: {
+				id: SettingIds.msgraph,
+				endpoint: 'https://graph.microsoft.com/',
+				azureResourceId: AzureResource.MsGraph
+			},
 			armResource: {
-				id: 'arm',
+				id: SettingIds.arm,
 				endpoint: 'https://management.azure.com',
 				azureResourceId: AzureResource.ResourceManagement
 			},
 			sqlResource: {
-				id: 'sql',
+				id: SettingIds.sql,
 				endpoint: 'https://database.windows.net/',
 				azureResourceId: AzureResource.Sql
 			},
 			ossRdbmsResource: {
-				id: 'ossrdbms',
+				id: SettingIds.ossrdbms,
 				endpoint: 'https://ossrdbms-aad.database.windows.net',
 				azureResourceId: AzureResource.OssRdbms
 			},
 			azureKeyVaultResource: {
-				id: 'vault',
+				id: SettingIds.vault,
 				endpoint: 'https://vault.azure.net',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
 			azureDevOpsResource: {
-				id: 'ado',
+				id: SettingIds.ado,
 				endpoint: '499b84ac-1321-427f-aa17-267ca6975798',
 				azureResourceId: AzureResource.AzureDevOps,
 			},
@@ -72,32 +88,32 @@ const usGovAzureSettings: ProviderSettings = {
 			host: 'https://login.microsoftonline.us/',
 			clientId: 'a69788c6-1d43-44ed-9ca3-b83e194da255',
 			microsoftResource: {
-				id: 'marm',
+				id: SettingIds.marm,
 				endpoint: 'https://management.core.usgovcloudapi.net/',
 				azureResourceId: AzureResource.MicrosoftResourceManagement
 			},
 			graphResource: {
-				id: 'graph',
+				id: SettingIds.graph,
 				endpoint: 'https://graph.windows.net',
 				azureResourceId: AzureResource.Graph
 			},
 			armResource: {
-				id: 'arm',
+				id: SettingIds.arm,
 				endpoint: 'https://management.usgovcloudapi.net',
 				azureResourceId: AzureResource.ResourceManagement
 			},
 			sqlResource: {
-				id: 'sql',
+				id: SettingIds.sql,
 				endpoint: 'https://database.usgovcloudapi.net/',
 				azureResourceId: AzureResource.Sql
 			},
 			ossRdbmsResource: {
-				id: 'ossrdbms',
+				id: SettingIds.ossrdbms,
 				endpoint: 'https://ossrdbms-aad.database.usgovcloudapi.net',
 				azureResourceId: AzureResource.OssRdbms
 			},
 			azureKeyVaultResource: {
-				id: 'vault',
+				id: SettingIds.vault,
 				endpoint: 'https://vault.usgovcloudapi.net',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
@@ -120,32 +136,32 @@ const usNatAzureSettings: ProviderSettings = {
 			host: 'https://login.microsoftonline.eaglex.ic.gov/',
 			clientId: 'a69788c6-1d43-44ed-9ca3-b83e194da255',
 			microsoftResource: {
-				id: 'marm',
+				id: SettingIds.marm,
 				endpoint: 'https://management.azure.eaglex.ic.gov/',
 				azureResourceId: AzureResource.MicrosoftResourceManagement
 			},
 			graphResource: {
-				id: 'graph',
+				id: SettingIds.graph,
 				endpoint: 'https://graph.eaglex.ic.gov',
 				azureResourceId: AzureResource.Graph
 			},
 			armResource: {
-				id: 'arm',
+				id: SettingIds.arm,
 				endpoint: 'https://management.core.eaglex.ic.gov/',
 				azureResourceId: AzureResource.ResourceManagement
 			},
 			sqlResource: {
-				id: 'sql',
+				id: SettingIds.sql,
 				endpoint: 'https://database.cloudapi.eaglex.ic.gov/',
 				azureResourceId: AzureResource.Sql
 			},
 			ossRdbmsResource: {
-				id: 'ossrdbms',
+				id: SettingIds.ossrdbms,
 				endpoint: 'https://ossrdbms-aad.database.cloudapi.eaglex.ic.gov',
 				azureResourceId: AzureResource.OssRdbms
 			},
 			azureKeyVaultResource: {
-				id: 'vault',
+				id: SettingIds.vault,
 				endpoint: 'https://vault.cloudapi.eaglex.ic.gov',
 				azureResourceId: AzureResource.AzureKeyVault
 			},
@@ -169,16 +185,24 @@ const germanyAzureSettings: ProviderSettings = {
 			host: 'https://login.microsoftazure.de/',
 			clientId: 'a69788c6-1d43-44ed-9ca3-b83e194da255',
 			graphResource: {
-				id: 'https://graph.cloudapi.de/',
-				endpoint: 'https://graph.cloudapi.de'
+				id: SettingIds.graph,
+				endpoint: 'https://graph.cloudapi.de',
+				azureResourceId: AzureResource.Graph
+			},
+			msGraphResource: {
+				id: SettingIds.msgraph,
+				endpoint: 'https://graph.microsoft.de',
+				azureResourceId: AzureResource.MsGraph
 			},
 			armResource: {
-				id: 'https://management.core.cloudapi.de/',
-				endpoint: 'https://management.microsoftazure.de'
+				id: SettingIds.arm,
+				endpoint: 'https://management.microsoftazure.de',
+				azureResourceId: AzureResource.ResourceManagement
 			},
 			azureKeyVaultResource: {
-				id: 'https://vault.microsoftazure.de',
-				endpoint: 'https://vault.microsoftazure.de'
+				id: SettingIds.vault,
+				endpoint: 'https://vault.microsoftazure.de',
+				azureResourceId: AzureResource.AzureKeyVault
 			},
 			redirectUri: 'https://vscode-redirect.azurewebsites.net/'
 		}
@@ -194,16 +218,24 @@ const chinaAzureSettings: ProviderSettings = {
 			host: 'https://login.chinacloudapi.cn/',
 			clientId: 'a69788c6-1d43-44ed-9ca3-b83e194da255',
 			graphResource: {
-				id: 'https://graph.chinacloudapi.cn/',
-				endpoint: 'https://graph.chinacloudapi.cn'
+				id: SettingIds.graph,
+				endpoint: 'https://graph.chinacloudapi.cn',
+				azureResourceId: AzureResource.Graph
+			},
+			msGraphResource: {
+				id: SettingIds.msgraph,
+				endpoint: 'https://microsoftgraph.chinacloudapi.cn',
+				azureResourceId: AzureResource.MsGraph
 			},
 			armResource: {
-				id: 'https://management.core.chinacloudapi.cn/',
-				endpoint: 'https://managemement.chinacloudapi.net'
+				id: SettingIds.arm,
+				endpoint: 'https://managemement.chinacloudapi.net',
+				azureResourceId: AzureResource.ResourceManagement
 			},
 			azureKeyVaultResource: {
-				id: 'https://vault.azure.cn',
-				endpoint: 'https://vault.azure.cn'
+				id: SettingIds.vault,
+				endpoint: 'https://vault.azure.cn',
+				azureResourceId: AzureResource.AzureKeyVault
 			},
 			redirectUri: 'https://vscode-redirect.azurewebsites.net/'
 

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -2220,12 +2220,33 @@ declare module 'azdata' {
 	}
 
 	export enum AzureResource {
+		/**
+		 * Azure Resource Management (ARM)
+		 */
 		ResourceManagement = 0,
+		/**
+		 * SQL Azure
+		 */
 		Sql = 1,
+		/**
+		 * OSS RDMS
+		 */
 		OssRdbms = 2,
+		/**
+		 * Azure Key Vault
+		 */
 		AzureKeyVault = 3,
+		/**
+		 * Azure AD Graph
+		 */
 		Graph = 4,
+		/**
+		 * Microsoft Resource Management
+		 */
 		MicrosoftResourceManagement = 5,
+		/**
+		 * Azure Dev Ops
+		 */
 		AzureDevOps = 6
 	}
 

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -857,4 +857,11 @@ declare module 'azdata' {
 		**/
 		name?: string;
 	}
+
+	export enum AzureResource {
+		/**
+		 * Microsoft Graph
+		 */
+		MsGraph = 7
+	}
 }

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -411,7 +411,8 @@ export enum AzureResource {
 	AzureKeyVault = 3,
 	Graph = 4,
 	MicrosoftResourceManagement = 5,
-	AzureDevOps = 6
+	AzureDevOps = 6,
+	MsGraph = 7
 }
 
 export class TreeItem extends vsExtTypes.TreeItem {


### PR DESCRIPTION
The main thing this is fixing is to use the correct graph endpoint for the Azure graph resource. It was `https://graph.microsoft.com` - but this resource is supposed to be for the Azure AD Graph (per https://github.com/microsoft/azuredatastudio/blob/main/extensions%2Fazurecore%2Fsrc%2Faccount-provider%2Finterfaces.ts#L75) and so the endpoint should actually be `https://graph.windows.net` per https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-request-differences#basic-requests.

While doing this I went ahead and added the MS Graph type as well though since AD Graph is deprecated and so we want to encourage using MS Graph when possible.

I also consolidated the IDs used for the resources - the china/germany ones were still left as their URLs which is something we just inherited from when this file was first made. As the IDs don't seem to be used for anything except token caching this shouldn't have any noticeable impact. 