### PR TITLE
Add setting to customize notebook markdown preview line height

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -237,12 +237,8 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			if (this._previewMode) {
 				let outputElement = <HTMLElement>this.output.nativeElement;
 				outputElement.innerHTML = this.markdownResult.element.innerHTML;
-				if (outputElement.innerHTML !== '<p><i>Double-click to edit</i></p>' && outputElement.innerHTML !== '') {
-					let lineHeight: number = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
-					outputElement.style.lineHeight = (lineHeight).toString();
-				} else {
-					outputElement.style.lineHeight = '22px';
-				}
+				let lineHeight: number = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
+				outputElement.style.lineHeight = lineHeight.toString();
 				this.cellModel.renderedOutputTextContent = this.getRenderedTextOutput();
 				outputElement.focus();
 			}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -243,11 +243,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			if (this._previewMode) {
 				let outputElement = <HTMLElement>this.output.nativeElement;
 				outputElement.innerHTML = this.markdownResult.element.innerHTML;
-				if (!this.isEditMode) {
-					outputElement.style.lineHeight = this.markdownPreviewLineHeight.toString();
-				} else {
-					outputElement.style.lineHeight = '22px';
-				}
+				outputElement.style.lineHeight = this.markdownPreviewLineHeight.toString();
 				this.cellModel.renderedOutputTextContent = this.getRenderedTextOutput();
 				outputElement.focus();
 			}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -237,6 +237,12 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			if (this._previewMode) {
 				let outputElement = <HTMLElement>this.output.nativeElement;
 				outputElement.innerHTML = this.markdownResult.element.innerHTML;
+				if (outputElement.innerHTML !== '<p><i>Double-click to edit</i></p>' && outputElement.innerHTML !== '') {
+					let lineHeight: number = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
+					outputElement.style.lineHeight = (lineHeight).toString();
+				} else {
+					outputElement.style.lineHeight = '22px';
+				}
 				this.cellModel.renderedOutputTextContent = this.getRenderedTextOutput();
 				outputElement.focus();
 			}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -242,8 +242,12 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			this.setLoading(false);
 			if (this._previewMode) {
 				let outputElement = <HTMLElement>this.output.nativeElement;
-				outputElement.innerHTML = this.markdownResult.element.innerHTML;
-				outputElement.style.lineHeight = this.markdownPreviewLineHeight.toString();
+				outputElement.innerHTML = this.markdownResult.element.innerHTML; //changes height
+				if (outputElement.innerHTML === '') {
+					outputElement.style.lineHeight = '50px';
+				} else {
+					outputElement.style.lineHeight = this.markdownPreviewLineHeight.toString();
+				}
 				this.cellModel.renderedOutputTextContent = this.getRenderedTextOutput();
 				outputElement.focus();
 			}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -242,11 +242,11 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			this.setLoading(false);
 			if (this._previewMode) {
 				let outputElement = <HTMLElement>this.output.nativeElement;
-				outputElement.innerHTML = this.markdownResult.element.innerHTML; //changes height
-				if (outputElement.innerHTML === '') {
-					outputElement.style.lineHeight = '50px';
-				} else {
+				outputElement.innerHTML = this.markdownResult.element.innerHTML;
+				if (!this.isEditMode) {
 					outputElement.style.lineHeight = this.markdownPreviewLineHeight.toString();
+				} else {
+					outputElement.style.lineHeight = '22px';
 				}
 				this.cellModel.renderedOutputTextContent = this.getRenderedTextOutput();
 				outputElement.focus();

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -119,13 +119,11 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			this.previewFeaturesEnabled = this._configurationService.getValue('workbench.enablePreviewFeatures');
-		}));
-		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			this.doubleClickEditEnabled = this._configurationService.getValue('notebook.enableDoubleClickEdit');
-		}));
-		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			this.markdownPreviewLineHeight = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
-			this.updatePreview();
+			if (e.affectsConfiguration('notebook.markdownPreviewLineHeight')) {
+				this.markdownPreviewLineHeight = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
+				this.updatePreview();
+			}
 		}));
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -95,6 +95,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	private markdownRenderer: NotebookMarkdownRenderer;
 	private markdownResult: IMarkdownRenderResult;
 	private _htmlMarkdownConverter: HTMLMarkdownConverter;
+	private markdownPreviewLineHeight: number;
 	public readonly onDidClickLink = this._onDidClickLink.event;
 	public previewFeaturesEnabled: boolean = false;
 	public doubleClickEditEnabled: boolean;
@@ -110,6 +111,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		super();
 		this.markdownRenderer = this._instantiationService.createInstance(NotebookMarkdownRenderer);
 		this.doubleClickEditEnabled = this._configurationService.getValue('notebook.enableDoubleClickEdit');
+		this.markdownPreviewLineHeight = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
 		this._register(toDisposable(() => {
 			if (this.markdownResult) {
 				this.markdownResult.dispose();
@@ -120,6 +122,10 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			this.doubleClickEditEnabled = this._configurationService.getValue('notebook.enableDoubleClickEdit');
+		}));
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			this.markdownPreviewLineHeight = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
+			this.updatePreview();
 		}));
 	}
 
@@ -237,8 +243,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			if (this._previewMode) {
 				let outputElement = <HTMLElement>this.output.nativeElement;
 				outputElement.innerHTML = this.markdownResult.element.innerHTML;
-				let lineHeight: number = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
-				outputElement.style.lineHeight = lineHeight.toString();
+				outputElement.style.lineHeight = this.markdownPreviewLineHeight.toString();
 				this.cellModel.renderedOutputTextContent = this.getRenderedTextOutput();
 				outputElement.focus();
 			}

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -231,6 +231,11 @@ configurationRegistry.registerConfiguration({
 			'default': false,
 			'description': localize('notebook.saveConnectionName', "(Preview) Save connection name in notebook metadata.")
 		},
+		'notebook.markdownPreviewLineHeight': {
+			'type': 'number',
+			'default': 1.5,
+			'description': localize('notebook.markdownPreviewLineHeight', "Set notebook markdown preview line height.")
+		}
 	}
 });
 

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -233,7 +233,8 @@ configurationRegistry.registerConfiguration({
 		},
 		'notebook.markdownPreviewLineHeight': {
 			'type': 'number',
-			'default': 1.6,
+			'default': 1.5,
+			'minimum': 1,
 			'description': localize('notebook.markdownPreviewLineHeight', "Controls the line height used in the notebook markdown preview. This number is relative to the font size.")
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -233,8 +233,8 @@ configurationRegistry.registerConfiguration({
 		},
 		'notebook.markdownPreviewLineHeight': {
 			'type': 'number',
-			'default': 1.5,
-			'description': localize('notebook.markdownPreviewLineHeight', "Set notebook markdown preview line height.")
+			'default': 1.6,
+			'description': localize('notebook.markdownPreviewLineHeight', "Controls the line height used in the notebook markdown preview. This number is relative to the font size.")
 		}
 	}
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/8978.

Left: line height = 1
Right: original (ADS version 1.25.1)
![Screen Shot 2021-01-06 at 11 33 03 AM](https://user-images.githubusercontent.com/23462877/103812882-08139080-5014-11eb-8f1a-dd82850ff6d1.png)

One thing to note:

1. Set line height to 1
2. Create new text cell
3. Type "hello"
4. Hit Enter
5. Type "world"
6. Exit cell

As shown in the GIF, space is added between "hello" and "world" upon exiting the cell. This is because they are converted to two separate p Elements and each element has margin space around it. In order to keep them as one p Element, you need to hit Shift+Enter instead of Enter.

![hello_world](https://user-images.githubusercontent.com/23462877/103816648-2a101180-501a-11eb-8950-3f2d6df3e3a6.gif)
**Question** - do we want to customize margin space between p elements as well?
