### PR TITLE
Update db dropdown in create project from database dialog to not be editable

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -161,9 +161,7 @@ export class CreateProjectFromDatabaseDialog {
 		this.sourceDatabaseDropDown = view.modelBuilder.dropDown().withProperties({
 			ariaLabel: constants.databaseNameLabel,
 			required: true,
-			width: cssStyles.createProjectFromDatabaseTextboxWidth,
-			editable: true,
-			fireOnTextChange: true
+			width: cssStyles.createProjectFromDatabaseTextboxWidth
 		}).component();
 
 		this.sourceDatabaseDropDown.onValueChanged(() => {


### PR DESCRIPTION
This PR fixes #14141. This dropdown shouldn't be editable since an existing database needs to be chosen.
