### PR TITLE
Fix validation errors

### DIFF
--- a/src/sql/platform/dashboard/browser/interfaces.ts
+++ b/src/sql/platform/dashboard/browser/interfaces.ts
@@ -77,7 +77,7 @@ export interface IModelStore {
 	/**
 	 * Run all validations for the given component and return the new validation value
 	 */
-	validate(component: IComponent): Thenable<boolean>;
+	validate(component: IComponent): Promise<boolean>;
 }
 
 /**

--- a/src/sql/workbench/browser/modelComponents/modelStore.ts
+++ b/src/sql/workbench/browser/modelComponents/modelStore.ts
@@ -76,9 +76,9 @@ export class ModelStore implements IModelStore {
 		this._validationCallbacks.push(callback);
 	}
 
-	validate(component: IComponent): Thenable<boolean> {
-		let componentId = entries(this._componentMappings).find(([id, mappedComponent]) => component === mappedComponent)[0];
-		return Promise.all(this._validationCallbacks.map(callback => callback(componentId))).then(validations => validations.every(validation => validation === true));
+	async validate(component: IComponent): Promise<boolean> {
+		const validations = await Promise.all(this._validationCallbacks.map(callback => callback(component.descriptor.id)));
+		return validations.every(validation => validation === true);
 	}
 
 	/**

--- a/src/sql/workbench/browser/modelComponents/modelStore.ts
+++ b/src/sql/workbench/browser/modelComponents/modelStore.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Deferred } from 'sql/base/common/promise';
-import { entries } from 'sql/base/common/collections';
 import { IComponentDescriptor, IModelStore, IComponent } from 'sql/platform/dashboard/browser/interfaces';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { ILogService } from 'vs/platform/log/common/log';


### PR DESCRIPTION
This fixes the occasional `can't read property 0 of undefined` errors that would show up occasionally. Sometimes the validations would be called for components that weren't actually in the store yet so the mapping table didn't have them. But we don't even need to do that in the first place - all we care about is the component ID so it doesn't make sense to look up the mapping anyways. 

I didn't dig into more of the reason why the validations were being called early in the first place so there may still be some underlying issues here. But this should at least expose them more directly instead of just as this original generic error. 