### PR TITLE
Update azdata tool requirements to 20.2.6

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -610,7 +610,7 @@
               },
               {
                 "name": "azdata",
-                "version": "20.2.5"
+                "version": "20.2.6"
               }
             ],
             "when": true
@@ -791,7 +791,7 @@
               },
               {
                 "name": "azdata",
-                "version": "20.2.5"
+                "version": "20.2.6"
               }
             ],
             "when": "true"
@@ -1041,7 +1041,7 @@
               },
               {
                 "name": "azdata",
-                "version": "20.2.5"
+                "version": "20.2.6"
               }
             ],
             "when": "true"

--- a/extensions/resource-deployment/package.json
+++ b/extensions/resource-deployment/package.json
@@ -255,7 +255,7 @@
               },
               {
                 "name": "azdata-old",
-                "version": "20.2.4"
+                "version": "20.2.6"
               }
             ],
             "when": "target=new-aks&&version=bdc2019"
@@ -272,7 +272,7 @@
               },
               {
                 "name": "azdata-old",
-                "version": "20.2.4"
+                "version": "20.2.6"
               }
             ],
             "when": "target=existing-aks&&version=bdc2019"
@@ -289,7 +289,7 @@
               },
               {
                 "name": "azdata-old",
-                "version": "20.2.4"
+                "version": "20.2.6"
               }
             ],
             "when": "target=existing-kubeadm&&version=bdc2019"
@@ -306,7 +306,7 @@
               },
               {
                 "name": "azdata-old",
-                "version": "20.2.4"
+                "version": "20.2.6"
               }
             ],
             "when": "target=existing-aro&&version=bdc2019"
@@ -323,7 +323,7 @@
               },
               {
                 "name": "azdata-old",
-                "version": "20.2.4"
+                "version": "20.2.6"
               }
             ],
             "when": "target=existing-openshift&&version=bdc2019"


### PR DESCRIPTION
No big changes in this release so shouldn't be anything needed to update on our side. Just keeping the tool version in sync with the latest release.