### PR TITLE
add confirm prompt for some profiler actions

### DIFF
--- a/src/sql/workbench/contrib/profiler/browser/profilerActions.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerActions.ts
@@ -16,6 +16,7 @@ import * as nls from 'vs/nls';
 import { IEditorAction } from 'vs/editor/common/editorCommon';
 import { IEditorService, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 
 export class ProfilerConnect extends Action {
 	private static readonly ConnectText = nls.localize('profilerAction.connect', "Connect");
@@ -155,13 +156,24 @@ export class ProfilerClear extends Action {
 	public static ID = 'profiler.clear';
 	public static LABEL = nls.localize('profiler.clear', "Clear Data");
 
-	constructor(id: string, label: string) {
+	constructor(id: string,
+		label: string,
+		@INotificationService private _notificationService: INotificationService) {
 		super(id, label, 'clear-results');
 	}
 
-	run(input: ProfilerInput): Promise<void> {
-		input.data.clear();
-		return Promise.resolve(null);
+	async run(input: ProfilerInput): Promise<void> {
+		this._notificationService.prompt(Severity.Warning, nls.localize('profiler.clearDataPrompt', "Are you sure you want to clear the data?"), [
+			{
+				label: nls.localize('profiler.yes', "Yes"),
+				run: () => {
+					input.data.clear();
+				}
+			}, {
+				label: nls.localize('profiler.no', "No"),
+				run: () => { }
+			}
+		]);
 	}
 }
 
@@ -317,13 +329,24 @@ export class ProfilerClearSessionFilter extends Action {
 	public static LABEL = nls.localize('profiler.clearFilter', "Clear Filter");
 
 	constructor(
-		id: string, label: string
+		id: string,
+		label: string,
+		@INotificationService private _notificationService: INotificationService
 	) {
 		super(id, label, 'clear-filter');
 	}
 
-	public run(input: ProfilerInput): Promise<boolean> {
-		input.clearFilter();
-		return Promise.resolve(true);
+	public async run(input: ProfilerInput): Promise<void> {
+		this._notificationService.prompt(Severity.Warning, nls.localize('profiler.clearFilterPrompt', "Are you sure you want to clear the filters?"), [
+			{
+				label: nls.localize('profiler.yes', "Yes"),
+				run: () => {
+					input.clearFilter();
+				}
+			}, {
+				label: nls.localize('profiler.no', "No"),
+				run: () => { }
+			}
+		]);
 	}
 }

--- a/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
+++ b/src/sql/workbench/contrib/profiler/browser/profilerEditor.ts
@@ -272,13 +272,14 @@ export class ProfilerEditor extends EditorPane {
 			{ action: this._stopAction },
 			{ action: this._pauseAction },
 			{ element: Taskbar.createTaskbarSeparator() },
+			{ action: this._instantiationService.createInstance(Actions.ProfilerClear, Actions.ProfilerClear.ID, Actions.ProfilerClear.LABEL) },
+			{ element: Taskbar.createTaskbarSeparator() },
 			{ action: this._filterAction },
 			{ action: this._clearFilterAction },
 			{ element: Taskbar.createTaskbarSeparator() },
 			{ element: this._createTextElement(nls.localize('profiler.viewSelectLabel', "Select View:")) },
 			{ element: viewTemplateContainer },
-			{ action: this._autoscrollAction },
-			{ action: this._instantiationService.createInstance(Actions.ProfilerClear, Actions.ProfilerClear.ID, Actions.ProfilerClear.LABEL) }
+			{ action: this._autoscrollAction }
 		]);
 	}
 


### PR DESCRIPTION
This PR fixes #12171

![image](https://user-images.githubusercontent.com/13777222/104408312-a3c36600-5518-11eb-9513-4b96d01a845e.png)

![image](https://user-images.githubusercontent.com/13777222/104408320-a6be5680-5518-11eb-92d2-c8ea9e588490.png)

also rearrange the actions to move 'clear data' next to the start/stop group
![image](https://user-images.githubusercontent.com/13777222/104408406-cf465080-5518-11eb-9ff4-b210b659a564.png)


