### PR TITLE
Fix editing workspace inputbox in open existing dialog not working

### DIFF
--- a/extensions/data-workspace/src/dialogs/openExistingDialog.ts
+++ b/extensions/data-workspace/src/dialogs/openExistingDialog.ts
@@ -13,8 +13,6 @@ import { fileExist } from '../common/utils';
 import { IconPathHelper } from '../common/iconHelper';
 
 export class OpenExistingDialog extends DialogBase {
-	public _projectFile: string = '';
-	public _workspaceFile: string = '';
 	public _targetTypeRadioCardGroup: azdata.RadioCardGroupComponent | undefined;
 	public _filePathTextBox: azdata.InputBoxComponent | undefined;
 	public formBuilder: azdata.FormBuilder | undefined;
@@ -37,7 +35,7 @@ export class OpenExistingDialog extends DialogBase {
 		try {
 			// the selected location should be an existing directory
 			if (this._targetTypeRadioCardGroup?.selectedCardId === constants.Project) {
-				if (!await this.validateFile(this._projectFile, constants.Project.toLowerCase())) {
+				if (!await this.validateFile(this._filePathTextBox!.value!, constants.Project.toLowerCase())) {
 					return false;
 				}
 
@@ -45,7 +43,7 @@ export class OpenExistingDialog extends DialogBase {
 					return false;
 				}
 			} else if (this._targetTypeRadioCardGroup?.selectedCardId === constants.Workspace) {
-				if (!await this.validateFile(this._workspaceFile, constants.Workspace.toLowerCase())) {
+				if (!await this.validateFile(this._filePathTextBox!.value!, constants.Workspace.toLowerCase())) {
 					return false;
 				}
 			}
@@ -71,11 +69,11 @@ export class OpenExistingDialog extends DialogBase {
 	async onComplete(): Promise<void> {
 		try {
 			if (this._targetTypeRadioCardGroup?.selectedCardId === constants.Workspace) {
-				await this.workspaceService.enterWorkspace(vscode.Uri.file(this._workspaceFile));
+				await this.workspaceService.enterWorkspace(vscode.Uri.file(this._filePathTextBox!.value!));
 			} else {
 				const validateWorkspace = await this.workspaceService.validateWorkspace();
 				if (validateWorkspace) {
-					await this.workspaceService.addProjectsToWorkspace([vscode.Uri.file(this._projectFile)], vscode.Uri.file(this.workspaceInputBox!.value!));
+					await this.workspaceService.addProjectsToWorkspace([vscode.Uri.file(this._filePathTextBox!.value!)], vscode.Uri.file(this.workspaceInputBox!.value!));
 				}
 			}
 		}
@@ -118,9 +116,8 @@ export class OpenExistingDialog extends DialogBase {
 			width: constants.DefaultInputWidth
 		}).component();
 		this.register(this._filePathTextBox.onTextChanged(() => {
-			this._projectFile = this._filePathTextBox!.value!;
-			this._filePathTextBox!.updateProperty('title', this._projectFile);
-			this.updateWorkspaceInputbox(path.dirname(this._projectFile), path.basename(this._projectFile, path.extname(this._projectFile)));
+			this._filePathTextBox!.updateProperty('title', this._filePathTextBox!.value!);
+			this.updateWorkspaceInputbox(path.dirname(this._filePathTextBox!.value!), path.basename(this._filePathTextBox!.value!, path.extname(this._filePathTextBox!.value!)));
 		}));
 
 		const browseFolderButton = view.modelBuilder.button().withProperties<azdata.ButtonProperties>({
@@ -187,7 +184,6 @@ export class OpenExistingDialog extends DialogBase {
 
 		const workspaceFilePath = fileUris[0].fsPath;
 		this._filePathTextBox!.value = workspaceFilePath;
-		this._workspaceFile = workspaceFilePath;
 	}
 
 	public async projectBrowse(): Promise<void> {
@@ -212,6 +208,5 @@ export class OpenExistingDialog extends DialogBase {
 
 		const projectFilePath = fileUris[0].fsPath;
 		this._filePathTextBox!.value = projectFilePath;
-		this._projectFile = projectFilePath;
 	}
 }

--- a/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
+++ b/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
@@ -26,13 +26,13 @@ suite('Open Existing Dialog', function (): void {
 		await dialog.open();
 
 		dialog._targetTypeRadioCardGroup?.updateProperty( 'selectedCardId', constants.Project);
-		dialog._projectFile = '';
+		dialog._filePathTextBox!.value = '';
 		dialog.workspaceInputBox!.value = 'test.code-workspace';
 
 		should.equal(await dialog.validate(), false, 'Validation fail because project file does not exist');
 
 		// create a project file
-		dialog._projectFile = await createProjectFile('testproj');
+		dialog._filePathTextBox!.value = await createProjectFile('testproj');
 		should.equal(await dialog.validate(), true, 'Validation pass because project file exists');
 	});
 
@@ -42,12 +42,12 @@ suite('Open Existing Dialog', function (): void {
 		await dialog.open();
 
 		dialog._targetTypeRadioCardGroup?.updateProperty( 'selectedCardId', constants.Workspace);
-		dialog._workspaceFile = '';
+		dialog._filePathTextBox!.value = '';
 		should.equal(await dialog.validate(), false, 'Validation fail because workspace file does not exist');
 
 		// create a workspace file
-		dialog._workspaceFile = generateUniqueWorkspaceFilePath();
-		await fs.writeFile(dialog._workspaceFile, '');
+		dialog._filePathTextBox!.value = generateUniqueWorkspaceFilePath();
+		await fs.writeFile(dialog._filePathTextBox!.value , '');
 		should.equal(await dialog.validate(), true, 'Validation pass because workspace file exists');
 	});
 
@@ -60,7 +60,7 @@ suite('Open Existing Dialog', function (): void {
 		const dialog = new OpenExistingDialog(workspaceServiceMock.object, mockExtensionContext.object);
 		await dialog.open();
 
-		dialog._projectFile = generateUniqueProjectFilePath('testproj');
+		dialog._filePathTextBox!.value = generateUniqueProjectFilePath('testproj');
 		should.doesNotThrow(async () => await dialog.onComplete());
 
 		workspaceServiceMock.setup(x => x.validateWorkspace()).throws(new Error('test error'));
@@ -75,15 +75,15 @@ suite('Open Existing Dialog', function (): void {
 
 		const dialog = new OpenExistingDialog(workspaceServiceMock.object, mockExtensionContext.object);
 		await dialog.open();
-		should.equal(dialog._workspaceFile, '');
+		should.equal(dialog._filePathTextBox!.value, '');
 		await dialog.workspaceBrowse();
-		should.equal(dialog._workspaceFile, '', 'Workspace file should not be set when no file is selected');
+		should.equal(dialog._filePathTextBox!.value, '', 'Workspace file should not be set when no file is selected');
 
 		sinon.restore();
 		const workspaceFile = vscode.Uri.file(generateUniqueWorkspaceFilePath());
 		sinon.stub(vscode.window, 'showOpenDialog').returns(Promise.resolve([workspaceFile]));
 		await dialog.workspaceBrowse();
-		should.equal(dialog._workspaceFile, workspaceFile.fsPath, 'Workspace file should get set');
+		should.equal(dialog._filePathTextBox!.value, workspaceFile.fsPath, 'Workspace file should get set');
 		should.equal(dialog._filePathTextBox?.value, workspaceFile.fsPath);
 	});
 
@@ -94,15 +94,15 @@ suite('Open Existing Dialog', function (): void {
 
 		const dialog = new OpenExistingDialog(workspaceServiceMock.object, mockExtensionContext.object);
 		await dialog.open();
-		should.equal(dialog._projectFile, '');
+		should.equal(dialog._filePathTextBox!.value, '');
 		await dialog.projectBrowse();
-		should.equal(dialog._projectFile, '', 'Project file should not be set when no file is selected');
+		should.equal(dialog._filePathTextBox!.value, '', 'Project file should not be set when no file is selected');
 
 		sinon.restore();
 		const projectFile = vscode.Uri.file(generateUniqueProjectFilePath('testproj'));
 		sinon.stub(vscode.window, 'showOpenDialog').returns(Promise.resolve([projectFile]));
 		await dialog.projectBrowse();
-		should.equal(dialog._projectFile, projectFile.fsPath, 'Project file should be set');
+		should.equal(dialog._filePathTextBox!.value, projectFile.fsPath, 'Project file should be set');
 		should.equal(dialog._filePathTextBox?.value, projectFile.fsPath);
 	});
 });


### PR DESCRIPTION
This PR fixes #13857. The _workspaceFile variable wasn't getting updated when the text in the inputbox changed, only when the file picker was being used. Since there isn't a reason to have intermediate variables to store the projectFile/workspaceFile, I got rid of them and now the value in the fileInputBox is used directly. 
