### PR TITLE
adds close workspace to data workspace view menu

### DIFF
--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -73,22 +73,22 @@
         {
           "command": "dataworkspace.refresh",
           "when": "view == dataworkspace.views.main",
-          "group": "secondary"
+          "group": "2_currentWorkspace"
         },
         {
           "command": "dataworkspace.close",
           "when": "view == dataworkspace.views.main && workbenchState == workspace",
-          "group": "tertiary"
+          "group": "3_commands"
         },
         {
           "command": "projects.new",
           "when": "view == dataworkspace.views.main",
-          "group": "navigation"
+          "group": "1_navigation"
         },
         {
           "command": "projects.openExisting",
           "when": "view == dataworkspace.views.main",
-          "group": "navigation"
+          "group": "1_navigation"
         }
       ],
       "commandPalette": [

--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -58,6 +58,12 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "dataworkspace.close",
+        "title": "%close-workspace-command%",
+        "category": "",
+        "icon": "$(close)"
+      },
+      {
         "command": "projects.removeProject",
         "title": "%remove-project-command%"
       }
@@ -68,6 +74,11 @@
           "command": "dataworkspace.refresh",
           "when": "view == dataworkspace.views.main",
           "group": "secondary"
+        },
+        {
+          "command": "dataworkspace.close",
+          "when": "view == dataworkspace.views.main && workbenchState == workspace",
+          "group": "tertiary"
         },
         {
           "command": "projects.new",
@@ -86,6 +97,10 @@
         },
         {
           "command": "dataworkspace.refresh",
+          "when": "false"
+        },
+        {
+          "command": "dataworkspace.close",
           "when": "false"
         },
         {

--- a/extensions/data-workspace/package.nls.json
+++ b/extensions/data-workspace/package.nls.json
@@ -5,6 +5,7 @@
 	"main-view-name": "Projects",
 	"new-command": "New",
 	"refresh-workspace-command": "Refresh",
+	"close-workspace-command": "Close Workspace",
 	"remove-project-command": "Remove Project",
 	"projects-view-no-workspace-content": "No workspace open, create new or open existing to get started.\n[Create new](command:projects.new)\n[Open existing](command:projects.openExisting)\nTo learn more about SQL Database projects [read our docs](https://aka.ms/azuredatastudio-sqlprojects)",
 	"projects-view-no-project-content": "No projects found in current workspace.\n[Create new](command:projects.new)\n[Open existing](command:projects.openExisting)\nTo learn more about SQL Database projects [read our docs](https://aka.ms/azuredatastudio-sqlprojects).\n",

--- a/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
+++ b/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
@@ -25,10 +25,6 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
 		this._onDidChangeTreeData?.fire();
 	}
 
-	close(): void {
-		vscode.commands.executeCommand('workbench.action.closeFolder');
-	}
-
 	getTreeItem(element: WorkspaceTreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
 		return element.treeDataProvider.getTreeItem(element.element);
 	}

--- a/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
+++ b/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
@@ -25,6 +25,10 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
 		this._onDidChangeTreeData?.fire();
 	}
 
+	close(): void {
+		vscode.commands.executeCommand('workbench.action.closeFolder');
+	}
+
 	getTreeItem(element: WorkspaceTreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
 		return element.treeDataProvider.getTreeItem(element.element);
 	}

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -36,7 +36,7 @@ export function activate(context: vscode.ExtensionContext): Promise<IExtension> 
 		workspaceTreeDataProvider.refresh();
 	}));
 	context.subscriptions.push(vscode.commands.registerCommand('dataworkspace.close', () => {
-		workspaceTreeDataProvider.close();
+		vscode.commands.executeCommand('workbench.action.closeFolder');
 	}));
 	context.subscriptions.push(vscode.commands.registerCommand('projects.removeProject', async (treeItem: WorkspaceTreeItem) => {
 		await workspaceService.removeProject(vscode.Uri.file(treeItem.element.project.projectFilePath));

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -35,6 +35,9 @@ export function activate(context: vscode.ExtensionContext): Promise<IExtension> 
 	context.subscriptions.push(vscode.commands.registerCommand('dataworkspace.refresh', () => {
 		workspaceTreeDataProvider.refresh();
 	}));
+	context.subscriptions.push(vscode.commands.registerCommand('dataworkspace.close', () => {
+		workspaceTreeDataProvider.close();
+	}));
 	context.subscriptions.push(vscode.commands.registerCommand('projects.removeProject', async (treeItem: WorkspaceTreeItem) => {
 		await workspaceService.removeProject(vscode.Uri.file(treeItem.element.project.projectFilePath));
 	}));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #13793
Changes are only in data-workspace extension.  Adds a command hidden from the command palette and visible in the menu of the workspace.  Command calls the native VSCode command to close the workspace (workbench.action.closeFolder) for consistency with the action in the File menu.

When no workspace is open, no change visible:
![image](https://user-images.githubusercontent.com/12227241/102174172-a9625900-3e51-11eb-9bc2-426e95e5c480.png)


When a workspace is open, new section in menu with item to close workspace:
![image](https://user-images.githubusercontent.com/12227241/102174195-b8e1a200-3e51-11eb-8a7a-d8538bc408dd.png)
