### PR TITLE
Change configure Jupyter server steps from async to sync

### DIFF
--- a/extensions/notebook/src/common/utils.ts
+++ b/extensions/notebook/src/common/utils.ts
@@ -30,6 +30,14 @@ export async function mkDir(dirPath: string, outputChannel?: vscode.OutputChanne
 		await fs.ensureDir(dirPath);
 	}
 }
+export function mkDirSync(dirPath: string, outputChannel?: vscode.OutputChannel): void {
+	if (!fs.pathExistsSync(dirPath)) {
+		if (outputChannel) {
+			outputChannel.appendLine(localize('mkdirOutputMsg', "... Creating {0}", dirPath));
+		}
+		fs.ensureDirSync(dirPath);
+	}
+}
 
 export function getErrorMessage(error: Error | string): string {
 	return (error instanceof Error) ? error.message : error;
@@ -245,6 +253,15 @@ export function setHostAndPort(delimeter: string, connection: azdata.IConnection
 export async function exists(path: string): Promise<boolean> {
 	try {
 		await fs.access(path);
+		return true;
+	} catch (e) {
+		return false;
+	}
+}
+
+export function existsSync(path: string): boolean {
+	try {
+		fs.accessSync(path);
 		return true;
 	} catch (e) {
 		return false;

--- a/extensions/notebook/src/common/utils.ts
+++ b/extensions/notebook/src/common/utils.ts
@@ -23,20 +23,16 @@ export function getLivyUrl(serverName: string, port: string): string {
 }
 
 export async function mkDir(dirPath: string, outputChannel?: vscode.OutputChannel): Promise<void> {
-	if (!await fs.pathExists(dirPath)) {
-		if (outputChannel) {
-			outputChannel.appendLine(localize('mkdirOutputMsg', "... Creating {0}", dirPath));
-		}
-		await fs.ensureDir(dirPath);
+	if (outputChannel) {
+		outputChannel.appendLine(localize('ensureDirOutputMsg', "... Ensuring {0} exists", dirPath));
 	}
+	await fs.ensureDir(dirPath);
 }
 export function mkDirSync(dirPath: string, outputChannel?: vscode.OutputChannel): void {
-	if (!fs.pathExistsSync(dirPath)) {
-		if (outputChannel) {
-			outputChannel.appendLine(localize('mkdirOutputMsg', "... Creating {0}", dirPath));
-		}
-		fs.ensureDirSync(dirPath);
+	if (outputChannel) {
+		outputChannel.appendLine(localize('ensureDirOutputMsg', "... Ensuring {0} exists", dirPath));
 	}
+	fs.ensureDirSync(dirPath);
 }
 
 export function getErrorMessage(error: Error | string): string {

--- a/extensions/notebook/src/common/utils.ts
+++ b/extensions/notebook/src/common/utils.ts
@@ -22,16 +22,12 @@ export function getLivyUrl(serverName: string, port: string): string {
 	return this.getKnoxUrl(serverName, port) + '/default/livy/v1/';
 }
 
-export async function mkDir(dirPath: string, outputChannel?: vscode.OutputChannel): Promise<void> {
-	if (outputChannel) {
-		outputChannel.appendLine(localize('ensureDirOutputMsg', "... Ensuring {0} exists", dirPath));
-	}
+export async function ensureDir(dirPath: string, outputChannel?: vscode.OutputChannel): Promise<void> {
+	outputChannel?.appendLine(localize('ensureDirOutputMsg', "... Ensuring {0} exists", dirPath));
 	await fs.ensureDir(dirPath);
 }
-export function mkDirSync(dirPath: string, outputChannel?: vscode.OutputChannel): void {
-	if (outputChannel) {
-		outputChannel.appendLine(localize('ensureDirOutputMsg', "... Ensuring {0} exists", dirPath));
-	}
+export function ensureDirSync(dirPath: string, outputChannel?: vscode.OutputChannel): void {
+	outputChannel?.appendLine(localize('ensureDirOutputMsg', "... Ensuring {0} exists", dirPath));
 	fs.ensureDirSync(dirPath);
 }
 

--- a/extensions/notebook/src/common/utils.ts
+++ b/extensions/notebook/src/common/utils.ts
@@ -259,15 +259,6 @@ export async function exists(path: string): Promise<boolean> {
 	}
 }
 
-export function existsSync(path: string): boolean {
-	try {
-		fs.accessSync(path);
-		return true;
-	} catch (e) {
-		return false;
-	}
-}
-
 const bdcConfigSectionName = 'bigDataCluster';
 const ignoreSslConfigName = 'ignoreSslVerification';
 

--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -259,7 +259,7 @@ export class JupyterSession implements nb.ISession {
 
 	public async configureKernel(): Promise<void> {
 		let sparkmagicConfDir = path.join(utils.getUserHome(), '.sparkmagic');
-		await utils.mkDir(sparkmagicConfDir);
+		await utils.ensureDir(sparkmagicConfDir);
 
 		// Default to localhost in config file.
 		let creds: ICredentials = {

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -153,9 +153,9 @@ export class PerFolderServerInstance implements IServerInstance {
 		this.baseDir = path.join(this.getSystemJupyterHomeDir(), 'instances', `${UUID.generateUuid()}`);
 		this.instanceConfigRoot = path.join(this.baseDir, 'config');
 		this.instanceDataRoot = path.join(this.baseDir, 'data');
-		utils.mkDirSync(this.baseDir, this.options.install.outputChannel);
-		utils.mkDirSync(this.instanceConfigRoot, this.options.install.outputChannel);
-		utils.mkDirSync(this.instanceDataRoot, this.options.install.outputChannel);
+		utils.ensureDirSync(this.baseDir, this.options.install.outputChannel);
+		utils.ensureDirSync(this.instanceConfigRoot, this.options.install.outputChannel);
+		utils.ensureDirSync(this.instanceDataRoot, this.options.install.outputChannel);
 	}
 
 	private copyInstanceConfig(resourcesFolder: string): void {
@@ -166,7 +166,7 @@ export class PerFolderServerInstance implements IServerInstance {
 
 	private copyCustomJs(resourcesFolder: string): void {
 		let customPath = path.join(this.instanceConfigRoot, 'custom');
-		utils.mkDirSync(customPath, this.options.install.outputChannel);
+		utils.ensureDirSync(customPath, this.options.install.outputChannel);
 		let customSource = path.join(resourcesFolder, CustomJsFilename);
 		let customDest = path.join(customPath, CustomJsFilename);
 		fs.copySync(customSource, customDest);
@@ -180,7 +180,7 @@ export class PerFolderServerInstance implements IServerInstance {
 			kernelsExtensionSource = path.join(this.options.install.extensionPath, 'kernels');
 		}
 		this._systemJupyterDir = path.join(this.getSystemJupyterHomeDir(), 'kernels');
-		utils.mkDirSync(this._systemJupyterDir, this.options.install.outputChannel);
+		utils.ensureDirSync(this._systemJupyterDir, this.options.install.outputChannel);
 		fs.copySync(kernelsExtensionSource, this._systemJupyterDir);
 		if (this.options.install.runningOnSaw) {
 			await this.options.install.updateKernelSpecPaths(this._systemJupyterDir);

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -142,34 +142,34 @@ export class PerFolderServerInstance implements IServerInstance {
 	}
 
 	private async configureJupyter(): Promise<void> {
-		await this.createInstanceFolders();
+		this.createInstanceFolders();
 		let resourcesFolder = path.join(this.options.install.extensionPath, 'resources', constants.jupyterConfigRootFolder);
-		await this.copyInstanceConfig(resourcesFolder);
-		await this.CopyCustomJs(resourcesFolder);
+		this.copyInstanceConfig(resourcesFolder);
+		this.copyCustomJs(resourcesFolder);
 		await this.copyKernelsToSystemJupyterDirs();
 	}
 
-	private async createInstanceFolders(): Promise<void> {
+	private createInstanceFolders(): void {
 		this.baseDir = path.join(this.getSystemJupyterHomeDir(), 'instances', `${UUID.generateUuid()}`);
 		this.instanceConfigRoot = path.join(this.baseDir, 'config');
 		this.instanceDataRoot = path.join(this.baseDir, 'data');
-		await utils.mkDir(this.baseDir, this.options.install.outputChannel);
-		await utils.mkDir(this.instanceConfigRoot, this.options.install.outputChannel);
-		await utils.mkDir(this.instanceDataRoot, this.options.install.outputChannel);
+		utils.mkDirSync(this.baseDir, this.options.install.outputChannel);
+		utils.mkDirSync(this.instanceConfigRoot, this.options.install.outputChannel);
+		utils.mkDirSync(this.instanceDataRoot, this.options.install.outputChannel);
 	}
 
-	private async copyInstanceConfig(resourcesFolder: string): Promise<void> {
+	private copyInstanceConfig(resourcesFolder: string): void {
 		let configSource = path.join(resourcesFolder, NotebookConfigFilename);
 		let configDest = path.join(this.instanceConfigRoot, NotebookConfigFilename);
-		await fs.copy(configSource, configDest);
+		fs.copySync(configSource, configDest);
 	}
 
-	private async CopyCustomJs(resourcesFolder: string): Promise<void> {
+	private copyCustomJs(resourcesFolder: string): void {
 		let customPath = path.join(this.instanceConfigRoot, 'custom');
-		await utils.mkDir(customPath, this.options.install.outputChannel);
+		utils.mkDirSync(customPath, this.options.install.outputChannel);
 		let customSource = path.join(resourcesFolder, CustomJsFilename);
 		let customDest = path.join(customPath, CustomJsFilename);
-		await fs.copy(customSource, customDest);
+		fs.copySync(customSource, customDest);
 	}
 
 	private async copyKernelsToSystemJupyterDirs(): Promise<void> {
@@ -180,10 +180,10 @@ export class PerFolderServerInstance implements IServerInstance {
 			kernelsExtensionSource = path.join(this.options.install.extensionPath, 'kernels');
 		}
 		this._systemJupyterDir = path.join(this.getSystemJupyterHomeDir(), 'kernels');
-		if (!(await utils.exists(this._systemJupyterDir))) {
-			await utils.mkDir(this._systemJupyterDir, this.options.install.outputChannel);
+		if (!(utils.existsSync(this._systemJupyterDir))) {
+			utils.mkDirSync(this._systemJupyterDir, this.options.install.outputChannel);
 		}
-		await fs.copy(kernelsExtensionSource, this._systemJupyterDir);
+		fs.copySync(kernelsExtensionSource, this._systemJupyterDir);
 		if (this.options.install.runningOnSaw) {
 			await this.options.install.updateKernelSpecPaths(this._systemJupyterDir);
 		}

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -180,9 +180,7 @@ export class PerFolderServerInstance implements IServerInstance {
 			kernelsExtensionSource = path.join(this.options.install.extensionPath, 'kernels');
 		}
 		this._systemJupyterDir = path.join(this.getSystemJupyterHomeDir(), 'kernels');
-		if (!(fs.pathExistsSync(this._systemJupyterDir))) {
-			utils.mkDirSync(this._systemJupyterDir, this.options.install.outputChannel);
-		}
+		utils.mkDirSync(this._systemJupyterDir, this.options.install.outputChannel);
 		fs.copySync(kernelsExtensionSource, this._systemJupyterDir);
 		if (this.options.install.runningOnSaw) {
 			await this.options.install.updateKernelSpecPaths(this._systemJupyterDir);

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -180,7 +180,7 @@ export class PerFolderServerInstance implements IServerInstance {
 			kernelsExtensionSource = path.join(this.options.install.extensionPath, 'kernels');
 		}
 		this._systemJupyterDir = path.join(this.getSystemJupyterHomeDir(), 'kernels');
-		if (!(utils.existsSync(this._systemJupyterDir))) {
+		if (!(fs.pathExistsSync(this._systemJupyterDir))) {
 			utils.mkDirSync(this._systemJupyterDir, this.options.install.outputChannel);
 		}
 		fs.copySync(kernelsExtensionSource, this._systemJupyterDir);

--- a/extensions/notebook/src/test/common/utils.test.ts
+++ b/extensions/notebook/src/test/common/utils.test.ts
@@ -28,10 +28,10 @@ describe('Utils Tests', function () {
 		should(utils.getLivyUrl(host, port)).endWith('/gateway/default/livy/v1/');
 	});
 
-	it('mkDir', async () => {
+	it('ensureDir', async () => {
 		const dirPath = path.join(os.tmpdir(), uuid.v4());
 		await should(fs.stat(dirPath)).be.rejected();
-		await utils.mkDir(dirPath, new MockOutputChannel());
+		await utils.ensureDir(dirPath, new MockOutputChannel());
 		should.exist(await fs.stat(dirPath), `Folder ${dirPath} did not exist after creation`);
 	});
 

--- a/extensions/notebook/src/test/model/serverInstance.test.ts
+++ b/extensions/notebook/src/test/model/serverInstance.test.ts
@@ -57,7 +57,6 @@ describe('Jupyter server instance', function (): void {
 		// Given a server instance
 		let mkdirStub = sinon.stub(utils,'mkDirSync').withArgs(sinon.match.any,sinon.match.any).returns();
 		let copyStub = sinon.stub(fs,'copySync').returns();
-		let pathStub = sinon.stub(fs,'pathExistsSync').withArgs(sinon.match.any).returns(false);
 
 		// When I run configure
 		await serverInstance.configure();
@@ -65,7 +64,6 @@ describe('Jupyter server instance', function (): void {
 		// Then I expect a folder to have been created with config and data subdirs
 		sinon.assert.callCount(mkdirStub,5);
 		sinon.assert.callCount(copyStub,3);
-		sinon.assert.callCount(pathStub,1);
 	});
 
 	it('Should have URI info after start', async function (): Promise<void> {

--- a/extensions/notebook/src/test/model/serverInstance.test.ts
+++ b/extensions/notebook/src/test/model/serverInstance.test.ts
@@ -55,14 +55,14 @@ describe('Jupyter server instance', function (): void {
 
 	it('Should create config and data directories on configure', async function (): Promise<void> {
 		// Given a server instance
-		let mkdirStub = sinon.stub(utils,'mkDirSync').withArgs(sinon.match.any,sinon.match.any).returns();
+		let ensureDirSyncStub = sinon.stub(utils,'ensureDirSync').withArgs(sinon.match.any,sinon.match.any).returns();
 		let copyStub = sinon.stub(fs,'copySync').returns();
 
 		// When I run configure
 		await serverInstance.configure();
 
 		// Then I expect a folder to have been created with config and data subdirs
-		sinon.assert.callCount(mkdirStub,5);
+		sinon.assert.callCount(ensureDirSyncStub,5);
 		sinon.assert.callCount(copyStub,3);
 	});
 
@@ -150,7 +150,7 @@ describe('Jupyter server instance', function (): void {
 
 	it('Should remove directory on close', async function (): Promise<void> {
 		// Given configure and startup are done
-		sinon.stub(utils,'mkDirSync').withArgs(sinon.match.any,sinon.match.any).returns();
+		sinon.stub(utils,'ensureDirSync').withArgs(sinon.match.any,sinon.match.any).returns();
 		sinon.stub(fs,'copySync').returns();
 
 		let process = setupSpawn({

--- a/extensions/notebook/src/test/model/serverInstance.test.ts
+++ b/extensions/notebook/src/test/model/serverInstance.test.ts
@@ -57,7 +57,7 @@ describe('Jupyter server instance', function (): void {
 		// Given a server instance
 		let mkdirStub = sinon.stub(utils,'mkDirSync').withArgs(sinon.match.any,sinon.match.any).returns();
 		let copyStub = sinon.stub(fs,'copySync').returns();
-		let pathStub = sinon.stub(utils,'existsSync').withArgs(sinon.match.any).returns(false);
+		let pathStub = sinon.stub(fs,'pathExistsSync').withArgs(sinon.match.any).returns(false);
 
 		// When I run configure
 		await serverInstance.configure();

--- a/extensions/notebook/src/test/model/serverInstance.test.ts
+++ b/extensions/notebook/src/test/model/serverInstance.test.ts
@@ -55,9 +55,9 @@ describe('Jupyter server instance', function (): void {
 
 	it('Should create config and data directories on configure', async function (): Promise<void> {
 		// Given a server instance
-		let mkdirStub = sinon.stub(utils,'mkDir').withArgs(sinon.match.any,sinon.match.any).returns(Promise.resolve());
-		let copyStub = sinon.stub(fs,'copy').returns();
-		let pathStub = sinon.stub(utils,'exists').withArgs(sinon.match.any).returns(Promise.resolve(false));
+		let mkdirStub = sinon.stub(utils,'mkDirSync').withArgs(sinon.match.any,sinon.match.any).returns();
+		let copyStub = sinon.stub(fs,'copySync').returns();
+		let pathStub = sinon.stub(utils,'existsSync').withArgs(sinon.match.any).returns(false);
 
 		// When I run configure
 		await serverInstance.configure();
@@ -152,8 +152,8 @@ describe('Jupyter server instance', function (): void {
 
 	it('Should remove directory on close', async function (): Promise<void> {
 		// Given configure and startup are done
-		sinon.stub(utils,'mkDir').withArgs(sinon.match.any,sinon.match.any).returns(Promise.resolve());
-		sinon.stub(fs,'copy').returns();
+		sinon.stub(utils,'mkDirSync').withArgs(sinon.match.any,sinon.match.any).returns();
+		sinon.stub(fs,'copySync').returns();
 
 		let process = setupSpawn({
 			sdtout: (listener: (msg: string) => void) => { },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR changes some of the configure Jupyter server steps from async to sync to improve the Python kernel loading time. On Windows, the loading time decreased by 1.3 seconds on average. (No difference seen on Mac as the configuration step only took a couple of ms on Mac).

The configuration steps are creating and copying small folders/files. The abundance of async calls likely caused the configuration step to sometimes take up to 3 seconds on Windows while other times only taking <1 second. 
