### PR TITLE
Notebooks: Fix Notebook validation Error when opened in Jupyter

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -718,7 +718,9 @@ export class CellModel extends Disposable implements ICellModel {
 				if (this._outputs.length > 0) {
 					for (let i = 0; i < this._outputs.length; i++) {
 						if (this._outputs[i].output_type === 'execute_result') {
-							// deletes transient node in the serialized JSON
+							// Deletes transient node in the serialized JSON
+							// "Optional transient data introduced in 5.1. Information not to be persisted to a notebook or other documents."
+							// (https://jupyter-client.readthedocs.io/en/stable/messaging.html)
 							delete output['transient'];
 							this._outputs.splice(i, 0, this.rewriteOutputUrls(output));
 							this.fireOutputsChanged();

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -718,6 +718,8 @@ export class CellModel extends Disposable implements ICellModel {
 				if (this._outputs.length > 0) {
 					for (let i = 0; i < this._outputs.length; i++) {
 						if (this._outputs[i].output_type === 'execute_result') {
+							// deletes transient node in the serialized JSON
+							delete output['transient'];
 							this._outputs.splice(i, 0, this.rewriteOutputUrls(output));
 							this.fireOutputsChanged();
 							added = true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes error shown when ADS notebook is opened in Jupyter:
![image](https://user-images.githubusercontent.com/23462877/106310567-9a284680-6218-11eb-9f32-0b47a97e0847.png)

The transient field in outputs of type 'display_data' was not being deleted before serialization.
