### PR TITLE
Notebooks: Fix "." not showing Intellisense suggestions list

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterController.ts
+++ b/extensions/notebook/src/jupyter/jupyterController.ts
@@ -80,7 +80,7 @@ export class JupyterController {
 			{ scheme: 'untitled', language: '*' }
 		];
 		this.registerNotebookProvider();
-		this.extensionContext.subscriptions.push(vscode.languages.registerCompletionItemProvider(supportedFileFilter, new NotebookCompletionItemProvider(this._notebookProvider)));
+		this.extensionContext.subscriptions.push(vscode.languages.registerCompletionItemProvider(supportedFileFilter, new NotebookCompletionItemProvider(this._notebookProvider), '.'));
 
 		this.registerDefaultPackageManageProviders();
 		return true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR address part of https://github.com/microsoft/azuredatastudio/issues/9067.
Added "." as a trigger character so that the Intellisense suggestions list will be shown when user types "." while using Python kernel.
