### PR TITLE
Fix deployment wizard for filtered options

### DIFF
--- a/extensions/resource-deployment/src/services/resourceTypeService.ts
+++ b/extensions/resource-deployment/src/services/resourceTypeService.ts
@@ -56,7 +56,7 @@ export class ResourceTypeService implements IResourceTypeService {
 					resourceType.getProvider = (selectedOptions) => { return this.getProvider(resourceType, selectedOptions); };
 					resourceType.getOkButtonText = (selectedOptions) => { return this.getOkButtonText(resourceType, selectedOptions); };
 					resourceType.getAgreementInfo = (selectedOptions) => { return this.getAgreementInfo(resourceType, selectedOptions); };
-					this.getResourceSubTypes(filterByPlatform, resourceType);
+					this.getResourceSubTypes(resourceType);
 					this._resourceTypes.push(resourceType);
 				});
 
@@ -125,7 +125,7 @@ export class ResourceTypeService implements IResourceTypeService {
 		}
 	}
 
-	private getResourceSubTypes(filterByPlatform: boolean = true, resourceType: ResourceType): void {
+	private getResourceSubTypes(resourceType: ResourceType): void {
 		const resourceSubTypes: ResourceSubType[] = [];
 		vscode.extensions.all.forEach((extension) => {
 			const extensionResourceSubTypes = extension.packageJSON.contributes?.resourceDeploymentSubTypes as ResourceSubType[];
@@ -155,7 +155,6 @@ export class ResourceTypeService implements IResourceTypeService {
 					}
 				}
 			});
-
 		});
 	}
 

--- a/extensions/resource-deployment/src/ui/resourceTypeWizard.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypeWizard.ts
@@ -64,8 +64,18 @@ export class ResourceTypeWizard {
 		 * Setting the first provider from the first value of the dropdowns.
 		 * If there are no options (dropdowns) then the resource type has only one provider which is set as default here.
 		 */
+		let filteredOptions = resourceType.options;
+		const optionsFilter = this._optionValuesFilter?.[this.resourceType.name];
+		if (optionsFilter) {
+			filteredOptions.forEach(option => {
+				const optionValuesFilter = optionsFilter[option.name];
+				if (optionValuesFilter) {
+					option.values = option.values.filter(optionValue => optionValuesFilter.includes(optionValue.name));
+				}
+			});
+		}
 		if (resourceType.options) {
-			this.provider = this.resourceType.getProvider(resourceType.options.map(option => { return { option: option.name, value: option.values[0].name }; }))!;
+			this.provider = this.resourceType.getProvider(filteredOptions.map(option => { return { option: option.name, value: option.values[0].name }; }))!;
 		} else {
 			this.provider = this.resourceType.providers[0];
 		}


### PR DESCRIPTION
The wizard wasn't filtering the options when setting the initial model so it was still choosing the first one in the list - even if that was filtered out. 

Also cleaned up an unused param while I was looking at this. 