### PR TITLE
Adding cloud tag to BDC resource

### DIFF
--- a/extensions/resource-deployment/package.json
+++ b/extensions/resource-deployment/package.json
@@ -200,7 +200,7 @@
         "description": "%resource-type-sql-bdc-description%",
         "platforms": "*",
         "icon": "./images/sql_bdc.svg",
-        "tags": ["On-premises", "SQL Server"],
+        "tags": ["On-premises", "SQL Server", "Cloud"],
         "options": [
           {
             "name": "version",


### PR DESCRIPTION
Adding the cloud tag to BDC deployment so that it appears under the cloud category. 
