### PR TITLE
Fix stringify error from resource deployment extension

### DIFF
--- a/extensions/resource-deployment/src/common/utils.ts
+++ b/extensions/resource-deployment/src/common/utils.ts
@@ -71,3 +71,22 @@ export async function tryExecuteAction<T>(action: () => T | PromiseLike<T>): Pro
 	}
 	return { result, error };
 }
+
+export function deepClone<T>(obj: T): T {
+	if (!obj || typeof obj !== 'object') {
+		return obj;
+	}
+	if (obj instanceof RegExp) {
+		// See https://github.com/Microsoft/TypeScript/issues/10990
+		return obj as any;
+	}
+	const result: any = Array.isArray(obj) ? [] : {};
+	Object.keys(<any>obj).forEach((key: string) => {
+		if ((<any>obj)[key] && typeof (<any>obj)[key] === 'object') {
+			result[key] = deepClone((<any>obj)[key]);
+		} else {
+			result[key] = (<any>obj)[key];
+		}
+	});
+	return result;
+}

--- a/extensions/resource-deployment/src/services/resourceTypeService.ts
+++ b/extensions/resource-deployment/src/services/resourceTypeService.ts
@@ -17,6 +17,7 @@ import { IPlatformService } from './platformService';
 import { IToolsService } from './toolsService';
 import * as loc from './../localizedConstants';
 import { ResourceTypeWizard } from '../ui/resourceTypeWizard';
+import { deepClone } from '../common/utils';
 
 const localize = nls.loadMessageBundle();
 
@@ -40,7 +41,8 @@ export class ResourceTypeService implements IResourceTypeService {
 			vscode.extensions.all.forEach((extension) => {
 				const extensionResourceTypes = extension.packageJSON.contributes && extension.packageJSON.contributes.resourceDeploymentTypes as ResourceType[];
 				if (extensionResourceTypes) {
-					extensionResourceTypes.forEach((resourceType: ResourceType) => {
+					extensionResourceTypes.forEach((extensionResourceType: ResourceType) => {
+						const resourceType = deepClone(extensionResourceType);
 						this.updatePathProperties(resourceType, extension.extensionPath);
 						resourceType.getProvider = (selectedOptions) => { return this.getProvider(resourceType, selectedOptions); };
 						resourceType.getOkButtonText = (selectedOptions) => { return this.getOkButtonText(resourceType, selectedOptions); };

--- a/extensions/resource-deployment/src/services/resourceTypeService.ts
+++ b/extensions/resource-deployment/src/services/resourceTypeService.ts
@@ -42,6 +42,9 @@ export class ResourceTypeService implements IResourceTypeService {
 				const extensionResourceTypes = extension.packageJSON.contributes && extension.packageJSON.contributes.resourceDeploymentTypes as ResourceType[];
 				if (extensionResourceTypes) {
 					extensionResourceTypes.forEach((extensionResourceType: ResourceType) => {
+						// Clone the object - we modify it by adding complex types and so if we modify the original contribution then
+						// we can break VS Code functionality since it will sometimes pass this object over the RPC layer which requires
+						// stringifying it - which can break with some of the complex types we add.
 						const resourceType = deepClone(extensionResourceType);
 						this.updatePathProperties(resourceType, extension.extensionPath);
 						resourceType.getProvider = (selectedOptions) => { return this.getProvider(resourceType, selectedOptions); };


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/14024

The root issue here is that we were modifying the extension contribution directly - which involved adding new properties to it. These properties were internal types and thus had references to things like tree views and much more complex objects than the original JSON definition.

This is a problem though because some VS Code implementations (such as withProgress) pass the entire extension contribution object over the RPC layer to the main thread - and so when it tried to convert that object to a string for passing over the RPC layer it failed converting these complex types since they had a circular reference loop.

This problem only showed up though after we parsed the extension contribution - which was only triggered by opening the resource deployment dialog. So if you started up ADS and immediately tried to do something like delete a PG instance it would work fine - but if you had opened up the deployment dialog first then it would fail because the extension contribution had been modified already.

The fix is simple - just clone the contribution object before modifying it so that any local changes the extension makes are kept within the extension itself. 