### PR TITLE
Skip checking if python is running when only doing package upgrades during python install.

### DIFF
--- a/extensions/notebook/src/dialog/configurePython/configurePathPage.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePathPage.ts
@@ -151,6 +151,9 @@ export class ConfigurePathPage extends BasePage {
 
 			this.model.pythonLocation = pythonLocation;
 			this.model.useExistingPython = !!this.existingInstallButton.checked;
+			this.model.packageUpgradeOnly = false;
+		} else {
+			this.model.packageUpgradeOnly = true;
 		}
 		return true;
 	}

--- a/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
+++ b/extensions/notebook/src/dialog/configurePython/configurePythonWizard.ts
@@ -23,6 +23,7 @@ export interface ConfigurePythonModel {
 	pythonPathLookup: PythonPathLookup;
 	packagesToInstall: PythonPkgDetails[];
 	installation: JupyterServerInstallation;
+	packageUpgradeOnly: boolean;
 }
 
 export class ConfigurePythonWizard {
@@ -164,7 +165,8 @@ export class ConfigurePythonWizard {
 		let installSettings: PythonInstallSettings = {
 			installPath: pythonLocation,
 			existingPython: useExistingPython,
-			packages: this.model.packagesToInstall
+			packages: this.model.packagesToInstall,
+			packageUpgradeOnly: this.model.packageUpgradeOnly
 		};
 		this.jupyterInstallation.startInstallProcess(false, installSettings)
 			.then(() => {

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -40,6 +40,7 @@ export interface PythonInstallSettings {
 	installPath: string;
 	existingPython: boolean;
 	packages: PythonPkgDetails[];
+	packageUpgradeOnly?: boolean;
 }
 export interface IJupyterServerInstallation {
 	installCondaPackages(packages: PythonPkgDetails[], useMinVersion: boolean): Promise<void>;
@@ -374,7 +375,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		// Check if Python is running before attempting to overwrite the installation.
 		// This step is skipped when using an existing installation, since we only add
 		// extra packages in that case and don't modify the install itself.
-		if (!installSettings.existingPython) {
+		if (!installSettings.existingPython && !installSettings.packageUpgradeOnly) {
 			let pythonExePath = JupyterServerInstallation.getPythonExePath(installSettings.installPath, false);
 			let isPythonRunning = await this.isPythonRunning(pythonExePath);
 			if (isPythonRunning) {

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -373,8 +373,8 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		}
 
 		// Check if Python is running before attempting to overwrite the installation.
-		// This step is skipped when using an existing installation, since we only add
-		// extra packages in that case and don't modify the install itself.
+		// This step is skipped when using an existing installation or when upgrading
+		// packages, since those cases wouldn't overwrite the installation.
 		if (!installSettings.existingPython && !installSettings.packageUpgradeOnly) {
 			let pythonExePath = JupyterServerInstallation.getPythonExePath(installSettings.installPath, false);
 			let isPythonRunning = await this.isPythonRunning(pythonExePath);


### PR DESCRIPTION
This PR fixes #13215

We throw an error during python installation if we're on Windows and Python is already running out of the specified install location. This is because Windows will throw file permission errors if we try to overwrite files that are currently in use. This same error was getting thrown when trying to install new pip packages after clicking on a notebook kernel, but we can install new pip packages without encountering any of those file permission errors. So I added a flag to skip the python-is-running check if we only want to install pip packages during setup.