### PR TITLE
Notebooks: Render SVGs as SVGs instead of Images

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/outputs/renderers.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/renderers.ts
@@ -338,10 +338,7 @@ export function renderSVG(options: renderSVG.IRenderOptions): Promise<void> {
 		return Promise.resolve(undefined);
 	}
 
-	// Render in img so that user can save it easily
-	const img = new Image();
-	img.src = `data:image/svg+xml,${encodeURIComponent(source)}`;
-	host.appendChild(img);
+	host.innerHTML = source;
 
 	if (unconfined === true) {
 		host.classList.add('jp-mod-unconfined');


### PR DESCRIPTION
When rendering SVGs in notebooks today, tooltips (and other info) get lost, because we do the following:

```
const img = new Image();	
img.src = `data:image/svg+xml,${encodeURIComponent(source)}`;
```

This follows the convention from JupyterLab, which appears to be the odd duck out for how they display SVGs. 

Here's what happens in Jupyter:
![image](https://user-images.githubusercontent.com/40371649/102424598-5d81f200-3fc0-11eb-9bf2-41ce20422d5b.png)
[Untrusted]

![image](https://user-images.githubusercontent.com/40371649/102424690-8bffcd00-3fc0-11eb-8557-e3e666bf0988.png)
[Trusted]

VS Code: https://github.com/microsoft/vscode/blob/d6e8feb774461355caf045fd6db88dc6aaccea5e/src/vs/workbench/contrib/notebook/browser/view/output/transforms/richTransform.ts#L167 (note that SVGs are displayed as is when executing):
![image](https://user-images.githubusercontent.com/40371649/102425276-d46bba80-3fc1-11eb-9660-75f317412e04.png)

With this change, this is what happens with ADS:

![image](https://user-images.githubusercontent.com/40371649/102424866-f1ec5480-3fc0-11eb-9af9-97048040a78e.png)
[Untrusted]

![image](https://user-images.githubusercontent.com/40371649/102424797-cec1a500-3fc0-11eb-9a2b-da1e4834bef2.png)
[Trusted]

