### PR TITLE
Notebooks: Stop forcing left text align on tables

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
@@ -72,7 +72,6 @@ text-cell-component thead {
 text-cell-component td,
 text-cell-component th,
 text-cell-component tr {
-	text-align: left;
 	vertical-align: middle;
 	padding: 0.5em 0.5em;
 	line-height: normal;


### PR DESCRIPTION
Fixes #12509. The "always center tables" bit is something we won't be addressing, but this is for table alignment issues. We were hardcoding left text-align for all tables, even though our table headers/row/cells render as left text-align regardless. This broke things like the following:

```
| Left Align | Right Align | Center |
| :- | -: | :-: |
| Stretched | Gaussian | .843 |
| Almost 100 | Is it?  | 99.99 |
```

Which should look like this:
| Left Align | Right Align | Center |
| :- | -: | :-: |
| Stretched | Gaussian | .843 |
| Almost 100 | Is it?  | 99.99 |

And in ADS:
![image](https://user-images.githubusercontent.com/40371649/102533518-61fae900-405a-11eb-92a5-19659dcf68b4.png)
