### PR TITLE
Rename name field of resourceSubType to resourceName

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -2,14 +2,14 @@
   "name": "arc",
   "displayName": "%arc.displayName%",
   "description": "%arc.description%",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "publisher": "Microsoft",
   "preview": true,
   "license": "https://raw.githubusercontent.com/Microsoft/azuredatastudio/main/LICENSE.txt",
   "icon": "images/extension.png",
   "engines": {
     "vscode": "*",
-    "azdata": ">=1.25.0"
+    "azdata": ">=1.26.0"
   },
   "activationEvents": [
     "onCommand:arc.connectToController",

--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -895,7 +895,7 @@
     ],
     "resourceDeploymentSubTypes": [
       {
-        "name": "azure-sql-mi",
+        "resourceName": "azure-sql-mi",
         "options": [
           {
             "name": "mi-type",

--- a/extensions/azdata/package.json
+++ b/extensions/azdata/package.json
@@ -9,7 +9,7 @@
   "icon": "images/extension.png",
   "engines": {
     "vscode": "*",
-    "azdata": ">=1.25.0"
+    "azdata": ">=1.26.0"
   },
   "activationEvents": [
     "*"

--- a/extensions/resource-deployment/src/interfaces.ts
+++ b/extensions/resource-deployment/src/interfaces.ts
@@ -30,7 +30,7 @@ export interface ResourceType {
 
 export interface ResourceSubType {
 	/**
-	 * The name should match the name in Resource Type
+	 * The name of the Resource Type this subtype is extending
 	 */
 	resourceName: string;
 	/**

--- a/extensions/resource-deployment/src/interfaces.ts
+++ b/extensions/resource-deployment/src/interfaces.ts
@@ -32,7 +32,7 @@ export interface ResourceSubType {
 	/**
 	 * The name should match the name in Resource Type
 	 */
-	name: string;
+	resourceName: string;
 	/**
 	 * The option name should have a matching name in ResourceType.options
 	 */

--- a/extensions/resource-deployment/src/services/resourceTypeService.ts
+++ b/extensions/resource-deployment/src/services/resourceTypeService.ts
@@ -124,7 +124,7 @@ export class ResourceTypeService implements IResourceTypeService {
 			const extensionResourceSubTypes = extension.packageJSON.contributes?.resourceDeploymentSubTypes as ResourceSubType[];
 			extensionResourceSubTypes?.forEach((extensionResourceSubType: ResourceSubType) => {
 				const resourceSubType = deepClone(extensionResourceSubType);
-				if (resourceSubType.name === resourceType.name) {
+				if (resourceSubType.resourceName === resourceType.name) {
 					this.updateProviderPathProperties(resourceSubType.provider, extension.extensionPath);
 					resourceSubTypes.push(resourceSubType);
 					const tagSet = new Set(resourceType.tags);


### PR DESCRIPTION
Name could potentially be confusing since people may think that it's the name of this "sub type" instead of the name of the actual resource type that's already defined elsewhere. 

It might not be a bad idea to see if we can find a better name for resourceSubType too - this isn't really a sub type at all but rather just additional options on top of an existing type. 