### PR TITLE
add support to accept visualization options 

### DIFF
--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -983,4 +983,23 @@ declare module 'azdata' {
 		 */
 		MsGraph = 7
 	}
+
+	export interface ResultSetSummary {
+		/**
+		 * The visualization options for the result set.
+		 */
+		visualization?: VisualizationOptions;
+	}
+
+	/**
+	 * Defines all the supported visualization types
+	 */
+	export type VisualizationType = 'Bar' | 'Count' | 'Doughnut' | 'HorizontalBar' | 'Image' | 'Line' | 'Pie' | 'Scatter' | 'Table' | 'TimeSeries';
+
+	/**
+	 * Defines the configuration options for visualization
+	 */
+	export interface VisualizationOptions {
+		type: VisualizationType;
+	}
 }

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -994,7 +994,7 @@ declare module 'azdata' {
 	/**
 	 * Defines all the supported visualization types
 	 */
-	export type VisualizationType = 'Bar' | 'Count' | 'Doughnut' | 'HorizontalBar' | 'Image' | 'Line' | 'Pie' | 'Scatter' | 'Table' | 'TimeSeries';
+	export type VisualizationType = 'bar' | 'count' | 'doughnut' | 'horizontalBar' | 'image' | 'line' | 'pie' | 'scatter' | 'table' | 'timeSeries';
 
 	/**
 	 * Defines the configuration options for visualization

--- a/src/sql/workbench/contrib/charts/browser/chartTab.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartTab.ts
@@ -9,13 +9,30 @@ import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 
 import { localize } from 'vs/nls';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { VisualizationOptions, VisualizationType } from 'sql/workbench/services/query/common/query';
+import { ChartType, InsightType } from 'sql/workbench/contrib/charts/common/interfaces';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+
+const VisualizationTypeMap = new Map<VisualizationType, (ChartType | InsightType)>([
+	['Bar', ChartType.Bar],
+	['Count', InsightType.Count],
+	['Doughnut', ChartType.Doughnut],
+	['HorizontalBar', ChartType.HorizontalBar],
+	['Image', InsightType.Image],
+	['Line', ChartType.Line],
+	['Pie', ChartType.Pie],
+	['Scatter', ChartType.Scatter],
+	['Table', InsightType.Table],
+	['TimeSeries', ChartType.TimeSeries],
+]);
 
 export class ChartTab implements IPanelTab {
 	public readonly title = localize('chartTabTitle', "Chart");
 	public readonly identifier = 'ChartTab';
 	public readonly view: ChartView;
 
-	constructor(@IInstantiationService instantiationService: IInstantiationService) {
+	constructor(@IInstantiationService instantiationService: IInstantiationService,
+		@INotificationService private notificationService: INotificationService) {
 		this.view = instantiationService.createInstance(ChartView, true);
 	}
 
@@ -25,6 +42,17 @@ export class ChartTab implements IPanelTab {
 
 	public chart(dataId: { batchId: number, resultId: number }): void {
 		this.view.chart(dataId);
+	}
+
+	public setOptions(options: VisualizationOptions): void {
+		let type = VisualizationTypeMap.get(options.type);
+		if (type) {
+			this.view.options = {
+				type: type
+			};
+		} else {
+			this.notificationService.error(localize('chart.unsupportedVisualizationType', "The visualization type: '{0}' is not supported", options.type));
+		}
 	}
 
 	public dispose() {

--- a/src/sql/workbench/contrib/charts/browser/chartTab.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartTab.ts
@@ -9,30 +9,13 @@ import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 
 import { localize } from 'vs/nls';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { VisualizationOptions, VisualizationType } from 'sql/workbench/services/query/common/query';
-import { ChartType, InsightType } from 'sql/workbench/contrib/charts/common/interfaces';
-import { INotificationService } from 'vs/platform/notification/common/notification';
-
-const VisualizationTypeMap = new Map<VisualizationType, (ChartType | InsightType)>([
-	['Bar', ChartType.Bar],
-	['Count', InsightType.Count],
-	['Doughnut', ChartType.Doughnut],
-	['HorizontalBar', ChartType.HorizontalBar],
-	['Image', InsightType.Image],
-	['Line', ChartType.Line],
-	['Pie', ChartType.Pie],
-	['Scatter', ChartType.Scatter],
-	['Table', InsightType.Table],
-	['TimeSeries', ChartType.TimeSeries],
-]);
 
 export class ChartTab implements IPanelTab {
 	public readonly title = localize('chartTabTitle', "Chart");
 	public readonly identifier = 'ChartTab';
 	public readonly view: ChartView;
 
-	constructor(@IInstantiationService instantiationService: IInstantiationService,
-		@INotificationService private notificationService: INotificationService) {
+	constructor(@IInstantiationService instantiationService: IInstantiationService) {
 		this.view = instantiationService.createInstance(ChartView, true);
 	}
 
@@ -42,17 +25,6 @@ export class ChartTab implements IPanelTab {
 
 	public chart(dataId: { batchId: number, resultId: number }): void {
 		this.view.chart(dataId);
-	}
-
-	public setOptions(options: VisualizationOptions): void {
-		let type = VisualizationTypeMap.get(options.type);
-		if (type) {
-			this.view.options = {
-				type: type
-			};
-		} else {
-			this.notificationService.error(localize('chart.unsupportedVisualizationType', "The visualization type: '{0}' is not supported", options.type));
-		}
 	}
 
 	public dispose() {

--- a/src/sql/workbench/contrib/charts/browser/chartView.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartView.ts
@@ -455,7 +455,7 @@ export class ChartView extends Disposable implements IPanelView {
 	}
 
 	/**
-	 * Set the visualization options
+	 * Set the visualization options, this method handles the conversion from VisualizationOptions(defined in azdata typing) to IInsightOptions
 	 * @param options visualization options returned by query
 	 */
 	public setVisualizationOptions(options: VisualizationOptions): void {

--- a/src/sql/workbench/contrib/charts/browser/chartView.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartView.ts
@@ -8,7 +8,7 @@ import 'vs/css!./media/chartView';
 import { IPanelView } from 'sql/base/browser/ui/panel/panel';
 import { Insight } from './insight';
 import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
-import { ICellValue } from 'sql/workbench/services/query/common/query';
+import { ICellValue, VisualizationOptions } from 'sql/workbench/services/query/common/query';
 import { ChartOptions, IChartOption, ControlType } from './chartOptions';
 import { Extensions, IInsightRegistry, IInsightData } from 'sql/platform/dashboard/browser/insightRegistry';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -24,7 +24,7 @@ import { isUndefinedOrNull } from 'vs/base/common/types';
 import { CreateInsightAction, CopyAction, SaveImageAction, IChartActionContext, ConfigureChartAction } from 'sql/workbench/contrib/charts/browser/actions';
 import { Taskbar, ITaskbarContent } from 'sql/base/browser/ui/taskbar/taskbar';
 import { Checkbox } from 'sql/base/browser/ui/checkbox/checkbox';
-import { IInsightOptions, ChartType } from 'sql/workbench/contrib/charts/common/interfaces';
+import { IInsightOptions, ChartType, InsightType } from 'sql/workbench/contrib/charts/common/interfaces';
 import { ChartState } from 'sql/workbench/common/editor/query/chartState';
 import * as nls from 'vs/nls';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -452,5 +452,15 @@ export class ChartView extends Disposable implements IPanelView {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Set the visualization options
+	 * @param options visualization options returned by query
+	 */
+	public setVisualizationOptions(options: VisualizationOptions): void {
+		this.options = {
+			type: options.type as (ChartType | InsightType)
+		};
 	}
 }

--- a/src/sql/workbench/contrib/charts/browser/chartView.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartView.ts
@@ -459,8 +459,10 @@ export class ChartView extends Disposable implements IPanelView {
 	 * @param options visualization options returned by query
 	 */
 	public setVisualizationOptions(options: VisualizationOptions): void {
-		this.options = {
-			type: options.type as (ChartType | InsightType)
-		};
+		if (options?.type) {
+			this.options = {
+				type: options.type as (ChartType | InsightType)
+			};
+		}
 	}
 }

--- a/src/sql/workbench/contrib/query/browser/queryResultsView.ts
+++ b/src/sql/workbench/contrib/query/browser/queryResultsView.ts
@@ -23,7 +23,6 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { Event } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
 import { attachTabbedPanelStyler } from 'sql/workbench/common/styler';
-import { INotificationService } from 'vs/platform/notification/common/notification';
 
 class MessagesView extends Disposable implements IPanelView {
 	private messagePanel: MessagePanel;
@@ -179,13 +178,12 @@ export class QueryResultsView extends Disposable {
 		container: HTMLElement,
 		@IThemeService themeService: IThemeService,
 		@IInstantiationService private instantiationService: IInstantiationService,
-		@IQueryModelService private queryModelService: IQueryModelService,
-		@INotificationService notificationService: INotificationService
+		@IQueryModelService private queryModelService: IQueryModelService
 	) {
 		super();
 		this.resultsTab = this._register(new ResultsTab(instantiationService));
 		this.messagesTab = this._register(new MessagesTab(instantiationService));
-		this.chartTab = this._register(new ChartTab(instantiationService, notificationService));
+		this.chartTab = this._register(new ChartTab(instantiationService));
 		this._panelView = this._register(new TabbedPanel(container, { showHeaderWhenSingleView: true }));
 		this._register(attachTabbedPanelStyler(this._panelView, themeService));
 		this.qpTab = this._register(new QueryPlanTab());
@@ -247,7 +245,7 @@ export class QueryResultsView extends Disposable {
 					resultId: batchSet.id,
 					batchId: resultSet.batchId
 				});
-				this.chartTab.setOptions(resultSet.visualization);
+				this.chartTab.view.setVisualizationOptions(resultSet.visualization);
 			}
 		}));
 

--- a/src/sql/workbench/services/query/common/query.ts
+++ b/src/sql/workbench/services/query/common/query.ts
@@ -11,12 +11,19 @@ export interface IColumn {
 	isJson?: boolean;
 }
 
+export type VisualizationType = 'Bar' | 'Count' | 'Doughnut' | 'HorizontalBar' | 'Image' | 'Line' | 'Pie' | 'Scatter' | 'Table' | 'TimeSeries';
+
+export interface VisualizationOptions {
+	type: VisualizationType
+}
+
 export interface ResultSetSummary {
 	id: number;
 	batchId: number;
 	rowCount: number;
 	columnInfo: IColumn[];
 	complete: boolean;
+	visualization?: VisualizationOptions;
 }
 
 export interface BatchStartSummary {

--- a/src/sql/workbench/services/query/common/query.ts
+++ b/src/sql/workbench/services/query/common/query.ts
@@ -11,7 +11,7 @@ export interface IColumn {
 	isJson?: boolean;
 }
 
-export type VisualizationType = 'Bar' | 'Count' | 'Doughnut' | 'HorizontalBar' | 'Image' | 'Line' | 'Pie' | 'Scatter' | 'Table' | 'TimeSeries';
+export type VisualizationType = 'bar' | 'count' | 'doughnut' | 'horizontalBar' | 'image' | 'line' | 'pie' | 'scatter' | 'table' | 'timeSeries';
 
 export interface VisualizationOptions {
 	type: VisualizationType


### PR DESCRIPTION
This is requested by Kusto team: the ability to specify visualization options in the result set. I only implemented this in the query editor, but it is very easy to do the same in notebook by calling the `chartView.setVisualizationOptions`, I'd leave it to @rajeshka or the notebook team to use this feature since there are already cell chart option serialization, I don't want to break it accidentally. 
![chart](https://user-images.githubusercontent.com/13777222/107596037-585daf80-6bcb-11eb-9e05-bb75e8c4546f.gif)

I'll have another PR to include the SQL tools service side of changes.

once my PRs are merged, @rajeshka you can add more charting options that you need. 