### PR TITLE
Remove unnecessary addItem from DeclarativeTable component

### DIFF
--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
@@ -277,23 +277,6 @@ export default class DeclarativeTableComponent extends ContainerBase<any, azdata
 		if (isDataPropertyChanged) {
 			this.clearContainer();
 			this._data = finalData;
-			this.data?.forEach(row => {
-				for (let i = 0; i < row.length; i++) {
-					if (this.isComponent(i)) {
-						const itemDescriptor = this.getItemDescriptor(row[i].value as string);
-						if (itemDescriptor) {
-							this.addToContainer(itemDescriptor, {});
-						} else {
-							// This should ideally never happen but it's possible for a race condition to happen when adding/removing components quickly where
-							// the child component is unregistered after it is defined because a component is only unregistered when it's destroyed by Angular
-							// which can take a while and we don't wait on that to happen currently.
-							// While this happening isn't desirable it typically doesn't have a huge impact since the component will still be displayed properly in
-							// most cases
-							this.logService.warn(`Could not find ItemDescriptor for component ${row[i].value} when adding to DeclarativeTable ${this.descriptor.id}`);
-						}
-					}
-				}
-			});
 		}
 		super.setProperties(properties);
 	}


### PR DESCRIPTION
We already add the items on the extension host side (https://github.com/microsoft/azuredatastudio/blob/main/src/sql/workbench/api/common/extHostModelView.ts#L1593) and so this should be unnecessary as far as I can tell. 

And getting rid of this gets rid of all the "Could not find ItemDescriptor..." warnings that were showing up - the reason being that when the property was set the child component may have not been created yet and so wasn't in the model store. addItem from the extension host side will ensure that the component is created before it adds it to the items of the table container. 