### PR TITLE
Search function to be case insensitive 

### DIFF
--- a/extensions/arc/src/ui/dashboards/postgres/postgresParametersPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresParametersPage.ts
@@ -373,14 +373,14 @@ export class PostgresParametersPage extends DashboardPage {
 		if (!this.searchBox!.value) {
 			this.parametersTable.setFilter(undefined);
 		} else {
-			this.filterParameters(this.searchBox!.value);
+			this.filterParameters(this.searchBox!.value.toUpperCase());
 		}
 	}
 
 	private filterParameters(search: string): void {
 		const filteredRowIndexes: number[] = [];
 		this.parametersTable.data?.forEach((row, index) => {
-			if (row[0]?.search(search) !== -1 || row[2]?.search(search) !== -1) {
+			if (row[0].toUpperCase()?.search(search) !== -1 || row[2].toUpperCase()?.search(search) !== -1) {
 				filteredRowIndexes.push(index);
 			}
 		});

--- a/extensions/arc/src/ui/dashboards/postgres/postgresParametersPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresParametersPage.ts
@@ -373,14 +373,14 @@ export class PostgresParametersPage extends DashboardPage {
 		if (!this.searchBox!.value) {
 			this.parametersTable.setFilter(undefined);
 		} else {
-			this.filterParameters(this.searchBox!.value.toUpperCase());
+			this.filterParameters(this.searchBox!.value);
 		}
 	}
 
 	private filterParameters(search: string): void {
 		const filteredRowIndexes: number[] = [];
 		this.parametersTable.data?.forEach((row, index) => {
-			if (row[0].toUpperCase()?.search(search) !== -1 || row[2].toUpperCase()?.search(search) !== -1) {
+			if (row[0].toUpperCase()?.search(search.toUpperCase()) !== -1 || row[2].toUpperCase()?.search(search.toUpperCase()) !== -1) {
 				filteredRowIndexes.push(index);
 			}
 		});


### PR DESCRIPTION
The search function was case sensitive which is not seen in portal.  
![searchFailCase](https://user-images.githubusercontent.com/69922333/107249047-ccd7f900-69e7-11eb-83ad-81e0795feed6.gif)

Edited to not care about case typed into search textbox.