### PR TITLE
Fix parameters page to show parameters if settings already loaded

### DIFF
--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -30,6 +30,8 @@ export const newSupportRequest = localize('arc.newSupportRequest', "New support 
 export const diagnoseAndSolveProblems = localize('arc.diagnoseAndSolveProblems', "Diagnose and solve problems");
 export const supportAndTroubleshooting = localize('arc.supportAndTroubleshooting', "Support + troubleshooting");
 export const resourceHealth = localize('arc.resourceHealth', "Resource health");
+export const parameterName = localize('arc.parameterName', "Parameter Name");
+export const value = localize('arc.value', "Value");
 
 export const newInstance = localize('arc.createNew', "New Instance");
 export const deleteText = localize('arc.delete', "Delete");

--- a/extensions/arc/src/ui/dashboards/postgres/postgresParametersPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresParametersPage.ts
@@ -91,7 +91,7 @@ export class PostgresParametersPage extends DashboardPage {
 			width: '100%',
 			columns: [
 				{
-					displayName: 'Parameter Name',
+					displayName: loc.parameterName,
 					valueType: azdata.DeclarativeDataType.string,
 					isReadOnly: true,
 					width: '20%',
@@ -99,7 +99,7 @@ export class PostgresParametersPage extends DashboardPage {
 					rowCssStyles: cssStyles.tableRow
 				},
 				{
-					displayName: 'Value',
+					displayName: loc.value,
 					valueType: azdata.DeclarativeDataType.component,
 					isReadOnly: false,
 					width: '20%',
@@ -107,7 +107,7 @@ export class PostgresParametersPage extends DashboardPage {
 					rowCssStyles: cssStyles.tableRow
 				},
 				{
-					displayName: 'Description',
+					displayName: loc.description,
 					valueType: azdata.DeclarativeDataType.string,
 					isReadOnly: true,
 					width: '50%',
@@ -121,7 +121,7 @@ export class PostgresParametersPage extends DashboardPage {
 					}
 				},
 				{
-					displayName: 'Reset To Default',
+					displayName: loc.resetToDefault,
 					valueType: azdata.DeclarativeDataType.component,
 					isReadOnly: false,
 					width: '10%',
@@ -536,6 +536,7 @@ export class PostgresParametersPage extends DashboardPage {
 			this.parameterContainer!.addItem(this._parametersTableLoading!);
 		} else {
 			this.parameterContainer!.addItem(this.parametersTable!);
+			this.refreshParametersTable();
 		}
 	}
 


### PR DESCRIPTION
Currently if you close the dashboard and re-open it the table will be blank since it never reloads the data into the table when the settings have already been loaded (it was only doing that when the connect button was clicked).

Also localized a few strings that weren't I noticed while working on this. 