### PR TITLE
Fix whitespace differences in sqlproj

### DIFF
--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -902,7 +902,12 @@ export class Project {
 
 	private async serializeToProjFile(projFileContents: any): Promise<void> {
 		let xml = new xmldom.XMLSerializer().serializeToString(projFileContents);
-		xml = xmlFormat(xml, <any>{ collapseContent: true, indentation: '  ', lineSeparator: os.EOL, whiteSpaceAtEndOfSelfclosingTag: true }); // TODO: replace <any>
+		xml = xmlFormat(xml, <any>{
+			collapseContent: true,
+			indentation: '  ',
+			lineSeparator: os.EOL,
+			whiteSpaceAtEndOfSelfclosingTag: true
+		}); // TODO: replace <any>
 
 		await fs.writeFile(this.projectFilePath, xml);
 	}

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -902,7 +902,7 @@ export class Project {
 
 	private async serializeToProjFile(projFileContents: any): Promise<void> {
 		let xml = new xmldom.XMLSerializer().serializeToString(projFileContents);
-		xml = xmlFormat(xml, <any>{ collapseContent: true, indentation: '  ', lineSeparator: os.EOL }); // TODO: replace <any>
+		xml = xmlFormat(xml, <any>{ collapseContent: true, indentation: '  ', lineSeparator: os.EOL, whiteSpaceAtEndOfSelfclosingTag: true }); // TODO: replace <any>
 
 		await fs.writeFile(this.projectFilePath, xml);
 	}

--- a/extensions/sql-database-projects/src/test/baselines/SSDTProjectAfterUpdateBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/SSDTProjectAfterUpdateBaseline.xml
@@ -52,29 +52,29 @@
     <SSDTExists Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets')">True</SSDTExists>
     <VisualStudioVersion Condition="'$(SSDTExists)' == ''">11.0</VisualStudioVersion>
   </PropertyGroup>
-  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
-  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <ItemGroup>
-    <Folder Include="Properties"/>
-    <Folder Include="Tables"/>
-    <Folder Include="Views"/>
-    <Folder Include="Views\Maintenance"/>
+    <Folder Include="Properties" />
+    <Folder Include="Tables" />
+    <Folder Include="Views" />
+    <Folder Include="Views\Maintenance" />
   </ItemGroup>
   <ItemGroup>
-    <Build Include="Tables\Users.sql"/>
-    <Build Include="Tables\Action History.sql"/>
-    <Build Include="Views\Maintenance\Database Performance.sql"/>
+    <Build Include="Tables\Users.sql" />
+    <Build Include="Tables\Action History.sql" />
+    <Build Include="Views\Maintenance\Database Performance.sql" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Views\User"/>
-    <Build Include="Views\User\Profile.sql"/>
+    <Folder Include="Views\User" />
+    <Build Include="Views\User\Profile.sql" />
   </ItemGroup>
-  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
+  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <ItemGroup>
-    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <Target Name="BeforeBuild">
-    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json"/>
+    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
   </Target>
   <ItemGroup>
     <ArtifactReference Condition="'$(NetCoreBuild)' == 'true'" Include="$(NETCoreTargetsPath)\SystemDacpacs\150\master.dacpac">

--- a/extensions/sql-database-projects/src/test/baselines/SSDTProjectBaselineWithBeforeBuildTargetAfterUpdate.xml
+++ b/extensions/sql-database-projects/src/test/baselines/SSDTProjectBaselineWithBeforeBuildTargetAfterUpdate.xml
@@ -52,29 +52,29 @@
     <SSDTExists Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets')">True</SSDTExists>
     <VisualStudioVersion Condition="'$(SSDTExists)' == ''">11.0</VisualStudioVersion>
   </PropertyGroup>
-  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
-  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <Target Name="BeforeBuild">
     <!-- Custom logic added by user -->
-    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json"/>
+    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
   </Target>
   <ItemGroup>
-    <Folder Include="Properties"/>
-    <Folder Include="Tables"/>
-    <Folder Include="Views"/>
-    <Folder Include="Views\Maintenance"/>
+    <Folder Include="Properties" />
+    <Folder Include="Tables" />
+    <Folder Include="Views" />
+    <Folder Include="Views\Maintenance" />
   </ItemGroup>
   <ItemGroup>
-    <Build Include="Tables\Users.sql"/>
-    <Build Include="Tables\Action History.sql"/>
-    <Build Include="Views\Maintenance\Database Performance.sql"/>
+    <Build Include="Tables\Users.sql" />
+    <Build Include="Tables\Action History.sql" />
+    <Build Include="Views\Maintenance\Database Performance.sql" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Views\User"/>
-    <Build Include="Views\User\Profile.sql"/>
+    <Folder Include="Views\User" />
+    <Build Include="Views\User\Profile.sql" />
   </ItemGroup>
-  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
+  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <ItemGroup>
-    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/extensions/sql-database-projects/src/test/baselines/SSDTUpdatedProjectAfterSystemDbUpdateBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/SSDTUpdatedProjectAfterSystemDbUpdateBaseline.xml
@@ -52,29 +52,29 @@
     <SSDTExists Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets')">True</SSDTExists>
     <VisualStudioVersion Condition="'$(SSDTExists)' == ''">11.0</VisualStudioVersion>
   </PropertyGroup>
-  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
-  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <ItemGroup>
-    <Folder Include="Properties"/>
-    <Folder Include="Tables"/>
-    <Folder Include="Views"/>
-    <Folder Include="Views\Maintenance"/>
+    <Folder Include="Properties" />
+    <Folder Include="Tables" />
+    <Folder Include="Views" />
+    <Folder Include="Views\Maintenance" />
   </ItemGroup>
   <ItemGroup>
-    <Build Include="Tables\Users.sql"/>
-    <Build Include="Tables\Action History.sql"/>
-    <Build Include="Views\Maintenance\Database Performance.sql"/>
+    <Build Include="Tables\Users.sql" />
+    <Build Include="Tables\Action History.sql" />
+    <Build Include="Views\Maintenance\Database Performance.sql" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Views\User"/>
-    <Build Include="Views\User\Profile.sql"/>
+    <Folder Include="Views\User" />
+    <Build Include="Views\User\Profile.sql" />
   </ItemGroup>
-  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
+  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <ItemGroup>
-    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <Target Name="BeforeBuild">
-    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json"/>
+    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
   </Target>
   <ItemGroup>
     <ArtifactReference Condition="'$(NetCoreBuild)' == 'true'" Include="$(NETCoreTargetsPath)\SystemDacpacs\150\master.dacpac">

--- a/extensions/sql-database-projects/src/test/baselines/SSDTUpdatedProjectBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/SSDTUpdatedProjectBaseline.xml
@@ -52,8 +52,8 @@
     <SSDTExists Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets')">True</SSDTExists>
     <VisualStudioVersion Condition="'$(SSDTExists)' == ''">11.0</VisualStudioVersion>
   </PropertyGroup>
-   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
-  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
+   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <ItemGroup>
     <Folder Include="Properties" />
     <Folder Include="Tables" />
@@ -69,12 +69,12 @@
     <Folder Include="Views\User" />
     <Build Include="Views\User\Profile.sql" />
   </ItemGroup>
-  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
+  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <ItemGroup>
-    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <Target Name="BeforeBuild">
-    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json"/>
+    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
   </Target>
   <ItemGroup>
     <ArtifactReference Condition="'$(NetCoreBuild)' == 'true'" Include="$(NETCoreTargetsPath)\SystemDacpacs\150\master.dacpac">

--- a/extensions/sql-database-projects/src/test/baselines/openSqlProjectBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSqlProjectBaseline.xml
@@ -98,12 +98,12 @@
     </ArtifactReference>
   </ItemGroup>
   <ItemGroup>
-    <PreDeploy Include="Script.PreDeployment1.sql"/>
-    <None Include="Script.PreDeployment2.sql"/>
+    <PreDeploy Include="Script.PreDeployment1.sql" />
+    <None Include="Script.PreDeployment2.sql" />
   </ItemGroup>
   <ItemGroup>
-    <PostDeploy Include="Script.PostDeployment1.sql"/>
-    <None Include="Tables\Script.PostDeployment1.sql"/>
+    <PostDeploy Include="Script.PostDeployment1.sql" />
+    <None Include="Tables\Script.PostDeployment1.sql" />
   </ItemGroup>
   <Target Name="BeforeBuild">
     <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />

--- a/extensions/sql-database-projects/src/test/baselines/openSqlProjectWithAdditionalSqlCmdVariablesBaseline.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSqlProjectWithAdditionalSqlCmdVariablesBaseline.xml
@@ -52,30 +52,30 @@
     <SSDTExists Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets')">True</SSDTExists>
     <VisualStudioVersion Condition="'$(SSDTExists)' == ''">11.0</VisualStudioVersion>
   </PropertyGroup>
-  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
-  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
-  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
+  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(NETCoreTargetsPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <ItemGroup>
-    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Properties"/>
-    <Folder Include="Tables"/>
-    <Folder Include="Views"/>
-    <Folder Include="Views\Maintenance"/>
+    <Folder Include="Properties" />
+    <Folder Include="Tables" />
+    <Folder Include="Views" />
+    <Folder Include="Views\Maintenance" />
   </ItemGroup>
   <ItemGroup>
-    <Build Include="Tables\Users.sql"/>
-    <Build Include="Tables\Action History.sql"/>
-    <Build Include="Views\Maintenance\Database Performance.sql"/>
-    <Build Include="..\Test\Test.sql"/>
+    <Build Include="Tables\Users.sql" />
+    <Build Include="Tables\Action History.sql" />
+    <Build Include="Views\Maintenance\Database Performance.sql" />
+    <Build Include="..\Test\Test.sql" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Views\User"/>
-    <Build Include="Views\User\Profile.sql"/>
+    <Folder Include="Views\User" />
+    <Build Include="Views\User\Profile.sql" />
   </ItemGroup>
   <ItemGroup>
-    <Build Include="MyExternalStreamingJob.sql" Type="ExternalStreamingJob"/>
+    <Build Include="MyExternalStreamingJob.sql" Type="ExternalStreamingJob" />
   </ItemGroup>
   <ItemGroup>
     <SqlCmdVariable Include="BackupDatabaseName">
@@ -102,14 +102,14 @@
     </ArtifactReference>
   </ItemGroup>
   <ItemGroup>
-    <PreDeploy Include="Script.PreDeployment1.sql"/>
-    <None Include="Script.PreDeployment2.sql"/>
+    <PreDeploy Include="Script.PreDeployment1.sql" />
+    <None Include="Script.PreDeployment2.sql" />
   </ItemGroup>
   <ItemGroup>
-    <PostDeploy Include="Script.PostDeployment1.sql"/>
-    <None Include="Tables\Script.PostDeployment1.sql"/>
+    <PostDeploy Include="Script.PostDeployment1.sql" />
+    <None Include="Tables\Script.PostDeployment1.sql" />
   </ItemGroup>
   <Target Name="BeforeBuild">
-    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json"/>
+    <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />
   </Target>
 </Project>

--- a/extensions/sql-database-projects/src/test/baselines/openSqlProjectWithPrePostDeploymentError.xml
+++ b/extensions/sql-database-projects/src/test/baselines/openSqlProjectWithPrePostDeploymentError.xml
@@ -95,12 +95,12 @@
     </ArtifactReference>
   </ItemGroup>
   <ItemGroup>
-    <PreDeploy Include="Script.PreDeployment1.sql"/>
-    <PreDeploy Include="Script.PreDeployment2.sql"/>
+    <PreDeploy Include="Script.PreDeployment1.sql" />
+    <PreDeploy Include="Script.PreDeployment2.sql" />
   </ItemGroup>
   <ItemGroup>
-    <PostDeploy Include="Script.PostDeployment1.sql"/>
-    <None Include="Tables\Script.PostDeployment1.sql"/>
+    <PostDeploy Include="Script.PostDeployment1.sql" />
+    <None Include="Tables\Script.PostDeployment1.sql" />
   </ItemGroup>
   <Target Name="BeforeBuild">
     <Delete Files="$(BaseIntermediateOutputPath)\project.assets.json" />


### PR DESCRIPTION
This PR fixes #13474. When opening a project created in SSDT in ADS, some updates are made to the project for it to work with the .NET Core build. Even though only a few lines were actually being modified, all the self closing tags were showing as a difference because a space was being removed by the xml serialization in ADS, resulting in many more differences that expected in source control. This fixes that by adding `whiteSpaceAtEndOfSelfclosingTag: true` as a parameter for the xml serialization in ADS.

before:
![image](https://user-images.githubusercontent.com/31145923/102145441-10fdb180-3e1c-11eb-8294-097ccdfca332.png)

after:
![image](https://user-images.githubusercontent.com/31145923/102145451-165afc00-3e1c-11eb-9e8a-487c92ab10c8.png)
