### PR TITLE
Fix Unstable Notebook Test

### DIFF
--- a/extensions/integration-tests/setEnvironmentVariables.js
+++ b/extensions/integration-tests/setEnvironmentVariables.js
@@ -57,7 +57,7 @@ if (!LAUNCH_OPTION) {
  * Below are the environment variable values that are not saved in AKV and might vary by machine
  */
 
-// Pyton for Notebooks
+// Python for Notebooks
 // This environment variable is required by notebook tests.
 // How to install it:
 // Open ADS and run command 'Configure Python for Notebooks' command and install it to the default folder,
@@ -73,7 +73,7 @@ const NOTEBOOK_PYTHON_INSTALL_PATH = path.join(os.homedir(), 'azuredatastudio-py
 
 // Environment variable value validation
 if (!fs.existsSync(NOTEBOOK_PYTHON_INSTALL_PATH)) {
-	const message = 'the specified Pyton install path does not exist.'
+	const message = 'the specified Python install path does not exist.'
 		+ os.EOL
 		+ 'if you have installed it, please update the NOTEBOOK_PYTHON_INSTALL_PATH variable in this script,'
 		+ os.EOL

--- a/extensions/integration-tests/src/test/notebook.test.ts
+++ b/extensions/integration-tests/src/test/notebook.test.ts
@@ -39,7 +39,7 @@ suite('Notebook integration test suite', function () {
 	});
 
 	test('Sql NB test @UNSTABLE@', async function () {
-		let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata, this.test.title + this.invocationCount++, true);
+		let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		await runCell(notebook);
 		const expectedOutput0 = '(1 row affected)';
 		let cellOutputs = notebook.document.cells[0].contents.outputs;


### PR DESCRIPTION
We had different connection logic for this sole integration test vs. the other tests in the file, but given other refactorings in this file, this change is no longer needed. Because it was unstable for so long, other tests look to have been fixed up, but this one never was.

Executed an unstable test build, and verified that it succeeded.

Oh, and fixed a minor typo in the process 😄 