### PR TITLE
Added fix for the infinite page refresh in resource Deployment tools page

### DIFF
--- a/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
@@ -198,19 +198,22 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 						}).component();
 						optionLabel.width = '150px';
 
+						const optionSelectedValue = (this.wizard.toolsEulaPagePresets) ? this.wizard.toolsEulaPagePresets[index] : option.values[0];
 						const optionSelectBox = this.view.modelBuilder.dropDown().withProperties<azdata.DropDownProperties>({
 							values: option.values,
-							value: (this.wizard.toolsEulaPagePresets) ? this.wizard.toolsEulaPagePresets[index] : option.values[0],
+							value: optionSelectedValue,
 							width: '300px',
 							ariaLabel: option.displayName
 						}).component();
 
-						resourceTypeOptions.push(option.values[0]);
+						resourceTypeOptions.push(optionSelectedValue);
 
 						this.wizard.registerDisposable(optionSelectBox.onValueChanged(async () => {
-							resourceTypeOptions[index] = <ResourceTypeOptionValue>optionSelectBox.value;
-							this.wizard.provider = this.getCurrentProvider();
-							await this.wizard.open();
+							if (resourceTypeOptions[index].name !== (<ResourceTypeOptionValue>optionSelectBox.value || true).name) {
+								resourceTypeOptions[index] = <ResourceTypeOptionValue>optionSelectBox.value;
+								this.wizard.provider = this.getCurrentProvider();
+								await this.wizard.open();
+							}
 						}));
 
 						this._optionDropDownMap.set(option.name, optionSelectBox);

--- a/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
@@ -209,7 +209,7 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 						resourceTypeOptions.push(optionSelectedValue);
 
 						this.wizard.registerDisposable(optionSelectBox.onValueChanged(async () => {
-							if (resourceTypeOptions[index].name !== (<ResourceTypeOptionValue>optionSelectBox.value || true).name) {
+							if (resourceTypeOptions[index].name !== (<ResourceTypeOptionValue>optionSelectBox.value).name) {
 								resourceTypeOptions[index] = <ResourceTypeOptionValue>optionSelectBox.value;
 								this.wizard.provider = this.getCurrentProvider();
 								await this.wizard.open();

--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -134,8 +134,7 @@ export class SelectBox extends vsSelectBox {
 	}
 
 	public onSelect(newInput: ISelectData) {
-		const selected = this._dialogOptions[newInput.index];
-		this._selectedOption = selected.value;
+		this.select(newInput.index);
 	}
 
 	private static createOptions(options: SelectOptionItemSQL[] | string[] | ISelectOptionItem[]): SelectOptionItemSQL[] {
@@ -197,6 +196,9 @@ export class SelectBox extends vsSelectBox {
 	}
 
 	public select(index: number): void {
+		if (this._selectedOption && this._optionsDictionary.get(this._selectedOption) === index) { // Not generating an event if the same value is selected.
+			return;
+		}
 		super.select(index);
 		if (this._dialogOptions !== undefined) {
 			this._selectedOption = this._dialogOptions[index]?.value;

--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -198,7 +198,7 @@ export class SelectBox extends vsSelectBox {
 
 	public select(index: number): void {
 		let selectedOptionIndex = this._optionsDictionary.get(this._selectedOption);
-		if (selectedOptionIndex === undefined || selectedOptionIndex === index) { // Not generating an event if the same value is selected.
+		if (selectedOptionIndex === index) { // Not generating an event if the same value is selected.
 			return;
 		}
 		super.select(index);

--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -134,7 +134,8 @@ export class SelectBox extends vsSelectBox {
 	}
 
 	public onSelect(newInput: ISelectData) {
-		this.select(newInput.index);
+		const selected = this._dialogOptions[newInput.index];
+		this._selectedOption = selected.value;
 	}
 
 	private static createOptions(options: SelectOptionItemSQL[] | string[] | ISelectOptionItem[]): SelectOptionItemSQL[] {
@@ -197,7 +198,7 @@ export class SelectBox extends vsSelectBox {
 
 	public select(index: number): void {
 		let selectedOptionIndex = this._optionsDictionary.get(this._selectedOption);
-		if (selectedOptionIndex === undefined && selectedOptionIndex === index) { // Not generating an event if the same value is selected.
+		if (selectedOptionIndex === undefined || selectedOptionIndex === index) { // Not generating an event if the same value is selected.
 			return;
 		}
 		super.select(index);

--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -196,7 +196,8 @@ export class SelectBox extends vsSelectBox {
 	}
 
 	public select(index: number): void {
-		if (this._selectedOption && this._optionsDictionary.get(this._selectedOption) === index) { // Not generating an event if the same value is selected.
+		let selectedOptionIndex = this._optionsDictionary.get(this._selectedOption);
+		if (selectedOptionIndex === undefined && selectedOptionIndex === index) { // Not generating an event if the same value is selected.
 			return;
 		}
 		super.select(index);


### PR DESCRIPTION
Generating events for select boxes only when the select box value is changed.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #13812 

For some reason, I was noticing a trailing value in the events generated. 

By trailing value, I mean, the value that was last selected and not the current one.
For example:
if A is the initial value and the user changes it to B, the event returned A instead of B 