### PR TITLE
Notebook Cell Conversion Language Fixes

### DIFF
--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -44,12 +44,11 @@ let expectedNotebookContent: nb.INotebookContents = {
 	cells: [{
 		cell_type: CellTypes.Code,
 		source: ['insert into t1 values (c1, c2)'],
-		metadata: { language: 'python' },
+		metadata: { language: 'sql' },
 		execution_count: 1
 	}, {
 		cell_type: CellTypes.Markdown,
 		source: ['I am *markdown*'],
-		metadata: { language: 'python' },
 		execution_count: 1
 	}],
 	metadata: {
@@ -57,6 +56,9 @@ let expectedNotebookContent: nb.INotebookContents = {
 			name: 'mssql',
 			language: 'sql',
 			display_name: 'SQL'
+		},
+		language_info: {
+			name: 'sql'
 		}
 	},
 	nbformat: 4,
@@ -542,6 +544,34 @@ suite('notebook model', function (): void {
 		model.cells[0].metadata = { 'test-field': 'test-value' };
 		assert(!isUndefinedOrNull(notebookContentChange));
 		assert.equal(notebookContentChange.changeType, NotebookChangeType.CellMetadataUpdated, 'notebookContentChange changeType should indicate ');
+	});
+
+	test('Should set cell language correctly after cell type conversion', async function (): Promise<void> {
+		let mockContentManager = TypeMoq.Mock.ofType(NotebookEditorContentManager);
+		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedNotebookContent));
+		defaultModelOptions.contentManager = mockContentManager.object;
+
+		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
+		await model.loadContents();
+
+		let newCell: ICellModel;
+		model.onCellTypeChanged(c => newCell = c);
+
+		let firstCell = model.cells[0];
+		let secondCell = model.cells[1];
+
+		assert.equal(firstCell.cellType, CellTypes.Code, 'Initial cell type for first cell should be code');
+		assert.equal(firstCell.language, 'sql', 'Initial language should be sql for first cell');
+
+		model.convertCellType(firstCell);
+		assert.equal(firstCell.cellType, CellTypes.Markdown, 'Failed to convert cell type after conversion');
+		assert.equal(firstCell.language, 'markdown', 'Language should be markdown for text cells');
+		assert.deepEqual(newCell, firstCell);
+
+		model.convertCellType(secondCell);
+		assert.equal(secondCell.cellType, CellTypes.Code, 'Failed to convert second cell type');
+		assert.equal(secondCell.language, 'sql', 'Language should be sql again for first cell');
+		assert.deepEqual(newCell, secondCell);
 	});
 
 	test('Should load contents but then go to error state if client session startup fails', async function (): Promise<void> {

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -570,7 +570,7 @@ suite('notebook model', function (): void {
 
 		model.convertCellType(secondCell);
 		assert.equal(secondCell.cellType, CellTypes.Code, 'Failed to convert second cell type');
-		assert.equal(secondCell.language, 'sql', 'Language should be sql again for first cell');
+		assert.equal(secondCell.language, 'sql', 'Language should be sql again for second cell');
 		assert.deepEqual(newCell, secondCell);
 	});
 

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -581,14 +581,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		if (cell) {
 			let index = this.findCellIndex(cell);
 			if (index > -1) {
-				// If cell is a markdown cell, transform into code cell (and vice versa)
-				if (cell.cellType === CellTypes.Markdown) {
-					cell.cellType = CellTypes.Code;
-					// Ensure override language is reset
-					cell.setOverrideLanguage('');
-				} else {
-					cell.cellType = CellTypes.Markdown;
-				}
+				// Ensure override language is reset
+				cell.setOverrideLanguage('');
+				cell.cellType = cell.cellType === CellTypes.Markdown ? CellTypes.Code : CellTypes.Markdown;
 				this._onCellTypeChanged.fire(cell);
 				this._contentChangedEmitter.fire({
 					changeType: NotebookChangeType.CellsModified,

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -581,7 +581,14 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		if (cell) {
 			let index = this.findCellIndex(cell);
 			if (index > -1) {
-				cell.cellType = cell.cellType === CellTypes.Markdown ? CellTypes.Code : CellTypes.Markdown;
+				// If cell is a markdown cell, transform into code cell (and vice versa)
+				if (cell.cellType === CellTypes.Markdown) {
+					cell.cellType = CellTypes.Code;
+					// Ensure override language is reset
+					cell.setOverrideLanguage('');
+				} else {
+					cell.cellType = CellTypes.Markdown;
+				}
 				this._onCellTypeChanged.fire(cell);
 				this._contentChangedEmitter.fire({
 					changeType: NotebookChangeType.CellsModified,


### PR DESCRIPTION
Fixes #12011.

When we were converting cells, we weren't resetting the language property on the cell model. Therefore, it was possible for a text cell to be converted to a code cell, but still think that the cell's language was markdown.


https://user-images.githubusercontent.com/40371649/106345437-0335ab80-6265-11eb-91a4-f8beea94fef7.mp4
