### PR TITLE
Fix account store silently failing

### DIFF
--- a/src/sql/platform/accounts/common/accountStore.ts
+++ b/src/sql/platform/accounts/common/accountStore.ts
@@ -38,19 +38,21 @@ export default class AccountStore implements IAccountStore {
 		});
 	}
 
-	public getAccountsByProvider(providerId: string): Promise<azdata.Account[]> {
-		return this.doOperation(() => {
-			return this.readFromMemento()
-				.then(accounts => accounts.filter(account => account.key.providerId === providerId));
+	public async getAccountsByProvider(providerId: string): Promise<azdata.Account[]> {
+		const accounts = await this.doOperation(async () => {
+			await this.cleanupDeprecatedAccounts();
+			const accounts = await this.readFromMemento();
+			return accounts.filter(account => account.key.providerId === providerId);
 		});
+		return accounts ?? [];
 	}
 
-	public getAllAccounts(): Promise<azdata.Account[]> {
-		return this.doOperation(() => {
-			return this.cleanupDeprecatedAccounts().then(() => {
-				return this.readFromMemento();
-			});
+	public async getAllAccounts(): Promise<azdata.Account[]> {
+		const accounts = await this.doOperation(async () => {
+			await this.cleanupDeprecatedAccounts();
+			return this.readFromMemento();
 		});
+		return accounts ?? [];
 	}
 
 	public cleanupDeprecatedAccounts(): Promise<void> {
@@ -114,16 +116,16 @@ export default class AccountStore implements IAccountStore {
 		target.isStale = source.isStale;
 	}
 
-	private doOperation<T>(op: () => Promise<T>) {
+	private doOperation<T>(op: () => Promise<T>): Promise<T | undefined> {
 		// Initialize the active operation to an empty promise if necessary
-		let activeOperation = this._activeOperation || Promise.resolve<any>(null);
+		let activeOperation = this._activeOperation || Promise.resolve();
 
 		// Chain the operation to perform to the end of the existing promise
 		activeOperation = activeOperation.then(op);
 
 		// Add a catch at the end to make sure we can continue after any errors
-		activeOperation = activeOperation.then(undefined, (err) => {
-			// TODO: Log the error
+		activeOperation = activeOperation.then(undefined, err => {
+			this.logService.error(err);
 		});
 
 		// Point the current active operation to this one

--- a/src/sql/platform/accounts/common/accountStore.ts
+++ b/src/sql/platform/accounts/common/accountStore.ts
@@ -40,8 +40,7 @@ export default class AccountStore implements IAccountStore {
 
 	public async getAccountsByProvider(providerId: string): Promise<azdata.Account[]> {
 		const accounts = await this.doOperation(async () => {
-			await this.cleanupDeprecatedAccounts();
-			const accounts = await this.readFromMemento();
+			const accounts = await this.getAllAccounts();
 			return accounts.filter(account => account.key.providerId === providerId);
 		});
 		return accounts ?? [];

--- a/src/sql/platform/accounts/common/accountStore.ts
+++ b/src/sql/platform/accounts/common/accountStore.ts
@@ -40,7 +40,8 @@ export default class AccountStore implements IAccountStore {
 
 	public async getAccountsByProvider(providerId: string): Promise<azdata.Account[]> {
 		const accounts = await this.doOperation(async () => {
-			const accounts = await this.getAllAccounts();
+			await this.cleanupDeprecatedAccounts();
+			const accounts = await this.readFromMemento();
 			return accounts.filter(account => account.key.providerId === providerId);
 		});
 		return accounts ?? [];


### PR DESCRIPTION
Somehow my ADS instance got in a state where it would never load the Azure Accounts upon startup.

The root issue that was happening was that somehow the memento got an empty object inside it - which then caused line 44 to throw an exception when it tries to access the property `account.key.providerId` (since key was undefined).

There's three fixes here : 

1. Log the exception. There was nothing in the logs when this failed originally, now we'll at least print it to the console for debugging purposes
2. Call cleanupDeprecatedAccounts before fetching the accounts when fetching by providerId like we already do for fetching all accounts. It would be nice if this wasn't necessary but until we know for sure how the memento is getting this invalid object then this is the safest way to handle it
3. Check for undefined when getting the accounts and returning an empty array as a default if it is. This is necessary because of the whole doOperation call - the way this is written if an exception occurs then it'll return undefined no matter the original return type. The cleanest way would be to refactor these calls a bit since the way it's written isn't the cleanest (should we really be ignoring all errors that happen when running an operation? Probably not). But I didn't want to do any bigger rewrites so just handling that so at least we won't hang if something does happen. 