### PR TITLE
acquireLogin/releaseLogin apis for data controller to ensure only one dc is logged in at a given time

### DIFF
--- a/extensions/arc/src/models/miaaModel.ts
+++ b/extensions/arc/src/models/miaaModel.ts
@@ -77,7 +77,7 @@ export class MiaaModel extends ResourceModel {
 		}
 		this._refreshPromise = new Deferred();
 		try {
-			await this.controllerModel.azdataLogin();
+			await this.controllerModel.acquireLogin();
 			try {
 				const result = await this._azdataApi.azdata.arc.sql.mi.show(this.info.name);
 				this._config = result.result;
@@ -119,6 +119,7 @@ export class MiaaModel extends ResourceModel {
 			this._refreshPromise.reject(err);
 			throw err;
 		} finally {
+			this.controllerModel.releaseLogin();
 			this._refreshPromise = undefined;
 		}
 	}

--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -91,7 +91,7 @@ export class PostgresModel extends ResourceModel {
 		this._refreshPromise = new Deferred();
 
 		try {
-			await this.controllerModel.azdataLogin();
+			await this.controllerModel.acquireLogin();
 			this._config = (await this._azdataApi.azdata.arc.postgres.server.show(this.info.name)).result;
 			this.configLastUpdated = new Date();
 			this._onConfigUpdated.fire(this._config);
@@ -100,6 +100,7 @@ export class PostgresModel extends ResourceModel {
 			this._refreshPromise.reject(err);
 			throw err;
 		} finally {
+			this.controllerModel.releaseLogin();
 			this._refreshPromise = undefined;
 		}
 	}

--- a/extensions/arc/src/test/models/controllerModel.test.ts
+++ b/extensions/arc/src/test/models/controllerModel.test.ts
@@ -23,7 +23,7 @@ describe('ControllerModel', function (): void {
 		sinon.restore();
 	});
 
-	describe('azdataLogin', function (): void {
+	describe('acquireLogin', function (): void {
 		let mockExtensionContext: TypeMoq.IMock<vscode.ExtensionContext>;
 		let mockGlobalState: TypeMoq.IMock<vscode.Memento>;
 
@@ -43,7 +43,8 @@ describe('ControllerModel', function (): void {
 			// Returning an undefined model here indicates that the dialog closed without clicking "Ok" - usually through the user clicking "Cancel"
 			sinon.stub(ConnectToControllerDialog.prototype, 'waitForClose').returns(Promise.resolve(undefined));
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] });
-			await should(model.azdataLogin()).be.rejectedWith(new UserCancelledError(loc.userCancelledError));
+			await should(model.acquireLogin()).be.rejectedWith(new UserCancelledError(loc.userCancelledError));
+			model.releaseLogin();
 		});
 
 		it('Reads password from cred store', async function (): Promise<void> {
@@ -63,8 +64,9 @@ describe('ControllerModel', function (): void {
 			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: azdataExtApiMock.object });
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] });
 
-			await model.azdataLogin();
+			await model.acquireLogin();
 			azdataMock.verify(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
+			model.releaseLogin();
 		});
 
 		it('Prompt for password when not in cred store', async function (): Promise<void> {
@@ -89,8 +91,9 @@ describe('ControllerModel', function (): void {
 
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] });
 
-			await model.azdataLogin();
+			await model.acquireLogin();
 			azdataMock.verify(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
+			model.releaseLogin();
 		});
 
 		it('Prompt for password when rememberPassword is true but prompt reconnect is true', async function (): Promise<void> {
@@ -114,9 +117,10 @@ describe('ControllerModel', function (): void {
 
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] });
 
-			await model.azdataLogin(true);
+			await model.acquireLogin(true);
 			should(waitForCloseStub.called).be.true('waitForClose should have been called');
 			azdataMock.verify(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
+			model.releaseLogin();
 		});
 
 		it('Prompt for password when we already have a password but prompt reconnect is true', async function (): Promise<void> {
@@ -141,9 +145,10 @@ describe('ControllerModel', function (): void {
 			// Set up original model with a password
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] }, 'originalPassword');
 
-			await model.azdataLogin(true);
+			await model.acquireLogin(true);
 			should(waitForCloseStub.called).be.true('waitForClose should have been called');
 			azdataMock.verify(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
+			model.releaseLogin();
 		});
 
 		it('Model values are updated correctly when modified during reconnect', async function (): Promise<void> {
@@ -199,10 +204,11 @@ describe('ControllerModel', function (): void {
 			const waitForCloseStub = sinon.stub(ConnectToControllerDialog.prototype, 'waitForClose').returns(Promise.resolve(
 				{ controllerModel: newModel, password: newPassword }));
 
-			await model.azdataLogin(true);
+			await model.acquireLogin(true);
 			should(waitForCloseStub.called).be.true('waitForClose should have been called');
 			should((await treeDataProvider.getChildren()).length).equal(1, 'Tree Data provider should still only have 1 node');
 			should(model.info).deepEqual(newInfo, 'Model info should have been updated');
+			model.releaseLogin();
 		});
 
 	});

--- a/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
@@ -130,12 +130,14 @@ export class MiaaComputeAndStoragePage extends DashboardPage {
 						},
 						async (_progress, _token): Promise<void> => {
 							try {
-								await this._miaaModel.controllerModel.azdataLogin();
+								await this._miaaModel.controllerModel.acquireLogin();
 								await this._azdataApi.azdata.arc.sql.mi.edit(
 									this._miaaModel.info.name, this.saveArgs);
 							} catch (err) {
 								this.saveButton!.enabled = true;
 								throw err;
+							} finally {
+								this._miaaModel.controllerModel.releaseLogin();
 							}
 
 							await this._miaaModel.refresh();

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -206,8 +206,12 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 								cancellable: false
 							},
 							async (_progress, _token) => {
-								await this._controllerModel.azdataLogin();
-								return await this._azdataApi.azdata.arc.sql.mi.delete(this._miaaModel.info.name);
+								try {
+									await this._controllerModel.acquireLogin();
+									return await this._azdataApi.azdata.arc.sql.mi.delete(this._miaaModel.info.name);
+								} finally {
+									this._controllerModel.releaseLogin();
+								}
 							}
 						);
 						await this._controllerModel.refreshTreeNode();

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -156,7 +156,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 						},
 						async (_progress, _token): Promise<void> => {
 							try {
-								await this._postgresModel.controllerModel.azdataLogin();
+								await this._postgresModel.controllerModel.acquireLogin();
 								await this._azdataApi.azdata.arc.postgres.server.edit(
 									this._postgresModel.info.name,
 									this.saveArgs,
@@ -167,6 +167,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 								// the edit wasn't successfully applied
 								this.saveButton!.enabled = true;
 								throw err;
+							} finally {
+								this._postgresModel.controllerModel.releaseLogin();
 							}
 							await this._postgresModel.refresh();
 						}

--- a/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
@@ -192,8 +192,12 @@ export class PostgresOverviewPage extends DashboardPage {
 								cancellable: false
 							},
 							async (_progress, _token) => {
-								await this._postgresModel.controllerModel.acquireLogin();
-								return await this._azdataApi.azdata.arc.postgres.server.delete(this._postgresModel.info.name);
+								try {
+									await this._postgresModel.controllerModel.acquireLogin();
+									return await this._azdataApi.azdata.arc.postgres.server.delete(this._postgresModel.info.name);
+								} finally {
+									this._postgresModel.controllerModel.releaseLogin();
+								}
 							}
 						);
 						await this._controllerModel.refreshTreeNode();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This change adds new api on arc ControllerModel object called acuireLogin and releaseLogin which ensure that a new login is not performed until previous logged in session has been released.

This PR fixes #13875

@charles-gagnon is taking over completion of this PR as  needed. 