### PR TITLE
Add resource deployment filtering by option values

### DIFF
--- a/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
@@ -147,7 +147,7 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 
 		this.disposables.push(
 			newInstance.onDidClick(async () => {
-				await vscode.commands.executeCommand('azdata.resource.deploy', 'arc.sql', ['arc.sql', 'arc.postgres']);
+				await vscode.commands.executeCommand('azdata.resource.deploy', 'azure-sql-mi', ['azure-sql-mi', 'arc.postgres'], { 'azure-sql-mi': { 'mi-type': ['arc-mi'] } });
 			}));
 
 		// Refresh

--- a/extensions/resource-deployment/src/main.ts
+++ b/extensions/resource-deployment/src/main.ts
@@ -8,7 +8,7 @@ import * as nls from 'vscode-nls';
 import { NotebookBasedDialogInfo } from './interfaces';
 import { NotebookService } from './services/notebookService';
 import { PlatformService } from './services/platformService';
-import { ResourceTypeService } from './services/resourceTypeService';
+import { OptionValuesFilter, ResourceTypeService } from './services/resourceTypeService';
 import { ToolsService } from './services/toolsService';
 import { DeploymentInputDialog } from './ui/deploymentInputDialog';
 import { ResourceTypePickerDialog } from './ui/resourceTypePickerDialog';
@@ -37,12 +37,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<rd.IEx
 	 * @param resourceTypeNameFilters Optional filters to apply to the resource types displayed. If undefined all
 	 * resource types will be displayed
 	 */
-	const openDialog = (defaultResourceTypeName: string, resourceTypeNameFilters?: string[]) => {
+	const openDialog = (defaultResourceTypeName: string, resourceTypeNameFilters?: string[], optionValuesFilter?: OptionValuesFilter) => {
 		const defaultResourceType = resourceTypes.find(resourceType => resourceType.name === defaultResourceTypeName);
 		if (!defaultResourceType) {
 			vscode.window.showErrorMessage(localize('resourceDeployment.UnknownResourceType', "The resource type: {0} is not defined", defaultResourceTypeName));
 		} else {
-			const dialog = new ResourceTypePickerDialog(resourceTypeService, defaultResourceType, resourceTypeNameFilters);
+			const dialog = new ResourceTypePickerDialog(resourceTypeService, defaultResourceType, resourceTypeNameFilters, optionValuesFilter);
 			dialog.open();
 		}
 	};
@@ -53,14 +53,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<rd.IEx
 	vscode.commands.registerCommand('azdata.resource.sql-bdc.deploy', () => {
 		openDialog('sql-bdc');
 	});
-	vscode.commands.registerCommand('azdata.resource.deploy', (defaultResourceTypeName?: string, resourceTypeNameFilters?: string[]) => {
+	/**
+	 * Command to open the Resource Deployment wizard - with options to filter the values shown
+	 * @param defaultResourceTypeName - The default resourceType to be selected
+	 * @param resourceTypeNameFilters - The list of resourceTypes to show in the wizard
+	 * @param optionValuesFilter - The list of resourceType option values to show in the wizard. This is an object in the format
+	 * { "resource-type-name": { "option-name": ["option-value-1", "option-value-2"] } }
+	 */
+	vscode.commands.registerCommand('azdata.resource.deploy', (defaultResourceTypeName?: string, resourceTypeNameFilters?: string[], optionValuesFilter?: OptionValuesFilter) => {
 		if ((resourceTypeNameFilters && !Array.isArray(resourceTypeNameFilters) ||
 			(resourceTypeNameFilters && resourceTypeNameFilters.length > 0 && typeof resourceTypeNameFilters[0] !== 'string'))) {
 			throw new Error('resourceTypeNameFilters must either be undefined or an array of strings');
 		}
 
 		if (typeof defaultResourceTypeName === 'string') {
-			openDialog(defaultResourceTypeName, resourceTypeNameFilters);
+			openDialog(defaultResourceTypeName, resourceTypeNameFilters, optionValuesFilter);
 		} else {
 			let defaultDeploymentType: string;
 			if (platformService.platform() === 'win32') {
@@ -68,7 +75,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<rd.IEx
 			} else {
 				defaultDeploymentType = 'sql-image';
 			}
-			openDialog(defaultDeploymentType, resourceTypeNameFilters);
+			openDialog(defaultDeploymentType, resourceTypeNameFilters, optionValuesFilter);
 		}
 	});
 	vscode.commands.registerCommand('azdata.openNotebookInputDialog', (dialogInfo: NotebookBasedDialogInfo) => {

--- a/extensions/resource-deployment/src/services/resourceTypeService.ts
+++ b/extensions/resource-deployment/src/services/resourceTypeService.ts
@@ -21,10 +21,13 @@ import { deepClone } from '../common/utils';
 
 const localize = nls.loadMessageBundle();
 
+export interface OptionValuesFilter {
+	[key: string]: Record<string, string[]>
+}
 export interface IResourceTypeService {
 	getResourceTypes(filterByPlatform?: boolean): ResourceType[];
 	validateResourceTypes(resourceTypes: ResourceType[]): string[];
-	startDeployment(resourceType: ResourceType): void;
+	startDeployment(resourceType: ResourceType, optionValuesFilter?: OptionValuesFilter): void;
 }
 
 export class ResourceTypeService implements IResourceTypeService {
@@ -124,7 +127,7 @@ export class ResourceTypeService implements IResourceTypeService {
 			const extensionResourceSubTypes = extension.packageJSON.contributes?.resourceDeploymentSubTypes as ResourceSubType[];
 			extensionResourceSubTypes?.forEach((extensionResourceSubType: ResourceSubType) => {
 				const resourceSubType = deepClone(extensionResourceSubType);
-				if (resourceSubType.name === resourceType.name) {
+				if (resourceSubType.resourceName === resourceType.name) {
 					this.updateProviderPathProperties(resourceSubType.provider, extension.extensionPath);
 					resourceSubTypes.push(resourceSubType);
 					const tagSet = new Set(resourceType.tags);
@@ -301,8 +304,8 @@ export class ResourceTypeService implements IResourceTypeService {
 		return undefined;
 	}
 
-	public startDeployment(resourceType: ResourceType): void {
-		const wizard = new ResourceTypeWizard(resourceType, new KubeService(), new AzdataService(this.platformService), this.notebookService, this.toolsService, this.platformService, this);
+	public startDeployment(resourceType: ResourceType, optionValuesFilter?: OptionValuesFilter): void {
+		const wizard = new ResourceTypeWizard(resourceType, new KubeService(), new AzdataService(this.platformService), this.notebookService, this.toolsService, this.platformService, this, optionValuesFilter);
 		wizard.open();
 	}
 

--- a/extensions/resource-deployment/src/services/resourceTypeService.ts
+++ b/extensions/resource-deployment/src/services/resourceTypeService.ts
@@ -21,9 +21,13 @@ import { deepClone } from '../common/utils';
 
 const localize = nls.loadMessageBundle();
 
+/**
+ * Used to filter the specific optionValues that the deployment wizard shows
+ */
 export interface OptionValuesFilter {
 	[key: string]: Record<string, string[]>
 }
+
 export interface IResourceTypeService {
 	getResourceTypes(filterByPlatform?: boolean): ResourceType[];
 	validateResourceTypes(resourceTypes: ResourceType[]): string[];
@@ -127,7 +131,7 @@ export class ResourceTypeService implements IResourceTypeService {
 			const extensionResourceSubTypes = extension.packageJSON.contributes?.resourceDeploymentSubTypes as ResourceSubType[];
 			extensionResourceSubTypes?.forEach((extensionResourceSubType: ResourceSubType) => {
 				const resourceSubType = deepClone(extensionResourceSubType);
-				if (resourceSubType.resourceName === resourceType.name) {
+				if (resourceSubType.name === resourceType.name) {
 					this.updateProviderPathProperties(resourceSubType.provider, extension.extensionPath);
 					resourceSubTypes.push(resourceSubType);
 					const tagSet = new Set(resourceType.tags);

--- a/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypePickerDialog.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
 import { ResourceType } from '../interfaces';
-import { IResourceTypeService } from '../services/resourceTypeService';
+import { IResourceTypeService, OptionValuesFilter } from '../services/resourceTypeService';
 import * as loc from './../localizedConstants';
 import { DialogBase } from './dialogBase';
 import * as constants from '../constants';
@@ -27,7 +27,8 @@ export class ResourceTypePickerDialog extends DialogBase {
 	constructor(
 		private resourceTypeService: IResourceTypeService,
 		defaultResourceType: ResourceType,
-		private _resourceTypeNameFilters?: string[]) {
+		private _resourceTypeNameFilters?: string[],
+		private _optionValuesFilter?: OptionValuesFilter) {
 		super(loc.resourceTypePickerDialogTitle, 'ResourceTypePickerDialog', true);
 		this._selectedResourceType = defaultResourceType;
 		this._dialogObject.okButton.label = loc.select;
@@ -188,7 +189,7 @@ export class ResourceTypePickerDialog extends DialogBase {
 	}
 
 	protected async onComplete(): Promise<void> {
-		this.resourceTypeService.startDeployment(this._selectedResourceType);
+		this.resourceTypeService.startDeployment(this._selectedResourceType, this._optionValuesFilter);
 	}
 
 	private getAllResourceTags(): string[] {

--- a/extensions/resource-deployment/src/ui/resourceTypeWizard.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypeWizard.ts
@@ -19,7 +19,7 @@ import { ResourceTypePage } from './resourceTypePage';
 import { NotebookWizardModel } from './notebookWizard/notebookWizardModel';
 import { DeployAzureSQLDBWizardModel } from './deployAzureSQLDBWizard/deployAzureSQLDBWizardModel';
 import { ToolsAndEulaPage } from './toolsAndEulaSettingsPage';
-import { ResourceTypeService } from '../services/resourceTypeService';
+import { OptionValuesFilter, ResourceTypeService } from '../services/resourceTypeService';
 import { PageLessDeploymentModel } from './pageLessDeploymentModel';
 
 export class ResourceTypeWizard {
@@ -58,7 +58,8 @@ export class ResourceTypeWizard {
 		public notebookService: INotebookService,
 		public toolsService: IToolsService,
 		public platformService: IPlatformService,
-		public resourceTypeService: ResourceTypeService) {
+		public resourceTypeService: ResourceTypeService,
+		private _optionValuesFilter?: OptionValuesFilter) {
 		/**
 		 * Setting the first provider from the first value of the dropdowns.
 		 * If there are no options (dropdowns) then the resource type has only one provider which is set as default here.
@@ -93,6 +94,7 @@ export class ResourceTypeWizard {
 		}));
 
 		this.toDispose.push(this.wizardObject.doneButton.onClick(async () => {
+			// TODO - Don't close this when the button is clicked, set up a page validator instead
 			await this._model.onOk();
 			this.dispose();
 		}));
@@ -144,7 +146,7 @@ export class ResourceTypeWizard {
 	}
 
 	public setPages(pages: ResourceTypePage[]) {
-		pages.unshift(new ToolsAndEulaPage(this));
+		pages.unshift(new ToolsAndEulaPage(this, this._optionValuesFilter));
 		this.wizardObject!.pages = pages.map(p => p.pageObject);
 		this.pages = pages;
 		this.pages.forEach((page) => {


### PR DESCRIPTION
Previously the Arc dashboards had a feature where when you clicked a button on the dashboards to deploy a new instance it would open up the Resource Deployment wizard with only certain arc-related options shown.

But a recent change put MIAA under a new overall MI resource type and so we no longer can filter down to just Arc related items - it only allowed filtering to the resource type granularity.

This PR adds in additional filtering capabilities for the optionValues to only display certain values for those as well.