### PR TITLE
Cleanup model component wrapper event handlers

### DIFF
--- a/src/sql/workbench/browser/modelComponents/modelComponentWrapper.component.ts
+++ b/src/sql/workbench/browser/modelComponents/modelComponentWrapper.component.ts
@@ -5,21 +5,18 @@
 
 import {
 	Component, Input, Inject, forwardRef, ComponentFactoryResolver, ViewChild,
-	ElementRef, ChangeDetectorRef, ReflectiveInjector, Injector, ComponentRef, AfterViewInit
+	ChangeDetectorRef, ReflectiveInjector, Injector, ComponentRef, AfterViewInit
 } from '@angular/core';
 
 import { AngularDisposable } from 'sql/base/browser/lifecycle';
 import { IComponentConfig, COMPONENT_CONFIG } from './interfaces';
 import { Extensions, IComponentRegistry } from 'sql/platform/dashboard/browser/modelComponentRegistry';
 
-import * as colors from 'vs/platform/theme/common/colorRegistry';
-import * as themeColors from 'vs/workbench/common/theme';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { memoize } from 'vs/base/common/decorators';
 import { generateUuid } from 'vs/base/common/uuid';
 import { Event } from 'vs/base/common/event';
 import { LayoutRequestParams } from 'sql/workbench/services/dialog/browser/dialogContainer.component';
-import { IThemeService, IColorTheme } from 'vs/platform/theme/common/themeService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IBootstrapParams } from 'sql/workbench/services/bootstrap/common/bootstrapParams';
 import { IComponentDescriptor, IModelStore, IComponent } from 'sql/platform/dashboard/browser/interfaces';
@@ -56,27 +53,23 @@ export class ModelComponentWrapper extends AngularDisposable implements AfterVie
 
 	constructor(
 		@Inject(forwardRef(() => ComponentFactoryResolver)) private _componentFactoryResolver: ComponentFactoryResolver,
-		@Inject(forwardRef(() => ElementRef)) private _ref: ElementRef,
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeref: ChangeDetectorRef,
 		@Inject(forwardRef(() => Injector)) private _injector: Injector,
-		@Inject(IThemeService) private themeService: IThemeService,
 		@Inject(ILogService) private readonly logService: ILogService,
 		@Inject(IBootstrapParams) params: ModelComponentParams
 	) {
 		super();
 		if (params && params.onLayoutRequested) {
 			this._modelViewId = params.modelViewId;
-			params.onLayoutRequested(layoutParams => {
+			this._register(params.onLayoutRequested(layoutParams => {
 				if (layoutParams && (layoutParams.alwaysRefresh || layoutParams.modelViewId === this._modelViewId)) {
 					this.layout();
 				}
-			});
+			}));
 		}
 	}
 
 	ngAfterViewInit() {
-		this._register(this.themeService.onDidColorThemeChange(event => this.updateTheme(event)));
-		this.updateTheme(this.themeService.getColorTheme());
 		if (this.componentHost) {
 			this.loadComponent();
 		}
@@ -143,21 +136,5 @@ export class ModelComponentWrapper extends AngularDisposable implements AfterVie
 		// set widget styles to conform to its box
 		el.style.overflow = 'hidden';
 		el.style.position = 'relative';
-	}
-
-	private updateTheme(theme: IColorTheme): void {
-		// TODO handle theming appropriately
-		let el = <HTMLElement>this._ref.nativeElement;
-		let backgroundColor = theme.getColor(colors.editorBackground, true);
-		let foregroundColor = theme.getColor(themeColors.SIDE_BAR_FOREGROUND, true);
-
-		if (backgroundColor) {
-			el.style.backgroundColor = backgroundColor.toString();
-		}
-
-		if (foregroundColor) {
-			el.style.color = foregroundColor.toString();
-		}
-
 	}
 }


### PR DESCRIPTION
1. Registered the onLayoutRequested handler to be disposed when the wrapper is destroyed
2. Removed the theme update handler - I tested it out and didn't see any change in things using the wrapper components. And in general we should have basic background colors like that be at a higher default level - not at the wrapper level (or overridden by the components themselves if needed). So just removing it since it shouldn't be necessary @llali Do you have any context on why this was put there in the first place (you worked on this stuff early on right?)

![Capture](https://user-images.githubusercontent.com/28519865/105398689-8311a500-5bd7-11eb-9462-d79b238937e0.gif)
