### PR TITLE
Bump vscode version product.json

### DIFF
--- a/product.json
+++ b/product.json
@@ -36,7 +36,7 @@
 	"gettingStartedUrl": "https://go.microsoft.com/fwlink/?linkid=862039",
 	"releaseNotesUrl": "https://go.microsoft.com/fwlink/?linkid=875578",
 	"documentationUrl": "https://go.microsoft.com/fwlink/?linkid=862277",
-	"vscodeVersion": "1.48.0",
+	"vscodeVersion": "1.51.0",
 	"commit": "9ca6200018fc206d67a47229f991901a8a453781",
 	"date": "2017-12-15T12:00:00.000Z",
 	"recommendedExtensions": [


### PR DESCRIPTION
The previous vscode merge brought our vscode compat level up to 1.51
