### PR TITLE
Remove unnecessary OutputChannel reference from PythonPathLookup class.

### DIFF
--- a/extensions/notebook/src/dialog/configurePython/configurePathPage.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePathPage.ts
@@ -8,7 +8,6 @@ import * as azdata from 'azdata';
 import { BasePage } from './basePage';
 import * as nls from 'vscode-nls';
 import { JupyterServerInstallation } from '../../jupyter/jupyterServerInstallation';
-import { PythonPathInfo } from '../pythonPathLookup';
 import * as utils from '../../common/utils';
 
 const localize = nls.loadMessageBundle();
@@ -160,10 +159,9 @@ export class ConfigurePathPage extends BasePage {
 		this.instance.wizard.nextButton.enabled = false;
 		this.pythonDropdownLoader.loading = true;
 		try {
-			let pythonPaths: PythonPathInfo[];
 			let dropdownValues: azdata.CategoryValue[];
 			if (useExistingPython) {
-				pythonPaths = await this.model.pythonPathsPromise;
+				let pythonPaths = await this.model.pythonPathLookup.getSuggestions();
 				if (pythonPaths && pythonPaths.length > 0) {
 					dropdownValues = pythonPaths.map(path => {
 						return {

--- a/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
@@ -5,7 +5,6 @@
 
 import * as nls from 'vscode-nls';
 import * as azdata from 'azdata';
-import * as vscode from 'vscode';
 import { BasePage } from './basePage';
 import { ConfigurePathPage } from './configurePathPage';
 import { PickPackagesPage } from './pickPackagesPage';
@@ -13,7 +12,7 @@ import { JupyterServerInstallation, PythonPkgDetails, PythonInstallSettings } fr
 import * as utils from '../../common/utils';
 import { promises as fs } from 'fs';
 import { Deferred } from '../../common/promise';
-import { PythonPathInfo, PythonPathLookup } from '../pythonPathLookup';
+import { PythonPathLookup } from '../pythonPathLookup';
 
 const localize = nls.loadMessageBundle();
 
@@ -21,7 +20,7 @@ export interface ConfigurePythonModel {
 	kernelName: string;
 	pythonLocation: string;
 	useExistingPython: boolean;
-	pythonPathsPromise: Promise<PythonPathInfo[]>;
+	pythonPathLookup: PythonPathLookup;
 	packagesToInstall: PythonPkgDetails[];
 	installation: JupyterServerInstallation;
 }
@@ -35,11 +34,9 @@ export class ConfigurePythonWizard {
 	private model: ConfigurePythonModel;
 
 	private _setupComplete: Deferred<void>;
-	private pythonPathsPromise: Promise<PythonPathInfo[]>;
 
-	constructor(private jupyterInstallation: JupyterServerInstallation, private readonly _outputChannel: vscode.OutputChannel) {
+	constructor(private jupyterInstallation: JupyterServerInstallation) {
 		this._setupComplete = new Deferred<void>();
-		this.pythonPathsPromise = (new PythonPathLookup(this._outputChannel)).getSuggestions();
 	}
 
 	public get wizard(): azdata.window.Wizard {
@@ -53,7 +50,7 @@ export class ConfigurePythonWizard {
 	public async start(kernelName?: string, rejectOnCancel?: boolean): Promise<void> {
 		this.model = <ConfigurePythonModel>{
 			kernelName: kernelName,
-			pythonPathsPromise: this.pythonPathsPromise,
+			pythonPathLookup: new PythonPathLookup(),
 			installation: this.jupyterInstallation,
 			pythonLocation: JupyterServerInstallation.getPythonPathSetting(),
 			useExistingPython: JupyterServerInstallation.getExistingPythonSetting()

--- a/extensions/notebook/src/dialog/pythonPathLookup.ts
+++ b/extensions/notebook/src/dialog/pythonPathLookup.ts
@@ -85,7 +85,7 @@ export class PythonPathLookup {
 		return results;
 	}
 
-	private async getPythonPath(options: { command: string; args?: string[] }): Promise<string> {
+	private async getPythonPath(options: { command: string; args?: string[] }): Promise<string | undefined> {
 		try {
 			let args = Array.isArray(options.args) ? options.args : [];
 			args = args.concat(['-c', '"import sys;print(sys.executable)"']);
@@ -140,7 +140,7 @@ export class PythonPathLookup {
 		});
 	}
 
-	private async getInfoForPath(pythonPath: string): Promise<PythonPathInfo> {
+	private async getInfoForPath(pythonPath: string): Promise<PythonPathInfo | undefined> {
 		try {
 			// "python --version" returns nothing from executeBufferedCommand with Python 2.X,
 			// so use sys.version_info here instead.

--- a/extensions/notebook/src/dialog/pythonPathLookup.ts
+++ b/extensions/notebook/src/dialog/pythonPathLookup.ts
@@ -56,7 +56,7 @@ export class PythonPathLookup {
 			let condaFiles = condaResults.reduce((first, second) => first.concat(second));
 			return condaFiles.filter(condaPath => condaPath && condaPath.length > 0);
 		} catch (err) {
-			console.log(err);
+			console.log(`Problem encountered getting Conda installations: ${err}`);
 		}
 		return [];
 	}
@@ -159,7 +159,7 @@ export class PythonPathLookup {
 				};
 			}
 		} catch (err) {
-			console.log(err);
+			console.log(`Problem encountered getting Python info for path: ${err}`);
 		}
 		return undefined;
 	}

--- a/extensions/notebook/src/dialog/pythonPathLookup.ts
+++ b/extensions/notebook/src/dialog/pythonPathLookup.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as glob from 'glob';
-import * as vscode from 'vscode';
 
 import * as utils from '../common/utils';
 import * as constants from '../common/constants';
@@ -16,7 +15,7 @@ export interface PythonPathInfo {
 
 export class PythonPathLookup {
 	private condaLocations: string[];
-	constructor(private readonly _outputChannel: vscode.OutputChannel) {
+	constructor() {
 		if (process.platform !== constants.winPlatform) {
 			let userFolder = process.env['HOME'];
 			this.condaLocations = [
@@ -57,7 +56,7 @@ export class PythonPathLookup {
 			let condaFiles = condaResults.reduce((first, second) => first.concat(second));
 			return condaFiles.filter(condaPath => condaPath && condaPath.length > 0);
 		} catch (err) {
-			this._outputChannel.appendLine(`Problem encountered getting Conda installations: ${err}`);
+			console.log(err);
 		}
 		return [];
 	}
@@ -97,7 +96,7 @@ export class PythonPathLookup {
 				return value;
 			}
 		} catch (err) {
-			this._outputChannel.appendLine(`Problem encountered getting Python path: ${err}`);
+			// Ignoring this error since it's probably from trying to run a non-existent python executable.
 		}
 
 		return undefined;
@@ -160,7 +159,7 @@ export class PythonPathLookup {
 				};
 			}
 		} catch (err) {
-			this._outputChannel.appendLine(`Problem encountered getting Python info for path: ${err}`);
+			console.log(err);
 		}
 		return undefined;
 	}

--- a/extensions/notebook/src/jupyter/jupyterController.ts
+++ b/extensions/notebook/src/jupyter/jupyterController.ts
@@ -234,7 +234,7 @@ export class JupyterController {
 	}
 
 	public doConfigurePython(jupyterInstaller: JupyterServerInstallation): void {
-		let pythonWizard = new ConfigurePythonWizard(jupyterInstaller, this.appContext.outputChannel);
+		let pythonWizard = new ConfigurePythonWizard(jupyterInstaller);
 		pythonWizard.start().catch((err: any) => {
 			vscode.window.showErrorMessage(utils.getErrorMessage(err));
 		});

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -435,7 +435,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		let isPythonInstalled = JupyterServerInstallation.isPythonInstalled();
 		let areRequiredPackagesInstalled = await this.areRequiredPackagesInstalled(kernelDisplayName);
 		if (!isPythonInstalled || !areRequiredPackagesInstalled) {
-			let pythonWizard = new ConfigurePythonWizard(this, this.outputChannel);
+			let pythonWizard = new ConfigurePythonWizard(this);
 			await pythonWizard.start(kernelDisplayName, true);
 			return pythonWizard.setupComplete.then(() => {
 				this._kernelSetupCache.set(kernelDisplayName, true);

--- a/extensions/notebook/src/test/python/configurePython.test.ts
+++ b/extensions/notebook/src/test/python/configurePython.test.ts
@@ -13,17 +13,14 @@ import { PickPackagesPage } from '../../dialog/configurePython/pickPackagesPage'
 import { python3DisplayName, allKernelsName } from '../../common/constants';
 import { TestContext, createViewContext, TestButton } from '../common';
 import { EventEmitter } from 'vscode';
-import { MockOutputChannel } from '../common/stubs';
 import { PythonPathLookup } from '../../dialog/pythonPathLookup';
 
 describe('Configure Python Wizard', function () {
 	let testWizard: ConfigurePythonWizard;
 	let viewContext: TestContext;
 	let testInstallation: JupyterServerInstallation;
-	let mockOutputChannel: TypeMoq.IMock<MockOutputChannel>;
 
 	beforeEach(() => {
-		mockOutputChannel = TypeMoq.Mock.ofType(MockOutputChannel);
 		let mockInstall = TypeMoq.Mock.ofType(JupyterServerInstallation);
 		mockInstall.setup(i => i.getInstalledPipPackages(TypeMoq.It.isAnyString())).returns(() => Promise.resolve([]));
 		mockInstall.setup(i => i.getRequiredPackagesForKernel(TypeMoq.It.isAnyString())).returns(() => [{ name: 'TestPkg', version: '1.0.0'}]);

--- a/extensions/notebook/src/test/python/configurePython.test.ts
+++ b/extensions/notebook/src/test/python/configurePython.test.ts
@@ -16,7 +16,7 @@ import { EventEmitter } from 'vscode';
 import { MockOutputChannel } from '../common/stubs';
 import { PythonPathLookup } from '../../dialog/pythonPathLookup';
 
-describe('ConfigurePythonWizard', function () {
+describe('Configure Python Wizard', function () {
 	let testWizard: ConfigurePythonWizard;
 	let viewContext: TestContext;
 	let testInstallation: JupyterServerInstallation;
@@ -36,7 +36,7 @@ describe('ConfigurePythonWizard', function () {
 		mockWizard.setup(w => w.doneButton).returns(() => mockDoneButton);
 		mockWizard.setup(w => w.nextButton).returns(() => mockNextButton);
 
-		let mockPythonWizard = TypeMoq.Mock.ofType(ConfigurePythonWizard, undefined, undefined, mockInstall.object, mockOutputChannel.object);
+		let mockPythonWizard = TypeMoq.Mock.ofType(ConfigurePythonWizard);
 		mockPythonWizard.setup(w => w.showErrorMessage(TypeMoq.It.isAnyString()));
 		mockPythonWizard.setup(w => w.wizard).returns(() => mockWizard.object);
 		testWizard = mockPythonWizard.object;

--- a/extensions/notebook/src/test/python/configurePython.test.ts
+++ b/extensions/notebook/src/test/python/configurePython.test.ts
@@ -35,7 +35,7 @@ describe('Configure Python Wizard', function () {
 		mockWizard.setup(w => w.doneButton).returns(() => mockDoneButton);
 		mockWizard.setup(w => w.nextButton).returns(() => mockNextButton);
 
-		let mockPythonWizard = TypeMoq.Mock.ofType(ConfigurePythonWizard);
+		let mockPythonWizard = TypeMoq.Mock.ofType(ConfigurePythonWizard, undefined, undefined, mockInstall.object, mockOutputChannel.object);
 		mockPythonWizard.setup(w => w.showErrorMessage(TypeMoq.It.isAnyString()));
 		mockPythonWizard.setup(w => w.wizard).returns(() => mockWizard.object);
 		testWizard = mockPythonWizard.object;
@@ -72,6 +72,7 @@ describe('Configure Python Wizard', function () {
 		should(wizard.wizard.message).be.undefined();
 
 		await wizard.close();
+		await should(wizard.setupComplete).be.resolved();
 	});
 
 	it('Configure Path Page test', async () => {


### PR DESCRIPTION
Noticed were getting some unhandled promise rejections from some of the python unit tests due to a mocked object not being passed an OutputChannel reference. Rather than fix that undefined error directly, I opted to remove the usage of OutputChannel from PythonPathLookup since we can replace it with a console.log() statement instead. Also scoped down the usage of the method call that was producing the unhandled promise error, so that we don't get any more noise in the tests.
