### PR TITLE
Use cryptography 3.2.1 for sparkmagic dependency

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -44,7 +44,7 @@ export interface PythonInstallSettings {
 }
 export interface IJupyterServerInstallation {
 	/**
-	 * Installs the specified packages using pip
+	 * Installs the specified packages using conda
 	 * @param packages The list of packages to install
 	 * @param useMinVersionDefault Whether we install each package as a min version (>=) or exact version (==) by default
 	 */

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -123,12 +123,12 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		};
 		this._requiredKernelPackages.set(constants.powershellDisplayName, [jupyterPkg, powershellPkg]);
 
-		let sparkPackages = [
+		let sparkPackages: PythonPkgDetails[] = [
 			jupyterPkg,
 			{
 				name: 'cryptography',
 				version: '3.2.1',
-				useExactVersion: true
+				installExactVersion: true
 			},
 			{
 				name: 'sparkmagic',

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -69,18 +69,18 @@ export interface IJupyterServerInstallation {
 	pythonInstallationPath: string;
 }
 
-export const jupyterPkg: PythonPkgDetails = {
+export const requiredJupyterPkg: PythonPkgDetails = {
 	name: 'jupyter',
 	version: '1.0.0'
 };
 
-export const powershellPkg: PythonPkgDetails = {
+export const requiredPowershellPkg: PythonPkgDetails = {
 	name: 'powershell-kernel',
 	version: '0.1.4'
 };
 
-export const sparkPackages: PythonPkgDetails[] = [
-	jupyterPkg,
+export const requiredSparkPackages: PythonPkgDetails[] = [
+	requiredJupyterPkg,
 	{
 		name: 'cryptography',
 		version: '3.2.1',
@@ -138,13 +138,13 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		this._kernelSetupCache = new Map<string, boolean>();
 		this._requiredKernelPackages = new Map<string, PythonPkgDetails[]>();
 
-		this._requiredKernelPackages.set(constants.python3DisplayName, [jupyterPkg]);
-		this._requiredKernelPackages.set(constants.powershellDisplayName, [jupyterPkg, powershellPkg]);
-		this._requiredKernelPackages.set(constants.pysparkDisplayName, sparkPackages);
-		this._requiredKernelPackages.set(constants.sparkScalaDisplayName, sparkPackages);
-		this._requiredKernelPackages.set(constants.sparkRDisplayName, sparkPackages);
+		this._requiredKernelPackages.set(constants.python3DisplayName, [requiredJupyterPkg]);
+		this._requiredKernelPackages.set(constants.powershellDisplayName, [requiredJupyterPkg, requiredPowershellPkg]);
+		this._requiredKernelPackages.set(constants.pysparkDisplayName, requiredSparkPackages);
+		this._requiredKernelPackages.set(constants.sparkScalaDisplayName, requiredSparkPackages);
+		this._requiredKernelPackages.set(constants.sparkRDisplayName, requiredSparkPackages);
 
-		let allPackages = sparkPackages.concat(powershellPkg);
+		let allPackages = requiredSparkPackages.concat(requiredPowershellPkg);
 		this._requiredKernelPackages.set(constants.allKernelsName, allPackages);
 
 		this._requiredPackagesSet = new Set<string>();

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -68,6 +68,33 @@ export interface IJupyterServerInstallation {
 	pythonExecutable: string;
 	pythonInstallationPath: string;
 }
+
+export const jupyterPkg: PythonPkgDetails = {
+	name: 'jupyter',
+	version: '1.0.0'
+};
+
+export const powershellPkg: PythonPkgDetails = {
+	name: 'powershell-kernel',
+	version: '0.1.4'
+};
+
+export const sparkPackages: PythonPkgDetails[] = [
+	jupyterPkg,
+	{
+		name: 'cryptography',
+		version: '3.2.1',
+		installExactVersion: true
+	},
+	{
+		name: 'sparkmagic',
+		version: '0.12.9'
+	}, {
+		name: 'pandas',
+		version: '0.24.2'
+	}
+];
+
 export class JupyterServerInstallation implements IJupyterServerInstallation {
 	public extensionPath: string;
 	public pythonBinPath: string;
@@ -111,33 +138,8 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 		this._kernelSetupCache = new Map<string, boolean>();
 		this._requiredKernelPackages = new Map<string, PythonPkgDetails[]>();
 
-		let jupyterPkg = {
-			name: 'jupyter',
-			version: '1.0.0'
-		};
 		this._requiredKernelPackages.set(constants.python3DisplayName, [jupyterPkg]);
-
-		let powershellPkg = {
-			name: 'powershell-kernel',
-			version: '0.1.4'
-		};
 		this._requiredKernelPackages.set(constants.powershellDisplayName, [jupyterPkg, powershellPkg]);
-
-		let sparkPackages: PythonPkgDetails[] = [
-			jupyterPkg,
-			{
-				name: 'cryptography',
-				version: '3.2.1',
-				installExactVersion: true
-			},
-			{
-				name: 'sparkmagic',
-				version: '0.12.9'
-			}, {
-				name: 'pandas',
-				version: '0.24.2'
-			}
-		];
 		this._requiredKernelPackages.set(constants.pysparkDisplayName, sparkPackages);
 		this._requiredKernelPackages.set(constants.sparkScalaDisplayName, sparkPackages);
 		this._requiredKernelPackages.set(constants.sparkRDisplayName, sparkPackages);

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -11,7 +11,7 @@ import * as uuid from 'uuid';
 import * as fs from 'fs-extra';
 import * as request from 'request';
 import * as utils from '../../common/utils';
-import { JupyterServerInstallation, PythonInstallSettings, PythonPkgDetails } from '../../jupyter/jupyterServerInstallation';
+import { jupyterPkg, JupyterServerInstallation, powershellPkg, PythonInstallSettings, PythonPkgDetails, sparkPackages } from '../../jupyter/jupyterServerInstallation';
 import { powershellDisplayName, pysparkDisplayName, python3DisplayName, sparkRDisplayName, sparkScalaDisplayName, winPlatform } from '../../common/constants';
 
 describe('Jupyter Server Installation', function () {
@@ -216,45 +216,24 @@ describe('Jupyter Server Installation', function () {
 	});
 
 	it('Get required packages test - Python 3 kernel', async function() {
-		let expectedPackages: PythonPkgDetails[] = [{
-			name: 'jupyter',
-			version: '1.0.0'
-		}];
 		let packages = installation.getRequiredPackagesForKernel(python3DisplayName);
-		should(packages).be.deepEqual(expectedPackages);
+		should(packages).be.deepEqual([jupyterPkg]);
 	});
 
 	it('Get required packages test - Powershell kernel', async function() {
-		let expectedPackages = [{
-			name: 'jupyter',
-			version: '1.0.0'
-		}, {
-			name: 'powershell-kernel',
-			version: '0.1.4'
-		}];
 		let packages = installation.getRequiredPackagesForKernel(powershellDisplayName);
-		should(packages).be.deepEqual(expectedPackages);
+		should(packages).be.deepEqual([jupyterPkg, powershellPkg]);
 	});
 
 	it('Get required packages test - Spark kernels', async function() {
-		let expectedPackages = [{
-			name: 'jupyter',
-			version: '1.0.0'
-		}, {
-			name: 'sparkmagic',
-			version: '0.12.9'
-		}, {
-			name: 'pandas',
-			version: '0.24.2'
-		}];
 		let packages = installation.getRequiredPackagesForKernel(pysparkDisplayName);
-		should(packages).be.deepEqual(expectedPackages, "Unexpected packages for PySpark kernel.");
+		should(packages).be.deepEqual(sparkPackages, 'Unexpected packages for PySpark kernel.');
 
 		packages = installation.getRequiredPackagesForKernel(sparkScalaDisplayName);
-		should(packages).be.deepEqual(expectedPackages, "Unexpected packages for Spark Scala kernel.");
+		should(packages).be.deepEqual(sparkPackages, 'Unexpected packages for Spark Scala kernel.');
 
 		packages = installation.getRequiredPackagesForKernel(sparkRDisplayName);
-		should(packages).be.deepEqual(expectedPackages, "Unexpected packages for Spark R kernel.");
+		should(packages).be.deepEqual(sparkPackages, 'Unexpected packages for Spark R kernel.');
 	});
 
 	it('Install python test - Run install while Python is already running', async function() {

--- a/extensions/notebook/src/test/python/jupyterInstallation.test.ts
+++ b/extensions/notebook/src/test/python/jupyterInstallation.test.ts
@@ -11,7 +11,7 @@ import * as uuid from 'uuid';
 import * as fs from 'fs-extra';
 import * as request from 'request';
 import * as utils from '../../common/utils';
-import { jupyterPkg, JupyterServerInstallation, powershellPkg, PythonInstallSettings, PythonPkgDetails, sparkPackages } from '../../jupyter/jupyterServerInstallation';
+import { requiredJupyterPkg, JupyterServerInstallation, requiredPowershellPkg, PythonInstallSettings, PythonPkgDetails, requiredSparkPackages } from '../../jupyter/jupyterServerInstallation';
 import { powershellDisplayName, pysparkDisplayName, python3DisplayName, sparkRDisplayName, sparkScalaDisplayName, winPlatform } from '../../common/constants';
 
 describe('Jupyter Server Installation', function () {
@@ -217,23 +217,23 @@ describe('Jupyter Server Installation', function () {
 
 	it('Get required packages test - Python 3 kernel', async function() {
 		let packages = installation.getRequiredPackagesForKernel(python3DisplayName);
-		should(packages).be.deepEqual([jupyterPkg]);
+		should(packages).be.deepEqual([requiredJupyterPkg]);
 	});
 
 	it('Get required packages test - Powershell kernel', async function() {
 		let packages = installation.getRequiredPackagesForKernel(powershellDisplayName);
-		should(packages).be.deepEqual([jupyterPkg, powershellPkg]);
+		should(packages).be.deepEqual([requiredJupyterPkg, requiredPowershellPkg]);
 	});
 
 	it('Get required packages test - Spark kernels', async function() {
 		let packages = installation.getRequiredPackagesForKernel(pysparkDisplayName);
-		should(packages).be.deepEqual(sparkPackages, 'Unexpected packages for PySpark kernel.');
+		should(packages).be.deepEqual(requiredSparkPackages, 'Unexpected packages for PySpark kernel.');
 
 		packages = installation.getRequiredPackagesForKernel(sparkScalaDisplayName);
-		should(packages).be.deepEqual(sparkPackages, 'Unexpected packages for Spark Scala kernel.');
+		should(packages).be.deepEqual(requiredSparkPackages, 'Unexpected packages for Spark Scala kernel.');
 
 		packages = installation.getRequiredPackagesForKernel(sparkRDisplayName);
-		should(packages).be.deepEqual(sparkPackages, 'Unexpected packages for Spark R kernel.');
+		should(packages).be.deepEqual(requiredSparkPackages, 'Unexpected packages for Spark R kernel.');
 	});
 
 	it('Install python test - Run install while Python is already running', async function() {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/14153

The issue here is that it's failing to build the wheel for cryptography > 3.2.1 - so for now just hardcode it to always install 3.2.1 if it doesn't detect the package already being installed.

Still need to investigate why there isn't a wheel already for the latest version of this package since previous versions had one.