### PR TITLE
Add acquireLoginSession API for Azdata

### DIFF
--- a/extensions/arc/src/models/controllerModel.ts
+++ b/extensions/arc/src/models/controllerModel.ts
@@ -65,7 +65,7 @@ export class ControllerModel {
 	 * calls from changing the context while commands for this session are being executed.
 	 * @param promptReconnect
 	 */
-	public async acquireAzdataLoginSession(promptReconnect: boolean = false): Promise<azdataExt.AzdataLoginSession> {
+	public async acquireAzdataSession(promptReconnect: boolean = false): Promise<azdataExt.AzdataSession> {
 		let promptForValidClusterContext: boolean = false;
 		try {
 			const contexts = await getKubeConfigClusterContexts(this.info.kubeConfigFilePath);
@@ -103,7 +103,7 @@ export class ControllerModel {
 			}
 		}
 
-		return this._azdataApi.azdata.acquireLoginSession(this.info.url, this.info.username, this._password, this.azdataAdditionalEnvVars);
+		return this._azdataApi.azdata.acquireSession(this.info.url, this.info.username, this._password, this.azdataAdditionalEnvVars);
 	}
 
 	/**
@@ -124,7 +124,7 @@ export class ControllerModel {
 		}
 		// create a new in progress promise object
 		ControllerModel._refreshInProgress = new Deferred<void>();
-		const session = await this.acquireAzdataLoginSession(promptReconnect);
+		const session = await this.acquireAzdataSession(promptReconnect);
 		const newRegistrations: Registration[] = [];
 		try {
 			await Promise.all([
@@ -134,7 +134,7 @@ export class ControllerModel {
 					this._onConfigUpdated.fire(this._controllerConfig);
 				}).catch(err => {
 					// If an error occurs show a message so the user knows something failed but still
-					// fire the event so callers can know to update (e.g. so dashboards don't show the
+					// fire the event so callers hooking into this can handle the error (e.g. so dashboards don't show the
 					// loading icon forever)
 					if (showErrors) {
 						vscode.window.showErrorMessage(loc.fetchConfigFailed(this.info.name, err));

--- a/extensions/arc/src/models/miaaModel.ts
+++ b/extensions/arc/src/models/miaaModel.ts
@@ -71,10 +71,11 @@ export class MiaaModel extends ResourceModel {
 			return this._refreshPromise.promise;
 		}
 		this._refreshPromise = new Deferred();
+		let loginSession: azdataExt.AzdataLoginSession | undefined = undefined;
 		try {
-			await this.controllerModel.azdataLogin();
+			loginSession = await this.controllerModel.acquireAzdataLoginSession();
 			try {
-				const result = await this._azdataApi.azdata.arc.sql.mi.show(this.info.name);
+				const result = await this._azdataApi.azdata.arc.sql.mi.show(this.info.name, this.controllerModel.azdataAdditionalEnvVars, loginSession);
 				this._config = result.result;
 				this.configLastUpdated = new Date();
 				this._onConfigUpdated.fire(this._config);
@@ -114,6 +115,7 @@ export class MiaaModel extends ResourceModel {
 			this._refreshPromise.reject(err);
 			throw err;
 		} finally {
+			loginSession?.dispose();
 			this._refreshPromise = undefined;
 		}
 	}

--- a/extensions/arc/src/models/miaaModel.ts
+++ b/extensions/arc/src/models/miaaModel.ts
@@ -71,11 +71,11 @@ export class MiaaModel extends ResourceModel {
 			return this._refreshPromise.promise;
 		}
 		this._refreshPromise = new Deferred();
-		let loginSession: azdataExt.AzdataLoginSession | undefined = undefined;
+		let session: azdataExt.AzdataSession | undefined = undefined;
 		try {
-			loginSession = await this.controllerModel.acquireAzdataLoginSession();
+			session = await this.controllerModel.acquireAzdataSession();
 			try {
-				const result = await this._azdataApi.azdata.arc.sql.mi.show(this.info.name, this.controllerModel.azdataAdditionalEnvVars, loginSession);
+				const result = await this._azdataApi.azdata.arc.sql.mi.show(this.info.name, this.controllerModel.azdataAdditionalEnvVars, session);
 				this._config = result.result;
 				this.configLastUpdated = new Date();
 				this._onConfigUpdated.fire(this._config);
@@ -115,7 +115,7 @@ export class MiaaModel extends ResourceModel {
 			this._refreshPromise.reject(err);
 			throw err;
 		} finally {
-			loginSession?.dispose();
+			session?.dispose();
 			this._refreshPromise = undefined;
 		}
 	}

--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -107,10 +107,10 @@ export class PostgresModel extends ResourceModel {
 			return this._refreshPromise.promise;
 		}
 		this._refreshPromise = new Deferred();
-		let loginSession: azdataExt.AzdataLoginSession | undefined = undefined;
+		let session: azdataExt.AzdataSession | undefined = undefined;
 		try {
-			loginSession = await this.controllerModel.acquireAzdataLoginSession();
-			this._config = (await this._azdataApi.azdata.arc.postgres.server.show(this.info.name, this.controllerModel.azdataAdditionalEnvVars, loginSession)).result;
+			session = await this.controllerModel.acquireAzdataSession();
+			this._config = (await this._azdataApi.azdata.arc.postgres.server.show(this.info.name, this.controllerModel.azdataAdditionalEnvVars, session)).result;
 			this.configLastUpdated = new Date();
 			this._onConfigUpdated.fire(this._config);
 			this._refreshPromise.resolve();
@@ -118,7 +118,7 @@ export class PostgresModel extends ResourceModel {
 			this._refreshPromise.reject(err);
 			throw err;
 		} finally {
-			loginSession?.dispose();
+			session?.dispose();
 			this._refreshPromise = undefined;
 		}
 	}

--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -107,10 +107,10 @@ export class PostgresModel extends ResourceModel {
 			return this._refreshPromise.promise;
 		}
 		this._refreshPromise = new Deferred();
-
+		let loginSession: azdataExt.AzdataLoginSession | undefined = undefined;
 		try {
-			await this.controllerModel.azdataLogin();
-			this._config = (await this._azdataApi.azdata.arc.postgres.server.show(this.info.name)).result;
+			loginSession = await this.controllerModel.acquireAzdataLoginSession();
+			this._config = (await this._azdataApi.azdata.arc.postgres.server.show(this.info.name, this.controllerModel.azdataAdditionalEnvVars, loginSession)).result;
 			this.configLastUpdated = new Date();
 			this._onConfigUpdated.fire(this._config);
 			this._refreshPromise.resolve();
@@ -118,6 +118,7 @@ export class PostgresModel extends ResourceModel {
 			this._refreshPromise.reject(err);
 			throw err;
 		} finally {
+			loginSession?.dispose();
 			this._refreshPromise = undefined;
 		}
 	}

--- a/extensions/arc/src/test/mocks/fakeAzdataApi.ts
+++ b/extensions/arc/src/test/mocks/fakeAzdataApi.ts
@@ -78,7 +78,7 @@ export class FakeAzdataApi implements azdataExt.IAzdataApi {
 	login(_endpoint: string, _username: string, _password: string): Promise<azdataExt.AzdataOutput<void>> {
 		return <any>undefined;
 	}
-	acquireLoginSession(_endpoint: string, _username: string, _password: string): Promise<azdataExt.AzdataLoginSession> {
+	acquireSession(_endpoint: string, _username: string, _password: string): Promise<azdataExt.AzdataSession> {
 		return Promise.resolve({ dispose: () => { } });
 	}
 	version(): Promise<azdataExt.AzdataOutput<string>> {

--- a/extensions/arc/src/test/mocks/fakeAzdataApi.ts
+++ b/extensions/arc/src/test/mocks/fakeAzdataApi.ts
@@ -78,6 +78,9 @@ export class FakeAzdataApi implements azdataExt.IAzdataApi {
 	login(_endpoint: string, _username: string, _password: string): Promise<azdataExt.AzdataOutput<any>> {
 		return <any>undefined;
 	}
+	acquireLoginSession(_endpoint: string, _username: string, _password: string): Promise<azdataExt.AzdataLoginSession> {
+		throw new Error('Method not implemented');
+	}
 	version(): Promise<azdataExt.AzdataOutput<string>> {
 		throw new Error('Method not implemented.');
 	}

--- a/extensions/arc/src/test/mocks/fakeAzdataApi.ts
+++ b/extensions/arc/src/test/mocks/fakeAzdataApi.ts
@@ -75,11 +75,11 @@ export class FakeAzdataApi implements azdataExt.IAzdataApi {
 	getPath(): Promise<string> {
 		throw new Error('Method not implemented.');
 	}
-	login(_endpoint: string, _username: string, _password: string): Promise<azdataExt.AzdataOutput<any>> {
+	login(_endpoint: string, _username: string, _password: string): Promise<azdataExt.AzdataOutput<void>> {
 		return <any>undefined;
 	}
 	acquireLoginSession(_endpoint: string, _username: string, _password: string): Promise<azdataExt.AzdataLoginSession> {
-		throw new Error('Method not implemented');
+		return Promise.resolve({ dispose: () => { } });
 	}
 	version(): Promise<azdataExt.AzdataOutput<string>> {
 		throw new Error('Method not implemented.');

--- a/extensions/arc/src/test/models/controllerModel.test.ts
+++ b/extensions/arc/src/test/models/controllerModel.test.ts
@@ -43,7 +43,7 @@ describe('ControllerModel', function (): void {
 			// Returning an undefined model here indicates that the dialog closed without clicking "Ok" - usually through the user clicking "Cancel"
 			sinon.stub(ConnectToControllerDialog.prototype, 'waitForClose').returns(Promise.resolve(undefined));
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] });
-			await should(model.acquireAzdataLoginSession()).be.rejectedWith(new UserCancelledError(loc.userCancelledError));
+			await should(model.acquireAzdataSession()).be.rejectedWith(new UserCancelledError(loc.userCancelledError));
 		});
 
 		it('Reads password from cred store', async function (): Promise<void> {
@@ -58,13 +58,13 @@ describe('ControllerModel', function (): void {
 
 			const azdataExtApiMock = TypeMoq.Mock.ofType<azdataExt.IExtension>();
 			const azdataMock = TypeMoq.Mock.ofType<azdataExt.IAzdataApi>();
-			azdataMock.setup(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
+			azdataMock.setup(x => x.acquireSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
 			azdataExtApiMock.setup(x => x.azdata).returns(() => azdataMock.object);
 			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: azdataExtApiMock.object });
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] });
 
-			await model.acquireAzdataLoginSession();
-			azdataMock.verify(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
+			await model.acquireAzdataSession();
+			azdataMock.verify(x => x.acquireSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 
 		it('Prompt for password when not in cred store', async function (): Promise<void> {
@@ -79,7 +79,7 @@ describe('ControllerModel', function (): void {
 
 			const azdataExtApiMock = TypeMoq.Mock.ofType<azdataExt.IExtension>();
 			const azdataMock = TypeMoq.Mock.ofType<azdataExt.IAzdataApi>();
-			azdataMock.setup(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
+			azdataMock.setup(x => x.acquireSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
 			azdataExtApiMock.setup(x => x.azdata).returns(() => azdataMock.object);
 			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: azdataExtApiMock.object });
 
@@ -89,8 +89,8 @@ describe('ControllerModel', function (): void {
 
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] });
 
-			await model.acquireAzdataLoginSession();
-			azdataMock.verify(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
+			await model.acquireAzdataSession();
+			azdataMock.verify(x => x.acquireSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 
 		it('Prompt for password when rememberPassword is true but prompt reconnect is true', async function (): Promise<void> {
@@ -104,7 +104,7 @@ describe('ControllerModel', function (): void {
 
 			const azdataExtApiMock = TypeMoq.Mock.ofType<azdataExt.IExtension>();
 			const azdataMock = TypeMoq.Mock.ofType<azdataExt.IAzdataApi>();
-			azdataMock.setup(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
+			azdataMock.setup(x => x.acquireSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
 			azdataExtApiMock.setup(x => x.azdata).returns(() => azdataMock.object);
 			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: azdataExtApiMock.object });
 
@@ -114,9 +114,9 @@ describe('ControllerModel', function (): void {
 
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] });
 
-			await model.acquireAzdataLoginSession(true);
+			await model.acquireAzdataSession(true);
 			should(waitForCloseStub.called).be.true('waitForClose should have been called');
-			azdataMock.verify(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
+			azdataMock.verify(x => x.acquireSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 
 		it('Prompt for password when we already have a password but prompt reconnect is true', async function (): Promise<void> {
@@ -130,7 +130,7 @@ describe('ControllerModel', function (): void {
 
 			const azdataExtApiMock = TypeMoq.Mock.ofType<azdataExt.IExtension>();
 			const azdataMock = TypeMoq.Mock.ofType<azdataExt.IAzdataApi>();
-			azdataMock.setup(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
+			azdataMock.setup(x => x.acquireSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
 			azdataExtApiMock.setup(x => x.azdata).returns(() => azdataMock.object);
 			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: azdataExtApiMock.object });
 
@@ -141,9 +141,9 @@ describe('ControllerModel', function (): void {
 			// Set up original model with a password
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] }, 'originalPassword');
 
-			await model.acquireAzdataLoginSession(true);
+			await model.acquireAzdataSession(true);
 			should(waitForCloseStub.called).be.true('waitForClose should have been called');
-			azdataMock.verify(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
+			azdataMock.verify(x => x.acquireSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 
 		it('Model values are updated correctly when modified during reconnect', async function (): Promise<void> {
@@ -158,7 +158,7 @@ describe('ControllerModel', function (): void {
 
 			const azdataExtApiMock = TypeMoq.Mock.ofType<azdataExt.IExtension>();
 			const azdataMock = TypeMoq.Mock.ofType<azdataExt.IAzdataApi>();
-			azdataMock.setup(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
+			azdataMock.setup(x => x.acquireSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
 			azdataExtApiMock.setup(x => x.azdata).returns(() => azdataMock.object);
 			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: azdataExtApiMock.object });
 
@@ -199,7 +199,7 @@ describe('ControllerModel', function (): void {
 			const waitForCloseStub = sinon.stub(ConnectToControllerDialog.prototype, 'waitForClose').returns(Promise.resolve(
 				{ controllerModel: newModel, password: newPassword }));
 
-			await model.acquireAzdataLoginSession(true);
+			await model.acquireAzdataSession(true);
 			should(waitForCloseStub.called).be.true('waitForClose should have been called');
 			should((await treeDataProvider.getChildren()).length).equal(1, 'Tree Data provider should still only have 1 node');
 			should(model.info).deepEqual(newInfo, 'Model info should have been updated');

--- a/extensions/arc/src/test/models/controllerModel.test.ts
+++ b/extensions/arc/src/test/models/controllerModel.test.ts
@@ -58,14 +58,13 @@ describe('ControllerModel', function (): void {
 
 			const azdataExtApiMock = TypeMoq.Mock.ofType<azdataExt.IExtension>();
 			const azdataMock = TypeMoq.Mock.ofType<azdataExt.IAzdataApi>();
-			azdataMock.setup(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
+			azdataMock.setup(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
 			azdataExtApiMock.setup(x => x.azdata).returns(() => azdataMock.object);
 			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: azdataExtApiMock.object });
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] });
 
-			const loginSession = await model.acquireAzdataLoginSession();
-			azdataMock.verify(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
-			loginSession.dispose();
+			await model.acquireAzdataLoginSession();
+			azdataMock.verify(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 
 		it('Prompt for password when not in cred store', async function (): Promise<void> {
@@ -80,7 +79,7 @@ describe('ControllerModel', function (): void {
 
 			const azdataExtApiMock = TypeMoq.Mock.ofType<azdataExt.IExtension>();
 			const azdataMock = TypeMoq.Mock.ofType<azdataExt.IAzdataApi>();
-			azdataMock.setup(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
+			azdataMock.setup(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
 			azdataExtApiMock.setup(x => x.azdata).returns(() => azdataMock.object);
 			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: azdataExtApiMock.object });
 
@@ -90,9 +89,8 @@ describe('ControllerModel', function (): void {
 
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] });
 
-			const loginSession = await model.acquireAzdataLoginSession();
-			azdataMock.verify(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
-			loginSession.dispose();
+			await model.acquireAzdataLoginSession();
+			azdataMock.verify(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 
 		it('Prompt for password when rememberPassword is true but prompt reconnect is true', async function (): Promise<void> {
@@ -106,7 +104,7 @@ describe('ControllerModel', function (): void {
 
 			const azdataExtApiMock = TypeMoq.Mock.ofType<azdataExt.IExtension>();
 			const azdataMock = TypeMoq.Mock.ofType<azdataExt.IAzdataApi>();
-			azdataMock.setup(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
+			azdataMock.setup(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
 			azdataExtApiMock.setup(x => x.azdata).returns(() => azdataMock.object);
 			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: azdataExtApiMock.object });
 
@@ -116,10 +114,9 @@ describe('ControllerModel', function (): void {
 
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] });
 
-			const loginSession = await model.acquireAzdataLoginSession(true);
+			await model.acquireAzdataLoginSession(true);
 			should(waitForCloseStub.called).be.true('waitForClose should have been called');
-			azdataMock.verify(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
-			loginSession.dispose();
+			azdataMock.verify(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 
 		it('Prompt for password when we already have a password but prompt reconnect is true', async function (): Promise<void> {
@@ -133,7 +130,7 @@ describe('ControllerModel', function (): void {
 
 			const azdataExtApiMock = TypeMoq.Mock.ofType<azdataExt.IExtension>();
 			const azdataMock = TypeMoq.Mock.ofType<azdataExt.IAzdataApi>();
-			azdataMock.setup(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
+			azdataMock.setup(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
 			azdataExtApiMock.setup(x => x.azdata).returns(() => azdataMock.object);
 			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: azdataExtApiMock.object });
 
@@ -144,10 +141,9 @@ describe('ControllerModel', function (): void {
 			// Set up original model with a password
 			const model = new ControllerModel(new AzureArcTreeDataProvider(mockExtensionContext.object), { id: uuid(), url: '127.0.0.1', kubeConfigFilePath: '/path/to/.kube/config', kubeClusterContext: 'currentCluster', username: 'admin', name: 'arc', rememberPassword: true, resources: [] }, 'originalPassword');
 
-			const loginSession = await model.acquireAzdataLoginSession(true);
+			await model.acquireAzdataLoginSession(true);
 			should(waitForCloseStub.called).be.true('waitForClose should have been called');
-			azdataMock.verify(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
-			loginSession.dispose();
+			azdataMock.verify(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), password, TypeMoq.It.isAny()), TypeMoq.Times.once());
 		});
 
 		it('Model values are updated correctly when modified during reconnect', async function (): Promise<void> {
@@ -162,7 +158,7 @@ describe('ControllerModel', function (): void {
 
 			const azdataExtApiMock = TypeMoq.Mock.ofType<azdataExt.IExtension>();
 			const azdataMock = TypeMoq.Mock.ofType<azdataExt.IAzdataApi>();
-			azdataMock.setup(x => x.login(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
+			azdataMock.setup(x => x.acquireLoginSession(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => <any>Promise.resolve(undefined));
 			azdataExtApiMock.setup(x => x.azdata).returns(() => azdataMock.object);
 			sinon.stub(vscode.extensions, 'getExtension').returns(<any>{ exports: azdataExtApiMock.object });
 
@@ -203,14 +199,10 @@ describe('ControllerModel', function (): void {
 			const waitForCloseStub = sinon.stub(ConnectToControllerDialog.prototype, 'waitForClose').returns(Promise.resolve(
 				{ controllerModel: newModel, password: newPassword }));
 
-			const loginSession = await model.acquireAzdataLoginSession(true);
-			try {
-				should(waitForCloseStub.called).be.true('waitForClose should have been called');
-				should((await treeDataProvider.getChildren()).length).equal(1, 'Tree Data provider should still only have 1 node');
-				should(model.info).deepEqual(newInfo, 'Model info should have been updated');
-			} finally {
-				loginSession.dispose();
-			}
+			await model.acquireAzdataLoginSession(true);
+			should(waitForCloseStub.called).be.true('waitForClose should have been called');
+			should((await treeDataProvider.getChildren()).length).equal(1, 'Tree Data provider should still only have 1 node');
+			should(model.info).deepEqual(newInfo, 'Model info should have been updated');
 
 		});
 

--- a/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
@@ -129,13 +129,16 @@ export class MiaaComputeAndStoragePage extends DashboardPage {
 							cancellable: false
 						},
 						async (_progress, _token): Promise<void> => {
+							let loginSession: azdataExt.AzdataLoginSession | undefined = undefined;
 							try {
-								await this._miaaModel.controllerModel.azdataLogin();
+								loginSession = await this._miaaModel.controllerModel.acquireAzdataLoginSession();
 								await this._azdataApi.azdata.arc.sql.mi.edit(
-									this._miaaModel.info.name, this.saveArgs);
+									this._miaaModel.info.name, this.saveArgs, this._miaaModel.controllerModel.azdataAdditionalEnvVars, loginSession);
 							} catch (err) {
 								this.saveButton!.enabled = true;
 								throw err;
+							} finally {
+								loginSession?.dispose();
 							}
 
 							await this._miaaModel.refresh();

--- a/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
@@ -129,16 +129,16 @@ export class MiaaComputeAndStoragePage extends DashboardPage {
 							cancellable: false
 						},
 						async (_progress, _token): Promise<void> => {
-							let loginSession: azdataExt.AzdataLoginSession | undefined = undefined;
+							let session: azdataExt.AzdataSession | undefined = undefined;
 							try {
-								loginSession = await this._miaaModel.controllerModel.acquireAzdataLoginSession();
+								session = await this._miaaModel.controllerModel.acquireAzdataSession();
 								await this._azdataApi.azdata.arc.sql.mi.edit(
-									this._miaaModel.info.name, this.saveArgs, this._miaaModel.controllerModel.azdataAdditionalEnvVars, loginSession);
+									this._miaaModel.info.name, this.saveArgs, this._miaaModel.controllerModel.azdataAdditionalEnvVars, session);
 							} catch (err) {
 								this.saveButton!.enabled = true;
 								throw err;
 							} finally {
-								loginSession?.dispose();
+								session?.dispose();
 							}
 
 							await this._miaaModel.refresh();

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -206,8 +206,13 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 								cancellable: false
 							},
 							async (_progress, _token) => {
-								await this._controllerModel.azdataLogin();
-								return await this._azdataApi.azdata.arc.sql.mi.delete(this._miaaModel.info.name);
+								const loginSession = await this._controllerModel.acquireAzdataLoginSession();
+								try {
+									return await this._azdataApi.azdata.arc.sql.mi.delete(this._miaaModel.info.name, this._controllerModel.azdataAdditionalEnvVars, loginSession);
+								} finally {
+									loginSession.dispose();
+								}
+
 							}
 						);
 						await this._controllerModel.refreshTreeNode();

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboardOverviewPage.ts
@@ -206,11 +206,11 @@ export class MiaaDashboardOverviewPage extends DashboardPage {
 								cancellable: false
 							},
 							async (_progress, _token) => {
-								const loginSession = await this._controllerModel.acquireAzdataLoginSession();
+								const session = await this._controllerModel.acquireAzdataSession();
 								try {
-									return await this._azdataApi.azdata.arc.sql.mi.delete(this._miaaModel.info.name, this._controllerModel.azdataAdditionalEnvVars, loginSession);
+									return await this._azdataApi.azdata.arc.sql.mi.delete(this._miaaModel.info.name, this._controllerModel.azdataAdditionalEnvVars, session);
 								} finally {
-									loginSession.dispose();
+									session.dispose();
 								}
 
 							}

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -155,18 +155,23 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 							cancellable: false
 						},
 						async (_progress, _token): Promise<void> => {
+							let loginSession: azdataExt.AzdataLoginSession | undefined = undefined;
 							try {
-								await this._postgresModel.controllerModel.azdataLogin();
+								loginSession = await this._postgresModel.controllerModel.acquireAzdataLoginSession();
 								await this._azdataApi.azdata.arc.postgres.server.edit(
 									this._postgresModel.info.name,
 									this.saveArgs,
-									this._postgresModel.engineVersion
+									this._postgresModel.engineVersion,
+									this._postgresModel.controllerModel.azdataAdditionalEnvVars,
+									loginSession
 								);
 							} catch (err) {
 								// If an error occurs while editing the instance then re-enable the save button since
 								// the edit wasn't successfully applied
 								this.saveButton!.enabled = true;
 								throw err;
+							} finally {
+								loginSession?.dispose();
 							}
 							await this._postgresModel.refresh();
 						}

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -155,15 +155,15 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 							cancellable: false
 						},
 						async (_progress, _token): Promise<void> => {
-							let loginSession: azdataExt.AzdataLoginSession | undefined = undefined;
+							let session: azdataExt.AzdataSession | undefined = undefined;
 							try {
-								loginSession = await this._postgresModel.controllerModel.acquireAzdataLoginSession();
+								session = await this._postgresModel.controllerModel.acquireAzdataSession();
 								await this._azdataApi.azdata.arc.postgres.server.edit(
 									this._postgresModel.info.name,
 									this.saveArgs,
 									this._postgresModel.engineVersion,
 									this._postgresModel.controllerModel.azdataAdditionalEnvVars,
-									loginSession
+									session
 								);
 							} catch (err) {
 								// If an error occurs while editing the instance then re-enable the save button since
@@ -171,7 +171,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 								this.saveButton!.enabled = true;
 								throw err;
 							} finally {
-								loginSession?.dispose();
+								session?.dispose();
 							}
 							await this._postgresModel.refresh();
 						}

--- a/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
@@ -151,7 +151,7 @@ export class PostgresOverviewPage extends DashboardPage {
 				try {
 					const password = await promptAndConfirmPassword(input => !input ? loc.enterANonEmptyPassword : '');
 					if (password) {
-						const loginSession = await this._postgresModel.controllerModel.acquireAzdataLoginSession();
+						const session = await this._postgresModel.controllerModel.acquireAzdataSession();
 						try {
 							await this._azdataApi.azdata.arc.postgres.server.edit(
 								this._postgresModel.info.name,
@@ -161,10 +161,10 @@ export class PostgresOverviewPage extends DashboardPage {
 								},
 								this._postgresModel.engineVersion,
 								Object.assign({ 'AZDATA_PASSWORD': password }, this._controllerModel.azdataAdditionalEnvVars),
-								loginSession
+								session
 							);
 						} finally {
-							loginSession.dispose();
+							session.dispose();
 						}
 						vscode.window.showInformationMessage(loc.passwordReset);
 					}
@@ -193,11 +193,11 @@ export class PostgresOverviewPage extends DashboardPage {
 								cancellable: false
 							},
 							async (_progress, _token) => {
-								const loginSession = await this._postgresModel.controllerModel.acquireAzdataLoginSession();
+								const session = await this._postgresModel.controllerModel.acquireAzdataSession();
 								try {
-									return await this._azdataApi.azdata.arc.postgres.server.delete(this._postgresModel.info.name, this._controllerModel.azdataAdditionalEnvVars, loginSession);
+									return await this._azdataApi.azdata.arc.postgres.server.delete(this._postgresModel.info.name, this._controllerModel.azdataAdditionalEnvVars, session);
 								} finally {
-									loginSession.dispose();
+									session.dispose();
 								}
 
 							}

--- a/extensions/arc/src/ui/dashboards/postgres/postgresParametersPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresParametersPage.ts
@@ -172,12 +172,12 @@ export class PostgresParametersPage extends DashboardPage {
 								this.engineSettingUpdates!.forEach((value: string) => {
 									this.engineSettings += value + ', ';
 								});
-								const loginSession = await this._postgresModel.controllerModel.acquireAzdataLoginSession();
+								const session = await this._postgresModel.controllerModel.acquireAzdataSession();
 								try {
 									await this._azdataApi.azdata.arc.postgres.server.edit(
 										this._postgresModel.info.name, { engineSettings: this.engineSettings + `'` });
 								} finally {
-									loginSession.dispose();
+									session.dispose();
 								}
 
 							} catch (err) {
@@ -243,9 +243,9 @@ export class PostgresParametersPage extends DashboardPage {
 						async (_progress, _token): Promise<void> => {
 							//all
 							// azdata arc postgres server edit -n <server group name> -e '' -re
-							let loginSession: azdataExt.AzdataLoginSession | undefined = undefined;
+							let session: azdataExt.AzdataSession | undefined = undefined;
 							try {
-								loginSession = await this._postgresModel.controllerModel.acquireAzdataLoginSession();
+								session = await this._postgresModel.controllerModel.acquireAzdataSession();
 								await this._azdataApi.azdata.arc.postgres.server.edit(
 									this._postgresModel.info.name, { engineSettings: `'' -re` });
 							} catch (err) {
@@ -254,7 +254,7 @@ export class PostgresParametersPage extends DashboardPage {
 								this.resetButton!.enabled = true;
 								throw err;
 							} finally {
-								loginSession?.dispose();
+								session?.dispose();
 							}
 							await this._postgresModel.refresh();
 						}
@@ -474,12 +474,12 @@ export class PostgresParametersPage extends DashboardPage {
 							cancellable: false
 						},
 						async (_progress, _token) => {
-							const loginSession = await this._postgresModel.controllerModel.acquireAzdataLoginSession();
+							const session = await this._postgresModel.controllerModel.acquireAzdataSession();
 							try {
 								this._azdataApi.azdata.arc.postgres.server.edit(
 									this._postgresModel.info.name, { engineSettings: name + '=' });
 							} finally {
-								loginSession.dispose();
+								session.dispose();
 							}
 						}
 					);

--- a/extensions/azdata/src/api.ts
+++ b/extensions/azdata/src/api.ts
@@ -45,47 +45,57 @@ export function getAzdataApi(localAzdataDiscovered: Promise<IAzdataTool | undefi
 	return {
 		arc: {
 			dc: {
-				create: async (namespace: string, name: string, connectivityMode: string, resourceGroup: string, location: string, subscription: string, profileName?: string, storageClass?: string, additionalEnvVars?: azdataExt.AdditionalEnvVars) => {
+				create: async (
+					namespace: string,
+					name: string,
+					connectivityMode: string,
+					resourceGroup: string,
+					location: string,
+					subscription: string,
+					profileName?: string,
+					storageClass?: string,
+					additionalEnvVars?: azdataExt.AdditionalEnvVars,
+					loginSession?: azdataExt.AzdataLoginSession) => {
 					await localAzdataDiscovered;
 					throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-					return azdataToolService.localAzdata.arc.dc.create(namespace, name, connectivityMode, resourceGroup, location, subscription, profileName, storageClass, additionalEnvVars);
+					return azdataToolService.localAzdata.arc.dc.create(namespace, name, connectivityMode, resourceGroup, location, subscription, profileName, storageClass, additionalEnvVars, loginSession);
 				},
 				endpoint: {
-					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars) => {
+					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.dc.endpoint.list(additionalEnvVars);
+						return azdataToolService.localAzdata.arc.dc.endpoint.list(additionalEnvVars, loginSession);
 					}
 				},
 				config: {
-					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars) => {
+					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.dc.config.list(additionalEnvVars);
+						return azdataToolService.localAzdata.arc.dc.config.list(additionalEnvVars, loginSession);
 					},
-					show: async (additionalEnvVars?: azdataExt.AdditionalEnvVars) => {
+					show: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.dc.config.show(additionalEnvVars);
+						return azdataToolService.localAzdata.arc.dc.config.show(additionalEnvVars, loginSession);
 					}
 				}
 			},
 			postgres: {
 				server: {
-					delete: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars) => {
+					delete: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.postgres.server.delete(name, additionalEnvVars);
+						return azdataToolService.localAzdata.arc.postgres.server.delete(name, additionalEnvVars, loginSession);
 					},
-					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars) => {
+					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.postgres.server.list(additionalEnvVars);
+						return azdataToolService.localAzdata.arc.postgres.server.list(additionalEnvVars, loginSession);
 					},
-					show: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars) => {
+					show: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.postgres.server.show(name, additionalEnvVars);
+						return azdataToolService.localAzdata.arc.postgres.server.show(name, additionalEnvVars, loginSession);
 					},
 					edit: async (
 						name: string,
@@ -103,29 +113,30 @@ export function getAzdataApi(localAzdataDiscovered: Promise<IAzdataTool | undefi
 							workers?: number;
 						},
 						engineVersion?: string,
-						additionalEnvVars?: { [key: string]: string; }) => {
+						additionalEnvVars?: azdataExt.AdditionalEnvVars,
+						loginSession?: azdataExt.AzdataLoginSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.postgres.server.edit(name, args, engineVersion, additionalEnvVars);
+						return azdataToolService.localAzdata.arc.postgres.server.edit(name, args, engineVersion, additionalEnvVars, loginSession);
 					}
 				}
 			},
 			sql: {
 				mi: {
-					delete: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars) => {
+					delete: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.sql.mi.delete(name, additionalEnvVars);
+						return azdataToolService.localAzdata.arc.sql.mi.delete(name, additionalEnvVars, loginSession);
 					},
-					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars) => {
+					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.sql.mi.list(additionalEnvVars);
+						return azdataToolService.localAzdata.arc.sql.mi.list(additionalEnvVars, loginSession);
 					},
-					show: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars) => {
+					show: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.sql.mi.show(name, additionalEnvVars);
+						return azdataToolService.localAzdata.arc.sql.mi.show(name, additionalEnvVars, loginSession);
 					},
 					edit: async (
 						name: string,
@@ -136,11 +147,12 @@ export function getAzdataApi(localAzdataDiscovered: Promise<IAzdataTool | undefi
 							memoryRequest?: string;
 							noWait?: boolean;
 						},
-						additionalEnvVars?: azdataExt.AdditionalEnvVars
+						additionalEnvVars?: azdataExt.AdditionalEnvVars,
+						loginSession?: azdataExt.AzdataLoginSession
 					) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.sql.mi.edit(name, args, additionalEnvVars);
+						return azdataToolService.localAzdata.arc.sql.mi.edit(name, args, additionalEnvVars, loginSession);
 					}
 				}
 			}
@@ -153,6 +165,10 @@ export function getAzdataApi(localAzdataDiscovered: Promise<IAzdataTool | undefi
 		login: async (endpoint: string, username: string, password: string, additionalEnvVars?: azdataExt.AdditionalEnvVars) => {
 			throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
 			return azdataToolService.localAzdata.login(endpoint, username, password, additionalEnvVars);
+		},
+		acquireLoginSession: async (endpoint: string, username: string, password: string, additionEnvVars?: azdataExt.AdditionalEnvVars) => {
+			throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
+			return azdataToolService.localAzdata?.acquireLoginSession(endpoint, username, password, additionEnvVars);
 		},
 		getSemVersion: async () => {
 			await localAzdataDiscovered;

--- a/extensions/azdata/src/api.ts
+++ b/extensions/azdata/src/api.ts
@@ -55,47 +55,47 @@ export function getAzdataApi(localAzdataDiscovered: Promise<IAzdataTool | undefi
 					profileName?: string,
 					storageClass?: string,
 					additionalEnvVars?: azdataExt.AdditionalEnvVars,
-					loginSession?: azdataExt.AzdataLoginSession) => {
+					session?: azdataExt.AzdataSession) => {
 					await localAzdataDiscovered;
 					throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-					return azdataToolService.localAzdata.arc.dc.create(namespace, name, connectivityMode, resourceGroup, location, subscription, profileName, storageClass, additionalEnvVars, loginSession);
+					return azdataToolService.localAzdata.arc.dc.create(namespace, name, connectivityMode, resourceGroup, location, subscription, profileName, storageClass, additionalEnvVars, session);
 				},
 				endpoint: {
-					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
+					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.dc.endpoint.list(additionalEnvVars, loginSession);
+						return azdataToolService.localAzdata.arc.dc.endpoint.list(additionalEnvVars, session);
 					}
 				},
 				config: {
-					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
+					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.dc.config.list(additionalEnvVars, loginSession);
+						return azdataToolService.localAzdata.arc.dc.config.list(additionalEnvVars, session);
 					},
-					show: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
+					show: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.dc.config.show(additionalEnvVars, loginSession);
+						return azdataToolService.localAzdata.arc.dc.config.show(additionalEnvVars, session);
 					}
 				}
 			},
 			postgres: {
 				server: {
-					delete: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
+					delete: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.postgres.server.delete(name, additionalEnvVars, loginSession);
+						return azdataToolService.localAzdata.arc.postgres.server.delete(name, additionalEnvVars, session);
 					},
-					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
+					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.postgres.server.list(additionalEnvVars, loginSession);
+						return azdataToolService.localAzdata.arc.postgres.server.list(additionalEnvVars, session);
 					},
-					show: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
+					show: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.postgres.server.show(name, additionalEnvVars, loginSession);
+						return azdataToolService.localAzdata.arc.postgres.server.show(name, additionalEnvVars, session);
 					},
 					edit: async (
 						name: string,
@@ -114,29 +114,29 @@ export function getAzdataApi(localAzdataDiscovered: Promise<IAzdataTool | undefi
 						},
 						engineVersion?: string,
 						additionalEnvVars?: azdataExt.AdditionalEnvVars,
-						loginSession?: azdataExt.AzdataLoginSession) => {
+						session?: azdataExt.AzdataSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.postgres.server.edit(name, args, engineVersion, additionalEnvVars, loginSession);
+						return azdataToolService.localAzdata.arc.postgres.server.edit(name, args, engineVersion, additionalEnvVars, session);
 					}
 				}
 			},
 			sql: {
 				mi: {
-					delete: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
+					delete: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.sql.mi.delete(name, additionalEnvVars, loginSession);
+						return azdataToolService.localAzdata.arc.sql.mi.delete(name, additionalEnvVars, session);
 					},
-					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
+					list: async (additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.sql.mi.list(additionalEnvVars, loginSession);
+						return azdataToolService.localAzdata.arc.sql.mi.list(additionalEnvVars, session);
 					},
-					show: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession) => {
+					show: async (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.sql.mi.show(name, additionalEnvVars, loginSession);
+						return azdataToolService.localAzdata.arc.sql.mi.show(name, additionalEnvVars, session);
 					},
 					edit: async (
 						name: string,
@@ -148,11 +148,11 @@ export function getAzdataApi(localAzdataDiscovered: Promise<IAzdataTool | undefi
 							noWait?: boolean;
 						},
 						additionalEnvVars?: azdataExt.AdditionalEnvVars,
-						loginSession?: azdataExt.AzdataLoginSession
+						session?: azdataExt.AzdataSession
 					) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.sql.mi.edit(name, args, additionalEnvVars, loginSession);
+						return azdataToolService.localAzdata.arc.sql.mi.edit(name, args, additionalEnvVars, session);
 					}
 				}
 			}
@@ -166,9 +166,9 @@ export function getAzdataApi(localAzdataDiscovered: Promise<IAzdataTool | undefi
 			throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
 			return azdataToolService.localAzdata.login(endpoint, username, password, additionalEnvVars);
 		},
-		acquireLoginSession: async (endpoint: string, username: string, password: string, additionEnvVars?: azdataExt.AdditionalEnvVars) => {
+		acquireSession: async (endpoint: string, username: string, password: string, additionEnvVars?: azdataExt.AdditionalEnvVars) => {
 			throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-			return azdataToolService.localAzdata?.acquireLoginSession(endpoint, username, password, additionEnvVars);
+			return azdataToolService.localAzdata?.acquireSession(endpoint, username, password, additionEnvVars);
 		},
 		getSemVersion: async () => {
 			await localAzdataDiscovered;

--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -280,7 +280,7 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 			this._currentlyExecutingCommands = this._currentlyExecutingCommands.filter(c => c !== executingDeferred);
 			executingDeferred.resolve();
 			// If there isn't an active session and we still have queued commands then we have to manually kick off the next one
-			if (this._currentlyExecutingCommands.length > 0 && !this._currentLoginSession) {
+			if (this._queuedCommands.length > 0 && !this._currentLoginSession) {
 				this._queuedCommands.shift()?.deferred.resolve();
 			}
 		}

--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -13,6 +13,7 @@ import { getPlatformDownloadLink, getPlatformReleaseVersion } from './azdataRele
 import { executeCommand, executeSudoCommand, ExitCodeError, ProcessOutput } from './common/childProcess';
 import { HttpClient } from './common/httpClient';
 import Logger from './common/logger';
+import { Deferred } from './common/promise';
 import { getErrorMessage, NoAzdataError, searchForCmd } from './common/utils';
 import { azdataAcceptEulaKey, azdataConfigSection, azdataFound, azdataInstallKey, azdataUpdateKey, debugConfigKey, eulaAccepted, eulaUrl, microsoftPrivacyStatementUrl } from './constants';
 import * as loc from './localizedConstants';
@@ -34,12 +35,29 @@ export interface IAzdataTool extends azdataExt.IAzdataApi {
 	executeCommand<R>(args: string[], additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<R>>
 }
 
+class AzdataLoginSession implements azdataExt.AzdataLoginSession {
+
+	private _session = new Deferred<void>();
+
+	public sessionEnded(): Promise<void> {
+		return this._session.promise;
+	}
+
+	public dispose(): void {
+		this._session.resolve();
+	}
+}
+
 /**
  * An object to interact with the azdata tool installed on the box.
  */
 export class AzdataTool implements azdataExt.IAzdataApi {
 
 	private _semVersion: SemVer;
+	private _currentLoginSession: azdataExt.AzdataLoginSession | undefined = undefined;
+	private _currentlyExecutingCommands: Deferred<void>[] = [];
+	private _queuedCommands: { deferred: Deferred<void>, session?: azdataExt.AzdataLoginSession }[] = [];
+
 	constructor(private _path: string, version: string) {
 		this._semVersion = new SemVer(version);
 	}
@@ -62,7 +80,17 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 
 	public arc = {
 		dc: {
-			create: (namespace: string, name: string, connectivityMode: string, resourceGroup: string, location: string, subscription: string, profileName?: string, storageClass?: string, additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<void>> => {
+			create: (
+				namespace: string,
+				name: string,
+				connectivityMode: string,
+				resourceGroup: string,
+				location: string,
+				subscription: string,
+				profileName?: string,
+				storageClass?: string,
+				additionalEnvVars?: azdataExt.AdditionalEnvVars,
+				loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<void>> => {
 				const args = ['arc', 'dc', 'create',
 					'--namespace', namespace,
 					'--name', name,
@@ -76,32 +104,32 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 				if (storageClass) {
 					args.push('--storage-class', storageClass);
 				}
-				return this.executeCommand<void>(args, additionalEnvVars);
+				return this.executeCommand<void>(args, additionalEnvVars, loginSession);
 			},
 			endpoint: {
-				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<azdataExt.DcEndpointListResult[]>> => {
-					return this.executeCommand<azdataExt.DcEndpointListResult[]>(['arc', 'dc', 'endpoint', 'list'], additionalEnvVars);
+				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.DcEndpointListResult[]>> => {
+					return this.executeCommand<azdataExt.DcEndpointListResult[]>(['arc', 'dc', 'endpoint', 'list'], additionalEnvVars, loginSession);
 				}
 			},
 			config: {
-				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<azdataExt.DcConfigListResult[]>> => {
-					return this.executeCommand<azdataExt.DcConfigListResult[]>(['arc', 'dc', 'config', 'list'], additionalEnvVars);
+				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.DcConfigListResult[]>> => {
+					return this.executeCommand<azdataExt.DcConfigListResult[]>(['arc', 'dc', 'config', 'list'], additionalEnvVars, loginSession);
 				},
-				show: (additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<azdataExt.DcConfigShowResult>> => {
-					return this.executeCommand<azdataExt.DcConfigShowResult>(['arc', 'dc', 'config', 'show'], additionalEnvVars);
+				show: (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.DcConfigShowResult>> => {
+					return this.executeCommand<azdataExt.DcConfigShowResult>(['arc', 'dc', 'config', 'show'], additionalEnvVars, loginSession);
 				}
 			}
 		},
 		postgres: {
 			server: {
-				delete: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<void>> => {
-					return this.executeCommand<void>(['arc', 'postgres', 'server', 'delete', '-n', name, '--force'], additionalEnvVars);
+				delete: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<void>> => {
+					return this.executeCommand<void>(['arc', 'postgres', 'server', 'delete', '-n', name, '--force'], additionalEnvVars, loginSession);
 				},
-				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<azdataExt.PostgresServerListResult[]>> => {
-					return this.executeCommand<azdataExt.PostgresServerListResult[]>(['arc', 'postgres', 'server', 'list'], additionalEnvVars);
+				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.PostgresServerListResult[]>> => {
+					return this.executeCommand<azdataExt.PostgresServerListResult[]>(['arc', 'postgres', 'server', 'list'], additionalEnvVars, loginSession);
 				},
-				show: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<azdataExt.PostgresServerShowResult>> => {
-					return this.executeCommand<azdataExt.PostgresServerShowResult>(['arc', 'postgres', 'server', 'show', '-n', name], additionalEnvVars);
+				show: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.PostgresServerShowResult>> => {
+					return this.executeCommand<azdataExt.PostgresServerShowResult>(['arc', 'postgres', 'server', 'show', '-n', name], additionalEnvVars, loginSession);
 				},
 				edit: (
 					name: string,
@@ -119,7 +147,8 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 						workers?: number
 					},
 					engineVersion?: string,
-					additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<void>> => {
+					additionalEnvVars?: azdataExt.AdditionalEnvVars,
+					loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<void>> => {
 					const argsArray = ['arc', 'postgres', 'server', 'edit', '-n', name];
 					if (args.adminPassword) { argsArray.push('--admin-password'); }
 					if (args.coresLimit) { argsArray.push('--cores-limit', args.coresLimit); }
@@ -133,20 +162,20 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 					if (args.replaceEngineSettings) { argsArray.push('--replace-engine-settings'); }
 					if (args.workers) { argsArray.push('--workers', args.workers.toString()); }
 					if (engineVersion) { argsArray.push('--engine-version', engineVersion); }
-					return this.executeCommand<void>(argsArray, additionalEnvVars);
+					return this.executeCommand<void>(argsArray, additionalEnvVars, loginSession);
 				}
 			}
 		},
 		sql: {
 			mi: {
-				delete: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<void>> => {
-					return this.executeCommand<void>(['arc', 'sql', 'mi', 'delete', '-n', name], additionalEnvVars);
+				delete: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<void>> => {
+					return this.executeCommand<void>(['arc', 'sql', 'mi', 'delete', '-n', name], additionalEnvVars, loginSession);
 				},
-				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<azdataExt.SqlMiListResult[]>> => {
-					return this.executeCommand<azdataExt.SqlMiListResult[]>(['arc', 'sql', 'mi', 'list'], additionalEnvVars);
+				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.SqlMiListResult[]>> => {
+					return this.executeCommand<azdataExt.SqlMiListResult[]>(['arc', 'sql', 'mi', 'list'], additionalEnvVars, loginSession);
 				},
-				show: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<azdataExt.SqlMiShowResult>> => {
-					return this.executeCommand<azdataExt.SqlMiShowResult>(['arc', 'sql', 'mi', 'show', '-n', name], additionalEnvVars);
+				show: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.SqlMiShowResult>> => {
+					return this.executeCommand<azdataExt.SqlMiShowResult>(['arc', 'sql', 'mi', 'show', '-n', name], additionalEnvVars, loginSession);
 				},
 				edit: (
 					name: string,
@@ -157,7 +186,8 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 						memoryRequest?: string,
 						noWait?: boolean,
 					},
-					additionalEnvVars?: azdataExt.AdditionalEnvVars
+					additionalEnvVars?: azdataExt.AdditionalEnvVars,
+					loginSession?: azdataExt.AzdataLoginSession
 				): Promise<azdataExt.AzdataOutput<void>> => {
 					const argsArray = ['arc', 'sql', 'mi', 'edit', '-n', name];
 					if (args.coresLimit) { argsArray.push('--cores-limit', args.coresLimit); }
@@ -165,14 +195,59 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 					if (args.memoryLimit) { argsArray.push('--memory-limit', args.memoryLimit); }
 					if (args.memoryRequest) { argsArray.push('--memory-request', args.memoryRequest); }
 					if (args.noWait) { argsArray.push('--no-wait'); }
-					return this.executeCommand<void>(argsArray, additionalEnvVars);
+					return this.executeCommand<void>(argsArray, additionalEnvVars, loginSession);
 				}
 			}
 		}
 	};
 
-	public login(endpoint: string, username: string, password: string, additionalEnvVars: azdataExt.AdditionalEnvVars = {}): Promise<azdataExt.AzdataOutput<void>> {
-		return this.executeCommand<void>(['login', '-e', endpoint, '-u', username], Object.assign({}, additionalEnvVars, { 'AZDATA_PASSWORD': password }));
+	public async login(endpoint: string, username: string, password: string, additionalEnvVars: azdataExt.AdditionalEnvVars = {}): Promise<azdataExt.AzdataOutput<void>> {
+		// Since login changes the context we want to wait until all currently executing commands are finished before this is executed
+		while (this._currentlyExecutingCommands.length > 0) {
+			await this._currentlyExecutingCommands[0];
+		}
+		// Logins need to be done outside the session aware logic so call impl directly
+		return this.executeCommandImpl<void>(['login', '-e', endpoint, '-u', username], Object.assign({}, additionalEnvVars, { 'AZDATA_PASSWORD': password }));
+	}
+
+	public async acquireLoginSession(endpoint: string, username: string, password: string, additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataLoginSession> {
+		const session = new AzdataLoginSession();
+		session.sessionEnded().then(async () => {
+			// Wait for all commands running for this session to end
+			while (this._currentlyExecutingCommands.length > 0) {
+				await this._currentlyExecutingCommands[0].promise;
+			}
+			this._currentLoginSession = undefined;
+			// Start our next command now that we're all done with this session
+			// TODO: Should we check if the command has a session that hasn't started? That should never happen..
+			// TODO: Look into kicking off multiple commands
+			this._queuedCommands.shift()?.deferred.resolve();
+		});
+
+		// We're not in a session or waiting on anything so just set the current session right now
+		if (!this._currentLoginSession && this._queuedCommands.length === 0) {
+			this._currentLoginSession = session;
+		} else {
+			// We're in a session or another command is executing so add this to the end of the queued commands and wait our turn
+			const deferred = new Deferred<void>();
+			deferred.promise.then(() => {
+				this._currentLoginSession = session;
+				// We've started a new session so look at all our queued commands and start
+				// the ones for this session now.
+				this._queuedCommands = this._queuedCommands.filter(c => {
+					if (c.session === this._currentLoginSession) {
+						c.deferred.resolve();
+						return false;
+					}
+					return true;
+				});
+			});
+			this._queuedCommands.push({ deferred, session: undefined });
+			await deferred.promise;
+		}
+
+		await this.login(endpoint, username, password, additionalEnvVars);
+		return session;
 	}
 
 	/**
@@ -190,7 +265,33 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 		};
 	}
 
-	public async executeCommand<R>(args: string[], additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<R>> {
+	public async executeCommand<R>(args: string[], additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<R>> {
+		if (this._currentLoginSession && this._currentLoginSession !== loginSession) {
+			const deferred = new Deferred<void>();
+			this._queuedCommands.push({ deferred, session: loginSession });
+			await deferred.promise;
+		}
+		const executingDeferred = new Deferred<void>();
+		this._currentlyExecutingCommands.push(executingDeferred);
+		try {
+			return await this.executeCommandImpl<R>(args, additionalEnvVars);
+		}
+		finally {
+			this._currentlyExecutingCommands = this._currentlyExecutingCommands.filter(c => c !== executingDeferred);
+			executingDeferred.resolve();
+			// If there isn't an active session and we still have queued commands then we have to manually kick off the next one
+			if (this._currentlyExecutingCommands.length > 0 && !this._currentLoginSession) {
+				this._queuedCommands.shift()?.deferred.resolve();
+			}
+		}
+	}
+
+	/**
+	 * Executes the specified azdata command. This is NOT session-aware so should only be used for calls that don't care about a session
+	 * @param args The args to pass to azdata
+	 * @param additionalEnvVars Additional environment variables to set for this execution
+	 */
+	private async executeCommandImpl<R>(args: string[], additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<R>> {
 		try {
 			const output = JSON.parse((await executeAzdataCommand(`"${this._path}"`, args.concat(['--output', 'json']), additionalEnvVars)).stdout);
 			return {

--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -35,7 +35,7 @@ export interface IAzdataTool extends azdataExt.IAzdataApi {
 	executeCommand<R>(args: string[], additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataOutput<R>>
 }
 
-class AzdataLoginSession implements azdataExt.AzdataLoginSession {
+class AzdataSession implements azdataExt.AzdataSession {
 
 	private _session = new Deferred<void>();
 
@@ -54,9 +54,9 @@ class AzdataLoginSession implements azdataExt.AzdataLoginSession {
 export class AzdataTool implements azdataExt.IAzdataApi {
 
 	private _semVersion: SemVer;
-	private _currentLoginSession: azdataExt.AzdataLoginSession | undefined = undefined;
+	private _currentSession: azdataExt.AzdataSession | undefined = undefined;
 	private _currentlyExecutingCommands: Deferred<void>[] = [];
-	private _queuedCommands: { deferred: Deferred<void>, session?: azdataExt.AzdataLoginSession }[] = [];
+	private _queuedCommands: { deferred: Deferred<void>, session?: azdataExt.AzdataSession }[] = [];
 
 	constructor(private _path: string, version: string) {
 		this._semVersion = new SemVer(version);
@@ -90,7 +90,7 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 				profileName?: string,
 				storageClass?: string,
 				additionalEnvVars?: azdataExt.AdditionalEnvVars,
-				loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<void>> => {
+				session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<void>> => {
 				const args = ['arc', 'dc', 'create',
 					'--namespace', namespace,
 					'--name', name,
@@ -104,32 +104,32 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 				if (storageClass) {
 					args.push('--storage-class', storageClass);
 				}
-				return this.executeCommand<void>(args, additionalEnvVars, loginSession);
+				return this.executeCommand<void>(args, additionalEnvVars, session);
 			},
 			endpoint: {
-				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.DcEndpointListResult[]>> => {
-					return this.executeCommand<azdataExt.DcEndpointListResult[]>(['arc', 'dc', 'endpoint', 'list'], additionalEnvVars, loginSession);
+				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<azdataExt.DcEndpointListResult[]>> => {
+					return this.executeCommand<azdataExt.DcEndpointListResult[]>(['arc', 'dc', 'endpoint', 'list'], additionalEnvVars, session);
 				}
 			},
 			config: {
-				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.DcConfigListResult[]>> => {
-					return this.executeCommand<azdataExt.DcConfigListResult[]>(['arc', 'dc', 'config', 'list'], additionalEnvVars, loginSession);
+				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<azdataExt.DcConfigListResult[]>> => {
+					return this.executeCommand<azdataExt.DcConfigListResult[]>(['arc', 'dc', 'config', 'list'], additionalEnvVars, session);
 				},
-				show: (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.DcConfigShowResult>> => {
-					return this.executeCommand<azdataExt.DcConfigShowResult>(['arc', 'dc', 'config', 'show'], additionalEnvVars, loginSession);
+				show: (additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<azdataExt.DcConfigShowResult>> => {
+					return this.executeCommand<azdataExt.DcConfigShowResult>(['arc', 'dc', 'config', 'show'], additionalEnvVars, session);
 				}
 			}
 		},
 		postgres: {
 			server: {
-				delete: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<void>> => {
-					return this.executeCommand<void>(['arc', 'postgres', 'server', 'delete', '-n', name, '--force'], additionalEnvVars, loginSession);
+				delete: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<void>> => {
+					return this.executeCommand<void>(['arc', 'postgres', 'server', 'delete', '-n', name, '--force'], additionalEnvVars, session);
 				},
-				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.PostgresServerListResult[]>> => {
-					return this.executeCommand<azdataExt.PostgresServerListResult[]>(['arc', 'postgres', 'server', 'list'], additionalEnvVars, loginSession);
+				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<azdataExt.PostgresServerListResult[]>> => {
+					return this.executeCommand<azdataExt.PostgresServerListResult[]>(['arc', 'postgres', 'server', 'list'], additionalEnvVars, session);
 				},
-				show: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.PostgresServerShowResult>> => {
-					return this.executeCommand<azdataExt.PostgresServerShowResult>(['arc', 'postgres', 'server', 'show', '-n', name], additionalEnvVars, loginSession);
+				show: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<azdataExt.PostgresServerShowResult>> => {
+					return this.executeCommand<azdataExt.PostgresServerShowResult>(['arc', 'postgres', 'server', 'show', '-n', name], additionalEnvVars, session);
 				},
 				edit: (
 					name: string,
@@ -148,7 +148,7 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 					},
 					engineVersion?: string,
 					additionalEnvVars?: azdataExt.AdditionalEnvVars,
-					loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<void>> => {
+					session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<void>> => {
 					const argsArray = ['arc', 'postgres', 'server', 'edit', '-n', name];
 					if (args.adminPassword) { argsArray.push('--admin-password'); }
 					if (args.coresLimit) { argsArray.push('--cores-limit', args.coresLimit); }
@@ -162,20 +162,20 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 					if (args.replaceEngineSettings) { argsArray.push('--replace-engine-settings'); }
 					if (args.workers) { argsArray.push('--workers', args.workers.toString()); }
 					if (engineVersion) { argsArray.push('--engine-version', engineVersion); }
-					return this.executeCommand<void>(argsArray, additionalEnvVars, loginSession);
+					return this.executeCommand<void>(argsArray, additionalEnvVars, session);
 				}
 			}
 		},
 		sql: {
 			mi: {
-				delete: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<void>> => {
-					return this.executeCommand<void>(['arc', 'sql', 'mi', 'delete', '-n', name], additionalEnvVars, loginSession);
+				delete: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<void>> => {
+					return this.executeCommand<void>(['arc', 'sql', 'mi', 'delete', '-n', name], additionalEnvVars, session);
 				},
-				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.SqlMiListResult[]>> => {
-					return this.executeCommand<azdataExt.SqlMiListResult[]>(['arc', 'sql', 'mi', 'list'], additionalEnvVars, loginSession);
+				list: (additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<azdataExt.SqlMiListResult[]>> => {
+					return this.executeCommand<azdataExt.SqlMiListResult[]>(['arc', 'sql', 'mi', 'list'], additionalEnvVars, session);
 				},
-				show: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<azdataExt.SqlMiShowResult>> => {
-					return this.executeCommand<azdataExt.SqlMiShowResult>(['arc', 'sql', 'mi', 'show', '-n', name], additionalEnvVars, loginSession);
+				show: (name: string, additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<azdataExt.SqlMiShowResult>> => {
+					return this.executeCommand<azdataExt.SqlMiShowResult>(['arc', 'sql', 'mi', 'show', '-n', name], additionalEnvVars, session);
 				},
 				edit: (
 					name: string,
@@ -187,7 +187,7 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 						noWait?: boolean,
 					},
 					additionalEnvVars?: azdataExt.AdditionalEnvVars,
-					loginSession?: azdataExt.AzdataLoginSession
+					session?: azdataExt.AzdataSession
 				): Promise<azdataExt.AzdataOutput<void>> => {
 					const argsArray = ['arc', 'sql', 'mi', 'edit', '-n', name];
 					if (args.coresLimit) { argsArray.push('--cores-limit', args.coresLimit); }
@@ -195,7 +195,7 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 					if (args.memoryLimit) { argsArray.push('--memory-limit', args.memoryLimit); }
 					if (args.memoryRequest) { argsArray.push('--memory-request', args.memoryRequest); }
 					if (args.noWait) { argsArray.push('--no-wait'); }
-					return this.executeCommand<void>(argsArray, additionalEnvVars, loginSession);
+					return this.executeCommand<void>(argsArray, additionalEnvVars, session);
 				}
 			}
 		}
@@ -210,14 +210,14 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 		return this.executeCommandImpl<void>(['login', '-e', endpoint, '-u', username], Object.assign({}, additionalEnvVars, { 'AZDATA_PASSWORD': password }));
 	}
 
-	public async acquireLoginSession(endpoint: string, username: string, password: string, additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataLoginSession> {
-		const session = new AzdataLoginSession();
+	public async acquireSession(endpoint: string, username: string, password: string, additionalEnvVars?: azdataExt.AdditionalEnvVars): Promise<azdataExt.AzdataSession> {
+		const session = new AzdataSession();
 		session.sessionEnded().then(async () => {
 			// Wait for all commands running for this session to end
 			while (this._currentlyExecutingCommands.length > 0) {
 				await this._currentlyExecutingCommands[0].promise;
 			}
-			this._currentLoginSession = undefined;
+			this._currentSession = undefined;
 			// Start our next command now that we're all done with this session
 			// TODO: Should we check if the command has a session that hasn't started? That should never happen..
 			// TODO: Look into kicking off multiple commands
@@ -225,17 +225,17 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 		});
 
 		// We're not in a session or waiting on anything so just set the current session right now
-		if (!this._currentLoginSession && this._queuedCommands.length === 0) {
-			this._currentLoginSession = session;
+		if (!this._currentSession && this._queuedCommands.length === 0) {
+			this._currentSession = session;
 		} else {
 			// We're in a session or another command is executing so add this to the end of the queued commands and wait our turn
 			const deferred = new Deferred<void>();
 			deferred.promise.then(() => {
-				this._currentLoginSession = session;
+				this._currentSession = session;
 				// We've started a new session so look at all our queued commands and start
 				// the ones for this session now.
 				this._queuedCommands = this._queuedCommands.filter(c => {
-					if (c.session === this._currentLoginSession) {
+					if (c.session === this._currentSession) {
 						c.deferred.resolve();
 						return false;
 					}
@@ -265,10 +265,10 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 		};
 	}
 
-	public async executeCommand<R>(args: string[], additionalEnvVars?: azdataExt.AdditionalEnvVars, loginSession?: azdataExt.AzdataLoginSession): Promise<azdataExt.AzdataOutput<R>> {
-		if (this._currentLoginSession && this._currentLoginSession !== loginSession) {
+	public async executeCommand<R>(args: string[], additionalEnvVars?: azdataExt.AdditionalEnvVars, session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<R>> {
+		if (this._currentSession && this._currentSession !== session) {
 			const deferred = new Deferred<void>();
-			this._queuedCommands.push({ deferred, session: loginSession });
+			this._queuedCommands.push({ deferred, session: session });
 			await deferred.promise;
 		}
 		const executingDeferred = new Deferred<void>();
@@ -280,7 +280,7 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 			this._currentlyExecutingCommands = this._currentlyExecutingCommands.filter(c => c !== executingDeferred);
 			executingDeferred.resolve();
 			// If there isn't an active session and we still have queued commands then we have to manually kick off the next one
-			if (this._queuedCommands.length > 0 && !this._currentLoginSession) {
+			if (this._queuedCommands.length > 0 && !this._currentSession) {
 				this._queuedCommands.shift()?.deferred.resolve();
 			}
 		}

--- a/extensions/azdata/src/test/api.test.ts
+++ b/extensions/azdata/src/test/api.test.ts
@@ -24,7 +24,7 @@ describe('api', function (): void {
 			await assertRejected(api.azdata.getPath(), 'getPath');
 			await assertRejected(api.azdata.getSemVersion(), 'getSemVersion');
 			await assertRejected(api.azdata.login('', '', ''), 'login');
-			await assertRejected(api.azdata.acquireLoginSession('', '', ''), 'acquireLoginSession');
+			await assertRejected(api.azdata.acquireSession('', '', ''), 'acquireSession');
 			await assertRejected(api.azdata.version(), 'version');
 
 			await assertRejected(api.azdata.arc.dc.create('', '', '', '', '', ''), 'arc dc create');

--- a/extensions/azdata/src/test/api.test.ts
+++ b/extensions/azdata/src/test/api.test.ts
@@ -24,6 +24,7 @@ describe('api', function (): void {
 			await assertRejected(api.azdata.getPath(), 'getPath');
 			await assertRejected(api.azdata.getSemVersion(), 'getSemVersion');
 			await assertRejected(api.azdata.login('', '', ''), 'login');
+			await assertRejected(api.azdata.acquireLoginSession('', '', ''), 'acquireLoginSession');
 			await assertRejected(api.azdata.version(), 'version');
 
 			await assertRejected(api.azdata.arc.dc.create('', '', '', '', '', ''), 'arc dc create');

--- a/extensions/azdata/src/test/azdata.test.ts
+++ b/extensions/azdata/src/test/azdata.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as azdataExt from 'azdata-ext';
 import * as should from 'should';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
@@ -16,6 +17,7 @@ import * as fs from 'fs';
 import { AzdataReleaseInfo } from '../azdataReleaseInfo';
 import * as TypeMoq from 'typemoq';
 import { eulaAccepted } from '../constants';
+import { sleep } from './testUtils';
 
 const oldAzdataMock = new azdata.AzdataTool('/path/to/azdata', '0.0.0');
 const currentAzdataMock = new azdata.AzdataTool('/path/to/azdata', '9999.999.999');
@@ -170,18 +172,6 @@ describe('azdata', function () {
 					});
 				});
 			});
-			it('login', async function (): Promise<void> {
-				const endpoint = 'myEndpoint';
-				const username = 'myUsername';
-				const password = 'myPassword';
-				await azdataTool.login(endpoint, username, password);
-				verifyExecuteCommandCalledWithArgs(['login', endpoint, username]);
-			});
-			it('version', async function (): Promise<void> {
-				executeCommandStub.resolves({ stdout: '1.0.0', stderr: '' });
-				await azdataTool.version();
-				verifyExecuteCommandCalledWithArgs(['--version']);
-			});
 			it('general error throws', async function (): Promise<void> {
 				const err = new Error();
 				executeCommandStub.throws(err);
@@ -228,12 +218,136 @@ describe('azdata', function () {
 			});
 		});
 
+		it('login', async function (): Promise<void> {
+			const endpoint = 'myEndpoint';
+			const username = 'myUsername';
+			const password = 'myPassword';
+			await azdataTool.login(endpoint, username, password);
+			verifyExecuteCommandCalledWithArgs(['login', endpoint, username]);
+		});
+
+		describe('acquireLoginSession', function (): void {
+			it('calls login', async function (): Promise<void> {
+				const endpoint = 'myEndpoint';
+				const username = 'myUsername';
+				const password = 'myPassword';
+				const session = await azdataTool.acquireLoginSession(endpoint, username, password);
+				session.dispose();
+				verifyExecuteCommandCalledWithArgs(['login', endpoint, username]);
+			});
+
+			it('command executed under current session completes', async function (): Promise<void> {
+				const session = await azdataTool.acquireLoginSession('', '', '');
+				try {
+					await azdataTool.arc.dc.config.show(undefined, session);
+				} finally {
+					session.dispose();
+				}
+				verifyExecuteCommandCalledWithArgs(['login'], 0);
+				verifyExecuteCommandCalledWithArgs(['arc', 'dc', 'config', 'show'], 1);
+			});
+			it('multiple commands executed under current session completes', async function (): Promise<void> {
+				const session = await azdataTool.acquireLoginSession('', '', '');
+				try {
+					// Kick off multiple commands at the same time and then ensure that they both complete
+					await Promise.all([
+						azdataTool.arc.dc.config.show(undefined, session),
+						azdataTool.arc.sql.mi.list(undefined, session)
+					]);
+				} finally {
+					session.dispose();
+				}
+				verifyExecuteCommandCalledWithArgs(['login'], 0);
+				verifyExecuteCommandCalledWithArgs(['arc', 'dc', 'config', 'show'], 1);
+				verifyExecuteCommandCalledWithArgs(['arc', 'sql', 'mi', 'list'], 2);
+			});
+			it('command executed without session context is queued up until session is closed', async function (): Promise<void> {
+				const session = await azdataTool.acquireLoginSession('', '', '');
+				let nonSessionCommand: Promise<any> | undefined = undefined;
+				try {
+					// Start one command in the current session
+					await azdataTool.arc.dc.config.show(undefined, session);
+					// Verify that the command isn't executed until after the session is disposed
+					let isFulfilled = false;
+					nonSessionCommand = azdataTool.arc.sql.mi.list().then(() => isFulfilled = true);
+					await sleep(2000);
+					should(isFulfilled).equal(false, 'The command should not be completed yet');
+				} finally {
+					session.dispose();
+				}
+				await nonSessionCommand;
+				verifyExecuteCommandCalledWithArgs(['login'], 0);
+				verifyExecuteCommandCalledWithArgs(['arc', 'dc', 'config', 'show'], 1);
+				verifyExecuteCommandCalledWithArgs(['arc', 'sql', 'mi', 'list'], 2);
+			});
+			it('multiple commands executed without session context are queued up until session is closed', async function (): Promise<void> {
+				const session = await azdataTool.acquireLoginSession('', '', '');
+				let nonSessionCommand1: Promise<any> | undefined = undefined;
+				let nonSessionCommand2: Promise<any> | undefined = undefined;
+				try {
+					// Start one command in the current session
+					await azdataTool.arc.dc.config.show(undefined, session);
+					// Verify that neither command is completed until the session is closed
+					let isFulfilled = false;
+					nonSessionCommand1 = azdataTool.arc.sql.mi.list().then(() => isFulfilled = true);
+					nonSessionCommand2 = azdataTool.arc.postgres.server.list().then(() => isFulfilled = true);
+					await sleep(2000);
+					should(isFulfilled).equal(false, 'The commands should not be completed yet');
+				} finally {
+					session.dispose();
+				}
+				await Promise.all([nonSessionCommand1, nonSessionCommand2]);
+				verifyExecuteCommandCalledWithArgs(['login'], 0);
+				verifyExecuteCommandCalledWithArgs(['arc', 'dc', 'config', 'show'], 1);
+				verifyExecuteCommandCalledWithArgs(['arc', 'sql', 'mi', 'list'], 2);
+				verifyExecuteCommandCalledWithArgs(['arc', 'postgres', 'server', 'list'], 3);
+			});
+			it('attempting to acquire a second session while a first is still active queues the second session', async function (): Promise<void> {
+				const firstSession = await azdataTool.acquireLoginSession('', '', '');
+				let loginSessionPromise: Promise<azdataExt.AzdataLoginSession> | undefined = undefined;
+				let secondSessionCommand: Promise<any> | undefined = undefined;
+				try {
+					try {
+						// Start one command in the current session
+						await azdataTool.arc.dc.config.show(undefined, firstSession);
+						// Verify that none of the commands for the second session are completed before the first is disposed
+						let isFulfilled = false;
+						loginSessionPromise = azdataTool.acquireLoginSession('', '', '');
+						loginSessionPromise.then(session => {
+							isFulfilled = true;
+							secondSessionCommand = azdataTool.arc.sql.mi.list(undefined, session).then(() => isFulfilled = true);
+						});
+						await sleep(2000);
+						should(isFulfilled).equal(false, 'The commands should not be completed yet');
+					} finally {
+						firstSession.dispose();
+					}
+				} finally {
+					(await loginSessionPromise)?.dispose();
+				}
+				should(secondSessionCommand).not.equal(undefined, 'The second command should have been queued already');
+				await secondSessionCommand!;
+
+
+				verifyExecuteCommandCalledWithArgs(['login'], 0);
+				verifyExecuteCommandCalledWithArgs(['arc', 'dc', 'config', 'show'], 1);
+				verifyExecuteCommandCalledWithArgs(['login'], 2);
+				verifyExecuteCommandCalledWithArgs(['arc', 'sql', 'mi', 'list'], 3);
+			});
+		});
+
+		it('version', async function (): Promise<void> {
+			executeCommandStub.resolves({ stdout: '1.0.0', stderr: '' });
+			await azdataTool.version();
+			verifyExecuteCommandCalledWithArgs(['--version']);
+		});
+
 		/**
 		 * Verifies that the specified args were included in the call to executeCommand
 		 * @param args The args to check were included in the execute command call
 		 */
-		function verifyExecuteCommandCalledWithArgs(args: string[]): void {
-			const commandArgs = executeCommandStub.args[0][1] as string[];
+		function verifyExecuteCommandCalledWithArgs(args: string[], callIndex = 0): void {
+			const commandArgs = executeCommandStub.args[callIndex][1] as string[];
 			args.forEach(arg => should(commandArgs).containEql(arg));
 		}
 
@@ -469,8 +583,8 @@ describe('azdata', function () {
 		});
 	});
 
-	describe('promptForEula', function(): void {
-		it('skipped because of config', async function(): Promise<void> {
+	describe('promptForEula', function (): void {
+		it('skipped because of config', async function (): Promise<void> {
 			const configMock = TypeMoq.Mock.ofType<vscode.WorkspaceConfiguration>();
 			configMock.setup(x => x.get(TypeMoq.It.isAny())).returns(() => azdata.AzdataDeployOption.dontPrompt);
 			sinon.stub(vscode.workspace, 'getConfiguration').returns(configMock.object);
@@ -479,7 +593,7 @@ describe('azdata', function () {
 			should(result).be.false();
 		});
 
-		it('always prompt if user requested', async function(): Promise<void> {
+		it('always prompt if user requested', async function (): Promise<void> {
 			const configMock = TypeMoq.Mock.ofType<vscode.WorkspaceConfiguration>();
 			configMock.setup(x => x.get(TypeMoq.It.isAny())).returns(() => azdata.AzdataDeployOption.dontPrompt);
 			sinon.stub(vscode.workspace, 'getConfiguration').returns(configMock.object);
@@ -490,7 +604,7 @@ describe('azdata', function () {
 			should(showInformationMessage.calledOnce).be.true('showInformationMessage should have been called to prompt user');
 		});
 
-		it('prompt if config set to do so', async function(): Promise<void> {
+		it('prompt if config set to do so', async function (): Promise<void> {
 			const configMock = TypeMoq.Mock.ofType<vscode.WorkspaceConfiguration>();
 			configMock.setup(x => x.get(TypeMoq.It.isAny())).returns(() => azdata.AzdataDeployOption.prompt);
 			sinon.stub(vscode.workspace, 'getConfiguration').returns(configMock.object);
@@ -501,7 +615,7 @@ describe('azdata', function () {
 			should(showInformationMessage.calledOnce).be.true('showInformationMessage should have been called to prompt user');
 		});
 
-		it('update config if user chooses not to prompt', async function(): Promise<void> {
+		it('update config if user chooses not to prompt', async function (): Promise<void> {
 			const configMock = TypeMoq.Mock.ofType<vscode.WorkspaceConfiguration>();
 			configMock.setup(x => x.get(TypeMoq.It.isAny())).returns(() => azdata.AzdataDeployOption.prompt);
 			sinon.stub(vscode.workspace, 'getConfiguration').returns(configMock.object);
@@ -513,7 +627,7 @@ describe('azdata', function () {
 			should(showInformationMessage.calledOnce).be.true('showInformationMessage should have been called to prompt user');
 		});
 
-		it('user accepted EULA', async function(): Promise<void> {
+		it('user accepted EULA', async function (): Promise<void> {
 			const configMock = TypeMoq.Mock.ofType<vscode.WorkspaceConfiguration>();
 			configMock.setup(x => x.get(TypeMoq.It.isAny())).returns(() => azdata.AzdataDeployOption.prompt);
 			sinon.stub(vscode.workspace, 'getConfiguration').returns(configMock.object);
@@ -525,7 +639,7 @@ describe('azdata', function () {
 			should(showInformationMessage.calledOnce).be.true('showInformationMessage should have been called to prompt user');
 		});
 
-		it('user accepted EULA - require user action', async function(): Promise<void> {
+		it('user accepted EULA - require user action', async function (): Promise<void> {
 			const configMock = TypeMoq.Mock.ofType<vscode.WorkspaceConfiguration>();
 			configMock.setup(x => x.get(TypeMoq.It.isAny())).returns(() => azdata.AzdataDeployOption.prompt);
 			sinon.stub(vscode.workspace, 'getConfiguration').returns(configMock.object);
@@ -538,7 +652,7 @@ describe('azdata', function () {
 		});
 	});
 
-	describe('isEulaAccepted', function(): void {
+	describe('isEulaAccepted', function (): void {
 		const mementoMock = TypeMoq.Mock.ofType<vscode.Memento>();
 		mementoMock.setup(x => x.get(TypeMoq.It.isAny())).returns(() => true);
 		should(azdata.isEulaAccepted(mementoMock.object)).be.true();

--- a/extensions/azdata/src/test/testUtils.ts
+++ b/extensions/azdata/src/test/testUtils.ts
@@ -18,3 +18,7 @@ export async function assertRejected(promise: Promise<any>, message: string): Pr
 	throw new Error(message);
 }
 
+export async function sleep(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+

--- a/extensions/azdata/src/typings/azdata-ext.d.ts
+++ b/extensions/azdata/src/typings/azdata-ext.d.ts
@@ -5,6 +5,7 @@
 
 declare module 'azdata-ext' {
 	import { SemVer } from 'semver';
+	import * as vscode from 'vscode';
 
 	/**
 	 * Covers defining what the azdata extension exports to other extensions
@@ -232,23 +233,25 @@ declare module 'azdata-ext' {
 		code?: number
 	}
 
+	export interface AzdataLoginSession extends vscode.Disposable { }
+
 	export interface IAzdataApi {
 		arc: {
 			dc: {
-				create(namespace: string, name: string, connectivityMode: string, resourceGroup: string, location: string, subscription: string, profileName?: string, storageClass?: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<void>>,
+				create(namespace: string, name: string, connectivityMode: string, resourceGroup: string, location: string, subscription: string, profileName?: string, storageClass?: string, additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<void>>,
 				endpoint: {
-					list(additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<DcEndpointListResult[]>>
+					list(additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<DcEndpointListResult[]>>
 				},
 				config: {
-					list(additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<DcConfigListResult[]>>,
-					show(additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<DcConfigShowResult>>
+					list(additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<DcConfigListResult[]>>,
+					show(additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<DcConfigShowResult>>
 				}
 			},
 			postgres: {
 				server: {
-					delete(name: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<void>>,
-					list(additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<PostgresServerListResult[]>>,
-					show(name: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<PostgresServerShowResult>>,
+					delete(name: string, additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<void>>,
+					list(additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<PostgresServerListResult[]>>,
+					show(name: string, additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<PostgresServerShowResult>>,
 					edit(
 						name: string,
 						args: {
@@ -265,15 +268,16 @@ declare module 'azdata-ext' {
 							workers?: number
 						},
 						engineVersion?: string,
-						additionalEnvVars?: AdditionalEnvVars
+						additionalEnvVars?: AdditionalEnvVars,
+						loginSession?: AzdataLoginSession
 					): Promise<AzdataOutput<void>>
 				}
 			},
 			sql: {
 				mi: {
-					delete(name: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<void>>,
-					list(additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<SqlMiListResult[]>>,
-					show(name: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<SqlMiShowResult>>,
+					delete(name: string, additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<void>>,
+					list(additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<SqlMiListResult[]>>,
+					show(name: string, additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<SqlMiShowResult>>,
 					edit(
 						name: string,
 						args: {
@@ -283,13 +287,23 @@ declare module 'azdata-ext' {
 							memoryRequest?: string,
 							noWait?: boolean,
 						},
-						additionalEnvVars?: AdditionalEnvVars
+						additionalEnvVars?: AdditionalEnvVars,
+						loginSession?: AzdataLoginSession
 					): Promise<AzdataOutput<void>>
 				}
 			}
 		},
 		getPath(): Promise<string>,
-		login(endpoint: string, username: string, password: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<any>>,
+		login(endpoint: string, username: string, password: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<void>>,
+		/**
+		 * Acquires a session for the specified controller, which will log in to the specified controller and then block all other commands
+		 * from executing until the session is released (disposed).
+		 * @param endpoint
+		 * @param username
+		 * @param password
+		 * @param additionalEnvVars
+		 */
+		acquireLoginSession(endpoint: string, username: string, password: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzdataLoginSession>,
 		/**
 		 * The semVersion corresponding to this installation of azdata. version() method should have been run
 		 * before fetching this value to ensure that correct value is returned. This is almost always correct unless

--- a/extensions/azdata/src/typings/azdata-ext.d.ts
+++ b/extensions/azdata/src/typings/azdata-ext.d.ts
@@ -233,25 +233,25 @@ declare module 'azdata-ext' {
 		code?: number
 	}
 
-	export interface AzdataLoginSession extends vscode.Disposable { }
+	export interface AzdataSession extends vscode.Disposable { }
 
 	export interface IAzdataApi {
 		arc: {
 			dc: {
-				create(namespace: string, name: string, connectivityMode: string, resourceGroup: string, location: string, subscription: string, profileName?: string, storageClass?: string, additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<void>>,
+				create(namespace: string, name: string, connectivityMode: string, resourceGroup: string, location: string, subscription: string, profileName?: string, storageClass?: string, additionalEnvVars?: AdditionalEnvVars, session?: AzdataSession): Promise<AzdataOutput<void>>,
 				endpoint: {
-					list(additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<DcEndpointListResult[]>>
+					list(additionalEnvVars?: AdditionalEnvVars, session?: AzdataSession): Promise<AzdataOutput<DcEndpointListResult[]>>
 				},
 				config: {
-					list(additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<DcConfigListResult[]>>,
-					show(additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<DcConfigShowResult>>
+					list(additionalEnvVars?: AdditionalEnvVars, session?: AzdataSession): Promise<AzdataOutput<DcConfigListResult[]>>,
+					show(additionalEnvVars?: AdditionalEnvVars, session?: AzdataSession): Promise<AzdataOutput<DcConfigShowResult>>
 				}
 			},
 			postgres: {
 				server: {
-					delete(name: string, additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<void>>,
-					list(additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<PostgresServerListResult[]>>,
-					show(name: string, additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<PostgresServerShowResult>>,
+					delete(name: string, additionalEnvVars?: AdditionalEnvVars, session?: AzdataSession): Promise<AzdataOutput<void>>,
+					list(additionalEnvVars?: AdditionalEnvVars, session?: AzdataSession): Promise<AzdataOutput<PostgresServerListResult[]>>,
+					show(name: string, additionalEnvVars?: AdditionalEnvVars, session?: AzdataSession): Promise<AzdataOutput<PostgresServerShowResult>>,
 					edit(
 						name: string,
 						args: {
@@ -269,15 +269,15 @@ declare module 'azdata-ext' {
 						},
 						engineVersion?: string,
 						additionalEnvVars?: AdditionalEnvVars,
-						loginSession?: AzdataLoginSession
+						session?: AzdataSession
 					): Promise<AzdataOutput<void>>
 				}
 			},
 			sql: {
 				mi: {
-					delete(name: string, additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<void>>,
-					list(additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<SqlMiListResult[]>>,
-					show(name: string, additionalEnvVars?: AdditionalEnvVars, loginSession?: AzdataLoginSession): Promise<AzdataOutput<SqlMiShowResult>>,
+					delete(name: string, additionalEnvVars?: AdditionalEnvVars, session?: AzdataSession): Promise<AzdataOutput<void>>,
+					list(additionalEnvVars?: AdditionalEnvVars, session?: AzdataSession): Promise<AzdataOutput<SqlMiListResult[]>>,
+					show(name: string, additionalEnvVars?: AdditionalEnvVars, session?: AzdataSession): Promise<AzdataOutput<SqlMiShowResult>>,
 					edit(
 						name: string,
 						args: {
@@ -288,7 +288,7 @@ declare module 'azdata-ext' {
 							noWait?: boolean,
 						},
 						additionalEnvVars?: AdditionalEnvVars,
-						loginSession?: AzdataLoginSession
+						session?: AzdataSession
 					): Promise<AzdataOutput<void>>
 				}
 			}
@@ -297,13 +297,13 @@ declare module 'azdata-ext' {
 		login(endpoint: string, username: string, password: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzdataOutput<void>>,
 		/**
 		 * Acquires a session for the specified controller, which will log in to the specified controller and then block all other commands
-		 * from executing until the session is released (disposed).
+		 * that are not part of the original session from executing until the session is released (disposed).
 		 * @param endpoint
 		 * @param username
 		 * @param password
 		 * @param additionalEnvVars
 		 */
-		acquireLoginSession(endpoint: string, username: string, password: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzdataLoginSession>,
+		acquireSession(endpoint: string, username: string, password: string, additionalEnvVars?: AdditionalEnvVars): Promise<AzdataSession>,
 		/**
 		 * The semVersion corresponding to this installation of azdata. version() method should have been run
 		 * before fetching this value to ensure that correct value is returned. This is almost always correct unless


### PR DESCRIPTION
This adds a new function - acquireLoginSession. When this is called it will create a session and (if there are no other active sessions) set the context such that only calls made for that specific session are allowed to execute. All other commands are queued up until the session is disposed (released) at which point it will start executing those commands (creating new sessions as requested).

There's still a lot of polish that needs to go into this - as well as tests. Getting this out now for early feedback on approach and any immediate issues seen.

This is also fixing a couple of places where we weren't passing in the additional env vars to calls such as MI edit. These additional vars need to be set to the current controller vars so that we correctly set the kube config vars when executing commands - otherwise we may end up executing commands against the wrong cluster (even if we do a login beforehand, since the login only sets the controller context. Not the kube context). 

Fixes https://github.com/microsoft/azuredatastudio/issues/13875