### PR TITLE
fix folder button being in wrong location in Create project from database dialog

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -403,7 +403,7 @@ export class CreateProjectFromDatabaseDialog {
 		} else {
 			// have browse button to help select where the workspace file should be created
 			const workspaceInput = view.modelBuilder.flexContainer().withItems([this.workspaceInputBox], { CSSStyles: { 'margin-right': '10px', 'margin-bottom': '10px', 'width': '100%' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
-			workspaceInput.addItem(browseFolderButton, { CSSStyles: { 'margin-top': '-10px' } });
+			workspaceInput.insertItem(browseFolderButton, 1, { CSSStyles: { 'margin-top': '-10px' } });
 			workspaceContainerRow = view.modelBuilder.flexContainer().withItems([workspaceLabel, workspaceInput], { flex: '0 0 auto', CSSStyles: { 'margin-top': '0px' } }).withLayout({ flexFlow: 'column' }).component();
 		}
 


### PR DESCRIPTION
This inputbox and button were added in December in https://github.com/microsoft/azuredatastudio/pull/13842. addItem() for a flexContainer used to add the item last, but something must have changed in the last month to change that so the folder button got added first instead of last. I fixed this here by inserting the folder button at the correct index instead. 

before: 
![image](https://user-images.githubusercontent.com/31145923/107264245-9a35fc80-69f7-11eb-8946-dba3e6e7f07e.png)


fixed: 
![image](https://user-images.githubusercontent.com/31145923/107264192-8ab6b380-69f7-11eb-9f67-746844e5137e.png)
