### PR TITLE
handle azure account load error

### DIFF
--- a/extensions/azurecore/src/azureResource/tree/connectionDialogTreeProvider.ts
+++ b/extensions/azurecore/src/azureResource/tree/connectionDialogTreeProvider.ts
@@ -53,20 +53,31 @@ export class ConnectionDialogTreeProvider implements vscode.TreeDataProvider<Tre
 			return [AzureResourceMessageTreeNode.create(localize('azure.resource.tree.treeProvider.loadingLabel', "Loading ..."), undefined)];
 		}
 
-		try {
-			if (this.accounts && this.accounts.length > 0) {
-				const accountNodes: FlatAccountTreeNode[] = [];
-				for (const account of this.accounts) {
+		if (this.accounts && this.accounts.length > 0) {
+			const accountNodes: FlatAccountTreeNode[] = [];
+			const errorMessages: string[] = [];
+			for (const account of this.accounts) {
+				try {
 					const accountNode = new FlatAccountTreeNode(account, this.appContext, this);
 					await accountNode.updateLabel();
 					accountNodes.push(accountNode);
 				}
-				return accountNodes;
-			} else {
-				return [new AzureResourceAccountNotSignedInTreeNode()];
+				catch (error) {
+					errorMessages.push(AzureResourceErrorMessageUtil.getErrorMessage(error));
+				}
 			}
-		} catch (error) {
-			return [AzureResourceMessageTreeNode.create(AzureResourceErrorMessageUtil.getErrorMessage(error), undefined)];
+			if (errorMessages.length > 0) {
+				const showAccountsAction = localize('azure.resource.tree.treeProvider.openAccountsDialog', "Show Azure accounts");
+				vscode.window.showErrorMessage(localize('azure.resource.tree.treeProvider.accountLoadError', "Failed to load some Azure accounts. {0}", errorMessages.join(',')), showAccountsAction).then(result => {
+					if (result === showAccountsAction) {
+						vscode.commands.executeCommand('azure.resource.signin');
+					}
+				});
+			}
+
+			return accountNodes;
+		} else {
+			return [new AzureResourceAccountNotSignedInTreeNode()];
 		}
 	}
 

--- a/extensions/azurecore/src/azureResource/tree/connectionDialogTreeProvider.ts
+++ b/extensions/azurecore/src/azureResource/tree/connectionDialogTreeProvider.ts
@@ -56,6 +56,7 @@ export class ConnectionDialogTreeProvider implements vscode.TreeDataProvider<Tre
 		if (this.accounts && this.accounts.length > 0) {
 			const accountNodes: FlatAccountTreeNode[] = [];
 			const errorMessages: string[] = [];
+			// We are doing sequential account loading to avoid the Azure request throttling
 			for (const account of this.accounts) {
 				try {
 					const accountNode = new FlatAccountTreeNode(account, this.appContext, this);

--- a/extensions/azurecore/src/azureResource/tree/flatAccountTreeNode.ts
+++ b/extensions/azurecore/src/azureResource/tree/flatAccountTreeNode.ts
@@ -127,7 +127,7 @@ async function getSubscriptionInfo(account: AzureAccount, subscriptionService: I
 			subscriptions.push(...(await subscriptionService.getSubscriptions(account, new TokenCredentials(token.token, token.tokenType), tenant.id) || <azureResource.AzureResourceSubscription[]>[]));
 		}
 	} catch (error) {
-		throw new AzureResourceCredentialError(localize('azure.resource.tree.accountTreeNode.credentialError', "Failed to get credential for account {0}. Please refresh the account.", account.key.accountId), error);
+		throw new AzureResourceCredentialError(localize('azure.resource.tree.accountTreeNode.credentialError', "Failed to get credential for account {0}. Please go to the accounts dialog and refresh the account.", account.key.accountId), error);
 	}
 	const total = subscriptions.length;
 	let selected = total;


### PR DESCRIPTION
This PR fixes #13757 

1. limit the impact of the error to the problematic account and show the accounts without issues
2. updated the error message slightly to tell user where to refresh the account
3. show the errors with a notification and provide an action to go to the accounts dialog.

this is how it looks in case of error now:

![image](https://user-images.githubusercontent.com/13777222/104248253-02f08000-541e-11eb-8be3-b2be558918f0.png)


