### PR TITLE
Notebooks: Fix Current Directory when Folder has Space

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterSessionManager.ts
+++ b/extensions/notebook/src/jupyter/jupyterSessionManager.ts
@@ -9,7 +9,6 @@ import * as fs from 'fs-extra';
 import * as nls from 'vscode-nls';
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { EOL } from 'os';
 import * as utils from '../common/utils';
 const localize = nls.loadMessageBundle();
 
@@ -364,15 +363,15 @@ export class JupyterSession implements nb.ISession {
 			let allCode: string = '';
 			// Ensure cwd matches notebook path (this follows Jupyter behavior)
 			if (this.path && path.dirname(this.path)) {
-				allCode += `%cd ${path.dirname(this.path)}${EOL}`;
+				allCode += `%cd ${path.dirname(this.path)}\n`;
 			}
 			for (let i = 0; i < Object.keys(process.env).length; i++) {
 				let key = Object.keys(process.env)[i];
 				if (key.toLowerCase() === 'path' && this._pythonEnvVarPath) {
-					allCode += `%set_env ${key}=${this._pythonEnvVarPath}${EOL}`;
+					allCode += `%set_env ${key}=${this._pythonEnvVarPath}\n`;
 				} else {
 					// Jupyter doesn't seem to alow for setting multiple variables at once, so doing it with multiple commands
-					allCode += `%set_env ${key}=${process.env[key]}${EOL}`;
+					allCode += `%set_env ${key}=${process.env[key]}\n`;
 				}
 			}
 


### PR DESCRIPTION
Fixes #12357.

![image](https://user-images.githubusercontent.com/40371649/107106857-99784d00-67e2-11eb-9811-319726dd3036.png)

The `%cd` magic, which we run behind the scenes when starting a new Jupyter session, translates Windows-style paths in an interesting way if the Windows-style newlines are included at the end of the command.

e.g. `'C:\users\chlafren\Hello World'` actually becomes `'c:\Users\chlafren\Desktop\Hello World '` (notice the extra space), resulting in Windows APIs complaining that that location doesn't exist.

In other places, we strip out the `\r` before sending it to Jupyter. Here, we're crafting a set of commands.