### PR TITLE
Clean up button component disposables

### DIFF
--- a/src/sql/platform/theme/common/styler.ts
+++ b/src/sql/platform/theme/common/styler.ts
@@ -283,7 +283,7 @@ export function attachEditableDropdownStyler(widget: IThemable, themeService: IT
 	}, widget);
 }
 
-export type ButtonStyle = {
+type ButtonStyle = {
 	buttonForeground?: cr.ColorIdentifier,
 	buttonBackground?: cr.ColorIdentifier,
 	buttonHoverBackground?: cr.ColorIdentifier,

--- a/src/sql/platform/theme/common/styler.ts
+++ b/src/sql/platform/theme/common/styler.ts
@@ -283,12 +283,14 @@ export function attachEditableDropdownStyler(widget: IThemable, themeService: IT
 	}, widget);
 }
 
-export function attachButtonStyler(widget: IThemable, themeService: IThemeService, style?: {
+export type ButtonStyle = {
 	buttonForeground?: cr.ColorIdentifier,
 	buttonBackground?: cr.ColorIdentifier,
 	buttonHoverBackground?: cr.ColorIdentifier,
 	buttonFocusOutline?: cr.ColorIdentifier
-}): IDisposable {
+};
+
+export function attachButtonStyler(widget: IThemable, themeService: IThemeService, style?: ButtonStyle): IDisposable {
 	return attachStyler(themeService, {
 		buttonForeground: (style && style.buttonForeground) || cr.buttonForeground,
 		buttonBackground: (style && style.buttonBackground) || cr.buttonBackground,

--- a/src/sql/workbench/browser/modelComponents/button.component.ts
+++ b/src/sql/workbench/browser/modelComponents/button.component.ts
@@ -11,7 +11,7 @@ import {
 import * as azdata from 'azdata';
 
 import { ComponentWithIconBase } from 'sql/workbench/browser/modelComponents/componentWithIconBase';
-import { attachButtonStyler, ButtonStyle } from 'sql/platform/theme/common/styler';
+import { attachButtonStyler } from 'sql/platform/theme/common/styler';
 
 import { SIDE_BAR_BACKGROUND, SIDE_BAR_TITLE_FOREGROUND } from 'vs/workbench/common/theme';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
@@ -24,12 +24,6 @@ import { convertSize } from 'sql/base/browser/dom';
 import { createIconCssClass } from 'sql/workbench/browser/modelComponents/iconUtils';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IDisposable } from 'vs/base/common/lifecycle';
-
-const NoIconButtonStyle: ButtonStyle = {
-	buttonBackground: SIDE_BAR_BACKGROUND,
-	buttonHoverBackground: SIDE_BAR_BACKGROUND,
-	buttonForeground: SIDE_BAR_TITLE_FOREGROUND
-};
 
 @Component({
 	selector: 'modelview-button',
@@ -96,7 +90,7 @@ export default class ButtonComponent extends ComponentWithIconBase<azdata.Button
 		}
 
 		this._register(this._button);
-		this._buttonStyler = this._register(attachButtonStyler(this._button, this.themeService, NoIconButtonStyle));
+		this.updateStyler();
 		this._register(this._button.onDidClick(e => {
 			if (this._fileInputContainer) {
 				const self = this;
@@ -124,6 +118,7 @@ export default class ButtonComponent extends ComponentWithIconBase<azdata.Button
 			}
 		}));
 	}
+
 	public setProperties(properties: { [key: string]: any; }): void {
 		super.setProperties(properties);
 		if (this._currentButtonType !== this.buttonType) {
@@ -183,21 +178,36 @@ export default class ButtonComponent extends ComponentWithIconBase<azdata.Button
 			if (!this._iconClass) {
 				super.updateIcon();
 				this._button.icon = this._iconClass + ' icon';
-				this._buttonStyler?.dispose();
-				// Styling for icon button
-				this._register(attachButtonStyler(this._button, this.themeService, {
-					buttonBackground: Color.transparent.toString(),
-					buttonHoverBackground: Color.transparent.toString(),
-					buttonFocusOutline: focusBorder,
-					buttonForeground: foreground
-				}));
+				this.updateStyler();
 			} else {
 				super.updateIcon();
 			}
 		} else {
-			this._buttonStyler?.dispose();
-			this._register(attachButtonStyler(this._button, this.themeService, NoIconButtonStyle));
+			this.updateStyler();
 		}
+	}
+
+	/**
+	 * Updates the styler for this button based on whether it has an icon or not
+	 */
+	private updateStyler(): void {
+		this._buttonStyler?.dispose();
+		if (this.iconPath) {
+			this._buttonStyler = this._register(attachButtonStyler(this._button, this.themeService, {
+				buttonBackground: Color.transparent.toString(),
+				buttonHoverBackground: Color.transparent.toString(),
+				buttonFocusOutline: focusBorder,
+				buttonForeground: foreground
+			}));
+		} else {
+			this._buttonStyler = this._register(attachButtonStyler(this._button, this.themeService, {
+				buttonBackground: SIDE_BAR_BACKGROUND,
+				buttonHoverBackground: SIDE_BAR_BACKGROUND,
+				buttonForeground: SIDE_BAR_TITLE_FOREGROUND
+			}));
+		}
+
+
 	}
 
 	protected get defaultIconHeight(): number {


### PR DESCRIPTION
We were creating a new button styler every time the icon was changed but never getting rid of the old one until the object was disposed. This likely wasn't much of an issue since it'd be uncommon for someone to be updating the icon much but this still should be doing the right thing. 

This could probably be made slightly more efficient if we only updated the styler if it's going to be switching modes but that should be a pretty minor thing so I decided not to do that extra work. 

Also fixed an issue I noticed where if a button with an icon had that icon removed it wouldn't go back to the original style - it'd still be using the style applied when the icon was updated.