### PR TITLE
comment out the unstable unit test step

### DIFF
--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -138,7 +138,7 @@ steps:
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { .\scripts\test-unstable.bat --build --tfs }
+      exec { .\scripts\test-unstable.bat --tfs }
     continueOnError: true
     condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
     displayName: Run unstable tests

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -138,7 +138,7 @@ steps:
   # - powershell: |
   #     . build/azure-pipelines/win32/exec.ps1
   #     $ErrorActionPreference = "Stop"
-  #     exec { .\scripts\test-unstable.bat --tfs }
+  #     exec { .\scripts\test-unstable.bat --build --tfs }
   #   continueOnError: true
   #   condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
   #   displayName: Run unstable tests

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -135,13 +135,13 @@ steps:
     displayName: Run integration tests (Electron)
     condition: and(succeeded(), eq(variables['RUN_TESTS'], 'true'))
 
-  - powershell: |
-      . build/azure-pipelines/win32/exec.ps1
-      $ErrorActionPreference = "Stop"
-      exec { .\scripts\test-unstable.bat --tfs }
-    continueOnError: true
-    condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
-    displayName: Run unstable tests
+  # - powershell: |
+  #     . build/azure-pipelines/win32/exec.ps1
+  #     $ErrorActionPreference = "Stop"
+  #     exec { .\scripts\test-unstable.bat --tfs }
+  #   continueOnError: true
+  #   condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
+  #   displayName: Run unstable tests
 
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'Sign out code'


### PR DESCRIPTION
the unstable test pipeline has been failing for a long time due to the unstable unit test timeout, I noticed even the stable test step has also been commented out by Anthony due to the same reason.

![image](https://user-images.githubusercontent.com/13777222/102450655-c894ee00-3feb-11eb-927d-e112be68002b.png)

I will investigate the timeout issue later, now, lets unblock the other unstable test run. we don't actually have any unstable unit test.

I have verified after this we can get the unstable integration test running as expected: pass with issues. https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=87127&view=results
