### PR TITLE
Update new workspace validation to throw errors to make code more reusable

### DIFF
--- a/extensions/data-workspace/src/dialogs/dialogBase.ts
+++ b/extensions/data-workspace/src/dialogs/dialogBase.ts
@@ -161,30 +161,25 @@ export abstract class DialogBase {
 		}
 	}
 
-	public async validateNewWorkspace(sameFolderAsNewProject: boolean): Promise<boolean> {
+	public async validateNewWorkspace(sameFolderAsNewProject: boolean): Promise<void> {
 		// workspace file should end in .code-workspace
 		const workspaceValid = this.workspaceInputBox!.value!.endsWith(constants.WorkspaceFileExtension);
 		if (!workspaceValid) {
-			this.showErrorMessage(constants.WorkspaceFileInvalidError(this.workspaceInputBox!.value!));
-			return false;
+			throw new Error(constants.WorkspaceFileInvalidError(this.workspaceInputBox!.value!));
 		}
 
 		// if the workspace file is not going to be in the same folder as the newly created project, then check that it's a valid folder
 		if (!sameFolderAsNewProject) {
 			const workspaceParentDirectoryExists = await directoryExist(path.dirname(this.workspaceInputBox!.value!));
 			if (!workspaceParentDirectoryExists) {
-				this.showErrorMessage(constants.WorkspaceParentDirectoryNotExistError(path.dirname(this.workspaceInputBox!.value!)));
-				return false;
+				throw new Error(constants.WorkspaceParentDirectoryNotExistError(path.dirname(this.workspaceInputBox!.value!)));
 			}
 		}
 
 		// workspace file should not be an existing workspace file
 		const workspaceFileExists = await fileExist(this.workspaceInputBox!.value!);
 		if (workspaceFileExists) {
-			this.showErrorMessage(constants.WorkspaceFileAlreadyExistsError(this.workspaceInputBox!.value!));
-			return false;
+			throw new Error(constants.WorkspaceFileAlreadyExistsError(this.workspaceInputBox!.value!));
 		}
-
-		return true;
 	}
 }

--- a/extensions/data-workspace/src/dialogs/newProjectDialog.ts
+++ b/extensions/data-workspace/src/dialogs/newProjectDialog.ts
@@ -43,9 +43,9 @@ export class NewProjectDialog extends DialogBase {
 				return false;
 			}
 
-			const sameFolderAsNewProject = path.join(this.model.location, this.model.name) === path.dirname(this.workspaceInputBox!.value!);
-			if (this.workspaceInputBox!.enabled && !await this.validateNewWorkspace(sameFolderAsNewProject)) {
-				return false;
+			if (this.workspaceInputBox!.enabled) {
+				const sameFolderAsNewProject = path.join(this.model.location, this.model.name) === path.dirname(this.workspaceInputBox!.value!);
+				await this.validateNewWorkspace(sameFolderAsNewProject);
 			}
 
 			return true;

--- a/extensions/data-workspace/src/dialogs/openExistingDialog.ts
+++ b/extensions/data-workspace/src/dialogs/openExistingDialog.ts
@@ -37,17 +37,13 @@ export class OpenExistingDialog extends DialogBase {
 		try {
 			// the selected location should be an existing directory
 			if (this._targetTypeRadioCardGroup?.selectedCardId === constants.Project) {
-				if (!await this.validateFile(this._projectFile, constants.Project.toLowerCase())) {
-					return false;
-				}
+				await this.validateFile(this._projectFile, constants.Project.toLowerCase());
 
-				if (this.workspaceInputBox!.enabled && !await this.validateNewWorkspace(false)) {
-					return false;
+				if (this.workspaceInputBox!.enabled) {
+					await this.validateNewWorkspace(false);
 				}
 			} else if (this._targetTypeRadioCardGroup?.selectedCardId === constants.Workspace) {
-				if (!await this.validateFile(this._workspaceFile, constants.Workspace.toLowerCase())) {
-					return false;
-				}
+				await this.validateFile(this._workspaceFile, constants.Workspace.toLowerCase());
 			}
 
 			return true;
@@ -58,14 +54,11 @@ export class OpenExistingDialog extends DialogBase {
 		}
 	}
 
-	public async validateFile(file: string, fileType: string) {
+	public async validateFile(file: string, fileType: string): Promise<void> {
 		const fileExists = await fileExist(file);
 		if (!fileExists) {
-			this.showErrorMessage(constants.FileNotExistError(fileType, file));
-			return false;
+			throw new Error(constants.FileNotExistError(fileType, file));
 		}
-
-		return true;
 	}
 
 	async onComplete(): Promise<void> {

--- a/extensions/data-workspace/src/test/dialogs/dialogBase.test.ts
+++ b/extensions/data-workspace/src/test/dialogs/dialogBase.test.ts
@@ -35,15 +35,13 @@ suite('DialogBase - workspace validation', function (): void {
 
 	test('Should validate new workspace location missing file extension', async function (): Promise<void> {
 		dialog.workspaceInputBox!.value = 'test';
-		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because workspace does not end in .code-workspace');
-		should.equal(dialog.getErrorMessage().text, constants.WorkspaceFileInvalidError(dialog.workspaceInputBox!.value));
+		await should(dialog.validateNewWorkspace(false)).be.rejectedWith(constants.WorkspaceFileInvalidError(dialog.workspaceInputBox!.value));
 	});
 
 	test('Should validate new workspace location with invalid location', async function (): Promise<void> {
 		// use invalid folder
 		dialog.workspaceInputBox!.value = 'invalidLocation/test.code-workspace';
-		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because the folder is invalid');
-		should.equal(dialog.getErrorMessage().text, constants.WorkspaceParentDirectoryNotExistError(path.dirname(dialog.workspaceInputBox!.value)));
+		await should(dialog.validateNewWorkspace(false)).be.rejectedWith(constants.WorkspaceParentDirectoryNotExistError(path.dirname(dialog.workspaceInputBox!.value)));
 	});
 
 	test('Should validate new workspace location that already exists', async function (): Promise<void> {
@@ -52,18 +50,17 @@ suite('DialogBase - workspace validation', function (): void {
 		fileExistStub.resolves(true);
 		const existingWorkspaceFilePath = path.join(os.tmpdir(), `${dialog.model.name}.code-workspace`);
 		dialog.workspaceInputBox!.value = existingWorkspaceFilePath;
-		should.equal(await dialog.validateNewWorkspace(false), false, 'Validation should fail because the selected workspace file already exists');
-		should.equal(dialog.getErrorMessage().text, constants.WorkspaceFileAlreadyExistsError(existingWorkspaceFilePath));
+		await should(dialog.validateNewWorkspace(false)).be.rejectedWith(constants.WorkspaceFileAlreadyExistsError(existingWorkspaceFilePath));
 	});
 
 	test('Should validate new workspace location that is valid', async function (): Promise<void> {
 		// same folder as the project should be valid even if the project folder isn't created yet
 		dialog.workspaceInputBox!.value = path.join(dialog.model.location, dialog.model.name, 'test.code-workspace');
-		should.equal(await dialog.validateNewWorkspace(true), true, `Validation should pass if the file location is the same folder as the project. Error was: ${dialog.getErrorMessage()?.text}`);
+		await should(dialog.validateNewWorkspace(true)).not.be.rejected();
 
 		// a workspace not in the same folder as the project should also be valid
 		dialog.workspaceInputBox!.value = path.join(os.tmpdir(), `TestWorkspace_${new Date().getTime()}.code-workspace`);
-		should.equal(await dialog.validateNewWorkspace(false), true, `Validation should pass because the parent directory exists, workspace filepath is unique, and the file extension is correct. Error was: ${dialog.getErrorMessage()?.text}`);
+		await should(dialog.validateNewWorkspace(false)).not.be.rejected();
 	});
 });
 


### PR DESCRIPTION
Updating the new workspace validation in the data-workspace extension to throw errors to make the code more reusable like what was done in #13842
