### PR TITLE
Fix unstable data-workspace tests

### DIFF
--- a/extensions/data-workspace/src/dialogs/dialogBase.ts
+++ b/extensions/data-workspace/src/dialogs/dialogBase.ts
@@ -159,7 +159,7 @@ export abstract class DialogBase {
 		}
 	}
 
-	protected async validateNewWorkspace(sameFolderAsNewProject: boolean): Promise<boolean> {
+	public async validateNewWorkspace(sameFolderAsNewProject: boolean): Promise<boolean> {
 		// workspace file should end in .code-workspace
 		const workspaceValid = this.workspaceInputBox!.value!.endsWith(constants.WorkspaceFileExtension);
 		if (!workspaceValid) {

--- a/extensions/data-workspace/src/dialogs/dialogBase.ts
+++ b/extensions/data-workspace/src/dialogs/dialogBase.ts
@@ -36,9 +36,7 @@ export abstract class DialogBase {
 
 	protected abstract initialize(view: azdata.ModelView): Promise<void>;
 
-	protected async validate(): Promise<boolean> {
-		return Promise.resolve(true);
-	}
+	abstract validate(): Promise<boolean>;
 
 	public async open(): Promise<void> {
 		const tab = azdata.window.createTab('');
@@ -75,6 +73,10 @@ export abstract class DialogBase {
 			text: message,
 			level: azdata.window.MessageLevel.Error
 		};
+	}
+
+	public getErrorMessage(): azdata.window.DialogMessage {
+		return this._dialogObject.message;
 	}
 
 	protected createHorizontalContainer(view: azdata.ModelView, items: azdata.Component[]): azdata.FlexContainer {

--- a/extensions/data-workspace/src/dialogs/dialogBase.ts
+++ b/extensions/data-workspace/src/dialogs/dialogBase.ts
@@ -173,7 +173,7 @@ export abstract class DialogBase {
 		if (!sameFolderAsNewProject) {
 			const workspaceParentDirectoryExists = await directoryExist(path.dirname(this.workspaceInputBox!.value!));
 			if (!workspaceParentDirectoryExists) {
-				this.showErrorMessage(constants.WorkspaceParentDirectoryNotExistError(this.workspaceInputBox!.value!));
+				this.showErrorMessage(constants.WorkspaceParentDirectoryNotExistError(path.dirname(this.workspaceInputBox!.value!)));
 				return false;
 			}
 		}

--- a/extensions/data-workspace/src/dialogs/openExistingDialog.ts
+++ b/extensions/data-workspace/src/dialogs/openExistingDialog.ts
@@ -37,9 +37,7 @@ export class OpenExistingDialog extends DialogBase {
 		try {
 			// the selected location should be an existing directory
 			if (this._targetTypeRadioCardGroup?.selectedCardId === constants.Project) {
-				const fileExists = await fileExist(this._projectFile);
-				if (!fileExists) {
-					this.showErrorMessage(constants.FileNotExistError(constants.Project.toLowerCase(), this._projectFile));
+				if (!await this.validateFile(this._projectFile, constants.Project.toLowerCase())) {
 					return false;
 				}
 
@@ -47,9 +45,7 @@ export class OpenExistingDialog extends DialogBase {
 					return false;
 				}
 			} else if (this._targetTypeRadioCardGroup?.selectedCardId === constants.Workspace) {
-				const fileExists = await fileExist(this._workspaceFile);
-				if (!fileExists) {
-					this.showErrorMessage(constants.FileNotExistError(constants.Workspace.toLowerCase(), this._workspaceFile));
+				if (!await this.validateFile(this._workspaceFile, constants.Workspace.toLowerCase())) {
 					return false;
 				}
 			}
@@ -60,6 +56,16 @@ export class OpenExistingDialog extends DialogBase {
 			this.showErrorMessage(err?.message ? err.message : err);
 			return false;
 		}
+	}
+
+	public async validateFile(file: string, fileType: string) {
+		const fileExists = await fileExist(file);
+		if (!fileExists) {
+			this.showErrorMessage(constants.FileNotExistError(fileType, file));
+			return false;
+		}
+
+		return true;
 	}
 
 	async onComplete(): Promise<void> {

--- a/extensions/data-workspace/src/test/dialogs/dialogBase.test.ts
+++ b/extensions/data-workspace/src/test/dialogs/dialogBase.test.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as should from 'should';
+import * as TypeMoq from 'typemoq';
+import * as os from 'os';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as utils from '../../common/utils';
+import * as constants from '../../common/constants';
+import { NewProjectDialog } from '../../dialogs/newProjectDialog';
+import { WorkspaceService } from '../../services/workspaceService';
+import { testProjectType } from '../testUtils';
+
+suite('DialogBase - workspace validation', function (): void {
+	// DialogBase is an abstract class, so we'll just use a NewProjectDialog to test the common base class functions
+	let dialog: NewProjectDialog;
+
+	this.beforeEach(async () => {
+		const workspaceServiceMock = TypeMoq.Mock.ofType<WorkspaceService>();
+		workspaceServiceMock.setup(x => x.getAllProjectTypes()).returns(() => Promise.resolve([testProjectType]));
+
+		dialog = new NewProjectDialog(workspaceServiceMock.object);
+		await dialog.open();
+
+		dialog.model.name = `TestProject_${new Date().getTime()}`;
+		dialog.model.location = os.tmpdir();
+	});
+
+	this.afterEach(() => {
+		sinon.restore();
+	});
+
+	test('Should validate new workspace location missing file extension', async function (): Promise<void> {
+		dialog.workspaceInputBox!.value = 'test';
+		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because workspace does not end in .code-workspace');
+		should.equal(dialog.getErrorMessage().text, constants.WorkspaceFileInvalidError(dialog.workspaceInputBox!.value));
+	});
+
+	test('Should validate new workspace location with invalid location', async function (): Promise<void> {
+		// use invalid folder
+		dialog.workspaceInputBox!.value = 'invalidLocation/test.code-workspace';
+		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because the folder is invalid');
+		should.equal(dialog.getErrorMessage().text, constants.WorkspaceParentDirectoryNotExistError(path.dirname(dialog.workspaceInputBox!.value)));
+	});
+
+	test('Should validate new workspace location that already exists', async function (): Promise<void> {
+		// use already existing workspace
+		const fileExistStub = sinon.stub(utils, 'fileExist');
+		fileExistStub.resolves(true);
+		const existingWorkspaceFilePath = path.join(os.tmpdir(), `${dialog.model.name}.code-workspace`);
+		dialog.workspaceInputBox!.value = existingWorkspaceFilePath;
+		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because the selected workspace file already exists');
+		should.equal(dialog.getErrorMessage().text, constants.WorkspaceFileAlreadyExistsError(existingWorkspaceFilePath));
+	});
+
+	test('Should validate new workspace location that is valid', async function (): Promise<void> {
+		// same folder as the project should be valid even if the project folder isn't created yet
+		dialog.workspaceInputBox!.value = path.join(dialog.model.location, dialog.model.name, 'test.code-workspace');
+		should.equal(await dialog.validateNewWorkspace(true), true, `Validation should pass if the file location is the same folder as the project. Error was: ${dialog.getErrorMessage()?.text}`);
+
+		// a workspace not in the same folder as the project should also be valid
+		dialog.workspaceInputBox!.value = path.join(os.tmpdir(), `TestWorkspace_${new Date().getTime()}.code-workspace`);
+		should.equal(await dialog.validateNewWorkspace(false), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage()?.text}`);
+	});
+});
+

--- a/extensions/data-workspace/src/test/dialogs/newProjectDialog.test.ts
+++ b/extensions/data-workspace/src/test/dialogs/newProjectDialog.test.ts
@@ -53,27 +53,27 @@ suite('New Project Dialog', function (): void {
 		dialog.model.name = `TestProject_${new Date().getTime()}`;
 		dialog.model.location = os.tmpdir();
 		dialog.workspaceInputBox!.value = 'test';
-		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because workspace does not end in .code-workspace');
+		should.equal(await dialog.validate(), false, 'Validation should fail because workspace does not end in .code-workspace');
 
 		const fileExistStub = sinon.stub(utils, 'fileExist');
 		fileExistStub.resolves(true);
 		// use invalid folder
 		dialog.workspaceInputBox!.value = 'invalidLocation/test.code-workspace';
-		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because the folder is invalid');
+		should.equal(await dialog.validate(), false, 'Validation should fail because the folder is invalid');
 
 		// use already existing workspace
 		const existingWorkspaceFilePath = path.join(os.tmpdir(), `${dialog.model.name}.code-workspace`);
 		dialog.workspaceInputBox!.value = existingWorkspaceFilePath;
-		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because the selected workspace file already exists');
+		should.equal(await dialog.validate(), false, 'Validation should fail because the selected workspace file already exists');
 
 		// same folder as the project should be valid even if the project folder isn't created yet
 		fileExistStub.resolves(false);
 		dialog.workspaceInputBox!.value = path.join(dialog.model.location, dialog.model.name, 'test.code-workspace');
-		should.equal(await dialog.validateNewWorkspace(true), true, `Validation should pass if the file location is the same folder as the project. Error was: ${dialog.getErrorMessage().text}`);
+		should.equal(await dialog.validate(), true, `Validation should pass if the file location is the same folder as the project. Error was: ${dialog.getErrorMessage().text}`);
 
 		// change workspace name to something that should pass
 		dialog.workspaceInputBox!.value = path.join(os.tmpdir(), `TestWorkspace_${new Date().getTime()}.code-workspace`);
-		should.equal(await dialog.validateNewWorkspace(false), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage().text}`);
+		should.equal(await dialog.validate(), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage().text}`);
 	});
 
 	test('Should validate workspace in onComplete', async function (): Promise<void> {

--- a/extensions/data-workspace/src/test/dialogs/newProjectDialog.test.ts
+++ b/extensions/data-workspace/src/test/dialogs/newProjectDialog.test.ts
@@ -69,11 +69,11 @@ suite('New Project Dialog', function (): void {
 		// same folder as the project should be valid even if the project folder isn't created yet
 		fileExistStub.resolves(false);
 		dialog.workspaceInputBox!.value = path.join(dialog.model.location, dialog.model.name, 'test.code-workspace');
-		should.equal(await dialog.validateNewWorkspace(true), true, 'Validation should pass if the file location is the same folder as the project');
+		should.equal(await dialog.validateNewWorkspace(true), true, `Validation should pass if the file location is the same folder as the project. Error was: ${dialog.getErrorMessage().text}`);
 
 		// change workspace name to something that should pass
 		dialog.workspaceInputBox!.value = path.join(os.tmpdir(), `TestWorkspace_${new Date().getTime()}.code-workspace`);
-		should.equal(await dialog.validateNewWorkspace(false), true, 'Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct');
+		should.equal(await dialog.validateNewWorkspace(false), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage().text}`);
 	});
 
 	test('Should validate workspace in onComplete', async function (): Promise<void> {

--- a/extensions/data-workspace/src/test/dialogs/newProjectDialog.test.ts
+++ b/extensions/data-workspace/src/test/dialogs/newProjectDialog.test.ts
@@ -9,7 +9,6 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
-import * as utils from '../../common/utils';
 import { promises as fs } from 'fs';
 import { NewProjectDialog } from '../../dialogs/newProjectDialog';
 import { WorkspaceService } from '../../services/workspaceService';
@@ -43,38 +42,6 @@ suite('New Project Dialog', function (): void {
 		should.equal(await dialog.validate(), true, 'Validation should pass because name is unique and parent directory exists');
 	});
 
-	test('Should validate new workspace location', async function (): Promise<void> {
-		const workspaceServiceMock = TypeMoq.Mock.ofType<WorkspaceService>();
-		workspaceServiceMock.setup(x => x.getAllProjectTypes()).returns(() => Promise.resolve([testProjectType]));
-
-		const dialog = new NewProjectDialog(workspaceServiceMock.object);
-		await dialog.open();
-
-		dialog.model.name = `TestProject_${new Date().getTime()}`;
-		dialog.model.location = os.tmpdir();
-		dialog.workspaceInputBox!.value = 'test';
-		should.equal(await dialog.validate(), false, 'Validation should fail because workspace does not end in .code-workspace');
-
-		const fileExistStub = sinon.stub(utils, 'fileExist');
-		fileExistStub.resolves(true);
-		// use invalid folder
-		dialog.workspaceInputBox!.value = 'invalidLocation/test.code-workspace';
-		should.equal(await dialog.validate(), false, 'Validation should fail because the folder is invalid');
-
-		// use already existing workspace
-		const existingWorkspaceFilePath = path.join(os.tmpdir(), `${dialog.model.name}.code-workspace`);
-		dialog.workspaceInputBox!.value = existingWorkspaceFilePath;
-		should.equal(await dialog.validate(), false, 'Validation should fail because the selected workspace file already exists');
-
-		// same folder as the project should be valid even if the project folder isn't created yet
-		fileExistStub.resolves(false);
-		dialog.workspaceInputBox!.value = path.join(dialog.model.location, dialog.model.name, 'test.code-workspace');
-		should.equal(await dialog.validate(), true, `Validation should pass if the file location is the same folder as the project. Error was: ${dialog.getErrorMessage().text}`);
-
-		// change workspace name to something that should pass
-		dialog.workspaceInputBox!.value = path.join(os.tmpdir(), `TestWorkspace_${new Date().getTime()}.code-workspace`);
-		should.equal(await dialog.validate(), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage().text}`);
-	});
 
 	test('Should validate workspace in onComplete', async function (): Promise<void> {
 		const workspaceServiceMock = TypeMoq.Mock.ofType<WorkspaceService>();

--- a/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
+++ b/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
@@ -75,12 +75,12 @@ suite('Open Existing Dialog', function (): void {
 		// use already existing workspace
 		const existingWorkspaceFilePath = path.join(os.tmpdir(), `test.code-workspace`);
 		dialog.workspaceInputBox!.value = existingWorkspaceFilePath;
-		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because the selected workspace file already exists');
+		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because the selected workspace file already exists.');
 
 		// change workspace name to something that should pass
 		fileExistStub.resolves(false);
 		dialog.workspaceInputBox!.value = path.join(os.tmpdir(), `TestWorkspace_${new Date().getTime()}.code-workspace`);
-		should.equal(await dialog.validateNewWorkspace(false), true, 'Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct');
+		should.equal(await dialog.validateNewWorkspace(false), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage().text}`);
 	});
 
 	test('Should validate workspace in onComplete when opening project', async function (): Promise<void> {

--- a/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
+++ b/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
@@ -7,10 +7,7 @@ import * as should from 'should';
 import * as TypeMoq from 'typemoq';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import * as os from 'os';
-import * as path from 'path';
 import * as constants from '../../common/constants';
-import * as utils from '../../common/utils';
 import { promises as fs } from 'fs';
 import { WorkspaceService } from '../../services/workspaceService';
 import { OpenExistingDialog } from '../../dialogs/openExistingDialog';
@@ -54,35 +51,6 @@ suite('Open Existing Dialog', function (): void {
 		should.equal(await dialog.validate(), true, 'Validation pass because workspace file exists');
 	});
 
-	test('Should validate new workspace location', async function (): Promise<void> {
-		const workspaceServiceMock = TypeMoq.Mock.ofType<WorkspaceService>();
-		workspaceServiceMock.setup(x => x.getAllProjectTypes()).returns(() => Promise.resolve([testProjectType]));
-
-		const dialog = new OpenExistingDialog(workspaceServiceMock.object, mockExtensionContext.object);
-		await dialog.open();
-
-		dialog._projectFile = await createProjectFile('testproj');
-		dialog.workspaceInputBox!.value = 'test';
-		should.equal(await dialog.validate(), false, 'Validation should fail because workspace does not end in code-workspace');
-
-		const fileExistStub = sinon.stub(utils, 'fileExist');
-		fileExistStub.resolves(true);
-		sinon.stub(OpenExistingDialog.prototype, 'validateFile').resolves(true);
-
-		// use invalid folder
-		dialog.workspaceInputBox!.value = 'invalidLocation/test.code-workspace';
-		should.equal(await dialog.validate(), false, 'Validation should fail because the folder is invalid');
-
-		// use already existing workspace
-		const existingWorkspaceFilePath = path.join(os.tmpdir(), `test.code-workspace`);
-		dialog.workspaceInputBox!.value = existingWorkspaceFilePath;
-		should.equal(await dialog.validate(), false, 'Validation should fail because the selected workspace file already exists.');
-
-		// change workspace name to something that should pass
-		fileExistStub.resolves(false);
-		dialog.workspaceInputBox!.value = path.join(os.tmpdir(), `TestWorkspace_${new Date().getTime()}.code-workspace`);
-		should.equal(await dialog.validate(), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage().text}`);
-	});
 
 	test('Should validate workspace in onComplete when opening project', async function (): Promise<void> {
 		const workspaceServiceMock = TypeMoq.Mock.ofType<WorkspaceService>();

--- a/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
+++ b/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
@@ -63,24 +63,25 @@ suite('Open Existing Dialog', function (): void {
 
 		dialog._projectFile = await createProjectFile('testproj');
 		dialog.workspaceInputBox!.value = 'test';
-		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because workspace does not end in code-workspace');
+		should.equal(await dialog.validate(), false, 'Validation should fail because workspace does not end in code-workspace');
 
 		const fileExistStub = sinon.stub(utils, 'fileExist');
 		fileExistStub.resolves(true);
+		sinon.stub(OpenExistingDialog.prototype, 'validateFile').resolves(true);
 
 		// use invalid folder
 		dialog.workspaceInputBox!.value = 'invalidLocation/test.code-workspace';
-		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because the folder is invalid');
+		should.equal(await dialog.validate(), false, 'Validation should fail because the folder is invalid');
 
 		// use already existing workspace
 		const existingWorkspaceFilePath = path.join(os.tmpdir(), `test.code-workspace`);
 		dialog.workspaceInputBox!.value = existingWorkspaceFilePath;
-		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because the selected workspace file already exists.');
+		should.equal(await dialog.validate(), false, 'Validation should fail because the selected workspace file already exists.');
 
 		// change workspace name to something that should pass
 		fileExistStub.resolves(false);
 		dialog.workspaceInputBox!.value = path.join(os.tmpdir(), `TestWorkspace_${new Date().getTime()}.code-workspace`);
-		should.equal(await dialog.validateNewWorkspace(false), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage().text}`);
+		should.equal(await dialog.validate(), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage().text}`);
 	});
 
 	test('Should validate workspace in onComplete when opening project', async function (): Promise<void> {


### PR DESCRIPTION
This removes the @UNSTABLE@ from the tests marked as unstable in #13822. I wasn't able to repro the failures locally, but I suspect the tests were flaky because they were creating a file and the validation for it existing wasn't always working. The changes in this PR: 
- stub the file existing function instead of actually creating files and checking if they exist
- change the validation tests to only call new workspace validation instead of overall validation, since the tests are only meant to validation that anyway