### PR TITLE
Fix error when rendering empty declarative table

### DIFF
--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
@@ -242,7 +242,7 @@ export default class DeclarativeTableComponent extends ContainerBase<any, azdata
 	private static ACCEPTABLE_VALUES = new Set<string>(['number', 'string', 'boolean']);
 	public setProperties(properties: azdata.DeclarativeTableProperties): void {
 		const basicData: any[][] = properties.data ?? [];
-		const complexData: azdata.DeclarativeTableCellValue[][] = properties.dataValues;
+		const complexData: azdata.DeclarativeTableCellValue[][] = properties.dataValues ?? [];
 		let finalData: azdata.DeclarativeTableCellValue[][];
 
 		finalData = basicData.map(row => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/14082

When setting data to an empty array we weren't properly checking for that and so ended up with _data being undefined which caused an error in the Angular template