### PR TITLE
Update SqlToolsService to .68 (SqlClient 2.1.1)

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.64",
+	"version": "3.0.0-release.68",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",


### PR DESCRIPTION
Primary update here is to get the new SqlClient version (2.1.1) that contains the Mac Kerberos fix as well as some things for Always Encrypted.

Will be doing thorough testing with private builds before merging this in. 