### PR TITLE
Notebook - text cell - minimum height fix

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/media/markdown.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/media/markdown.css
@@ -5,8 +5,6 @@
 
 .notebook-preview {
 	font-size: 14px;
-	line-height: 22px;
-	min-height: 22px;
 	word-wrap: break-word;
 }
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
@@ -9,6 +9,7 @@ text-cell-component {
 text-cell-component .notebook-text {
 	display: flex;
 	outline: none;
+	min-height: 50px;
 }
 text-cell-component code-component {
 	flex-direction: column;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
@@ -21,7 +21,7 @@ text-cell-component .notebook-preview {
 	user-select: none;
 	width: 100%;
 	outline: none;
-	padding-top: 1.2em;
+	padding-top: 14px;
 }
 text-cell-component .notebook-preview > *:first-child {
 	margin-top: 0;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
@@ -21,6 +21,11 @@ text-cell-component .notebook-preview {
 	user-select: none;
 	width: 100%;
 	outline: none;
+	padding-top: 1.2em;
+}
+text-cell-component .notebook-preview > *:first-child {
+	margin-top: 0;
+	padding-top: 0;
 }
 text-cell-component .show-markdown.show-preview code-component {
 	width: 50%


### PR DESCRIPTION


https://user-images.githubusercontent.com/12279161/106187691-cc736e80-615a-11eb-9d50-c4bdfb41ec64.mov



Sets minimum height to text cell element so whether empty or occupied with a single line of content, the container is the same height.

Attached MOV of UI in action.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
