### PR TITLE
fix focus trap issue

### DIFF
--- a/src/sql/base/browser/ui/panel/panel.ts
+++ b/src/sql/base/browser/ui/panel/panel.ts
@@ -87,7 +87,6 @@ export class TabbedPanel extends Disposable {
 		this._styleElement = DOM.createStyleSheet(this.parent);
 		container.appendChild(this.parent);
 		this.header = DOM.$('.composite.title');
-		this.header.setAttribute('tabindex', '0');
 		this.tabList = DOM.$('.tabList');
 		this.tabList.setAttribute('role', 'tablist');
 		this.tabList.style.height = this.headersize + 'px';
@@ -104,7 +103,6 @@ export class TabbedPanel extends Disposable {
 		this.body = DOM.$('.tabBody');
 		this.body.setAttribute('role', 'tabpanel');
 		this.parent.appendChild(this.body);
-		this._register(DOM.addDisposableListener(this.header, DOM.EventType.FOCUS, e => this.focusCurrentTab()));
 	}
 
 	public get element(): HTMLElement {
@@ -173,7 +171,7 @@ export class TabbedPanel extends Disposable {
 
 		tab.disposables.add(DOM.addDisposableListener(tabHeaderElement, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
 			let event = new StandardKeyboardEvent(e);
-			if (event.equals(KeyCode.Enter)) {
+			if (event.equals(KeyCode.Enter) || event.equals(KeyCode.Space)) {
 				this.showTab(tab.tab.identifier);
 				invokeTabSelectedHandler();
 				e.stopImmediatePropagation();
@@ -220,6 +218,7 @@ export class TabbedPanel extends Disposable {
 				shownTab.label.classList.remove('active');
 				shownTab.header.classList.remove('active');
 				shownTab.header.setAttribute('aria-selected', 'false');
+				shownTab.header.tabIndex = -1;
 				if (shownTab.body) {
 					shownTab.body.remove();
 					if (shownTab.tab.view.onHide) {
@@ -232,7 +231,7 @@ export class TabbedPanel extends Disposable {
 		this._shownTabId = id;
 		this.tabHistory.push(id);
 		const tab = this._tabMap.get(this._shownTabId)!; // @anthonydresser we know this can't be undefined since we check further up if the map contains the id
-
+		tab.header.tabIndex = 0;
 		if (tab.destroyTabBody && tab.body) {
 			tab.body.remove();
 			tab.body = undefined;


### PR DESCRIPTION
This PR fixes #13959

How it works previously:
the tabindex for the tab container is set to 0, (means it can receive keyboard focus by tabbing or mouse click), and the individual tab headers have tabindex set to -1 (only focusable programmatically), when the container gets focus, while handling the focus event, it will call header.focus to set the focus to individual header.

what is the problem:
when tabbing backward, the previous focusable element is the tab container, based on above description, it will set focus to the current tab header, and the focus is trapped here.

fix:
instead of letting the container to handle where the focus should go, I am setting the tabindex of the active tab to 0 and other tab's tabindex to -1, so that the tabs maintain the tab index by themselves.