### PR TITLE
Remove error message properties from events

### DIFF
--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -128,7 +128,6 @@ export class ProjectsController {
 			return project.dacpacOutputPath;
 		} catch (err) {
 			TelemetryReporter.createErrorEvent(TelemetryViews.ProjectController, TelemetryActions.build)
-				.withAdditionalProperties({ error: utils.getErrorMessage(err) })
 				.withAdditionalMeasurements({ duration: new Date().getMilliseconds() - startTime.getMilliseconds() })
 				.send();
 
@@ -203,7 +202,6 @@ export class ProjectsController {
 			const actionEndTime = new Date().getMilliseconds();
 			telemetryProps.actionDuration = (actionEndTime - actionStartTime).toString();
 			telemetryProps.totalDuration = (actionEndTime - buildStartTime).toString();
-			telemetryProps.errorMessage = utils.getErrorMessage(err);
 
 			TelemetryReporter.createErrorEvent(TelemetryViews.ProjectController, TelemetryActions.publishProject)
 				.withAdditionalProperties(telemetryProps)


### PR DESCRIPTION
From what I can see these are sending the raw error messages which could contain PII - removing them for now until logic can be added to sanitize them before upload. 