### PR TITLE
Fix ModelView addItem/withItem ordering

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -152,7 +152,7 @@ export class CreateProjectFromDatabaseDialog {
 		}).component();
 
 		const connectionRow = view.modelBuilder.flexContainer().withItems([serverLabel, sourceConnectionTextBox], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px', 'margin-bottom': '-5px', 'margin-top': '-10px' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
-		connectionRow.insertItem(selectConnectionButton, 2, { CSSStyles: { 'margin-right': '0px', 'margin-bottom': '-5px', 'margin-top': '-10px' } });
+		connectionRow.addItem(selectConnectionButton, { CSSStyles: { 'margin-right': '0px', 'margin-bottom': '-5px', 'margin-top': '-10px' } });
 
 		return connectionRow;
 	}
@@ -293,7 +293,7 @@ export class CreateProjectFromDatabaseDialog {
 		}).component();
 
 		const projectLocationRow = view.modelBuilder.flexContainer().withItems([projectLocationLabel, this.projectLocationTextBox], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px', 'margin-bottom': '-10px' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
-		projectLocationRow.insertItem(browseFolderButton, 2, { CSSStyles: { 'margin-right': '0px', 'margin-bottom': '-10px' } });
+		projectLocationRow.addItem(browseFolderButton, { CSSStyles: { 'margin-right': '0px', 'margin-bottom': '-10px' } });
 
 		return projectLocationRow;
 	}

--- a/src/sql/workbench/browser/modelComponents/viewBase.ts
+++ b/src/sql/workbench/browser/modelComponents/viewBase.ts
@@ -75,7 +75,7 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 					initial: true
 				};
 			});
-			this.addToContainer(component.id, items);
+			this.addToContainer(component.id, items, true);
 		}
 
 		return descriptor;


### PR DESCRIPTION
Fix for issue described in https://github.com/microsoft/azuredatastudio/pull/14198

I didn't track down why/if this actually changed with https://github.com/microsoft/azuredatastudio/pull/13842 - but the issue here is that addItem/addItems/insertItem were adding the items immediately to the container - but withItems was delaying that until the container component was created on the main thread side - at which point it would then go create and add the ItemConfigs and add them to the container.

But because this wasn't done first we would have the addItem queued up first and thus it would try to add that first and then afterwards go add all the defined itemConfigs.

I vaguely recall that when I added the whole "initial" actions stuff in https://github.com/microsoft/azuredatastudio/pull/13317 I purposely didn't have those added as initial actions. But I can't remember exactly why and don't see any issues currently poking around a bunch of different dialogs/dashboards so I think it's fine to go forward with this now and then if we see issues try to find out what's broken there. 

![image](https://user-images.githubusercontent.com/28519865/107299698-df285600-6a2c-11eb-81d9-576a7549e6bc.png)
