### PR TITLE
Fix data workspace test

### DIFF
--- a/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
+++ b/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
@@ -8,7 +8,7 @@ import * as TypeMoq from 'typemoq';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as constants from '../../common/constants';
-import { promises as fs } from 'fs';
+import * as utils from '../../common/utils';
 import { WorkspaceService } from '../../services/workspaceService';
 import { OpenExistingDialog } from '../../dialogs/openExistingDialog';
 import { createProjectFile, generateUniqueProjectFilePath, generateUniqueWorkspaceFilePath, testProjectType } from '../testUtils';
@@ -47,16 +47,16 @@ suite('Open Existing Dialog', function (): void {
 
 		dialog._targetTypeRadioCardGroup?.updateProperty( 'selectedCardId', constants.Workspace);
 		dialog._filePathTextBox!.value = 'nonExistentWorkspaceFile';
+		const fileExistStub = sinon.stub(utils, 'fileExist').resolves(false);
 
 		const validateResult = await dialog.validate();
-
 		const msg = constants.FileNotExistError('workspace', 'nonExistentWorkspaceFile');
 		should.equal(dialog.dialogObject.message.text, msg);
 		should.equal(validateResult, false, 'Validation should fail because workspace file does not exist, but passed');
 
-		// create a workspace file
+		// validation should pass if workspace file exists
 		dialog._filePathTextBox!.value = generateUniqueWorkspaceFilePath();
-		await fs.writeFile(dialog._filePathTextBox!.value , '');
+		fileExistStub.resolves(true);
 		should.equal(await dialog.validate(), true, `Validation should pass because workspace file exists, but failed with: ${dialog.dialogObject.message.text}`);
 	});
 


### PR DESCRIPTION
This test has been failing intermittently. The fix is similar to what was done in #13824 to stub the file existing function  instead of actually creating files and checking if they exist. Those tests have been passing, so hopefully this fixes this test too.