### PR TITLE
increment version for fixes to tempdb xevents

### DIFF
--- a/samples/serverReports/package.json
+++ b/samples/serverReports/package.json
@@ -2,7 +2,7 @@
   "name": "server-report",
   "displayName": "Server Reports",
   "description": "Server Reports",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "Microsoft",
   "preview": true,
   "engines": {


### PR DESCRIPTION
bumps from 0.2.2 to 0.2.3, will be opening a PR for the marketplace galleries

related to https://github.com/microsoft/azuredatastudio/pull/13565