### PR TITLE
Removed padding-top / bottom declarations for text cell 

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
@@ -17,8 +17,6 @@ text-cell-component .notebook-preview {
 	flex-direction: column;
 	padding-left: 8px;
 	padding-right: 8px;
-	padding-top: 14px;
-	padding-bottom: 14px;
 	user-select: none;
 	width: 100%;
 	outline: none;
@@ -32,8 +30,6 @@ text-cell-component .show-markdown .notebook-preview {
 	border-style: solid;
 	border-top-width: 0;
 	width: 50%;
-	padding-top: 0px;
-	padding-bottom: 0px;
 }
 .notebook-preview.actionselect {
 	user-select: text;


### PR DESCRIPTION
This compacts the text cell by 14px on top and bottom.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
_screenshot showing recent changes_
![image](https://user-images.githubusercontent.com/12279161/102269654-cdfe1580-3ed1-11eb-99d8-6a9d967a7d43.png)

This PR is for #13810
