### PR TITLE
Fix "not externalized correctly" warnings

### DIFF
--- a/extensions/kusto/src/features.ts
+++ b/extensions/kusto/src/features.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as nls from 'vscode-nls';
 import { SqlOpsDataClient, SqlOpsFeature } from 'dataprotocol-client';
 import { ClientCapabilities, StaticFeature, RPCMessageType, ServerCapabilities } from 'vscode-languageclient';
 import { Disposable, window } from 'vscode';
@@ -11,7 +12,8 @@ import * as contracts from './contracts';
 import * as azdata from 'azdata';
 import * as Utils from './utils';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
-import { localize } from './localize';
+
+const localize = nls.loadMessageBundle();
 
 export class TelemetryFeature implements StaticFeature {
 

--- a/extensions/kusto/src/kustoServer.ts
+++ b/extensions/kusto/src/kustoServer.ts
@@ -7,15 +7,17 @@ import { ServerProvider, IConfig, Events } from 'service-downloader';
 import { ServerOptions, TransportKind } from 'vscode-languageclient';
 import * as Constants from './constants';
 import * as vscode from 'vscode';
+import * as nls from 'vscode-nls';
 import * as path from 'path';
 import { getCommonLaunchArgsAndCleanupOldLogFiles } from './utils';
-import { localize } from './localize';
 import { Telemetry, LanguageClientErrorHandler } from './telemetry';
 import { SqlOpsDataClient, ClientOptions } from 'dataprotocol-client';
 import { TelemetryFeature, SerializationFeature, AccountFeature } from './features';
 import { AppContext } from './appContext';
 import { CompletionExtensionParams, CompletionExtLoadRequest } from './contracts';
 import { promises as fs } from 'fs';
+
+const localize = nls.loadMessageBundle();
 
 const outputChannel = vscode.window.createOutputChannel(Constants.serviceName);
 const statusView = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);

--- a/extensions/kusto/src/localize.ts
+++ b/extensions/kusto/src/localize.ts
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the Source EULA. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
-import * as nls from 'vscode-nls';
-
-export const localize = nls.loadMessageBundle();

--- a/extensions/kusto/src/main.ts
+++ b/extensions/kusto/src/main.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as nls from 'vscode-nls';
 import * as azdata from 'azdata';
 import * as path from 'path';
 
@@ -16,9 +17,10 @@ import { KustoObjectExplorerNodeProvider } from './objectExplorerNodeProvider/ob
 import { registerSearchServerCommand } from './objectExplorerNodeProvider/command';
 import { KustoIconProvider } from './iconProvider';
 import { createKustoApi } from './kustoApiFactory';
-import { localize } from './localize';
 import { KustoServer } from './kustoServer';
 import { promises as fs } from 'fs';
+
+const localize = nls.loadMessageBundle();
 
 export async function activate(context: vscode.ExtensionContext): Promise<IExtension | undefined> {
 	// lets make sure we support this platform first

--- a/extensions/kusto/src/telemetry.ts
+++ b/extensions/kusto/src/telemetry.ts
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as nls from 'vscode-nls';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { ErrorAction, ErrorHandler, Message, CloseAction } from 'vscode-languageclient';
 
 import * as Utils from './utils';
 import * as Constants from './constants';
-import { localize } from './localize';
+
+const localize = nls.loadMessageBundle();
 
 const packageJson = require('../package.json');
 const viewKnownIssuesAction = localize('viewKnownIssuesText', "View Known Issues");


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13651

The loadMessageBundle call needs to happen in the same module that the localize call is being used - that's part of the key used to look up the strings and so having a single import like this doesn't work unless all the strings are in that file. 