### PR TITLE
Notebooks: add multi_connection field to notebook metadata

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -78,10 +78,6 @@ declare module 'azdata' {
 			multi_connection_mode?: boolean;
 		}
 
-		export interface INotebookMetadataInternal extends INotebookMetadata {
-			azdata_notebook_guid?: string;
-		}
-
 		export interface ICellMetadata {
 			connection_name?: string;
 		}

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -73,10 +73,16 @@ declare module 'azdata' {
 			data: any;
 		}
 
+		/**
+		 * Note: Update expectedMetadataKeys field in NotebookModel when updating this interface.
+		 */
 		export interface INotebookMetadata {
-			azdata_notebook_guid?: string;
 			connection_name?: string;
 			multi_connection_mode?: boolean;
+		}
+
+		export interface INotebookMetadataInternal extends INotebookMetadata {
+			azdata_notebook_guid?: string;
 		}
 
 		export interface ICellMetadata {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -73,9 +73,6 @@ declare module 'azdata' {
 			data: any;
 		}
 
-		/**
-		 * Note: Update expectedMetadataKeys field in NotebookModel when updating this interface.
-		 */
 		export interface INotebookMetadata {
 			connection_name?: string;
 			multi_connection_mode?: boolean;

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -75,6 +75,7 @@ declare module 'azdata' {
 
 		export interface INotebookMetadata {
 			connection_name?: string;
+			multi_connection?: boolean;
 		}
 
 		export interface ICellMetadata {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -74,8 +74,9 @@ declare module 'azdata' {
 		}
 
 		export interface INotebookMetadata {
+			azdata_notebook_guid?: string;
 			connection_name?: string;
-			multi_connection?: boolean;
+			multi_connection_mode?: boolean;
 		}
 
 		export interface ICellMetadata {

--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -76,6 +76,9 @@ export class NotebookModelStub implements INotebookModel {
 	get savedConnectionName(): string {
 		throw new Error('method not implemented.');
 	}
+	get multiConnection(): boolean {
+		throw new Error('method not implemented.');
+	}
 	get providerId(): string {
 		throw new Error('method not implemented.');
 	}

--- a/src/sql/workbench/contrib/notebook/test/stubs.ts
+++ b/src/sql/workbench/contrib/notebook/test/stubs.ts
@@ -76,7 +76,7 @@ export class NotebookModelStub implements INotebookModel {
 	get savedConnectionName(): string {
 		throw new Error('method not implemented.');
 	}
-	get multiConnection(): boolean {
+	get multiConnectionMode(): boolean {
 		throw new Error('method not implemented.');
 	}
 	get providerId(): string {

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -310,9 +310,9 @@ export interface INotebookModel {
 	readonly savedConnectionName: string | undefined;
 
 	/**
-	 * Whether not the notebook has multiple connections
+	 * The connection mode of the notebook (single vs multiple connections)
 	 */
-	multiConnection: boolean;
+	multiConnectionMode: boolean;
 
 	/**
 	 * Event fired on first initialization of the cells and

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -308,6 +308,12 @@ export interface INotebookModel {
 	 * or undefined if none.
 	 */
 	readonly savedConnectionName: string | undefined;
+
+	/**
+	 * Whether not the notebook has multiple connections
+	 */
+	multiConnection: boolean;
+
 	/**
 	 * Event fired on first initialization of the cells and
 	 * on subsequent change events

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -48,6 +48,15 @@ export class ErrorInfo {
 	}
 }
 
+type NotebookMetadataKeys = Required<nb.INotebookMetadata>;
+const expectedMetadataKeys: NotebookMetadataKeys = {
+	kernelspec: null,
+	language_info: null,
+	tags: null,
+	connection_name: null,
+	multi_connection_mode: null
+};
+
 const saveConnectionNameConfigName = 'notebook.saveConnectionName';
 const injectedParametersMsg = localize('injectedParametersMsg', '# Injected-Parameters\n');
 
@@ -79,7 +88,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private _savedConnectionName: string | undefined;
 	private readonly _nbformat: number = nbversion.MAJOR_VERSION;
 	private readonly _nbformatMinor: number = nbversion.MINOR_VERSION;
-	private readonly expectedMetadataKeys = ['kernelspec', 'language_info', 'tags', 'connection_name', 'multi_connection'];
 	private _activeConnection: ConnectionProfile | undefined;
 	private _activeCell: ICellModel | undefined;
 	private _providerId: string;
@@ -457,7 +465,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		}
 		Object.keys(metadata).forEach(key => {
 			// If custom metadata is defined, add to the _existingMetadata object
-			if (this.expectedMetadataKeys.indexOf(key) < 0) {
+			if (!Object.keys(expectedMetadataKeys).includes(key)) {
 				this._existingMetadata[key] = metadata[key];
 			}
 		});

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -434,7 +434,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		}
 	}
 
-	private loadContentMetadata(metadata: nb.INotebookMetadata): void {
+	private loadContentMetadata(metadata: nb.INotebookMetadataInternal): void {
 		this._savedKernelInfo = metadata.kernelspec;
 		this._defaultLanguageInfo = metadata.language_info;
 		// If language info was serialized in the notebook, attempt to use that to decrease time

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -48,13 +48,17 @@ export class ErrorInfo {
 	}
 }
 
+interface INotebookMetadataInternal extends nb.INotebookMetadata {
+	azdata_notebook_guid?: string;
+}
+
 type NotebookMetadataKeys = Required<nb.INotebookMetadata>;
 const expectedMetadataKeys: NotebookMetadataKeys = {
-	kernelspec: null,
-	language_info: null,
-	tags: null,
-	connection_name: null,
-	multi_connection_mode: null
+	kernelspec: undefined,
+	language_info: undefined,
+	tags: undefined,
+	connection_name: undefined,
+	multi_connection_mode: undefined
 };
 
 const saveConnectionNameConfigName = 'notebook.saveConnectionName';
@@ -442,7 +446,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		}
 	}
 
-	private loadContentMetadata(metadata: nb.INotebookMetadataInternal): void {
+	private loadContentMetadata(metadata: INotebookMetadataInternal): void {
 		this._savedKernelInfo = metadata.kernelspec;
 		this._defaultLanguageInfo = metadata.language_info;
 		// If language info was serialized in the notebook, attempt to use that to decrease time

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -32,6 +32,7 @@ import { ICapabilitiesService } from 'sql/platform/capabilities/common/capabilit
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 import { values } from 'vs/base/common/collections';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { isUUID } from 'vs/base/common/uuid';
 
 /*
 * Used to control whether a message in a dialog/wizard is displayed as an error,
@@ -460,8 +461,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		//Telemetry of loading notebook
 		if (metadata.azdata_notebook_guid && metadata.azdata_notebook_guid.length === 36) {
 			//Verify if it is actual GUID and then send it to the telemetry
-			let regex = new RegExp('(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}');
-			if (regex.test(metadata.azdata_notebook_guid)) {
+			if (isUUID(metadata.azdata_notebook_guid)) {
 				this.adstelemetryService.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.TelemetryAction.Open)
 					.withAdditionalProperties({ azdata_notebook_guid: metadata.azdata_notebook_guid })
 					.send();

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -93,6 +93,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private _kernelAliases: string[] = [];
 	private _currentKernelAlias: string | undefined;
 	private _selectedKernelDisplayName: string | undefined;
+	private _multiConnection: boolean = false;
 
 	public requestConnectionHandler: (() => Promise<boolean>) | undefined;
 
@@ -212,6 +213,14 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	public get savedConnectionName(): string | undefined {
 		return this._savedConnectionName;
+	}
+
+	public get multiConnection(): boolean {
+		return this._multiConnection;
+	}
+
+	public set multiConnection(isMultiConnection: boolean) {
+		this._multiConnection = isMultiConnection;
 	}
 
 	public get specs(): nb.IAllKernels | undefined {
@@ -373,33 +382,8 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			// if cells already exist, create them with language info (if it is saved)
 			this._cells = [];
 			if (contents) {
-				this._defaultLanguageInfo = contents.metadata?.language_info;
-				// If language info was serialized in the notebook, attempt to use that to decrease time
-				// required until colorization occurs
-				if (this._defaultLanguageInfo) {
-					this.updateLanguageInfo(this._defaultLanguageInfo);
-				}
-				this._savedKernelInfo = this.getSavedKernelInfo(contents);
-				this._savedConnectionName = this.getSavedConnectionName(contents);
 				if (contents.metadata) {
-					//Telemetry of loading notebook
-					let metadata: any = contents.metadata;
-					if (metadata.azdata_notebook_guid && metadata.azdata_notebook_guid.length === 36) {
-						//Verify if it is actual GUID and then send it to the telemetry
-						let regex = new RegExp('(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}');
-						if (regex.test(metadata.azdata_notebook_guid)) {
-							this.adstelemetryService.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.TelemetryAction.Open)
-								.withAdditionalProperties({ azdata_notebook_guid: metadata.azdata_notebook_guid })
-								.send();
-						}
-					}
-					Object.keys(contents.metadata).forEach(key => {
-						let expectedKeys = ['kernelspec', 'language_info', 'tags', 'connection_name'];
-						// If custom metadata is defined, add to the _existingMetadata object
-						if (expectedKeys.indexOf(key) < 0) {
-							this._existingMetadata[key] = contents.metadata[key];
-						}
-					});
+					this.loadContentMetadata(contents.metadata);
 				}
 				// Modify Notebook URI Params format from URI query to string space delimited format
 				let notebookUriParams: string = this.notebookUri.query;
@@ -447,6 +431,36 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			this._inErrorState = true;
 			throw error;
 		}
+	}
+
+	private loadContentMetadata(metadata: any): void {
+		this._savedKernelInfo = metadata.kernelspec;
+		this._defaultLanguageInfo = metadata.language_info;
+		// If language info was serialized in the notebook, attempt to use that to decrease time
+		// required until colorization occurs
+		if (this._defaultLanguageInfo) {
+			this.updateLanguageInfo(this._defaultLanguageInfo);
+		}
+		this._savedConnectionName = metadata.connection_name;
+		this._multiConnection = metadata.multi_connection ? metadata.multi_connection : false;
+
+		//Telemetry of loading notebook
+		if (metadata.azdata_notebook_guid && metadata.azdata_notebook_guid.length === 36) {
+			//Verify if it is actual GUID and then send it to the telemetry
+			let regex = new RegExp('(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}');
+			if (regex.test(metadata.azdata_notebook_guid)) {
+				this.adstelemetryService.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.TelemetryAction.Open)
+					.withAdditionalProperties({ azdata_notebook_guid: metadata.azdata_notebook_guid })
+					.send();
+			}
+		}
+		Object.keys(metadata).forEach(key => {
+			let expectedKeys = ['kernelspec', 'language_info', 'tags', 'connection_name', 'multi_connection'];
+			// If custom metadata is defined, add to the _existingMetadata object
+			if (expectedKeys.indexOf(key) < 0) {
+				this._existingMetadata[key] = metadata[key];
+			}
+		});
 	}
 
 	public async requestModelLoad(): Promise<void> {
@@ -1007,16 +1021,6 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return values(connections).find(connection => connection.connectionName === connectionName);
 	}
 
-	// Get saved connection name if saved in notebook file
-	private getSavedConnectionName(notebook: nb.INotebookContents): string | undefined {
-		return notebook?.metadata?.connection_name ? notebook.metadata.connection_name : undefined;
-	}
-
-	// Get default kernel info if saved in notebook file
-	private getSavedKernelInfo(notebook: nb.INotebookContents): nb.IKernelSpec | undefined {
-		return (notebook && notebook.metadata && notebook.metadata.kernelspec) ? notebook.metadata.kernelspec : undefined;
-	}
-
 	private getKernelSpecFromDisplayName(displayName: string): nb.IKernelSpec | undefined {
 		let kernel: nb.IKernelSpec = this.specs.kernels.find(k => k.display_name.toLowerCase() === displayName.toLowerCase());
 		if (!kernel) {
@@ -1249,6 +1253,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		metadata.kernelspec = this._savedKernelInfo;
 		metadata.language_info = this.languageInfo;
 		metadata.tags = this._tags;
+		metadata.multi_connection = this._multiConnection ? this._multiConnection : undefined;
 		if (this.configurationService.getValue(saveConnectionNameConfigName)) {
 			metadata.connection_name = this._savedConnectionName;
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds the multi_connection field to notebook metadata and moves the loading content metadata logic into a separate method in NotebookModel.

