### PR TITLE
populate drop down options values from options source

### DIFF
--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -640,6 +640,9 @@ async function processOptionsTypeField(context: FieldContext): Promise<void> {
 		optionsComponent = await processRadioOptionsTypeField(context, getRadioOptions);
 	} else {
 		throwUnless(context.fieldInfo.options.optionsType === OptionsType.Dropdown, loc.optionsTypeRadioOrDropdown);
+		if (optionsSource?.provider) {
+			context.fieldInfo.options.values = await optionsSource.provider.getOptions();
+		}
 		optionsComponent = processDropdownOptionsTypeField(context);
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
In a previous change we had stopped populating the options.values field for a dropdown from options sources. This change adds it back.

This PR fixes #13789
