### PR TITLE
Make new workspace inputbox editable in Create project from database dialog

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -38,9 +38,9 @@ export const NewWorkspaceWillBeCreated = localize('dataworkspace.NewWorkspaceWil
 export const WorkspaceLocationTitle = localize('dataworkspace.workspaceLocationTitle', "Workspace location");
 export const ProjectParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.projectParentDirectoryNotExistError', "The selected project location '{0}' does not exist or is not a directory.", location); };
 export const ProjectDirectoryAlreadyExistError = (projectName: string, location: string): string => { return localize('dataworkspace.projectDirectoryAlreadyExistError', "There is already a directory named '{0}' in the selected location: '{1}'.", projectName, location); };
-export const WorkspaceFileInvalidError = (workspace: string): string => { return localize('dataworkspace.workspaceFileInvalidError', "The selected workspace file path '{0}' does not have the required file extension {1}", workspace, WorkspaceFileExtension); };
-export const WorkspaceParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.workspaceParentDirectoryNotExistError', "The selected workspace location '{0}' does not exist or is not a directory", location); };
-export const WorkspaceFileAlreadyExistsError = (file: string): string => { return localize('dataworkspace.workspaceFileAlreadyExistsError', "The selected workspace file '{0}' already exists. To add the project to an existing workspace, use the Open Existing dialog to first open the workspace", file); };
+export const WorkspaceFileInvalidError = (workspace: string): string => { return localize('dataworkspace.workspaceFileInvalidError', "The selected workspace file path '{0}' does not have the required file extension {1}.", workspace, WorkspaceFileExtension); };
+export const WorkspaceParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.workspaceParentDirectoryNotExistError', "The selected workspace location '{0}' does not exist or is not a directory.", location); };
+export const WorkspaceFileAlreadyExistsError = (file: string): string => { return localize('dataworkspace.workspaceFileAlreadyExistsError', "The selected workspace file '{0}' already exists. To add the project to an existing workspace, use the Open Existing dialog to first open the workspace.", file); };
 
 //Open Existing Dialog
 export const OpenExistingDialogTitle = localize('dataworkspace.openExistingDialogTitle', "Open existing");

--- a/extensions/data-workspace/src/common/dataWorkspaceExtension.ts
+++ b/extensions/data-workspace/src/common/dataWorkspaceExtension.ts
@@ -16,8 +16,8 @@ export class DataWorkspaceExtension implements IExtension {
 		return this.workspaceService.getProjectsInWorkspace();
 	}
 
-	addProjectsToWorkspace(projectFiles: vscode.Uri[]): Promise<void> {
-		return this.workspaceService.addProjectsToWorkspace(projectFiles);
+	addProjectsToWorkspace(projectFiles: vscode.Uri[], workspaceFilePath?: vscode.Uri): Promise<void> {
+		return this.workspaceService.addProjectsToWorkspace(projectFiles, workspaceFilePath);
 	}
 
 	showProjectsView(): void {

--- a/extensions/data-workspace/src/dataworkspace.d.ts
+++ b/extensions/data-workspace/src/dataworkspace.d.ts
@@ -20,9 +20,10 @@ declare module 'dataworkspace' {
 
 		/**
 		 * Add projects to the workspace
-		 * @param projectFiles Uris of project files to add
+		 * @param projectFiles Uris of project files to add,
+		 * @param workspaceFilePath workspace file to create if no workspace is open
 		 */
-		addProjectsToWorkspace(projectFiles: vscode.Uri[]): Promise<void>;
+		addProjectsToWorkspace(projectFiles: vscode.Uri[], workspaceFilePath?: vscode.Uri): Promise<void>;
 
 		/**
 		 * Change focus to Projects view

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -140,9 +140,9 @@ export const workspace = localize('workspace', "Workspace");
 export const WorkspaceFileExtension = '.code-workspace';
 export const ProjectParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.projectParentDirectoryNotExistError', "The selected project location '{0}' does not exist or is not a directory.", location); };
 export const ProjectDirectoryAlreadyExistError = (projectName: string, location: string): string => { return localize('dataworkspace.projectDirectoryAlreadyExistError', "There is already a directory named '{0}' in the selected location: '{1}'.", projectName, location); };
-export const WorkspaceFileInvalidError = (workspace: string): string => { return localize('dataworkspace.workspaceFileInvalidError', "The selected workspace file path '{0}' does not have the required file extension {1}", workspace, WorkspaceFileExtension); };
-export const WorkspaceParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.workspaceParentDirectoryNotExistError', "The selected workspace location '{0}' does not exist or is not a directory", location); };
-export const WorkspaceFileAlreadyExistsError = (file: string): string => { return localize('dataworkspace.workspaceFileAlreadyExistsError', "The selected workspace file '{0}' already exists. To add the project to an existing workspace, use the Open Existing dialog to first open the workspace", file); };
+export const WorkspaceFileInvalidError = (workspace: string): string => { return localize('dataworkspace.workspaceFileInvalidError', "The selected workspace file path '{0}' does not have the required file extension {1}.", workspace, WorkspaceFileExtension); };
+export const WorkspaceParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.workspaceParentDirectoryNotExistError', "The selected workspace location '{0}' does not exist or is not a directory.", location); };
+export const WorkspaceFileAlreadyExistsError = (file: string): string => { return localize('dataworkspace.workspaceFileAlreadyExistsError', "The selected workspace file '{0}' already exists. To add the project to an existing workspace, use the Open Existing dialog to first open the workspace.", file); };
 
 
 // Error messages

--- a/extensions/sql-database-projects/src/common/constants.ts
+++ b/extensions/sql-database-projects/src/common/constants.ts
@@ -137,6 +137,12 @@ export const addProjectToCurrentWorkspace = localize('addProjectToCurrentWorkspa
 export const newWorkspaceWillBeCreated = localize('newWorkspaceWillBeCreated', "A new workspace will be created for this project.");
 export const workspaceLocationTitle = localize('workspaceLocationTitle', "Workspace location");
 export const workspace = localize('workspace', "Workspace");
+export const WorkspaceFileExtension = '.code-workspace';
+export const ProjectParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.projectParentDirectoryNotExistError', "The selected project location '{0}' does not exist or is not a directory.", location); };
+export const ProjectDirectoryAlreadyExistError = (projectName: string, location: string): string => { return localize('dataworkspace.projectDirectoryAlreadyExistError', "There is already a directory named '{0}' in the selected location: '{1}'.", projectName, location); };
+export const WorkspaceFileInvalidError = (workspace: string): string => { return localize('dataworkspace.workspaceFileInvalidError', "The selected workspace file path '{0}' does not have the required file extension {1}", workspace, WorkspaceFileExtension); };
+export const WorkspaceParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.workspaceParentDirectoryNotExistError', "The selected workspace location '{0}' does not exist or is not a directory", location); };
+export const WorkspaceFileAlreadyExistsError = (file: string): string => { return localize('dataworkspace.workspaceFileAlreadyExistsError', "The selected workspace file '{0}' already exists. To add the project to an existing workspace, use the Open Existing dialog to first open the workspace", file); };
 
 
 // Error messages

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -658,7 +658,7 @@ export class ProjectsController {
 
 				// add project to workspace
 				workspaceApi.showProjectsView();
-				await workspaceApi.addProjectsToWorkspace([vscode.Uri.file(newProjFilePath)]);
+				await workspaceApi.addProjectsToWorkspace([vscode.Uri.file(newProjFilePath)], model.newWorkspaceFilePath);
 			}
 		}
 		catch (err) {

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -529,4 +529,8 @@ export class CreateProjectFromDatabaseDialog {
 			level: azdata.window.MessageLevel.Error
 		};
 	}
+
+	public getErrorMessage(): azdata.window.DialogMessage {
+		return this.dialog.message;
+	}
 }

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -494,7 +494,7 @@ export class CreateProjectFromDatabaseDialog {
 		}
 	}
 
-	protected async validateNewWorkspace(): Promise<boolean> {
+	protected async validateNewWorkspace(): Promise<void> {
 		const sameFolderAsNewProject = path.join(this.projectLocationTextBox!.value!, this.projectNameTextBox!.value!) === path.dirname(this.workspaceInputBox!.value!);
 
 		// workspace file should end in .code-workspace
@@ -516,8 +516,6 @@ export class CreateProjectFromDatabaseDialog {
 		if (workspaceFileExists) {
 			throw new Error(constants.WorkspaceFileAlreadyExistsError(this.workspaceInputBox!.value!));
 		}
-
-		return true;
 	}
 
 	protected showErrorMessage(message: string): void {

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -164,7 +164,7 @@ export class CreateProjectFromDatabaseDialog {
 
 		this.sourceDatabaseDropDown.onValueChanged(() => {
 			this.setProjectName();
-			this.updateWorkspaceInputbox(this.projectLocationTextBox!.value!, this.projectNameTextBox!.value!);
+			this.updateWorkspaceInputbox(path.join(this.projectLocationTextBox!.value!, this.projectNameTextBox!.value!), this.projectNameTextBox!.value!);
 			this.tryEnableCreateButton();
 		});
 
@@ -252,7 +252,7 @@ export class CreateProjectFromDatabaseDialog {
 		this.projectNameTextBox.onTextChanged(() => {
 			this.projectNameTextBox!.value = this.projectNameTextBox!.value?.trim();
 			this.projectNameTextBox!.updateProperty('title', this.projectNameTextBox!.value);
-			this.updateWorkspaceInputbox(this.projectLocationTextBox!.value!, this.projectNameTextBox!.value!);
+			this.updateWorkspaceInputbox(path.join(this.projectLocationTextBox!.value!, this.projectNameTextBox!.value!), this.projectNameTextBox!.value!);
 			this.tryEnableCreateButton();
 		});
 
@@ -280,7 +280,7 @@ export class CreateProjectFromDatabaseDialog {
 
 		this.projectLocationTextBox.onTextChanged(() => {
 			this.projectLocationTextBox!.updateProperty('title', this.projectLocationTextBox!.value);
-			this.updateWorkspaceInputbox(this.projectLocationTextBox!.value!, this.projectNameTextBox!.value!);
+			this.updateWorkspaceInputbox(path.join(this.projectLocationTextBox!.value!, this.projectNameTextBox!.value!), this.projectNameTextBox!.value!);
 			this.tryEnableCreateButton();
 		});
 
@@ -318,7 +318,7 @@ export class CreateProjectFromDatabaseDialog {
 
 			this.projectLocationTextBox!.value = folderUris[0].fsPath;
 			this.projectLocationTextBox!.updateProperty('title', folderUris[0].fsPath);
-			this.updateWorkspaceInputbox(this.projectLocationTextBox!.value!, this.projectNameTextBox!.value!);
+			this.updateWorkspaceInputbox(path.join(this.projectLocationTextBox!.value!, this.projectNameTextBox!.value!), this.projectNameTextBox!.value!);
 		});
 
 		return browseFolderButton;
@@ -356,17 +356,54 @@ export class CreateProjectFromDatabaseDialog {
 	private createWorkspaceContainerRow(view: azdata.ModelView): azdata.FlexContainer {
 		this.workspaceInputBox = view.modelBuilder.inputBox().withProperties({
 			ariaLabel: constants.workspaceLocationTitle,
-			enabled: false,
+			enabled: !vscode.workspace.workspaceFile, // want it editable if no workspace is open
 			value: vscode.workspace.workspaceFile?.fsPath ?? '',
-			title: vscode.workspace.workspaceFile?.fsPath ?? '' // hovertext for if file path is too long to be seen in textbox
+			title: vscode.workspace.workspaceFile?.fsPath ?? '', // hovertext for if file path is too long to be seen in textbox
+			width: '100%'
 		}).component();
+
+		const browseFolderButton = view.modelBuilder.button().withProperties<azdata.ButtonProperties>({
+			ariaLabel: constants.browseButtonText,
+			iconPath: IconPathHelper.folder_blue,
+			height: '16px',
+			width: '18px'
+		}).component();
+
+		this.toDispose.push(browseFolderButton.onDidClick(async () => {
+			const currentFileName = path.parse(this.workspaceInputBox!.value!).base;
+
+			// let user select folder for workspace file to be created in
+			const folderUris = await vscode.window.showOpenDialog({
+				canSelectFiles: false,
+				canSelectFolders: true,
+				canSelectMany: false,
+				defaultUri: vscode.Uri.file(path.parse(this.workspaceInputBox!.value!).dir)
+			});
+			if (!folderUris || folderUris.length === 0) {
+				return;
+			}
+			const selectedFolder = folderUris[0].fsPath;
+
+			const selectedFile = path.join(selectedFolder, currentFileName);
+			this.workspaceInputBox!.value = selectedFile;
+			this.workspaceInputBox!.title = selectedFile;
+		}));
 
 		const workspaceLabel = view.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
 			value: vscode.workspace.workspaceFile ? constants.addProjectToCurrentWorkspace : constants.newWorkspaceWillBeCreated,
 			CSSStyles: { 'margin-top': '-10px', 'margin-bottom': '5px' }
 		}).component();
 
-		const workspaceContainerRow = view.modelBuilder.flexContainer().withItems([workspaceLabel, this.workspaceInputBox], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px', 'margin-top': '0px' } }).withLayout({ flexFlow: 'column' }).component();
+		let workspaceContainerRow;
+		if (vscode.workspace.workspaceFile) {
+			workspaceContainerRow = view.modelBuilder.flexContainer().withItems([workspaceLabel, this.workspaceInputBox], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px', 'margin-top': '0px' } }).withLayout({ flexFlow: 'column' }).component();
+
+		} else {
+			// have browse button to help select where the workspace file should be created
+			const workspaceInput = view.modelBuilder.flexContainer().withItems([this.workspaceInputBox], { CSSStyles: { 'margin-right': '10px', 'margin-bottom': '10px', 'width': '100%' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
+			workspaceInput.addItem(browseFolderButton, { CSSStyles: { 'margin-top': '-10px' } });
+			workspaceContainerRow = view.modelBuilder.flexContainer().withItems([workspaceLabel, workspaceInput], { flex: '0 0 auto', CSSStyles: { 'margin-top': '0px' } }).withLayout({ flexFlow: 'column' }).component();
+		}
 
 		return workspaceContainerRow;
 	}
@@ -401,7 +438,8 @@ export class CreateProjectFromDatabaseDialog {
 			projName: this.projectNameTextBox!.value!,
 			filePath: this.projectLocationTextBox!.value!,
 			version: '1.0.0.0',
-			extractTarget: this.mapExtractTargetEnum(<string>this.folderStructureDropDown!.value)
+			extractTarget: this.mapExtractTargetEnum(<string>this.folderStructureDropDown!.value),
+			newWorkspaceFilePath: this.workspaceInputBox!.enabled ? vscode.Uri.file(this.workspaceInputBox!.value!) : undefined
 		};
 
 		azdata.window.closeDialog(this.dialog);

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -483,8 +483,8 @@ export class CreateProjectFromDatabaseDialog {
 				return false;
 			}
 
-			if (this.workspaceInputBox!.enabled && !await this.validateNewWorkspace()) {
-				return false;
+			if (this.workspaceInputBox!.enabled) {
+				await this.validateNewWorkspace();
 			}
 
 			return true;
@@ -500,24 +500,21 @@ export class CreateProjectFromDatabaseDialog {
 		// workspace file should end in .code-workspace
 		const workspaceValid = this.workspaceInputBox!.value!.endsWith(constants.WorkspaceFileExtension);
 		if (!workspaceValid) {
-			this.showErrorMessage(constants.WorkspaceFileInvalidError(this.workspaceInputBox!.value!));
-			return false;
+			throw new Error(constants.WorkspaceFileInvalidError(this.workspaceInputBox!.value!));
 		}
 
 		// if the workspace file is not going to be in the same folder as the newly created project, then check that it's a valid folder
 		if (!sameFolderAsNewProject) {
 			const workspaceParentDirectoryExists = await exists(path.dirname(this.workspaceInputBox!.value!));
 			if (!workspaceParentDirectoryExists) {
-				this.showErrorMessage(constants.WorkspaceParentDirectoryNotExistError(path.dirname(this.workspaceInputBox!.value!)));
-				return false;
+				throw new Error(constants.WorkspaceParentDirectoryNotExistError(path.dirname(this.workspaceInputBox!.value!)));
 			}
 		}
 
 		// workspace file should not be an existing workspace file
 		const workspaceFileExists = await exists(this.workspaceInputBox!.value!);
 		if (workspaceFileExists) {
-			this.showErrorMessage(constants.WorkspaceFileAlreadyExistsError(this.workspaceInputBox!.value!));
-			return false;
+			throw new Error(constants.WorkspaceFileAlreadyExistsError(this.workspaceInputBox!.value!));
 		}
 
 		return true;
@@ -528,9 +525,5 @@ export class CreateProjectFromDatabaseDialog {
 			text: message,
 			level: azdata.window.MessageLevel.Error
 		};
-	}
-
-	public getErrorMessage(): azdata.window.DialogMessage {
-		return this.dialog.message;
 	}
 }

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -483,20 +483,20 @@ export class CreateProjectFromDatabaseDialog {
 				return false;
 			}
 
-			const sameFolderAsNewProject = path.join(this.projectLocationTextBox!.value!, this.projectNameTextBox!.value!) === path.dirname(this.workspaceInputBox!.value!);
-			if (this.workspaceInputBox!.enabled && !await this.validateNewWorkspace(sameFolderAsNewProject)) {
+			if (this.workspaceInputBox!.enabled && !await this.validateNewWorkspace()) {
 				return false;
 			}
 
 			return true;
-		}
-		catch (err) {
+		} catch (err) {
 			this.showErrorMessage(err?.message ? err.message : err);
 			return false;
 		}
 	}
 
-	protected async validateNewWorkspace(sameFolderAsNewProject: boolean): Promise<boolean> {
+	protected async validateNewWorkspace(): Promise<boolean> {
+		const sameFolderAsNewProject = path.join(this.projectLocationTextBox!.value!, this.projectNameTextBox!.value!) === path.dirname(this.workspaceInputBox!.value!);
+
 		// workspace file should end in .code-workspace
 		const workspaceValid = this.workspaceInputBox!.value!.endsWith(constants.WorkspaceFileExtension);
 		if (!workspaceValid) {
@@ -508,7 +508,7 @@ export class CreateProjectFromDatabaseDialog {
 		if (!sameFolderAsNewProject) {
 			const workspaceParentDirectoryExists = await exists(path.dirname(this.workspaceInputBox!.value!));
 			if (!workspaceParentDirectoryExists) {
-				this.showErrorMessage(constants.WorkspaceParentDirectoryNotExistError(this.workspaceInputBox!.value!));
+				this.showErrorMessage(constants.WorkspaceParentDirectoryNotExistError(path.dirname(this.workspaceInputBox!.value!)));
 				return false;
 			}
 		}

--- a/extensions/sql-database-projects/src/models/api/import.ts
+++ b/extensions/sql-database-projects/src/models/api/import.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Uri } from 'vscode';
 import { ExtractTarget } from '../../../../mssql';
 
 /**
@@ -15,4 +16,5 @@ export interface ImportDataModel {
 	filePath: string;
 	version: string;
 	extractTarget: ExtractTarget;
+	newWorkspaceFilePath?: Uri;
 }

--- a/extensions/sql-database-projects/src/test/dialogs/createProjectFromDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/createProjectFromDatabaseDialog.test.ts
@@ -145,11 +145,11 @@ describe('Create Project From Database Dialog', () => {
 
 		// same folder as the project should be valid even if the project folder isn't created yet
 		dialog.workspaceInputBox!.value = path.join(dialog.projectLocationTextBox!.value!, dialog.projectNameTextBox!.value!, 'test.code-workspace');
-		should.equal(await dialog.validate(), true, 'Validation should pass if the file location is the same folder as the project');
+		should.equal(await dialog.validate(), true, `Validation should pass if the file location is the same folder as the project. Error was: ${dialog.getErrorMessage()}`);
 
 		// change workspace name to something that should pass
 		dialog.workspaceInputBox!.value = path.join(os.tmpdir(), `TestWorkspace_${new Date().getTime()}.code-workspace`);
-		should.equal(await dialog.validate(), true, 'Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct');
+		should.equal(await dialog.validate(), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage()}`);
 	});
 
 });

--- a/extensions/sql-database-projects/src/test/dialogs/createProjectFromDatabaseDialog.test.ts
+++ b/extensions/sql-database-projects/src/test/dialogs/createProjectFromDatabaseDialog.test.ts
@@ -8,9 +8,6 @@ import * as azdata from 'azdata';
 import * as mssql from '../../../../mssql';
 import * as sinon from 'sinon';
 import * as path from 'path';
-import * as os from 'os';
-import * as vscode from 'vscode';
-import { promises as fs } from 'fs';
 import { CreateProjectFromDatabaseDialog } from '../../dialogs/createProjectFromDatabaseDialog';
 import { mockConnectionProfile } from '../testContext';
 import { ImportDataModel } from '../../models/api/import';
@@ -122,34 +119,4 @@ describe('Create Project From Database Dialog', () => {
 
 		should(model!).deepEqual(expectedImportDataModel);
 	});
-
-	it('Should validate new workspace location', async function (): Promise<void> {
-		sinon.stub(azdata.connection, 'listDatabases').resolves(['My Database']);
-		const dialog = new CreateProjectFromDatabaseDialog(mockConnectionProfile);
-		await dialog.openDialog();
-
-		dialog.projectNameTextBox!.value = `TestProject_${new Date().getTime()}`;
-		dialog.projectLocationTextBox!.value = os.tmpdir();
-		dialog.workspaceInputBox!.value = 'test';
-		should.equal(await dialog.validate(), false, 'Validation should fail because workspace does not end in .code-workspace');
-
-		// use invalid folder
-		dialog.workspaceInputBox!.value = 'invalidLocation/test.code-workspace';
-		should.equal(await dialog.validate(), false, 'Validation should fail because the folder is invalid');
-
-		// use already existing workspace
-		const existingWorkspaceFilePath = path.join(os.tmpdir(), `${dialog.projectNameTextBox!.value!}.code-workspace`);
-		await fs.writeFile(existingWorkspaceFilePath, '');
-		dialog.workspaceInputBox!.value = existingWorkspaceFilePath;
-		should.equal(await dialog.validate(), false, 'Validation should fail because the selected workspace file already exists');
-
-		// same folder as the project should be valid even if the project folder isn't created yet
-		dialog.workspaceInputBox!.value = path.join(dialog.projectLocationTextBox!.value!, dialog.projectNameTextBox!.value!, 'test.code-workspace');
-		should.equal(await dialog.validate(), true, `Validation should pass if the file location is the same folder as the project. Error was: ${dialog.getErrorMessage()}`);
-
-		// change workspace name to something that should pass
-		dialog.workspaceInputBox!.value = path.join(os.tmpdir(), `TestWorkspace_${new Date().getTime()}.code-workspace`);
-		should.equal(await dialog.validate(), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage()}`);
-	});
-
 });


### PR DESCRIPTION
Fixes #13799. This makes the new workspace inputbox editable for the create project from database dialog, like what was done in #13508 for the data workspace dialogs.

Default location for new workspace is in the new project folder
![image](https://user-images.githubusercontent.com/31145923/102534986-688a6000-405c-11eb-85a4-cbc4948e01e9.png)

validates that the .code-workspace file extension is there
![image](https://user-images.githubusercontent.com/31145923/102534998-6cb67d80-405c-11eb-8b66-55cb2291bcdc.png)

validates location exists
![image](https://user-images.githubusercontent.com/31145923/102535005-70e29b00-405c-11eb-9d3e-ab20b58df395.png)

also added validation that there isn't already a folder with the same project name at the selected location
![image](https://user-images.githubusercontent.com/31145923/102535010-73dd8b80-405c-11eb-9b72-d894e43c055b.png)
