### PR TITLE
Fix arc dashboard component order error

### DIFF
--- a/extensions/arc/src/ui/components/dashboardPage.ts
+++ b/extensions/arc/src/ui/components/dashboardPage.ts
@@ -26,8 +26,9 @@ export abstract class DashboardPage extends InitializingComponent {
 			title: this.title,
 			id: this.id,
 			icon: this.icon,
-			content: this.container,
-			toolbar: this.toolbarContainer
+			// Get toolbar first since things in the container might depend on these being created
+			toolbar: this.toolbarContainer,
+			content: this.container
 		};
 	}
 


### PR DESCRIPTION
Saw this a couple of times - the PG dashboard container references stuff from the toolbar and so with the current ordering it would throw errors. Not the most ideal fix but as a quick solution this is fine - and it makes sense anyways since generally the toolbar would only reference container stuff when the buttons are clicked so having it go first is better anyways.