### PR TITLE
Fix decorations for modified notebooks in Books View

### DIFF
--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -82,7 +82,8 @@ export class BookTreeItem extends vscode.TreeItem {
 			}
 			this._rootContentPath = getContentPath(this.book.version, this.book.root, '');
 			this.tooltip = this.book.type === BookTreeItemType.Book ? this._rootContentPath : this.book.contentPath;
-			this.resourceUri = vscode.Uri.file(this.book.root);
+			//this.resourceUri = this.book.type === BookTreeItemType.Book ? vscode.Uri.file(this._rootContentPath) : vscode.Uri.file(this.book.contentPath);
+			this.resourceUri = this.book.type === BookTreeItemType.Book ? vscode.Uri.file(this.book.root) : vscode.Uri.file(this.book.contentPath);
 		}
 	}
 

--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -82,7 +82,6 @@ export class BookTreeItem extends vscode.TreeItem {
 			}
 			this._rootContentPath = getContentPath(this.book.version, this.book.root, '');
 			this.tooltip = this.book.type === BookTreeItemType.Book ? this._rootContentPath : this.book.contentPath;
-			//this.resourceUri = this.book.type === BookTreeItemType.Book ? vscode.Uri.file(this._rootContentPath) : vscode.Uri.file(this.book.contentPath);
 			this.resourceUri = this.book.type === BookTreeItemType.Book ? vscode.Uri.file(this.book.root) : vscode.Uri.file(this.book.contentPath);
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet.ts
@@ -291,7 +291,7 @@ export class NotebookExplorerViewPaneContainer extends ViewPaneContainer {
 									filesToIncludeFiltered = filesToIncludeFiltered + path.join(folderToSearch.folder.fsPath, '**', '*.md') + ',' + path.join(folderToSearch.folder.fsPath, '**', '*.ipynb') + ',';
 								} else {
 									let pattern = {};
-									let rootFolder = URI.file(root.resourceUri.path);
+									let rootFolder = URI.file(path.dirname(root.resourceUri.path));
 									let pathToNotebook = isString(root.tooltip) ? root.tooltip : root.tooltip.value;
 									let baseName = path.join('**', path.basename(pathToNotebook));
 									pattern[baseName] = true;


### PR DESCRIPTION
The tree item resource uri is used to apply file decorations when a notebook is modified. 
If the tree item is a book then the resource should be the book root, and if it's a notebook then it should be the the notebook's content path.
This PR fixes #13688
