### PR TITLE
Fix search results display

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet.ts
@@ -260,7 +260,10 @@ export class NotebookExplorerViewPaneContainer extends ViewPaneContainer {
 			if (this.views.length > 1) {
 				let filesToIncludeFiltered: string = '';
 				// search book results first and then notebooks
-				this.views.reverse().forEach(async (v) => {
+				const pinnedNotebookIndex = this.views.findIndex(view => view.id === 'pinnedBooksView');
+				const viewPanes = this.views;
+				viewPanes.push(viewPanes.splice(pinnedNotebookIndex, 1)[0]);
+				viewPanes.forEach(async (v) => {
 					if (v instanceof TreeViewPane) {
 						const { treeView } = (<ITreeViewDescriptor>Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).getView(v.id));
 						if (treeView.dataProvider) {
@@ -280,14 +283,14 @@ export class NotebookExplorerViewPaneContainer extends ViewPaneContainer {
 								} else {
 									let pattern = {};
 									const rootFolder = URI.file(path.dirname(root.resourceUri.path));
-									const baseName = path.join('**', path.basename(root.resourceUri.path));
+									const baseName = path.join('**', path.basename(root.resourceUri.path)).replace(/\\/g, '/');
 									let isOpenedInBooksView = false;
 									pattern[baseName] = true;
 									query.folderQueries.forEach((folder) => {
 										//check for books
 										if ((folder.includePattern === undefined || folder.includePattern['content/**']) && !isOpenedInBooksView) {
 											//verify if pinned notebook is not opened in Books Viewlet
-											const relativePath = path.relative(folder.folder.fsPath, root.resourceUri.path);
+											const relativePath = path.relative(folder.folder.fsPath, rootFolder.fsPath);
 											isOpenedInBooksView = !relativePath.startsWith('..') || !relativePath.startsWith('.');
 										}
 									});


### PR DESCRIPTION
Previously, we used to identify the root of a tree item with the resourceUri but since we were sending always the root of the book instead of the actual path of a notebook it would cause the following issue: https://github.com/microsoft/azuredatastudio/issues/13688.

In order to fix how the results were display, I keep track of the opened books in the Provided Book Tree View and the actual Book Tree View. For this reason, I iterate over the Pinned Books View last.
The `folder.includePattern` is `undefined` for the new version of Jupyter Books, it's `content/**` for the legacy version of Books and it is the name of a` file + extension `for individual notebooks (either pinned or standalone notebooks in the Books View).
I added this check to identify which queries were books and check if the tree item (saved notebook or pinned notebook) belongs to a book that has been added to the query before. If they haven't been added, then I proceed to add it to the query.

This PR addresses  #14259
