### PR TITLE
fix projects view title commands

### DIFF
--- a/extensions/data-workspace/package.json
+++ b/extensions/data-workspace/package.json
@@ -78,22 +78,22 @@
         {
           "command": "dataworkspace.refresh",
           "when": "view == dataworkspace.views.main",
-          "group": "2_currentWorkspace"
+          "group": "1_currentWorkspace"
         },
         {
           "command": "dataworkspace.close",
           "when": "view == dataworkspace.views.main && workbenchState == workspace",
-          "group": "3_commands"
+          "group": "2_commands"
         },
         {
           "command": "projects.new",
           "when": "view == dataworkspace.views.main",
-          "group": "1_navigation"
+          "group": "navigation"
         },
         {
           "command": "projects.openExisting",
           "when": "view == dataworkspace.views.main",
-          "group": "1_navigation"
+          "group": "navigation"
         }
       ],
       "commandPalette": [

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -156,7 +156,7 @@
         {
           "command": "sqlDatabaseProjects.createProjectFromDatabase",
           "when": "view == dataworkspace.views.main",
-          "group": "secondary"
+          "group": "1_currentWorkspace"
         }
       ],
       "commandPalette": [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #14085. The New and Open existing icon buttons stopped showing after some refactoring was done in https://github.com/microsoft/azuredatastudio/pull/13809. This PR adds them back and also moves "Create Project From Database" to be in the same group as Refresh.

Previously:
![image](https://user-images.githubusercontent.com/31145923/106076980-88825a00-60c5-11eb-840c-62668d94054f.png)


Now:
![image](https://user-images.githubusercontent.com/31145923/106076971-84eed300-60c5-11eb-9329-11ff283f64fb.png)

