### PR TITLE
Arc - Update Postgres name length limit

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -868,7 +868,7 @@
                           "description": "%arc.postgres.server.group.name.validation.description%",
                           "validations" : [{
                             "type": "regex_match",
-                            "regex": "^[a-z]([-a-z0-9]{0,10}[a-z0-9])?$",
+                            "regex": "^[a-z]([-a-z0-9]{0,9}[a-z0-9])?$",
                             "description": "%arc.postgres.server.group.name.validation.description%"
                           }],
                           "required": true

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -125,7 +125,7 @@
 	"arc.postgres.settings.resource.title": "Resource settings",
 	"arc.postgres.settings.storage.title": "Storage settings",
 	"arc.postgres.server.group.name": "Server group name",
-	"arc.postgres.server.group.name.validation.description": "Server group name must consist of lower case alphanumeric characters or '-', start with a letter, end with an alphanumeric character, and be 12 characters or fewer in length.",
+	"arc.postgres.server.group.name.validation.description": "Server group name must consist of lower case alphanumeric characters or '-', start with a letter, end with an alphanumeric character, and be 11 characters or fewer in length.",
 	"arc.postgres.server.group.workers.label": "Number of workers",
 	"arc.postgres.server.group.workers.description": "The number of worker nodes to provision in a sharded cluster, or zero (the default) for single-node Postgres.",
 	"arc.postgres.server.group.port": "Port",


### PR DESCRIPTION
Arc - Update Postgres name length limit.  It was recently reduced from 12 to 11:

```
azdata arc postgres server create -n abcdefghijkl
Azure Arc enabled PostgreSQL Hyperscale server group name 'abcdefghijkl' exceeds 11 character length limit
```