### PR TITLE
Notebooks: Fix duplicate SVG rendering

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/outputs/renderers.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/renderers.ts
@@ -325,9 +325,11 @@ export function renderSVG(options: renderSVG.IRenderOptions): Promise<void> {
 	// Unpack the options.
 	let { host, source, trusted, unconfined } = options;
 
+	// Clear the content in the host.
+	host.textContent = '';
+
 	// Clear the content if there is no source.
 	if (!source) {
-		host.textContent = '';
 		return Promise.resolve(undefined);
 	}
 


### PR DESCRIPTION
Fixes #13827.

Taking the logic from the `renderImage()` method, and clearing out content regardless. This is a longstanding bug that we've had with rendering SVG images.

Result:
![image](https://user-images.githubusercontent.com/40371649/102417122-f4927e00-3faf-11eb-9aa7-c3ac7f7bf381.png)
