### PR TITLE
Add an informational message when a user tries to open an already opened project

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -50,6 +50,7 @@ export const Workspace = localize('dataworkspace.workspace', "Workspace");
 export const LocationSelectorTitle = localize('dataworkspace.locationSelectorTitle', "Location");
 export const ProjectFilePlaceholder = localize('dataworkspace.projectFilePlaceholder', "Select project (.sqlproj) file");
 export const WorkspacePlaceholder = localize('dataworkspace.workspacePlaceholder', "Select workspace ({0}) file", WorkspaceFileExtension);
+export const ProjectAlreadyOpened = (path: string): string => { return localize('dataworkspace.projectAlreadyOpened', "Project '{0}' is already opened.", path); };
 
 // Workspace settings for saving new projects
 export const ProjectConfigurationKey = 'projects';

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -121,6 +121,8 @@ export class WorkspaceService implements IWorkspaceService {
 				if (vscode.Uri.file(relativePath).fsPath === projectFile.fsPath) {
 					newWorkspaceFolders.push(path.dirname(projectFile.path));
 				}
+			} else {
+				vscode.window.showInformationMessage(constants.ProjectAlreadyOpened(projectFile.fsPath));
 			}
 		}
 

--- a/extensions/data-workspace/src/test/workspaceService.test.ts
+++ b/extensions/data-workspace/src/test/workspaceService.test.ts
@@ -13,6 +13,7 @@ import * as TypeMoq from 'typemoq';
 import { WorkspaceService } from '../services/workspaceService';
 import { ProjectProviderRegistry } from '../common/projectProviderRegistry';
 import { createProjectProvider } from './projectProviderRegistry.test';
+import { ProjectAlreadyOpened } from '../common/constants';
 
 const DefaultWorkspaceFilePath = '/test/folder/ws.code-workspace';
 
@@ -204,6 +205,7 @@ suite('WorkspaceService Tests', function (): void {
 		const updateConfigurationStub = sinon.stub();
 		const getConfigurationStub = sinon.stub().returns([processPath('folder1/proj2.sqlproj')]);
 		const onWorkspaceProjectsChangedStub = sinon.stub();
+		const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage');
 		const onWorkspaceProjectsChangedDisposable = service.onDidWorkspaceProjectsChange(() => {
 			onWorkspaceProjectsChangedStub();
 		});
@@ -220,6 +222,8 @@ suite('WorkspaceService Tests', function (): void {
 		]);
 		should.strictEqual(updateConfigurationStub.calledOnce, true, 'update configuration should have been called once');
 		should.strictEqual(updateWorkspaceFoldersStub.calledOnce, true, 'updateWorkspaceFolders should have been called once');
+		should.strictEqual(showInformationMessageStub.calledOnce, true, 'showInformationMessage should be called once');
+		should(showInformationMessageStub.calledWith(ProjectAlreadyOpened(processPath('/test/folder/folder1/proj2.sqlproj')))).be.true(`showInformationMessage not called with expected message '${ProjectAlreadyOpened(processPath('/test/folder/folder1/proj2.sqlproj'))}' Actual '${showInformationMessageStub.getCall(0).args[0]}'`);
 		should.strictEqual(updateConfigurationStub.calledWith('projects', sinon.match.array.deepEquals([
 			processPath('folder1/proj2.sqlproj'),
 			processPath('proj1.sqlproj'),


### PR DESCRIPTION
This PR fixes #13448. Following message pops up if a project is already opened:
![image](https://user-images.githubusercontent.com/57200045/102648726-e615a500-411c-11eb-99af-1565514b297a.png)
