### PR TITLE
archive logs step

### DIFF
--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -153,9 +153,10 @@ steps:
       set -e
       mkdir -p $(Build.ArtifactStagingDirectory)/logs/linux-x64
       cd /tmp
-      for f in adsuser*/
+      for folder in adsuser*/
       do
-      tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/$f.tar.gz $f
+      folder=${folder%/}
+      tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/$folder.tar.gz $folder
       done
 
     displayName: Archive Logs

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -149,11 +149,14 @@ steps:
     continueOnError: true
     condition: and(succeeded(), eq(variables['RUN_UNSTABLE_TESTS'], 'true'))
 
-  - script: |
+  - bash: |
       set -e
       mkdir -p $(Build.ArtifactStagingDirectory)/logs/linux-x64
       cd /tmp
-      for f in adsuser*/; { tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/$f.tar.gz $f }
+      for f in adsuser*/
+      do
+      tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/$f.tar.gz $f
+      done
 
     displayName: Archive Logs
     continueOnError: true

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -153,7 +153,8 @@ steps:
       set -e
       mkdir -p $(Build.ArtifactStagingDirectory)/logs/linux-x64
       cd /tmp
-      tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/logs-linux-x64.tar.gz adsuser*
+      for f in adsuser*/; { tar -czvf $(Build.ArtifactStagingDirectory)/logs/linux-x64/$f.tar.gz $f }
+
     displayName: Archive Logs
     continueOnError: true
     condition: succeededOrFailed()


### PR DESCRIPTION
we had 3 canary build failures due to archive logs steps, there are not enough information about why it happened, I am separating it so that we have one zip per folder, hope it will make it easier to spot the issue. I am not sure whether this will actually fix the problem

![image](https://user-images.githubusercontent.com/13777222/102700459-5f3af800-4202-11eb-9115-ddd6267cb1ec.png)
