### PR TITLE
Enable Parameterization via Notebook URI

### DIFF
--- a/extensions/notebook/src/protocol/notebookUriHandler.ts
+++ b/extensions/notebook/src/protocol/notebookUriHandler.ts
@@ -33,8 +33,25 @@ export class NotebookUriHandler implements vscode.UriHandler {
 		}
 	}
 	/**
-	 * Our Azuredatastudio URIs follow the standard URI format of
-	 * azuredatastudio://microsoft.notebook/open?url=...
+	 * Our Azure Data Studio URIs follow the standard URI format, and we currently only support https and http URI schemes
+	 * azuredatastudio://microsoft.notebook/open?url=https://
+	 * azuredatastudio://microsoft.notebook/open?url=http://
+	 *
+	 * Example of URI (encoded):
+	 * azuredatastudio://microsoft.notebook/open?url=https%3A%2F%2Fraw.githubusercontent.com%2FVasuBhog%2FAzureDataStudio-Notebooks%2Fmain%2FDemo_Parameterization%2FInput.ipynb
+	 *
+	 * We also support parameters added to the URI for parameterization scenarios
+	 *
+	 * Parameters via the URI are formatted by adding the parameters after the .ipynb with a
+	 * query '?' and use '&' to distinguish a new parameter
+	 *
+	 * Example of Parameters query:
+	 * ...Input.ipynb?x=1&y=2'
+	 *
+	 * Encoded URI with parameters:
+	 * azuredatastudio://microsoft.notebook/open?url=https%3A%2F%2Fraw.githubusercontent.com%2FVasuBhog%2FAzureDataStudio-Notebooks%2Fmain%2FDemo_Parameterization%2FInput.ipynb%3Fx%3D1%26y%3D2
+	 * Decoded URI with parameters:
+	 * azuredatastudio://microsoft.notebook/open?url=https://raw.githubusercontent.com/VasuBhog/AzureDataStudio-Notebooks/main/Demo_Parameterization/Input.ipynb?x=1&y=2
 	 */
 	private open(uri: vscode.Uri): Promise<void> {
 		let data: string;
@@ -48,6 +65,7 @@ export class NotebookUriHandler implements vscode.UriHandler {
 
 		if (!data) {
 			console.warn('Failed to open URI:', uri);
+			return;
 		}
 
 		return this.openNotebook(data);

--- a/extensions/notebook/src/protocol/notebookUriHandler.ts
+++ b/extensions/notebook/src/protocol/notebookUriHandler.ts
@@ -126,6 +126,6 @@ export class NotebookUriHandler implements vscode.UriHandler {
 			}
 			nextVal++;
 		}
-		return `${title}`;
+		return title;
 	}
 }

--- a/extensions/notebook/src/protocol/notebookUriHandler.ts
+++ b/extensions/notebook/src/protocol/notebookUriHandler.ts
@@ -34,7 +34,7 @@ export class NotebookUriHandler implements vscode.UriHandler {
 	}
 
 	private open(uri: vscode.Uri): Promise<void> {
-		const data = uri.query.toString();
+		const data = uri.query.toString().split('url=')[1];
 
 		if (!data) {
 			console.warn('Failed to open URI:', uri);
@@ -77,7 +77,7 @@ export class NotebookUriHandler implements vscode.UriHandler {
 					preserveFocus: true
 				});
 			} else {
-				let doc = await vscode.workspace.openTextDocument(untitledUriPath);
+				let doc = await vscode.workspace.openTextDocument(untitledUri);
 				let editor = await vscode.window.showTextDocument(doc, vscode.ViewColumn.Active, true);
 				await editor.edit(builder => {
 					builder.insert(new vscode.Position(0, 0), contents);

--- a/extensions/notebook/src/protocol/notebookUriHandler.ts
+++ b/extensions/notebook/src/protocol/notebookUriHandler.ts
@@ -34,7 +34,7 @@ export class NotebookUriHandler implements vscode.UriHandler {
 	}
 
 	private open(uri: vscode.Uri): Promise<void> {
-		const data = uri.query.toString().split('url=')[1];
+		const data = uri.query.substr(uri.query.indexOf('url=') + 4);
 
 		if (!data) {
 			console.warn('Failed to open URI:', uri);

--- a/extensions/notebook/src/protocol/notebookUriHandler.ts
+++ b/extensions/notebook/src/protocol/notebookUriHandler.ts
@@ -32,9 +32,19 @@ export class NotebookUriHandler implements vscode.UriHandler {
 				vscode.window.showErrorMessage(localize('notebook.unsupportedAction', "Action {0} is not supported for this handler", uri.path));
 		}
 	}
-
+	/**
+	 * Our Azuredatastudio URIs follow the standard URI format of
+	 * azuredatastudio://microsoft.notebook/open?url=...
+	 */
 	private open(uri: vscode.Uri): Promise<void> {
-		const data = uri.query.substr(uri.query.indexOf('url=') + 4);
+		let data: string;
+		// We ensure that the URI is formatted properly
+		let urlIndex = uri.query.indexOf('url=');
+		if (urlIndex > 0) {
+			// Querystring can not be used as it incorrectly turns parameters attached
+			// to the URI query into key/value pairs and would then fail to open the URI
+			data = uri.query.substr(urlIndex + 4);
+		}
 
 		if (!data) {
 			console.warn('Failed to open URI:', uri);

--- a/extensions/notebook/src/protocol/notebookUriHandler.ts
+++ b/extensions/notebook/src/protocol/notebookUriHandler.ts
@@ -57,7 +57,7 @@ export class NotebookUriHandler implements vscode.UriHandler {
 		let data: string;
 		// We ensure that the URI is formatted properly
 		let urlIndex = uri.query.indexOf('url=');
-		if (urlIndex > 0) {
+		if (urlIndex >= 0) {
 			// Querystring can not be used as it incorrectly turns parameters attached
 			// to the URI query into key/value pairs and would then fail to open the URI
 			data = uri.query.substr(urlIndex + 4);
@@ -65,7 +65,6 @@ export class NotebookUriHandler implements vscode.UriHandler {
 
 		if (!data) {
 			console.warn('Failed to open URI:', uri);
-			return;
 		}
 
 		return this.openNotebook(data);

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -81,7 +81,31 @@ let expectedNotebookContentOneCell: nb.INotebookContents = {
 	nbformat_minor: 5
 };
 
+let expectedParameterizedNotebookContent: nb.INotebookContents = {
+	cells: [{
+		cell_type: CellTypes.Code,
+		source: ['x = 1 \ny = 2'],
+		metadata: { language: 'python', tags: ['parameters'] },
+		execution_count: 1
+	}, {
+		cell_type: CellTypes.Code,
+		source: ['x = 2 \ny = 5)'],
+		metadata: { language: 'python', tags: ['injected-parameters'] },
+		execution_count: 2
+	}],
+	metadata: {
+		kernelspec: {
+			name: 'python3',
+			language: 'python',
+			display_name: 'Python 3'
+		}
+	},
+	nbformat: 4,
+	nbformat_minor: 5
+};
+
 let defaultUri = URI.file('/some/path.ipynb');
+let notebookUriParams = URI.parse('https://hello.ipynb?x=1&y=2');
 
 let mockClientSession: IClientSession;
 let clientSessionOptions: IClientSessionOptions;
@@ -316,6 +340,118 @@ suite('notebook model', function (): void {
 		// Ensure new cell is active cell
 		assert.deepEqual(model.activeCell, newCell, 'Active cell does not match newly created cell');
 		assert.equal(activeCellChangeCount, 5, 'Active cell change count is incorrect; should be 5');
+	});
+
+	test('Should set notebook parameter and injected parameter cell correctly', async function (): Promise<void> {
+		let mockContentManager = TypeMoq.Mock.ofType(NotebookEditorContentManager);
+		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedParameterizedNotebookContent));
+		defaultModelOptions.notebookUri = defaultUri;
+		defaultModelOptions.contentManager = mockContentManager.object;
+
+		// When I initialize the model
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
+		await model.loadContents();
+
+		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.equal(model.cells.length, 2, 'Two cells should be entered');
+
+		// Set parameter cell and injected parameters cell
+		let notebookParamsCell = model.cells[0];
+		let notebookInjectedParamsCell = model.cells[1];
+
+		// Parameters Cell Validation
+		assert.equal(model.cells.indexOf(notebookParamsCell), 0, 'Notebook parameters cell should be first cell in notebook');
+		assert.equal(notebookParamsCell.isParameter, true, 'Notebook parameters cell should be tagged paramter');
+		assert.equal(notebookParamsCell.isInjectedParameter, false, 'Notebook parameters cell should be tagged paramter');
+
+		// Injected Parameters Cell Validation
+		assert.equal(model.cells.indexOf(notebookInjectedParamsCell), 1, 'Notebook injected parameters cell should be first cell in notebook');
+		assert.equal(notebookInjectedParamsCell.isParameter, false, 'Notebook injected parameters cell should not be tagged paramters cell');
+		assert.equal(notebookInjectedParamsCell.isInjectedParameter, true, 'Notebook injected parameters cell should be tagged injected paramter');
+	});
+
+	test('Should set notebookUri parameters to new cell correctly', async function (): Promise<void> {
+		let mockContentManager = TypeMoq.Mock.ofType(NotebookEditorContentManager);
+		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedNotebookContentOneCell));
+		defaultModelOptions.notebookUri = notebookUriParams;
+		defaultModelOptions.contentManager = mockContentManager.object;
+
+		// When I initialize the model
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
+		await model.loadContents();
+
+		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.equal(model.cells.length, 2, 'Two cells should be entered');
+
+		// Validate notebookUri parameter cell is set as the only parameter cell
+		let notebookUriParamsCell = model.cells[0];
+		assert.equal(model.cells.indexOf(notebookUriParamsCell), 0, 'NotebookURI parameters cell should be first cell in notebook');
+		assert.equal(notebookUriParamsCell.isParameter, true, 'NotebookURI parameters cell should be tagged paramter');
+		assert.equal(notebookUriParamsCell.isInjectedParameter, false, 'NotebookURI parameters Cell should not be injected paramter');
+	});
+
+	test('Should set notebookUri parameters to new cell after parameters cell correctly', async function (): Promise<void> {
+		let mockContentManager = TypeMoq.Mock.ofType(NotebookEditorContentManager);
+		let expectedNotebookContentParameterCell = expectedNotebookContentOneCell;
+		//Set the cell to be tagged as parameter cell
+		expectedNotebookContentParameterCell.cells[0].metadata.tags = ['parameters'];
+
+		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedNotebookContentParameterCell));
+		defaultModelOptions.notebookUri = notebookUriParams;
+		defaultModelOptions.contentManager = mockContentManager.object;
+
+		// When I initialize the model
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
+		await model.loadContents();
+
+		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.equal(model.cells.length, 2, 'Two cells should be entered');
+
+		// Validate notebookUri parameter cell is set as injected parameter
+		let notebookUriParamsCell = model.cells[1];
+		assert.equal(model.cells.indexOf(notebookUriParamsCell), 1, 'NotebookURI parameters cell should be first cell in notebook');
+		assert.equal(notebookUriParamsCell.isParameter, false, 'NotebookURI parameters cell should be tagged paramter');
+		assert.equal(notebookUriParamsCell.isInjectedParameter, true, 'NotebookURI parameters Cell should not be injected paramter');
+	});
+
+	test('Should move first cell below second cell correctly', async function (): Promise<void> {
+		let mockContentManager = TypeMoq.Mock.ofType(NotebookEditorContentManager);
+		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedNotebookContent));
+		defaultModelOptions.contentManager = mockContentManager.object;
+
+		// When I initialize the model
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
+		await model.loadContents();
+
+		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.equal(model.cells.length, 2, 'Two cells should be entered');
+
+		let firstCell = model.cells[0];
+		let secondCell = model.cells[1];
+		// Move First Cell down
+		model.moveCell(firstCell, 1);
+		assert.equal(model.cells.indexOf(firstCell), 1, 'First Cell did not move down correctly');
+		assert.equal(model.cells.indexOf(secondCell), 0, 'Second Cell did not move up correctly');
+	});
+
+	test('Should move second cell up above the first cell correctly', async function (): Promise<void> {
+		let mockContentManager = TypeMoq.Mock.ofType(NotebookEditorContentManager);
+		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedNotebookContent));
+		defaultModelOptions.contentManager = mockContentManager.object;
+
+		// When I initialize the model
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
+		await model.loadContents();
+
+		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.equal(model.cells.length, 2, 'Two cells should be entered');
+
+		let firstCell = model.cells[0];
+		let secondCell = model.cells[1];
+		// Move Second Cell up
+		model.moveCell(secondCell, 0);
+		assert.equal(model.cells.indexOf(firstCell), 1, 'First Cell did not move down correctly');
+		assert.equal(model.cells.indexOf(secondCell), 0, 'Second Cell did not move up correctly');
 	});
 
 	test('Should delete cells correctly', async function (): Promise<void> {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -353,7 +353,7 @@ suite('notebook model', function (): void {
 		await model.loadContents();
 
 		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
-		assert.equal(model.cells.length, 2, 'Two cells should be entered');
+		assert.equal(model.cells.length, 2, 'Cell count in notebook model is not correct');
 
 		// Set parameter cell and injected parameters cell
 		let notebookParamsCell = model.cells[0];
@@ -381,7 +381,7 @@ suite('notebook model', function (): void {
 		await model.loadContents();
 
 		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
-		assert.equal(model.cells.length, 2, 'Two cells should be entered');
+		assert.equal(model.cells.length, 2, 'Cell count in notebook model is not correct');
 
 		// Validate notebookUri parameter cell is set as the only parameter cell
 		let notebookUriParamsCell = model.cells[0];
@@ -405,11 +405,32 @@ suite('notebook model', function (): void {
 		await model.loadContents();
 
 		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
-		assert.equal(model.cells.length, 2, 'Two cells should be entered');
+		assert.equal(model.cells.length, 2, 'Cell count in notebook model is not correct');
 
 		// Validate notebookUri parameter cell is set as injected parameter
 		let notebookUriParamsCell = model.cells[1];
 		assert.equal(model.cells.indexOf(notebookUriParamsCell), 1, 'NotebookURI parameters cell should be second cell in notebook');
+		assert.equal(notebookUriParamsCell.isParameter, false, 'NotebookURI parameters cell should not be tagged parameter cell');
+		assert.equal(notebookUriParamsCell.isInjectedParameter, true, 'NotebookURI parameters Cell should be injected parameter');
+	});
+
+	test('Should set notebookUri parameters to new cell after injected parameters cell correctly', async function (): Promise<void> {
+		let mockContentManager = TypeMoq.Mock.ofType(NotebookEditorContentManager);
+
+		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedParameterizedNotebookContent));
+		defaultModelOptions.notebookUri = notebookUriParams;
+		defaultModelOptions.contentManager = mockContentManager.object;
+
+		// When I initialize the model
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
+		await model.loadContents();
+
+		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
+		assert.equal(model.cells.length, 3, 'Cell count in notebook model is not correct');
+
+		// Validate notebookUri parameter cell is set as an injected parameter after parameter and injected parameter cells
+		let notebookUriParamsCell = model.cells[2];
+		assert.equal(model.cells.indexOf(notebookUriParamsCell), 2, 'NotebookURI parameters cell should be third cell in notebook');
 		assert.equal(notebookUriParamsCell.isParameter, false, 'NotebookURI parameters cell should not be tagged parameter cell');
 		assert.equal(notebookUriParamsCell.isInjectedParameter, true, 'NotebookURI parameters Cell should be injected parameter');
 	});
@@ -424,7 +445,7 @@ suite('notebook model', function (): void {
 		await model.loadContents();
 
 		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
-		assert.equal(model.cells.length, 2, 'Two cells should be entered');
+		assert.equal(model.cells.length, 2, 'Cell count in notebook model is not correct');
 
 		let firstCell = model.cells[0];
 		let secondCell = model.cells[1];
@@ -444,7 +465,7 @@ suite('notebook model', function (): void {
 		await model.loadContents();
 
 		assert.equal(model.notebookUri, defaultModelOptions.notebookUri, 'Notebook model has incorrect URI');
-		assert.equal(model.cells.length, 2, 'Two cells should be entered');
+		assert.equal(model.cells.length, 2, 'Cell count in notebook model is not correct');
 
 		let firstCell = model.cells[0];
 		let secondCell = model.cells[1];

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -361,7 +361,7 @@ suite('notebook model', function (): void {
 
 		// Parameters Cell Validation
 		assert.equal(model.cells.indexOf(notebookParamsCell), 0, 'Notebook parameters cell should be first cell in notebook');
-		assert.equal(notebookParamsCell.isParameter, true, 'Notebook parameters cell should be tagged parameter cell');
+		assert.equal(notebookParamsCell.isParameter, true, 'Notebook parameters cell should be tagged parameter');
 		assert.equal(notebookParamsCell.isInjectedParameter, false, 'Notebook parameters cell should not be tagged injected parameter');
 
 		// Injected Parameters Cell Validation
@@ -386,8 +386,8 @@ suite('notebook model', function (): void {
 		// Validate notebookUri parameter cell is set as the only parameter cell
 		let notebookUriParamsCell = model.cells[0];
 		assert.equal(model.cells.indexOf(notebookUriParamsCell), 0, 'NotebookURI parameters cell should be first cell in notebook');
-		assert.equal(notebookUriParamsCell.isParameter, true, 'NotebookURI parameters cell should be tagged paramter');
-		assert.equal(notebookUriParamsCell.isInjectedParameter, false, 'NotebookURI parameters Cell should not be injected paramter');
+		assert.equal(notebookUriParamsCell.isParameter, true, 'NotebookURI parameters cell should be tagged parameter');
+		assert.equal(notebookUriParamsCell.isInjectedParameter, false, 'NotebookURI parameters Cell should not be injected parameter');
 	});
 
 	test('Should set notebookUri parameters to new cell after parameters cell correctly', async function (): Promise<void> {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -410,8 +410,8 @@ suite('notebook model', function (): void {
 		// Validate notebookUri parameter cell is set as injected parameter
 		let notebookUriParamsCell = model.cells[1];
 		assert.equal(model.cells.indexOf(notebookUriParamsCell), 1, 'NotebookURI parameters cell should be second cell in notebook');
-		assert.equal(notebookUriParamsCell.isParameter, false, 'NotebookURI parameters cell should not be tagged paramter cell');
-		assert.equal(notebookUriParamsCell.isInjectedParameter, true, 'NotebookURI parameters Cell should be injected paramter');
+		assert.equal(notebookUriParamsCell.isParameter, false, 'NotebookURI parameters cell should not be tagged parameter cell');
+		assert.equal(notebookUriParamsCell.isInjectedParameter, true, 'NotebookURI parameters Cell should be injected parameter');
 	});
 
 	test('Should move first cell below second cell correctly', async function (): Promise<void> {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -361,13 +361,13 @@ suite('notebook model', function (): void {
 
 		// Parameters Cell Validation
 		assert.equal(model.cells.indexOf(notebookParamsCell), 0, 'Notebook parameters cell should be first cell in notebook');
-		assert.equal(notebookParamsCell.isParameter, true, 'Notebook parameters cell should be tagged paramter');
-		assert.equal(notebookParamsCell.isInjectedParameter, false, 'Notebook parameters cell should be tagged paramter');
+		assert.equal(notebookParamsCell.isParameter, true, 'Notebook parameters cell should be tagged parameter cell');
+		assert.equal(notebookParamsCell.isInjectedParameter, false, 'Notebook parameters cell should not be tagged injected parameter');
 
 		// Injected Parameters Cell Validation
-		assert.equal(model.cells.indexOf(notebookInjectedParamsCell), 1, 'Notebook injected parameters cell should be first cell in notebook');
-		assert.equal(notebookInjectedParamsCell.isParameter, false, 'Notebook injected parameters cell should not be tagged paramters cell');
-		assert.equal(notebookInjectedParamsCell.isInjectedParameter, true, 'Notebook injected parameters cell should be tagged injected paramter');
+		assert.equal(model.cells.indexOf(notebookInjectedParamsCell), 1, 'Notebook injected parameters cell should be second cell in notebook');
+		assert.equal(notebookInjectedParamsCell.isParameter, false, 'Notebook injected parameters cell should not be tagged parameter cell');
+		assert.equal(notebookInjectedParamsCell.isInjectedParameter, true, 'Notebook injected parameters cell should be tagged injected parameter');
 	});
 
 	test('Should set notebookUri parameters to new cell correctly', async function (): Promise<void> {
@@ -409,9 +409,9 @@ suite('notebook model', function (): void {
 
 		// Validate notebookUri parameter cell is set as injected parameter
 		let notebookUriParamsCell = model.cells[1];
-		assert.equal(model.cells.indexOf(notebookUriParamsCell), 1, 'NotebookURI parameters cell should be first cell in notebook');
-		assert.equal(notebookUriParamsCell.isParameter, false, 'NotebookURI parameters cell should be tagged paramter');
-		assert.equal(notebookUriParamsCell.isInjectedParameter, true, 'NotebookURI parameters Cell should not be injected paramter');
+		assert.equal(model.cells.indexOf(notebookUriParamsCell), 1, 'NotebookURI parameters cell should be second cell in notebook');
+		assert.equal(notebookUriParamsCell.isParameter, false, 'NotebookURI parameters cell should not be tagged paramter cell');
+		assert.equal(notebookUriParamsCell.isInjectedParameter, true, 'NotebookURI parameters Cell should be injected paramter');
 	});
 
 	test('Should move first cell below second cell correctly', async function (): Promise<void> {

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -364,12 +364,13 @@ export class NotebookModel extends Disposable implements INotebookModel {
 					});
 				}
 				// Get Notebook URI Params & adjust to string
-				let notebookUriParams: string = this.notebookUri?.query;
+				let notebookUriParams: string = this.notebookUri.query;
 				// Format query to code cell format
 				notebookUriParams = notebookUriParams.replace(/&/g, '\n').replace(/=/g, ' = ');
 				// Get parameter cell and index to place new notebookUri parameters accordingly
 				let parameterCellIndex = 0;
 				let hasParameterCell = false;
+				let injectedParametersMsg = localize('injectedParametersMsg', '# Injected-Parameters\n');
 				if (contents.cells && contents.cells.length > 0) {
 					this._cells = contents.cells.map(c => {
 						let cellModel = factory.createCell(c, { notebook: this, isTrusted: isTrusted });
@@ -385,7 +386,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						*/
 						if (cellModel.isInjectedParameter) {
 							cellModel.source = cellModel.source.slice(1);
-							cellModel.source = ['# Injected-Parameters\n'].concat(cellModel.source);
+							cellModel.source = [injectedParametersMsg].concat(cellModel.source);
 						}
 						this.trackMarkdownTelemetry(<nb.ICellContents>c, cellModel);
 						return cellModel;
@@ -466,15 +467,16 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return cell;
 	}
 
-	// Adds Paramters cell based on Notebook URI parameters
+	/* Adds Paramters cell based on Notebook URI parameters */
 	private addParametersCell(notebookUriParams: string, hasParameterCell: boolean, parameterCellIndex: number): void {
+		let injectedParametersMsg = localize('injectedParametersMsg', '# Injected-Parameters\n');
 		let uriParamsIndex = parameterCellIndex;
 		// Set new parameters as Injected Parameters cell after original parameter cell
 		if (hasParameterCell) {
 			uriParamsIndex = parameterCellIndex + 1;
 			this.addUriParameterCell(uriParamsIndex, notebookUriParams);
 			this.cells[uriParamsIndex].isInjectedParameter = true;
-			this.cells[uriParamsIndex].source = ['# Injected-Parameters\n'].concat(this.cells[uriParamsIndex].source);
+			this.cells[uriParamsIndex].source = [injectedParametersMsg].concat(this.cells[uriParamsIndex].source);
 		} else {
 			// Set new parameters as the parameters cell as the first cell in the notebook
 			this.addUriParameterCell(uriParamsIndex, notebookUriParams);
@@ -482,7 +484,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		}
 	}
 
-	// Add new notebook URI parameters cell to notebook
+	/** Add new notebook URI parameters cell to notebook */
 	private addUriParameterCell(uriParamsIndex, notebookUriParams): void {
 		this.addCell('code', uriParamsIndex);
 		this._cells[uriParamsIndex].source = [notebookUriParams];

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -49,6 +49,8 @@ export class ErrorInfo {
 }
 
 const saveConnectionNameConfigName = 'notebook.saveConnectionName';
+const injectedParametersMsg = localize('injectedParametersMsg', '# Injected-Parameters\n');
+
 
 export class NotebookModel extends Disposable implements INotebookModel {
 	private _contextsChangedEmitter = new Emitter<void>();
@@ -371,7 +373,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				let parameterCellIndex = 0;
 				let hasParameterCell = false;
 				let hasInjectedCell = false;
-				let injectedParametersMsg = localize('injectedParametersMsg', '# Injected-Parameters\n');
 				if (contents.cells && contents.cells.length > 0) {
 					this._cells = contents.cells.map(c => {
 						let cellModel = factory.createCell(c, { notebook: this, isTrusted: isTrusted });
@@ -469,9 +470,8 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return cell;
 	}
 
-	/* Adds Paramters cell based on Notebook URI parameters */
+	/** Adds Paramters cell based on Notebook URI parameters */
 	private addParametersCell(notebookUriParams: string, hasParameterCell: boolean, parameterCellIndex: number, hasInjectedCell: boolean): void {
-		let injectedParametersMsg = localize('injectedParametersMsg', '# Injected-Parameters\n');
 		let uriParamsIndex = parameterCellIndex;
 		// Set new uri parameters as a Injected Parameters cell after original parameter cell
 		if (hasParameterCell) {

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -364,9 +364,8 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						}
 					});
 				}
-				// Get Notebook URI Params & adjust to string
+				// Modify Notebook URI Params format from URI query to string space delimited format
 				let notebookUriParams: string = this.notebookUri.query;
-				// Format query to code cell format
 				notebookUriParams = notebookUriParams.replace(/&/g, '\n').replace(/=/g, ' = ');
 				// Get parameter cell and index to place new notebookUri parameters accordingly
 				let parameterCellIndex = 0;
@@ -396,7 +395,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				}
 				// Only add new parameter cell if notebookUri Parameters are found
 				if (notebookUriParams) {
-					this.addParametersCell(notebookUriParams, hasParameterCell, parameterCellIndex, hasInjectedCell);
+					this.addUriParameterCell(notebookUriParams, hasParameterCell, parameterCellIndex, hasInjectedCell);
 				}
 			}
 
@@ -469,8 +468,14 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return cell;
 	}
 
-	/** Adds Paramters cell based on Notebook URI parameters */
-	private addParametersCell(notebookUriParams: string, hasParameterCell: boolean, parameterCellIndex: number, hasInjectedCell: boolean): void {
+	/**
+	 * Adds Parameters cell based on Notebook URI parameters
+	 * @param notebookUriParams contains the parameters from Notebook URI
+	 * @param hasParameterCell notebook contains a parameter cell
+	 * @param parameterCellIndex index of the parameter cell in notebook
+	 * @param hasInjectedCell notebook contains a injected parameter cell
+	 */
+	private addUriParameterCell(notebookUriParams: string, hasParameterCell: boolean, parameterCellIndex: number, hasInjectedCell: boolean): void {
 		let uriParamsIndex = parameterCellIndex;
 		// Set new uri parameters as a Injected Parameters cell after original parameter cell
 		if (hasParameterCell) {
@@ -479,20 +484,15 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			if (hasInjectedCell) {
 				uriParamsIndex = uriParamsIndex + 1;
 			}
-			this.addUriParameterCell(uriParamsIndex, notebookUriParams);
+			this.addCell('code', uriParamsIndex);
 			this.cells[uriParamsIndex].isInjectedParameter = true;
-			this.cells[uriParamsIndex].source = [injectedParametersMsg].concat(this.cells[uriParamsIndex].source);
+			this.cells[uriParamsIndex].source = [injectedParametersMsg].concat(notebookUriParams);
 		} else {
 			// Set new parameters as the parameters cell as the first cell in the notebook
-			this.addUriParameterCell(uriParamsIndex, notebookUriParams);
+			this.addCell('code', uriParamsIndex);
 			this.cells[uriParamsIndex].isParameter = true;
+			this.cells[uriParamsIndex].source = [notebookUriParams];
 		}
-	}
-
-	/** Add new notebook URI parameters cell to notebook */
-	private addUriParameterCell(uriParamsIndex, notebookUriParams): void {
-		this.addCell('code', uriParamsIndex);
-		this._cells[uriParamsIndex].source = [notebookUriParams];
 	}
 
 	moveCell(cell: ICellModel, direction: MoveDirection): void {

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -366,6 +366,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				// Get Notebook URI Params & adjust to string
 				let notebookUriParams: string = this.notebookUri?.query;
 				notebookUriParams = notebookUriParams.split('').join(' ').replace('& ', '\n');
+				// Get parameter cell and index to place new notebookUri parameters accordingly
 				let parameterCellIndex = 0;
 				let parameterCell = false;
 				if (contents.cells && contents.cells.length > 0) {
@@ -389,7 +390,10 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						return cellModel;
 					});
 				}
-				this.addParametersCell(notebookUriParams, parameterCell, parameterCellIndex);
+				// Only add new parameter cell if notebookUri Parameters are found
+				if (notebookUriParams) {
+					this.addParametersCell(notebookUriParams, parameterCell, parameterCellIndex);
+				}
 			}
 
 			// Trust notebook by default if there are no code cells
@@ -461,22 +465,23 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return cell;
 	}
 
+	// Adds Paramters cell based on Notebook URI parameters
 	private addParametersCell(notebookUriParams: string, parameterCell: boolean, parameterCellIndex: number): void {
-		// Add New Parameters Cell
-		if (notebookUriParams) {
-			let uriParamsIndex = parameterCellIndex;
-			if (parameterCell) {
-				uriParamsIndex = parameterCellIndex + 1;
-				this.addUriParameterCell(uriParamsIndex, notebookUriParams);
-				this.cells[uriParamsIndex].isInjectedParameter = true;
-				this.cells[uriParamsIndex].source = ['# Injected-Parameters\n'].concat(this.cells[uriParamsIndex].source);
-			} else {
-				this.addUriParameterCell(uriParamsIndex, notebookUriParams);
-				this.cells[uriParamsIndex].isParameter = true;
-			}
+		let uriParamsIndex = parameterCellIndex;
+		// Set new parameters as Injected Parameters cell after original parameter cell
+		if (parameterCell) {
+			uriParamsIndex = parameterCellIndex + 1;
+			this.addUriParameterCell(uriParamsIndex, notebookUriParams);
+			this.cells[uriParamsIndex].isInjectedParameter = true;
+			this.cells[uriParamsIndex].source = ['# Injected-Parameters\n'].concat(this.cells[uriParamsIndex].source);
+		} else {
+			// Set new parameters as the parameters cell as the first cell in the notebook
+			this.addUriParameterCell(uriParamsIndex, notebookUriParams);
+			this.cells[uriParamsIndex].isParameter = true;
 		}
 	}
 
+	// Add new notebook URI parameters cell to notebook
 	private addUriParameterCell(uriParamsIndex, notebookUriParams): void {
 		this.addCell('code', uriParamsIndex);
 		this._cells[uriParamsIndex].source = [notebookUriParams];

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -51,7 +51,6 @@ export class ErrorInfo {
 const saveConnectionNameConfigName = 'notebook.saveConnectionName';
 const injectedParametersMsg = localize('injectedParametersMsg', '# Injected-Parameters\n');
 
-
 export class NotebookModel extends Disposable implements INotebookModel {
 	private _contextsChangedEmitter = new Emitter<void>();
 	private _contextsLoadingEmitter = new Emitter<void>();

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -368,13 +368,13 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				notebookUriParams = notebookUriParams.split('').join(' ').replace('& ', '\n');
 				// Get parameter cell and index to place new notebookUri parameters accordingly
 				let parameterCellIndex = 0;
-				let parameterCell = false;
+				let hasParameterCell = false;
 				if (contents.cells && contents.cells.length > 0) {
 					this._cells = contents.cells.map(c => {
 						let cellModel = factory.createCell(c, { notebook: this, isTrusted: isTrusted });
 						if (cellModel.isParameter) {
 							parameterCellIndex = contents.cells.indexOf(c);
-							parameterCell = true;
+							hasParameterCell = true;
 						}
 						/*
 						In a parameterized notebook there will be an injected parameter cell.
@@ -392,7 +392,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				}
 				// Only add new parameter cell if notebookUri Parameters are found
 				if (notebookUriParams) {
-					this.addParametersCell(notebookUriParams, parameterCell, parameterCellIndex);
+					this.addParametersCell(notebookUriParams, hasParameterCell, parameterCellIndex);
 				}
 			}
 
@@ -466,10 +466,10 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	}
 
 	// Adds Paramters cell based on Notebook URI parameters
-	private addParametersCell(notebookUriParams: string, parameterCell: boolean, parameterCellIndex: number): void {
+	private addParametersCell(notebookUriParams: string, hasParameterCell: boolean, parameterCellIndex: number): void {
 		let uriParamsIndex = parameterCellIndex;
 		// Set new parameters as Injected Parameters cell after original parameter cell
-		if (parameterCell) {
+		if (hasParameterCell) {
 			uriParamsIndex = parameterCellIndex + 1;
 			this.addUriParameterCell(uriParamsIndex, notebookUriParams);
 			this.cells[uriParamsIndex].isInjectedParameter = true;

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -365,7 +365,8 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				}
 				// Get Notebook URI Params & adjust to string
 				let notebookUriParams: string = this.notebookUri?.query;
-				notebookUriParams = notebookUriParams.split('').join(' ').replace('& ', '\n');
+				// Format query to code cell format
+				notebookUriParams = notebookUriParams.replace(/&/g, '\n').replace(/=/g, ' = ');
 				// Get parameter cell and index to place new notebookUri parameters accordingly
 				let parameterCellIndex = 0;
 				let hasParameterCell = false;

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -370,6 +370,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				// Get parameter cell and index to place new notebookUri parameters accordingly
 				let parameterCellIndex = 0;
 				let hasParameterCell = false;
+				let hasInjectedCell = false;
 				let injectedParametersMsg = localize('injectedParametersMsg', '# Injected-Parameters\n');
 				if (contents.cells && contents.cells.length > 0) {
 					this._cells = contents.cells.map(c => {
@@ -385,6 +386,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 						So to make it clear we edit the injected parameters comment to indicate it is the Injected-Parameters cell.
 						*/
 						if (cellModel.isInjectedParameter) {
+							hasInjectedCell = true;
 							cellModel.source = cellModel.source.slice(1);
 							cellModel.source = [injectedParametersMsg].concat(cellModel.source);
 						}
@@ -394,7 +396,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				}
 				// Only add new parameter cell if notebookUri Parameters are found
 				if (notebookUriParams) {
-					this.addParametersCell(notebookUriParams, hasParameterCell, parameterCellIndex);
+					this.addParametersCell(notebookUriParams, hasParameterCell, parameterCellIndex, hasInjectedCell);
 				}
 			}
 
@@ -468,12 +470,16 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	}
 
 	/* Adds Paramters cell based on Notebook URI parameters */
-	private addParametersCell(notebookUriParams: string, hasParameterCell: boolean, parameterCellIndex: number): void {
+	private addParametersCell(notebookUriParams: string, hasParameterCell: boolean, parameterCellIndex: number, hasInjectedCell: boolean): void {
 		let injectedParametersMsg = localize('injectedParametersMsg', '# Injected-Parameters\n');
 		let uriParamsIndex = parameterCellIndex;
-		// Set new parameters as Injected Parameters cell after original parameter cell
+		// Set new uri parameters as a Injected Parameters cell after original parameter cell
 		if (hasParameterCell) {
 			uriParamsIndex = parameterCellIndex + 1;
+			// Set the uri parameters after the injected parameter cell
+			if (hasInjectedCell) {
+				uriParamsIndex = uriParamsIndex + 1;
+			}
 			this.addUriParameterCell(uriParamsIndex, notebookUriParams);
 			this.cells[uriParamsIndex].isInjectedParameter = true;
 			this.cells[uriParamsIndex].source = [injectedParametersMsg].concat(this.cells[uriParamsIndex].source);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->



This PR enables parameterization via Notebook URI as shown below.

The implementation covers how a user opens a new notebook via azuredatastudio://URI that contains parameters. 

ex. 
`URI with Parameter cell: azuredatastudio://microsoft.notebook/open?url=https://raw.githubusercontent.com/VasuBhog/AzureDataStudio-Notebooks/main/Demo_Parameterization/Input.ipynb?x=1&y=2`

Parameters will be parsed from the URI, then transformed to string format to then be added as a new cell to the notebook. The new cell will either be added as a _parameters tagged cell_ or as _injected parameters cell_ depending on if there is already a parameter cell in the notebook.

![ParameterizationV2](https://user-images.githubusercontent.com/23587151/102957992-c1a92800-4490-11eb-851f-17a55226f9f0.gif)

