### PR TITLE
Fix tabbed panel error

### DIFF
--- a/src/sql/workbench/browser/modelComponents/tabbedPanel.component.ts
+++ b/src/sql/workbench/browser/modelComponents/tabbedPanel.component.ts
@@ -83,7 +83,7 @@ export default class TabbedPanelComponent extends ContainerBase<TabConfig> imple
 
 	get tabs(): Tab[] {
 		if (this.items.length > this._itemIndexToProcess) {
-			let currentGroup: string | undefined = this.items.length === 1 ? undefined : this.items[this._itemIndexToProcess - 1].config.group;
+			let currentGroup: string | undefined = this.items.length === 1 ? undefined : this.items[this._itemIndexToProcess - 1]?.config.group;
 			for (let i = this._itemIndexToProcess; i < this.items.length; i++) {
 				const item = this.items[i];
 				if (item.config.group !== currentGroup) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/14073

This would throw if there was a single tab registered and then another one was added (`this._itemIndexToProcess - 1` would be -1)

Undefined is the expected value for the first iteration of the loop - we'll update the currentGroup as we go through the items. 