### PR TITLE
Fix notebook smoke tests: change openFile method implementation 

### DIFF
--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -22,8 +22,7 @@ export class Notebook {
 	async openFile(fileName: string): Promise<void> {
 		await this.quickAccess.openQuickAccess(fileName);
 		await this.quickInput.waitForQuickInputElements(names => names[0] === fileName);
-		await this.code.waitForActiveElement('.quick-input-widget .quick-input-box input');
-		await this.code.dispatchKeybinding('enter');
+		await this.code.waitAndClick('.quick-input-widget .quick-input-list .monaco-list-row');
 		await this.editors.waitForActiveTab(fileName);
 		await this.code.waitForElement('.notebookEditor');
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR changes the way we open notebook files in smoke tests to clicking on the filename in the quick input result list. The old way (typing the filename into quick input and hitting enter) sometimes failed due to the quick input box no longer being in focus.
