### PR TITLE
Fix service dependency startup warning

### DIFF
--- a/src/sql/platform/instantiation/test/common/instantiationServiceMock.ts
+++ b/src/sql/platform/instantiation/test/common/instantiationServiceMock.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
+import { TestInstantiationService as VsTestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+
+/**
+ * An extension of the VS TestInstantiationService which allows for stubbing out createInstance calls
+ * as well as services.
+ */
+export class TestInstantiationService extends VsTestInstantiationService {
+
+	private _createInstanceStubsMap: Map<any | SyncDescriptor<any>, any> = new Map<any | SyncDescriptor<any>, any>();
+
+	/**
+	 * Adds a stub for a ctor or descriptor which is then returned when createInstance is called
+	 * for that ctor or descriptor.
+	 * @param ctorOrDescriptor The ctor or descriptor to stub out
+	 * @param obj The object to return instead when createInstance is invoked
+	 */
+	public stubCreateInstance(ctorOrDescriptor: any | SyncDescriptor<any>, obj: any): void {
+		this._createInstanceStubsMap.set(ctorOrDescriptor, obj);
+	}
+
+	createInstance(ctorOrDescriptor: any | SyncDescriptor<any>, ...rest: any[]): any {
+		if (this._createInstanceStubsMap.has(ctorOrDescriptor)) {
+			return this._createInstanceStubsMap.get(ctorOrDescriptor);
+		}
+		return super.createInstance(ctorOrDescriptor, ...rest);
+	}
+}

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookEditorModel.test.ts
@@ -77,8 +77,6 @@ suite('Notebook Editor Model', function (): void {
 	testinstantiationService.stub(IStorageService, new TestStorageService());
 	testinstantiationService.stub(IProductService, { quality: 'stable' });
 	const queryConnectionService = TypeMoq.Mock.ofType(ConnectionManagementService, TypeMoq.MockBehavior.Loose,
-		undefined, // connection store
-		undefined, // connection status manager
 		undefined, // connection dialog service
 		testinstantiationService, // instantiation service
 		undefined, // editor service

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/serverTreeView.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/serverTreeView.test.ts
@@ -28,8 +28,6 @@ suite('ServerTreeView onAddConnectionProfile handler tests', () => {
 		let instantiationService = new TestInstantiationService();
 		instantiationService.stub(IStorageService, new TestStorageService());
 		let mockConnectionManagementService = TypeMoq.Mock.ofType(ConnectionManagementService, TypeMoq.MockBehavior.Strict,
-			undefined, //connection store
-			undefined, // connectionstatusmanager
 			undefined, // connectiondialog service
 			instantiationService, // instantiation service
 			undefined, // editor service

--- a/src/sql/workbench/contrib/query/test/browser/queryEditor.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryEditor.test.ts
@@ -93,8 +93,6 @@ suite('SQL QueryEditor Tests', () => {
 		let testinstantiationService = new TestInstantiationService();
 		testinstantiationService.stub(IStorageService, new TestStorageService());
 		connectionManagementService = TypeMoq.Mock.ofType(ConnectionManagementService, TypeMoq.MockBehavior.Loose,
-			undefined, // connection store
-			undefined, // connection status manager
 			undefined, // connection dialog service
 			testinstantiationService, // instantiation service
 			undefined, // editor service
@@ -267,8 +265,6 @@ suite('SQL QueryEditor Tests', () => {
 			let testinstantiationService = new TestInstantiationService();
 			testinstantiationService.stub(IStorageService, new TestStorageService());
 			connectionManagementService = TypeMoq.Mock.ofType(ConnectionManagementService, TypeMoq.MockBehavior.Loose,
-				undefined, // connection store
-				undefined, // connection status manager
 				undefined, // connection dialog service
 				testinstantiationService, // instantiation service
 				undefined, // editor service

--- a/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountManagementService.ts
@@ -50,7 +50,6 @@ export class AccountManagementService implements IAccountManagementService {
 
 	// CONSTRUCTOR /////////////////////////////////////////////////////////
 	constructor(
-		private _mementoObj: object,
 		@IInstantiationService private _instantiationService: IInstantiationService,
 		@IStorageService private _storageService: IStorageService,
 		@IClipboardService private _clipboardService: IClipboardService,
@@ -58,12 +57,9 @@ export class AccountManagementService implements IAccountManagementService {
 		@ILogService private readonly _logService: ILogService,
 		@INotificationService private readonly _notificationService: INotificationService
 	) {
-		// Create the account store
-		if (!this._mementoObj) {
-			this._mementoContext = new Memento(AccountManagementService.ACCOUNT_MEMENTO, this._storageService);
-			this._mementoObj = this._mementoContext.getMemento(StorageScope.GLOBAL);
-		}
-		this._accountStore = this._instantiationService.createInstance(AccountStore, this._mementoObj);
+		this._mementoContext = new Memento(AccountManagementService.ACCOUNT_MEMENTO, this._storageService);
+		const mementoObj = this._mementoContext.getMemento(StorageScope.GLOBAL);
+		this._accountStore = this._instantiationService.createInstance(AccountStore, mementoObj);
 
 		// Setup the event emitters
 		this._addAccountProviderEmitter = new Emitter<AccountProviderAddedEventParams>();

--- a/src/sql/workbench/services/accountManagement/test/browser/accountManagementService.test.ts
+++ b/src/sql/workbench/services/accountManagement/test/browser/accountManagementService.test.ts
@@ -214,7 +214,7 @@ suite('Account Management Service Tests:', () => {
 		// If: I add an account when the provider doesn't exist
 		// Then: It should not resolve
 		return Promise.race([
-			new Promise((resolve, reject) => setTimeout(() => resolve(), 100)),
+			new Promise<void>((resolve, reject) => setTimeout(() => resolve(), 100)),
 			ams.addAccount('doesNotExist').then(() => { throw new Error('Promise resolved when the provider did not exist'); })
 		]);
 	});
@@ -283,7 +283,7 @@ suite('Account Management Service Tests:', () => {
 		// If: I get accounts when the provider doesn't exist
 		// Then: It should not resolve
 		return Promise.race([
-			new Promise((resolve, reject) => setTimeout(() => resolve(), 100)),
+			new Promise<void>((resolve, reject) => setTimeout(() => resolve(), 100)),
 			ams.getAccountsForProvider('doesNotExist').then(() => { throw new Error('Promise resolved when the provider did not exist'); })
 		]);
 	});
@@ -529,13 +529,10 @@ function getTestState(): AccountManagementState {
 	mockInstantiationService.setup(x => x.createInstance(TypeMoq.It.isValue(AccountStore), TypeMoq.It.isAny()))
 		.returns(() => mockAccountStore.object);
 
-	// Create mock memento
-	let mockMemento = {};
-
 	const testNotificationService = new TestNotificationService();
 
 	// Create the account management service
-	let ams = new AccountManagementService(mockMemento, mockInstantiationService.object, new TestStorageService(), undefined!, undefined!, undefined!, testNotificationService);
+	let ams = new AccountManagementService(mockInstantiationService.object, new TestStorageService(), undefined!, undefined!, undefined!, testNotificationService);
 
 	// Wire up event handlers
 	let evUpdate = new EventVerifierSingle<UpdateAccountListEventParams>();

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -41,8 +41,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { ILogService } from 'vs/platform/log/common/log';
 import * as interfaces from 'sql/platform/connection/common/interfaces';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
-import { Memento } from 'vs/workbench/common/memento';
-import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { Memento, MementoObject } from 'vs/workbench/common/memento';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { entries } from 'sql/base/common/collections';
 import { values } from 'vs/base/common/collections';
@@ -70,14 +69,15 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	private _connectionGlobalStatus = new ConnectionGlobalStatus(this._notificationService);
 
 	private _mementoContext: Memento;
-	private _mementoObj: any;
+	private _mementoObj: MementoObject;
+	private _connectionStore: ConnectionStore;
+	private _connectionStatusManager: ConnectionStatusManager;
+
 	private static readonly CONNECTION_MEMENTO = 'ConnectionManagement';
 	private static readonly _azureResources: AzureResource[] =
 		[AzureResource.ResourceManagement, AzureResource.Sql, AzureResource.OssRdbms];
 
 	constructor(
-		private _connectionStore: ConnectionStore,
-		private _connectionStatusManager: ConnectionStatusManager,
 		@IConnectionDialogService private _connectionDialogService: IConnectionDialogService,
 		@IInstantiationService private _instantiationService: IInstantiationService,
 		@IEditorService private _editorService: IEditorService,
@@ -91,18 +91,12 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		@IAccountManagementService private _accountManagementService: IAccountManagementService,
 		@ILogService private _logService: ILogService,
 		@IStorageService private _storageService: IStorageService,
-		@IEnvironmentService private _environmentService: IEnvironmentService,
 		@IExtensionService private readonly extensionService: IExtensionService
 	) {
 		super();
 
-		if (!this._connectionStore) {
-			this._connectionStore = _instantiationService.createInstance(ConnectionStore);
-		}
-		if (!this._connectionStatusManager) {
-			this._connectionStatusManager = new ConnectionStatusManager(this._capabilitiesService, this._logService, this._environmentService, this._notificationService);
-		}
-
+		this._connectionStore = _instantiationService.createInstance(ConnectionStore);
+		this._connectionStatusManager = _instantiationService.createInstance(ConnectionStatusManager);
 		if (this._storageService) {
 			this._mementoContext = new Memento(ConnectionManagementService.CONNECTION_MEMENTO, this._storageService);
 			this._mementoObj = this._mementoContext.getMemento(StorageScope.GLOBAL);

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogService.test.ts
@@ -90,8 +90,6 @@ suite('ConnectionDialogService tests', () => {
 		let errorMessageService = getMockErrorMessageService();
 		let capabilitiesService = new TestCapabilitiesService();
 		mockConnectionManagementService = TypeMoq.Mock.ofType(ConnectionManagementService, TypeMoq.MockBehavior.Strict,
-			undefined, // connection store
-			undefined, // connection status manager
 			undefined, // connection dialog service
 			testInstantiationService, // instantiation service
 			undefined, // editor service

--- a/src/sql/workbench/services/connection/test/browser/connectionDialogWidget.test.ts
+++ b/src/sql/workbench/services/connection/test/browser/connectionDialogWidget.test.ts
@@ -57,8 +57,6 @@ suite('ConnectionDialogWidget tests', () => {
 		cmInstantiationService.stub(IContextKeyService, new MockContextKeyService());
 
 		mockConnectionManagementService = TypeMoq.Mock.ofType(ConnectionManagementService, TypeMoq.MockBehavior.Strict,
-			undefined, // connection store
-			undefined, // connection status manager
 			undefined, // connection dialog service
 			cmInstantiationService, // instantiation service
 			undefined, // editor service

--- a/src/sql/workbench/services/insights/test/browser/insightsDialogController.test.ts
+++ b/src/sql/workbench/services/insights/test/browser/insightsDialogController.test.ts
@@ -45,8 +45,6 @@ suite('Insights Dialog Controller Tests', () => {
 		let testinstantiationService = new TestInstantiationService();
 		testinstantiationService.stub(IStorageService, new TestStorageService());
 		let connMoq = Mock.ofType(ConnectionManagementService, MockBehavior.Strict,
-			undefined, // connection store
-			undefined, // connection status manager
 			undefined, // connection dialog service
 			testinstantiationService, // instantiation service
 			undefined, // editor service

--- a/src/sql/workbench/services/objectExplorer/test/browser/asyncServerTreeDragAndDrop.test.ts
+++ b/src/sql/workbench/services/objectExplorer/test/browser/asyncServerTreeDragAndDrop.test.ts
@@ -54,8 +54,6 @@ suite('AsyncServerTreeDragAndDrop', () => {
 		let instantiationService = new TestInstantiationService();
 		instantiationService.stub(IStorageService, new TestStorageService());
 		let mockConnectionManagementService = TypeMoq.Mock.ofType(ConnectionManagementService, TypeMoq.MockBehavior.Strict,
-			undefined, //connection store
-			undefined, // connectionstatusmanager
 			undefined, // connectiondialog service
 			instantiationService, // instantiation service
 			undefined, // editor service

--- a/src/sql/workbench/services/objectExplorer/test/browser/dragAndDropController.test.ts
+++ b/src/sql/workbench/services/objectExplorer/test/browser/dragAndDropController.test.ts
@@ -59,8 +59,6 @@ suite('SQL Drag And Drop Controller tests', () => {
 		let instantiationService = new TestInstantiationService();
 		instantiationService.stub(IStorageService, new TestStorageService());
 		let mockConnectionManagementService = TypeMoq.Mock.ofType(ConnectionManagementService, TypeMoq.MockBehavior.Strict,
-			undefined, //connection store
-			undefined, // connectionstatusmanager
 			undefined, // connectiondialog service
 			instantiationService, // instantiation service
 			undefined, // editor service


### PR DESCRIPTION
This fixes the `First service dependency of e at position 2 conflicts with 0 static arguments` warnings that would show up on launch.

What was happening here is that these services had non-injected parameters, but during normal runtime these services are created as part of the instantiation service stuff which doesn't know about those so it would throw out that warning (and then leave them as undefined).

I looked into it and turns out they were just used for injecting test objects into the services for mocking - during runtime we just defaulted to creating the objects if they weren't passed in. But that isn't needed as we can just use a mocked instantiation service to handle this for us. 

This isn't really fixing any actual functionality issue here but it's been annoying me ever since I first saw it and finally decided to sit down and just fix it. 