### PR TITLE
fix system db references going away when project target platform is changed

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -2,7 +2,7 @@
   "name": "sql-database-projects",
   "displayName": "SQL Database Projects",
   "description": "The SQL Database Projects extension for Azure Data Studio allows users to develop and publish database schemas.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publisher": "Microsoft",
   "preview": true,
   "engines": {

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -376,7 +376,7 @@ export class Project {
 			// update any system db references
 			const systemDbReferences = this.databaseReferences.filter(r => r instanceof SystemDatabaseReferenceProjectEntry) as SystemDatabaseReferenceProjectEntry[];
 			if (systemDbReferences.length > 0) {
-				systemDbReferences.forEach((r) => {
+				for (let r of systemDbReferences) {
 					// remove old entry in sqlproj
 					this.removeDatabaseReferenceFromProjFile(r);
 
@@ -385,8 +385,8 @@ export class Project {
 					r.ssdtUri = this.getSystemDacpacSsdtUri(`${r.databaseName}.dacpac`);
 
 					// add updated system db reference to sqlproj
-					this.addDatabaseReferenceToProjFile(r);
-				});
+					await this.addDatabaseReferenceToProjFile(r);
+				}
 			}
 
 			await this.serializeToProjFile(this.projFileXmlDoc);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #14252. I think this got broken when awaits were added in #13114 for addDatabaseReferenceToProjFile. I added a test that would have caught this.
