### PR TITLE
Clean up telemetry keys

### DIFF
--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -12,8 +12,6 @@ export const AddServerGroup = 'AddServerGroup';
 export const MoveServerGroup = 'MoveServerGroup';
 export const MoveServerConnection = 'MoveServerConnection';
 export const DeleteServerGroup = 'DeleteServerGroup';
-export const ModalDialogClosed = 'ModalDialogClosed';
-export const ModalDialogOpened = 'ModalDialogOpened';
 export const BackupCreated = 'BackupCreated';
 export const RestoreRequested = 'RestoreRequested';
 export const ChartCreated = 'ChartCreated';
@@ -27,7 +25,6 @@ export const FirewallRuleRequested = 'FirewallRuleCreated';
 export const DashboardNavigated = 'DashboardNavigated';
 export const GetDataGridItems = 'GetDataGridItems';
 export const GetDataGridColumns = 'GetDataGridColumns';
-export const WizardPagesNavigation = 'WizardPagesNavigation';
 
 // Telemetry Properties
 
@@ -47,23 +44,14 @@ export const AutoOAuth = 'AutoOAuth';
 export const AddNewDashboardTab = 'AddNewDashboardTab';
 export const ProfilerFilter = 'ProfilerFilter';
 
-// SQL Agent Events:
-
-// Views
-export const JobsView = 'JobsViewOpened';
-export const JobHistoryView = 'JobHistoryViewOpened';
-export const JobStepsView = 'JobStepsViewOpened';
-
-// Actions
-export const RunAgentJob = 'RunAgentJob';
-export const StopAgentJob = 'StopAgentJob';
-export const DeleteAgentJob = 'DeleteAgentJob';
-export const DeleteAgentJobStep = 'DeleteAgentJobStep';
-export const DeleteAgentAlert = 'DeleteAgentAlert';
-export const DeleteAgentOperator = 'DeleteAgentOperator';
-export const DeleteAgentProxy = 'DeleteAgentProxy';
 
 export enum TelemetryView {
+	Agent = 'Agent',
+	AgentJobs = 'AgentJobs',
+	AgentJobHistory = 'AgentJobHistory',
+	AgentJobSteps = 'AgentJobSteps',
+	AgentNotebookHistory = 'AgentNotebookHistory',
+	AgentNotebooks = 'AgentNotebooks',
 	Shell = 'Shell',
 	ExtensionRecommendationDialog = 'ExtensionRecommendationDialog',
 	ResultsPanel = 'ResultsPanel',
@@ -72,9 +60,20 @@ export enum TelemetryView {
 }
 
 export enum TelemetryAction {
+	adsCommandExecuted = 'adsCommandExecuted',
 	Click = 'Click',
 	Open = 'Open',
-	ModelViewDashboardOpened = 'ModelViewDashboardOpened'
+	ModelViewDashboardOpened = 'ModelViewDashboardOpened',
+	ModalDialogClosed = 'ModalDialogClosed',
+	ModalDialogOpened = 'ModalDialogOpened',
+	RunAgentJob = 'RunAgentJob',
+	StopAgentJob = 'StopAgentJob',
+	DeleteAgentJob = 'DeleteAgentJob',
+	DeleteAgentJobStep = 'DeleteAgentJobStep',
+	DeleteAgentAlert = 'DeleteAgentAlert',
+	DeleteAgentOperator = 'DeleteAgentOperator',
+	DeleteAgentProxy = 'DeleteAgentProxy',
+	WizardPagesNavigation = 'WizardPagesNavigation'
 }
 
 export enum NbTelemetryAction {

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -378,7 +378,7 @@ export abstract class Modal extends Disposable implements IThemable {
 		}));
 
 		this.layout(DOM.getTotalHeight(this._modalBodySection!));
-		this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.ModalDialogOpened)
+		this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.TelemetryAction.ModalDialogOpened)
 			.withAdditionalProperties({ name: this._name })
 			.send();
 	}
@@ -395,7 +395,7 @@ export abstract class Modal extends Disposable implements IThemable {
 		this._modalShowingContext.get()!.pop();
 		this._bodyContainer!.remove();
 		this.disposableStore.clear();
-		this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.ModalDialogClosed)
+		this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.TelemetryAction.ModalDialogClosed)
 			.withAdditionalProperties({
 				name: this._name,
 				reason: reason,

--- a/src/sql/workbench/contrib/jobManagement/browser/jobActions.ts
+++ b/src/sql/workbench/contrib/jobManagement/browser/jobActions.ts
@@ -16,11 +16,11 @@ import { AlertsViewComponent } from 'sql/workbench/contrib/jobManagement/browser
 import { OperatorsViewComponent } from 'sql/workbench/contrib/jobManagement/browser/operatorsView.component';
 import { ProxiesViewComponent } from 'sql/workbench/contrib/jobManagement/browser/proxiesView.component';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
+import { TelemetryView, TelemetryAction } from 'sql/platform/telemetry/common/telemetryKeys';
 import { IErrorMessageService } from 'sql/platform/errorMessage/common/errorMessageService';
 import { JobManagementView } from 'sql/workbench/contrib/jobManagement/browser/jobManagementView';
 import { NotebooksViewComponent } from 'sql/workbench/contrib/jobManagement/browser/notebooksView.component';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 
 export const successLabel: string = nls.localize('jobaction.successLabel', "Success");
 export const errorLabel: string = nls.localize('jobaction.faillabel', "Error");
@@ -92,7 +92,7 @@ export class RunJobAction extends Action {
 		@IErrorMessageService private errorMessageService: IErrorMessageService,
 		@IJobManagementService private jobManagementService: IJobManagementService,
 		@IInstantiationService private instantationService: IInstantiationService,
-		@ITelemetryService private telemetryService: ITelemetryService
+		@IAdsTelemetryService private telemetryService: IAdsTelemetryService
 	) {
 		super(RunJobAction.ID, RunJobAction.LABEL, 'start');
 	}
@@ -101,7 +101,7 @@ export class RunJobAction extends Action {
 		let jobName = context.targetObject.job.name;
 		let ownerUri = context.ownerUri;
 		let refreshAction = this.instantationService.createInstance(JobsRefreshAction);
-		this.telemetryService.publicLog(TelemetryKeys.RunAgentJob);
+		this.telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.RunAgentJob);
 		return new Promise<boolean>((resolve, reject) => {
 			this.jobManagementService.jobAction(ownerUri, jobName, JobActions.Run).then(async (result) => {
 				if (result.success) {
@@ -127,7 +127,7 @@ export class StopJobAction extends Action {
 		@IErrorMessageService private errorMessageService: IErrorMessageService,
 		@IJobManagementService private jobManagementService: IJobManagementService,
 		@IInstantiationService private instantationService: IInstantiationService,
-		@ITelemetryService private telemetryService: ITelemetryService
+		@IAdsTelemetryService private telemetryService: IAdsTelemetryService
 	) {
 		super(StopJobAction.ID, StopJobAction.LABEL, 'stop');
 	}
@@ -136,7 +136,7 @@ export class StopJobAction extends Action {
 		let jobName = context.targetObject.name;
 		let ownerUri = context.ownerUri;
 		let refreshAction = this.instantationService.createInstance(JobsRefreshAction);
-		this.telemetryService.publicLog(TelemetryKeys.StopAgentJob);
+		this.telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.StopAgentJob);
 		return new Promise<boolean>((resolve, reject) => {
 			this.jobManagementService.jobAction(ownerUri, jobName, JobActions.Stop).then(async (result) => {
 				if (result.success) {
@@ -194,7 +194,7 @@ export class DeleteJobAction extends Action {
 		@INotificationService private _notificationService: INotificationService,
 		@IErrorMessageService private _errorMessageService: IErrorMessageService,
 		@IJobManagementService private _jobService: IJobManagementService,
-		@ITelemetryService private _telemetryService: ITelemetryService
+		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
 	) {
 		super(DeleteJobAction.ID, DeleteJobAction.LABEL);
 	}
@@ -208,7 +208,7 @@ export class DeleteJobAction extends Action {
 			[{
 				label: DeleteJobAction.LABEL,
 				run: () => {
-					this._telemetryService.publicLog(TelemetryKeys.DeleteAgentJob);
+					this._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentJob);
 					self._jobService.deleteJob(actionInfo.ownerUri, actionInfo.targetObject.job).then(result => {
 						if (!result || !result.success) {
 							let errorMessage = nls.localize("jobaction.failedToDeleteJob", "Could not delete job '{0}'.\nError: {1}",
@@ -260,7 +260,7 @@ export class DeleteStepAction extends Action {
 		@IErrorMessageService private _errorMessageService: IErrorMessageService,
 		@IJobManagementService private _jobService: IJobManagementService,
 		@IInstantiationService private instantationService: IInstantiationService,
-		@ITelemetryService private _telemetryService: ITelemetryService
+		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
 	) {
 		super(DeleteStepAction.ID, DeleteStepAction.LABEL);
 	}
@@ -275,7 +275,7 @@ export class DeleteStepAction extends Action {
 			[{
 				label: DeleteStepAction.LABEL,
 				run: () => {
-					this._telemetryService.publicLog(TelemetryKeys.DeleteAgentJobStep);
+					this._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentJobStep);
 					self._jobService.deleteJobStep(actionInfo.ownerUri, actionInfo.targetObject).then(async (result) => {
 						if (!result || !result.success) {
 							let errorMessage = nls.localize('jobaction.failedToDeleteStep', "Could not delete step '{0}'.\nError: {1}",
@@ -350,7 +350,7 @@ export class DeleteAlertAction extends Action {
 		@INotificationService private _notificationService: INotificationService,
 		@IErrorMessageService private _errorMessageService: IErrorMessageService,
 		@IJobManagementService private _jobService: IJobManagementService,
-		@ITelemetryService private _telemetryService: ITelemetryService
+		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
 	) {
 		super(DeleteAlertAction.ID, DeleteAlertAction.LABEL);
 	}
@@ -364,7 +364,7 @@ export class DeleteAlertAction extends Action {
 			[{
 				label: DeleteAlertAction.LABEL,
 				run: () => {
-					this._telemetryService.publicLog(TelemetryKeys.DeleteAgentAlert);
+					self._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentAlert);
 					self._jobService.deleteAlert(actionInfo.ownerUri, alert).then(result => {
 						if (!result || !result.success) {
 							let errorMessage = nls.localize("jobaction.failedToDeleteAlert", "Could not delete alert '{0}'.\nError: {1}",
@@ -436,7 +436,7 @@ export class DeleteOperatorAction extends Action {
 		@INotificationService private _notificationService: INotificationService,
 		@IErrorMessageService private _errorMessageService: IErrorMessageService,
 		@IJobManagementService private _jobService: IJobManagementService,
-		@ITelemetryService private _telemetryService: ITelemetryService
+		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
 	) {
 		super(DeleteOperatorAction.ID, DeleteOperatorAction.LABEL);
 	}
@@ -450,7 +450,7 @@ export class DeleteOperatorAction extends Action {
 			[{
 				label: DeleteOperatorAction.LABEL,
 				run: () => {
-					self._telemetryService.publicLog(TelemetryKeys.DeleteAgentOperator);
+					self._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentOperator);
 					self._jobService.deleteOperator(actionInfo.ownerUri, actionInfo.targetObject).then(result => {
 						if (!result || !result.success) {
 							let errorMessage = nls.localize("jobaction.failedToDeleteOperator", "Could not delete operator '{0}'.\nError: {1}",
@@ -531,7 +531,7 @@ export class DeleteProxyAction extends Action {
 		@INotificationService private _notificationService: INotificationService,
 		@IErrorMessageService private _errorMessageService: IErrorMessageService,
 		@IJobManagementService private _jobService: IJobManagementService,
-		@ITelemetryService private _telemetryService: ITelemetryService
+		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
 	) {
 		super(DeleteProxyAction.ID, DeleteProxyAction.LABEL);
 	}
@@ -545,7 +545,7 @@ export class DeleteProxyAction extends Action {
 			[{
 				label: DeleteProxyAction.LABEL,
 				run: () => {
-					this._telemetryService.publicLog(TelemetryKeys.DeleteAgentProxy);
+					self._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentProxy);
 					self._jobService.deleteProxy(actionInfo.ownerUri, actionInfo.targetObject).then(result => {
 						if (!result || !result.success) {
 							let errorMessage = nls.localize("jobaction.failedToDeleteProxy", "Could not delete proxy '{0}'.\nError: {1}",
@@ -626,7 +626,7 @@ export class DeleteNotebookAction extends Action {
 		@IErrorMessageService private _errorMessageService: IErrorMessageService,
 		@IJobManagementService private _jobService: IJobManagementService,
 		@IInstantiationService private instantationService: IInstantiationService,
-		@ITelemetryService private _telemetryService: ITelemetryService
+		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
 	) {
 		super(DeleteNotebookAction.ID, DeleteNotebookAction.LABEL);
 	}
@@ -641,7 +641,7 @@ export class DeleteNotebookAction extends Action {
 			[{
 				label: DeleteNotebookAction.LABEL,
 				run: () => {
-					this._telemetryService.publicLog(TelemetryKeys.DeleteAgentJob);
+					self._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentJob);
 					self._jobService.deleteNotebook(actionInfo.ownerUri, actionInfo.targetObject.job).then(async (result) => {
 						if (!result || !result.success) {
 							await refreshAction.run(actionInfo);

--- a/src/sql/workbench/contrib/jobManagement/browser/jobHistory.component.ts
+++ b/src/sql/workbench/contrib/jobManagement/browser/jobHistory.component.ts
@@ -31,8 +31,8 @@ import { JobManagementView, JobActionContext } from 'sql/workbench/contrib/jobMa
 import { TabChild } from 'sql/base/browser/ui/panel/tab.component';
 import { IDashboardService } from 'sql/platform/dashboard/browser/dashboardService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
+import { TelemetryView } from 'sql/platform/telemetry/common/telemetryKeys';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 
 export const DASHBOARD_SELECTOR: string = 'jobhistory-component';
 
@@ -83,7 +83,7 @@ export class JobHistoryComponent extends JobManagementView implements OnInit {
 		@Inject(IJobManagementService) private _jobManagementService: IJobManagementService,
 		@Inject(IKeybindingService) keybindingService: IKeybindingService,
 		@Inject(IDashboardService) dashboardService: IDashboardService,
-		@Inject(ITelemetryService) private _telemetryService: ITelemetryService
+		@Inject(IAdsTelemetryService) private _telemetryService: IAdsTelemetryService
 	) {
 		super(commonService, dashboardService, contextMenuService, keybindingService, instantiationService, _agentViewComponent);
 		this._treeController = new JobHistoryController();
@@ -148,7 +148,7 @@ export class JobHistoryComponent extends JobManagementView implements OnInit {
 		}, { verticalScrollMode: ScrollbarVisibility.Visible });
 		this._register(attachListStyler(this._tree, this.themeService));
 		this._tree.layout(dom.getContentHeight(this._tableContainer.nativeElement));
-		this._telemetryService.publicLog(TelemetryKeys.JobHistoryView);
+		this._telemetryService.sendViewEvent(TelemetryView.AgentJobHistory);
 	}
 
 	private loadHistory() {

--- a/src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component.ts
+++ b/src/sql/workbench/contrib/jobManagement/browser/jobStepsView.component.ts
@@ -23,9 +23,9 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { TabChild } from 'sql/base/browser/ui/panel/tab.component';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
+import { TelemetryView } from 'sql/platform/telemetry/common/telemetryKeys';
 import { IJobManagementService } from 'sql/workbench/services/jobManagement/common/interfaces';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 
 export const JOBSTEPSVIEW_SELECTOR: string = 'jobstepsview-component';
 
@@ -53,7 +53,7 @@ export class JobStepsViewComponent extends JobManagementView implements OnInit, 
 		@Inject(IContextMenuService) contextMenuService: IContextMenuService,
 		@Inject(IKeybindingService) keybindingService: IKeybindingService,
 		@Inject(IDashboardService) dashboardService: IDashboardService,
-		@Inject(ITelemetryService) private _telemetryService: ITelemetryService
+		@Inject(IAdsTelemetryService) private _telemetryService: IAdsTelemetryService
 	) {
 		super(commonService, dashboardService, contextMenuService, keybindingService, instantiationService, undefined);
 	}
@@ -111,7 +111,7 @@ export class JobStepsViewComponent extends JobManagementView implements OnInit, 
 			this._treeDataSource.data = data;
 			await this._tree.refresh();
 		});
-		this._telemetryService.publicLog(TelemetryKeys.JobStepsView);
+		this._telemetryService.sendViewEvent(TelemetryView.AgentJobSteps);
 	}
 
 	public onFirstVisible() {

--- a/src/sql/workbench/contrib/jobManagement/browser/jobsView.component.ts
+++ b/src/sql/workbench/contrib/jobManagement/browser/jobsView.component.ts
@@ -29,11 +29,11 @@ import { IDashboardService } from 'sql/platform/dashboard/browser/dashboardServi
 import { escape } from 'sql/base/common/strings';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { tableBackground, cellBackground, cellBorderColor } from 'sql/platform/theme/common/colors';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
+import { TelemetryView } from 'sql/platform/telemetry/common/telemetryKeys';
 import { attachButtonStyler } from 'sql/platform/theme/common/styler';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 import { onUnexpectedError } from 'vs/base/common/errors';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 
 export const JOBSVIEW_SELECTOR: string = 'jobsview-component';
 export const ROW_HEIGHT: number = 45;
@@ -107,7 +107,7 @@ export class JobsViewComponent extends JobManagementView implements OnInit, OnDe
 		@Inject(IContextMenuService) contextMenuService: IContextMenuService,
 		@Inject(IKeybindingService) keybindingService: IKeybindingService,
 		@Inject(IDashboardService) _dashboardService: IDashboardService,
-		@Inject(ITelemetryService) private _telemetryService: ITelemetryService
+		@Inject(IAdsTelemetryService) private _telemetryService: IAdsTelemetryService
 	) {
 		super(commonService, _dashboardService, contextMenuService, keybindingService, instantiationService, _agentViewComponent);
 		let jobCacheObjectMap = this._jobManagementService.jobCacheObjectMap;
@@ -127,7 +127,7 @@ export class JobsViewComponent extends JobManagementView implements OnInit, OnDe
 		this._visibilityElement = this._gridEl;
 		this._parentComponent = this._agentViewComponent;
 		this._register(this._themeService.onDidColorThemeChange(e => this.updateTheme(e)));
-		this._telemetryService.publicLog(TelemetryKeys.JobsView);
+		this._telemetryService.sendViewEvent(TelemetryView.AgentJobs);
 	}
 
 	ngOnDestroy() {

--- a/src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component.ts
+++ b/src/sql/workbench/contrib/jobManagement/browser/notebookHistory.component.ts
@@ -24,9 +24,9 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { TabChild } from 'sql/base/browser/ui/panel/tab.component';
 import { IDashboardService } from 'sql/platform/dashboard/browser/dashboardService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
+import { TelemetryView } from 'sql/platform/telemetry/common/telemetryKeys';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 
 export const DASHBOARD_SELECTOR: string = 'notebookhistory-component';
 export class GridSection {
@@ -82,7 +82,7 @@ export class NotebookHistoryComponent extends JobManagementView implements OnIni
 		@Inject(ICommandService) private _commandService: ICommandService,
 		@Inject(IKeybindingService) keybindingService: IKeybindingService,
 		@Inject(IDashboardService) dashboardService: IDashboardService,
-		@Inject(ITelemetryService) private _telemetryService: ITelemetryService,
+		@Inject(IAdsTelemetryService) private _telemetryService: IAdsTelemetryService,
 		@Inject(IQuickInputService) private _quickInputService: IQuickInputService
 	) {
 		super(commonService, dashboardService, contextMenuService, keybindingService, instantiationService, _agentViewComponent);
@@ -104,7 +104,7 @@ export class NotebookHistoryComponent extends JobManagementView implements OnIni
 		this._parentComponent = this._agentViewComponent;
 		this._agentNotebookInfo = this._agentViewComponent.agentNotebookInfo;
 		this.initActionBar();
-		this._telemetryService.publicLog(TelemetryKeys.JobHistoryView);
+		this._telemetryService.sendViewEvent(TelemetryView.AgentNotebookHistory);
 	}
 
 	private loadHistory() {

--- a/src/sql/workbench/contrib/jobManagement/browser/notebooksView.component.ts
+++ b/src/sql/workbench/contrib/jobManagement/browser/notebooksView.component.ts
@@ -29,12 +29,12 @@ import { IDashboardService } from 'sql/platform/dashboard/browser/dashboardServi
 import { escape } from 'sql/base/common/strings';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { tableBackground, cellBackground, cellBorderColor } from 'sql/platform/theme/common/colors';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
+import { TelemetryView } from 'sql/platform/telemetry/common/telemetryKeys';
 import { attachButtonStyler } from 'sql/platform/theme/common/styler';
 import { Taskbar } from 'sql/base/browser/ui/taskbar/taskbar';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 
 
 export const NOTEBOOKSVIEW_SELECTOR: string = 'notebooksview-component';
@@ -106,7 +106,7 @@ export class NotebooksViewComponent extends JobManagementView implements OnInit,
 		@Inject(IContextMenuService) contextMenuService: IContextMenuService,
 		@Inject(IKeybindingService) keybindingService: IKeybindingService,
 		@Inject(IDashboardService) _dashboardService: IDashboardService,
-		@Inject(ITelemetryService) private _telemetryService: ITelemetryService
+		@Inject(IAdsTelemetryService) private _telemetryService: IAdsTelemetryService
 	) {
 		super(commonService, _dashboardService, contextMenuService, keybindingService, instantiationService, _agentViewComponent);
 		let notebookCacheObjectMap = this._jobManagementService.notebookCacheObjectMap;
@@ -126,7 +126,7 @@ export class NotebooksViewComponent extends JobManagementView implements OnInit,
 		this._visibilityElement = this._gridEl;
 		this._parentComponent = this._agentViewComponent;
 		this._register(this._themeService.onDidColorThemeChange(e => this.updateTheme(e)));
-		this._telemetryService.publicLog(TelemetryKeys.JobsView);
+		this._telemetryService.sendViewEvent(TelemetryView.AgentNotebooks);
 	}
 
 	ngOnDestroy() {

--- a/src/sql/workbench/contrib/telemetry/common/telemetry.contribution.ts
+++ b/src/sql/workbench/contrib/telemetry/common/telemetry.contribution.ts
@@ -10,7 +10,7 @@ import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ICommandService, ICommandEvent } from 'vs/platform/commands/common/commands';
-import { TelemetryView } from 'sql/platform/telemetry/common/telemetryKeys';
+import { TelemetryAction, TelemetryView } from 'sql/platform/telemetry/common/telemetryKeys';
 
 export class SqlTelemetryContribution extends Disposable implements IWorkbenchContribution {
 
@@ -35,7 +35,7 @@ export class SqlTelemetryContribution extends Disposable implements IWorkbenchCo
 						// Events from src\vs\editor\contrib\wordOperations\wordOperations.ts
 						!e.commandId.startsWith('cursor') &&
 						!e.commandId.startsWith('_vscode_delegate')) {
-						telemetryService.sendActionEvent(TelemetryView.Shell, 'adsCommandExecuted', e.commandId);
+						telemetryService.sendActionEvent(TelemetryView.Shell, TelemetryAction.adsCommandExecuted, e.commandId);
 					}
 				}));
 	}

--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import 'vs/css!./media/dialogModal';
 import { Modal, IModalOptions } from 'sql/workbench/browser/modal/modal';
 import { Wizard, DialogButton, WizardPage } from 'sql/workbench/services/dialog/common/dialogTypes';
@@ -28,6 +27,7 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 import { attachModalDialogStyler } from 'sql/workbench/common/styler';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { status } from 'vs/base/browser/ui/aria/aria';
+import { TelemetryView, TelemetryAction } from 'sql/platform/telemetry/common/telemetryKeys';
 
 export class WizardModal extends Modal {
 	private _dialogPanes = new Map<WizardPage, DialogPane>();
@@ -213,7 +213,7 @@ export class WizardModal extends Modal {
 		});
 
 		if (index !== prevPageIndex) {
-			this._telemetryEventService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.WizardPagesNavigation)
+			this._telemetryEventService.createActionEvent(TelemetryView.Shell, TelemetryAction.WizardPagesNavigation)
 				.withAdditionalProperties({
 					wizardName: this._wizard.name,
 					pageNavigationFrom: this._wizard.pages[prevPageIndex].pageName ?? prevPageIndex,


### PR DESCRIPTION
This is part of some cleanup work I've been meaning to do for a while just to get the stuff in TelemetryKeys more properly organized.

I also updated the agent stuff to use the AdsTelemetryService to align to the common schema we're using elsewhere. This does mean that we won't be able to easily correlate events from before this change to ones after - but given that we don't actually use these events for any reporting currently I don't think it's a huge deal to do this now.