### PR TITLE
Fix issue reporter URLs for extensions

### DIFF
--- a/product.json
+++ b/product.json
@@ -20,7 +20,7 @@
 	"darwinBundleIdentifier": "com.azuredatastudio.oss",
 	"linuxIconName": "com.azuredatastudio.oss",
 	"licenseFileName": "LICENSE.txt",
-	"reportIssueUrl": "https://github.com/Microsoft/azuredatastudio/issues/new?labels=customer%20reported%20issue",
+	"reportIssueUrl": "https://github.com/Microsoft/azuredatastudio/issues/new",
 	"requestFeatureUrl": "https://go.microsoft.com/fwlink/?linkid=2118021",
 	"privacyStatementUrl": "https://privacy.microsoft.com/en-us/privacystatement",
 	"telemetryOptOutUrl": "https://github.com/Microsoft/azuredatastudio/wiki/How-to-Disable-Telemetry-Reporting",
@@ -30,7 +30,7 @@
 		"asimovKey": "AIF-37eefaf0-8022-4671-a3fb-64752724682e"
 	},
 	"sendASmile": {
-		"reportIssueUrl": "https://github.com/Microsoft/azuredatastudio/issues/new?labels=customer%20reported%20issue",
+		"reportIssueUrl": "https://github.com/Microsoft/azuredatastudio/issues/new",
 		"requestFeatureUrl": "https://go.microsoft.com/fwlink/?linkid=2118115"
 	},
 	"gettingStartedUrl": "https://go.microsoft.com/fwlink/?linkid=862039",

--- a/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
@@ -861,7 +861,7 @@ export class IssueReporter extends Disposable {
 			}
 		}
 
-		const queryStringPrefix = this.configuration.product.reportIssueUrl && this.configuration.product.reportIssueUrl.indexOf('?') === -1 ? '?' : '&';
+		const queryStringPrefix = repositoryUrl && repositoryUrl.indexOf('?') === -1 ? '?' : '&';
 		return `${repositoryUrl}${queryStringPrefix}title=${encodeURIComponent(issueTitle)}`;
 	}
 

--- a/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterMain.ts
@@ -861,7 +861,7 @@ export class IssueReporter extends Disposable {
 			}
 		}
 
-		const queryStringPrefix = repositoryUrl && repositoryUrl.indexOf('?') === -1 ? '?' : '&';
+		const queryStringPrefix = repositoryUrl && repositoryUrl.indexOf('?') === -1 ? '?' : '&'; // {{ SQL CARBON EDIT }}
 		return `${repositoryUrl}${queryStringPrefix}title=${encodeURIComponent(issueTitle)}`;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13587

This logic pulls the base URL from either product.json or the extension package.json - but it was only checking the product.json string to see if the query prefix should be a & or a ? - and so our URL (which had a ? in it) caused it to always use a & as the prefix which wouldn't work with extension URLs which typically are just going to be something like `https://github.com/Microsoft/azuredatastudio.git`

Also removed the custom label from our issues URL - we don't even have that label defined so it wasn't doing anything anyways. 