### PR TITLE
Making the Postgres Properties Page Visible

### DIFF
--- a/extensions/arc/src/ui/dashboards/postgres/postgresDashboard.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresDashboard.ts
@@ -15,6 +15,7 @@ import { PostgresDiagnoseAndSolveProblemsPage } from './postgresDiagnoseAndSolve
 import { PostgresSupportRequestPage } from './postgresSupportRequestPage';
 import { PostgresComputeAndStoragePage } from './postgresComputeAndStoragePage';
 import { PostgresParametersPage } from './postgresParametersPage';
+import { PostgresPropertiesPage } from './postgresPropertiesPage';
 
 export class PostgresDashboard extends Dashboard {
 	constructor(private _context: vscode.ExtensionContext, private _controllerModel: ControllerModel, private _postgresModel: PostgresModel) {
@@ -33,8 +34,7 @@ export class PostgresDashboard extends Dashboard {
 		const overviewPage = new PostgresOverviewPage(modelView, this._controllerModel, this._postgresModel);
 		const connectionStringsPage = new PostgresConnectionStringsPage(modelView, this._postgresModel);
 		const computeAndStoragePage = new PostgresComputeAndStoragePage(modelView, this._postgresModel);
-		// TODO: Removed properties page while investigating bug where refreshed values don't appear in UI
-		// const propertiesPage = new PostgresPropertiesPage(modelView, this._controllerModel, this._postgresModel);
+		const propertiesPage = new PostgresPropertiesPage(modelView, this._controllerModel, this._postgresModel);
 		const parametersPage = new PostgresParametersPage(modelView, this._postgresModel);
 		const diagnoseAndSolveProblemsPage = new PostgresDiagnoseAndSolveProblemsPage(modelView, this._context, this._postgresModel);
 		const supportRequestPage = new PostgresSupportRequestPage(modelView, this._controllerModel, this._postgresModel);
@@ -44,6 +44,7 @@ export class PostgresDashboard extends Dashboard {
 			{
 				title: loc.settings,
 				tabs: [
+					propertiesPage.tab,
 					connectionStringsPage.tab,
 					computeAndStoragePage.tab,
 					parametersPage.tab

--- a/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresPropertiesPage.ts
@@ -50,6 +50,7 @@ export class PostgresPropertiesPage extends DashboardPage {
 		}).component());
 
 		this.keyValueContainer = new KeyValueContainer(this.modelView.modelBuilder, this.getProperties());
+		this.keyValueContainer.container.updateCssStyles({ 'max-width': '750px' });
 		this.disposables.push(this.keyValueContainer);
 
 		this.loading = this.modelView.modelBuilder.loadingComponent()


### PR DESCRIPTION
Postgres properties page is at a place to be visible. Has shown to update accurately. 

This PR

Gives access to the properties page on the postgres instance dashboard
Gives a max-width for the text boxes. 
<img width="700" alt="proppage" src="https://user-images.githubusercontent.com/69922333/106941271-76ad4200-66d7-11eb-9d2a-b629220082d2.PNG">
