### PR TITLE
Turn back on Notebook unit tests

### DIFF
--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -46,8 +46,7 @@ jobs:
   steps:
   - template: linux/sql-product-build-linux.yml
     parameters:
-      # extensionsToUnitTest: ["admin-tool-ext-win", "agent", "azdata", "azurecore", "cms", "dacpac", "import", "schema-compare", "notebook", "resource-deployment", "machine-learning", "sql-database-projects", "data-workspace"]
-      extensionsToUnitTest: ["admin-tool-ext-win", "agent", "azdata", "azurecore", "cms", "dacpac", "import", "schema-compare", "resource-deployment", "machine-learning", "sql-database-projects", "data-workspace"]
+      extensionsToUnitTest: ["admin-tool-ext-win", "agent", "azdata", "azurecore", "cms", "dacpac", "import", "schema-compare", "notebook", "resource-deployment", "machine-learning", "sql-database-projects", "data-workspace"]
   timeoutInMinutes: 70
 
 - job: LinuxWeb

--- a/extensions/integration-tests/src/test/notebook.test.ts
+++ b/extensions/integration-tests/src/test/notebook.test.ts
@@ -55,7 +55,7 @@ suite('Notebook integration test suite', function () {
 		assert(actualOutput2[0] === '1', `Expected result: 1, Actual: '${actualOutput2[0]}'`);
 	});
 
-	test('Sql NB multiple cells test', async function (done) {
+	test('Sql NB multiple cells test', async function () {
 		let notebook = await openNotebook(sqlNotebookMultipleCellsContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		await runCells(notebook);
 		const expectedOutput0 = '(1 row affected)';
@@ -82,10 +82,9 @@ suite('Notebook integration test suite', function () {
 			assert(actualOutput2[0] === i.toString(), `Expected result: ${i.toString()}, Actual: '${actualOutput2[0]}'`);
 			console.log('Sql multiple cells NB done');
 		}
-		done();
 	});
 
-	test('Sql NB run cells above and below test', async function (done) {
+	test('Sql NB run cells above and below test', async function () {
 		let notebook = await openNotebook(sqlNotebookMultipleCellsContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		// When running all cells above a cell, ensure that only cells preceding current cell have output
 		await runCells(notebook, true, undefined, notebook.document.cells[1]);
@@ -100,24 +99,21 @@ suite('Notebook integration test suite', function () {
 		assert(notebook.document.cells[0].contents.outputs.length === 0, `Expected length: '0', Actual: '${notebook.document.cells[0].contents.outputs.length}'`);
 		assert(notebook.document.cells[1].contents.outputs.length === 3, `Expected length: '3', Actual: '${notebook.document.cells[1].contents.outputs.length}'`);
 		assert(notebook.document.cells[2].contents.outputs.length === 3, `Expected length: '3', Actual: '${notebook.document.cells[2].contents.outputs.length}'`);
-		done();
 	});
 
-	test('Clear cell output - SQL notebook', async function (done) {
+	test('Clear cell output - SQL notebook', async function () {
 		let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		await runCell(notebook);
 		await verifyClearOutputs(notebook);
-		done();
 	});
 
-	test('Clear all outputs - SQL notebook', async function (done) {
+	test('Clear all outputs - SQL notebook', async function () {
 		let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		await runCell(notebook);
 		await verifyClearAllOutputs(notebook);
-		done();
 	});
 
-	test('sql language test', async function (done) {
+	test('sql language test', async function () {
 		let language = 'sql';
 		await cellLanguageTest(notebookContentForCellLanguageTest, this.test.title + this.invocationCount++, language, {
 			'kernelspec': {
@@ -130,10 +126,9 @@ suite('Notebook integration test suite', function () {
 				'mimetype': ''
 			}
 		});
-		done();
 	});
 
-	test('should not be dirty after saving notebook test', async function (done) {
+	test('should not be dirty after saving notebook test', async function () {
 		// Given a notebook that's been edited (in this case, open notebook runs the 1st cell and adds an output)
 		let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata, this.test.title);
 		await runCell(notebook);
@@ -166,7 +161,6 @@ suite('Notebook integration test suite', function () {
 		await sleep(100);
 		assert(saved === true, 'Expect save after edit to succeed');
 		assert(notebook.document.isDirty === false, 'Notebook should not be dirty after 2nd save');
-		done();
 	});
 
 	if (process.env['RUN_PYTHON3_TEST'] === '1') {

--- a/extensions/integration-tests/src/test/notebook.test.ts
+++ b/extensions/integration-tests/src/test/notebook.test.ts
@@ -55,7 +55,7 @@ suite('Notebook integration test suite', function () {
 		assert(actualOutput2[0] === '1', `Expected result: 1, Actual: '${actualOutput2[0]}'`);
 	});
 
-	test.skip('Sql NB multiple cells test', async function (done) {
+	test('Sql NB multiple cells test', async function (done) {
 		let notebook = await openNotebook(sqlNotebookMultipleCellsContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		await runCells(notebook);
 		const expectedOutput0 = '(1 row affected)';
@@ -85,7 +85,7 @@ suite('Notebook integration test suite', function () {
 		done();
 	});
 
-	test.skip('Sql NB run cells above and below test', async function (done) {
+	test('Sql NB run cells above and below test', async function (done) {
 		let notebook = await openNotebook(sqlNotebookMultipleCellsContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		// When running all cells above a cell, ensure that only cells preceding current cell have output
 		await runCells(notebook, true, undefined, notebook.document.cells[1]);
@@ -103,21 +103,21 @@ suite('Notebook integration test suite', function () {
 		done();
 	});
 
-	test.skip('Clear cell output - SQL notebook', async function (done) {
+	test('Clear cell output - SQL notebook', async function (done) {
 		let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		await runCell(notebook);
 		await verifyClearOutputs(notebook);
 		done();
 	});
 
-	test.skip('Clear all outputs - SQL notebook', async function (done) {
+	test('Clear all outputs - SQL notebook', async function (done) {
 		let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		await runCell(notebook);
 		await verifyClearAllOutputs(notebook);
 		done();
 	});
 
-	test.skip('sql language test', async function (done) {
+	test('sql language test', async function (done) {
 		let language = 'sql';
 		await cellLanguageTest(notebookContentForCellLanguageTest, this.test.title + this.invocationCount++, language, {
 			'kernelspec': {
@@ -133,7 +133,7 @@ suite('Notebook integration test suite', function () {
 		done();
 	});
 
-	test.skip('should not be dirty after saving notebook test', async function (done) {
+	test('should not be dirty after saving notebook test', async function (done) {
 		// Given a notebook that's been edited (in this case, open notebook runs the 1st cell and adds an output)
 		let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata, this.test.title);
 		await runCell(notebook);


### PR DESCRIPTION
Need to re-enable the Notebook unit tests.  I expect CI will fail initially but I'll push additional commits until the CI is green.
