### PR TITLE
Use a minimum cell height to prevent whitespace markdown cells from becoming invisible.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/media/markdown.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/media/markdown.css
@@ -6,6 +6,7 @@
 .notebook-preview {
 	font-size: 14px;
 	line-height: 22px;
+	min-height: 22px;
 	word-wrap: break-word;
 }
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -222,15 +222,12 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		let contentChanged = contentJoined !== cellModelSourceJoined || cellModelSourceJoined.length === 0 || this._previewMode === true;
 		if (trustedChanged || contentChanged) {
 			this._lastTrustedMode = this.cellModel.trustedMode;
-			let setPlaceholderText = () => {
+			if ((!cellModelSourceJoined) && !this.isEditMode) {
 				if (this.doubleClickEditEnabled) {
 					this._content = localize('doubleClickEdit', "<i>Double-click to edit</i>");
 				} else {
 					this._content = localize('addContent', "<i>Add content here...</i>");
 				}
-			};
-			if ((!cellModelSourceJoined) && !this.isEditMode) {
-				setPlaceholderText();
 			} else {
 				this._content = this.cellModel.source;
 			}
@@ -246,12 +243,6 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 				outputElement.innerHTML = this.markdownResult.element.innerHTML;
 				outputElement.style.lineHeight = this.markdownPreviewLineHeight.toString();
 				this.cellModel.renderedOutputTextContent = this.getRenderedTextOutput();
-				let hasTextContent = this.cellModel.renderedOutputTextContent.some(text => text && text.trim() !== '');
-				if (!hasTextContent) {
-					// Some text (like rich-text tabs) can get reduced to an empty string after markdown rendering,
-					// so re-add the placeholder here so that the cell doesn't become invisible.
-					setPlaceholderText();
-				}
 				outputElement.focus();
 			}
 		}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -222,12 +222,15 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		let contentChanged = contentJoined !== cellModelSourceJoined || cellModelSourceJoined.length === 0 || this._previewMode === true;
 		if (trustedChanged || contentChanged) {
 			this._lastTrustedMode = this.cellModel.trustedMode;
-			if ((!cellModelSourceJoined) && !this.isEditMode) {
+			let setPlaceholderText = () => {
 				if (this.doubleClickEditEnabled) {
 					this._content = localize('doubleClickEdit', "<i>Double-click to edit</i>");
 				} else {
 					this._content = localize('addContent', "<i>Add content here...</i>");
 				}
+			};
+			if ((!cellModelSourceJoined) && !this.isEditMode) {
+				setPlaceholderText();
 			} else {
 				this._content = this.cellModel.source;
 			}
@@ -243,6 +246,12 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 				outputElement.innerHTML = this.markdownResult.element.innerHTML;
 				outputElement.style.lineHeight = this.markdownPreviewLineHeight.toString();
 				this.cellModel.renderedOutputTextContent = this.getRenderedTextOutput();
+				let hasTextContent = this.cellModel.renderedOutputTextContent.some(text => text && text.trim() !== '');
+				if (!hasTextContent) {
+					// Some text (like rich-text tabs) can get reduced to an empty string after markdown rendering,
+					// so re-add the placeholder here so that the cell doesn't become invisible.
+					setPlaceholderText();
+				}
 				outputElement.focus();
 			}
 		}


### PR DESCRIPTION
Currently if you type only tab characters into a rich-text markdown cell, the cell itself will collapse to a height of 1px when you click away. This is because we set a minimum line-height for the preview cell's contents, but not the cell itself. Ideally we should be displaying the "Double-click to edit" placeholder when we have rich-text whitespace like this, but that's proving to be a bit complicated since rich-text "whitespace" doesn't always use actual whitespace characters. Typing a bunch of tabs results in the output containing a bunch of angle brackets instead ("> > > > > >"), which looks like valid text to the rest of the notebook code. This is a partial fix for now since it at least makes the cell clickable, but the markdown preview will still look blank on the page.
