### PR TITLE
toggle focus between query and results

### DIFF
--- a/src/sql/base/browser/ui/panel/panel.ts
+++ b/src/sql/base/browser/ui/panel/panel.ts
@@ -311,7 +311,7 @@ export class TabbedPanel extends Disposable {
 		}
 	}
 
-	private focusCurrentTab(): void {
+	public focusCurrentTab(): void {
 		if (this._shownTabId) {
 			const tab = this._tabMap.get(this._shownTabId);
 			if (tab) {

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -306,6 +306,33 @@ export class ToggleQueryResultsKeyboardAction extends Action {
 	}
 }
 
+
+
+/**
+ * Toggle the focus between query editor and results pane
+ */
+export class ToggleFocusBetweenQueryEditorAndResultsAction extends Action {
+	public static ID = 'ToggleFocusBetweenQueryEditorAndResultsAction';
+	public static LABEL = nls.localize('ToggleFocusBetweenQueryEditorAndResultsAction', "Toggle Focus Between Query And Results");
+
+	constructor(
+		id: string,
+		label: string,
+		@IEditorService private _editorService: IEditorService
+	) {
+		super(id, label);
+		this.enabled = true;
+	}
+
+	public run(): Promise<void> {
+		const editor = this._editorService.activeEditorPane;
+		if (editor instanceof QueryEditor) {
+			editor.toggleFocusBetweenQueryEditorAndResults();
+		}
+		return Promise.resolve();
+	}
+}
+
 /**
  * Action class that runs a query in the active SQL text document.
  */

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -324,12 +324,11 @@ export class ToggleFocusBetweenQueryEditorAndResultsAction extends Action {
 		this.enabled = true;
 	}
 
-	public run(): Promise<void> {
+	public async run(): Promise<void> {
 		const editor = this._editorService.activeEditorPane;
 		if (editor instanceof QueryEditor) {
 			editor.toggleFocusBetweenQueryEditorAndResults();
 		}
-		return Promise.resolve();
 	}
 }
 

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -19,7 +19,7 @@ import { QueryResultsInput } from 'sql/workbench/common/editor/query/queryResult
 import * as queryContext from 'sql/workbench/contrib/query/common/queryContext';
 import {
 	RunQueryKeyboardAction, RunCurrentQueryKeyboardAction, CancelQueryKeyboardAction, RefreshIntellisenseKeyboardAction, ToggleQueryResultsKeyboardAction,
-	RunQueryShortcutAction, RunCurrentQueryWithActualPlanKeyboardAction, CopyQueryWithResultsKeyboardAction, FocusOnCurrentQueryKeyboardAction, ParseSyntaxAction
+	RunQueryShortcutAction, RunCurrentQueryWithActualPlanKeyboardAction, CopyQueryWithResultsKeyboardAction, FocusOnCurrentQueryKeyboardAction, ParseSyntaxAction, ToggleFocusBetweenQueryEditorAndResultsAction
 } from 'sql/workbench/contrib/query/browser/keyboardQueryActions';
 import * as gridActions from 'sql/workbench/contrib/editData/browser/gridActions';
 import * as gridCommands from 'sql/workbench/contrib/editData/browser/gridCommands';
@@ -198,6 +198,17 @@ actionRegistry.registerWorkbenchAction(
 		QueryEditorVisibleCondition
 	),
 	ToggleQueryResultsKeyboardAction.LABEL
+);
+
+actionRegistry.registerWorkbenchAction(
+	SyncActionDescriptor.create(
+		ToggleFocusBetweenQueryEditorAndResultsAction,
+		ToggleFocusBetweenQueryEditorAndResultsAction.ID,
+		ToggleFocusBetweenQueryEditorAndResultsAction.LABEL,
+		{ primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.KEY_N },
+		QueryEditorVisibleCondition
+	),
+	ToggleFocusBetweenQueryEditorAndResultsAction.LABEL
 );
 
 // Register Flavor Action

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -205,7 +205,7 @@ actionRegistry.registerWorkbenchAction(
 		ToggleFocusBetweenQueryEditorAndResultsAction,
 		ToggleFocusBetweenQueryEditorAndResultsAction.ID,
 		ToggleFocusBetweenQueryEditorAndResultsAction.LABEL,
-		{ primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.KEY_N },
+		{ primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.KEY_F },
 		QueryEditorVisibleCondition
 	),
 	ToggleFocusBetweenQueryEditorAndResultsAction.LABEL

--- a/src/sql/workbench/contrib/query/browser/queryEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryEditor.ts
@@ -470,6 +470,14 @@ export class QueryEditor extends EditorPane {
 		this.currentTextEditor.focus();
 	}
 
+	public toggleFocusBetweenQueryEditorAndResults(): void {
+		if (!this.resultsVisible || this.resultsEditorContainer.contains(document.activeElement)) {
+			this.focus();
+		} else {
+			this.resultsEditor.focus();
+		}
+	}
+
 	/**
 	 * Updates the internal variable keeping track of the editor's size, and re-calculates the sash position.
 	 * To be called when the container of this editor changes size.

--- a/src/sql/workbench/contrib/query/browser/queryResultsEditor.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsEditor.ts
@@ -153,4 +153,8 @@ export class QueryResultsEditor extends EditorPane {
 	public registerQueryModelViewTab(title: string, componentId: string): void {
 		this.resultsView.registerQueryModelViewTab(title, componentId);
 	}
+
+	public focus(): void {
+		this.resultsView.focus();
+	}
 }

--- a/src/sql/workbench/contrib/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsView.ts
@@ -432,6 +432,6 @@ export class QueryResultsView extends Disposable {
 	}
 
 	public focus(): void {
-		this._panelView.focus();
+		this._panelView.focusCurrentTab();
 	}
 }

--- a/src/sql/workbench/contrib/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsView.ts
@@ -430,4 +430,8 @@ export class QueryResultsView extends Disposable {
 			tab.putState(this.input.state.dynamicModelViewTabsState);
 		}
 	}
+
+	public focus(): void {
+		this._panelView.focus();
+	}
 }


### PR DESCRIPTION
This PR fixes #13661 

added a new action(win+shift+n) to toggle focus between the query editor and results pane

![abc](https://user-images.githubusercontent.com/13777222/103939321-7160d580-50e0-11eb-8c51-4e6f291801e0.gif)

