### PR TITLE
Fix notebook connection dropdown opening multiple connection dialogs

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -451,8 +451,10 @@ export class AttachToDropdown extends SelectBox {
 	}
 
 	public doChangeContext(connection?: ConnectionProfile, hideErrorMessage?: boolean): void {
-		if (this.value === msgChangeConnection || this.value === msgSelectConnection) {
+		if (this.value === msgChangeConnection) {
 			this.openConnectionDialog().catch(err => this._notificationService.error(getErrorMessage(err)));
+		} else if (this.value === msgSelectConnection) {
+			// no-op, select connection is the default option and so shouldn't have any action done when selected (which only happens if a user cancels out of the connection dialog)
 		} else {
 			this.model.changeContext(this.value, connection, hideErrorMessage).catch(err => this._notificationService.error(getErrorMessage(err)));
 		}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13837

Previously we weren't firing the event when selecting an option with `this.select`. This was changed in https://github.com/microsoft/azuredatastudio/pull/13691 though but this code was never updated to take that into account.

I didn't see any reason why we'd want to open the connection dialog for the `Select Connection` option so just no-op'ing when that's selected (which is always done if the user cancels out of the connection dialog since we want have that showing in the dropdown again in that case) 

![Capture](https://user-images.githubusercontent.com/28519865/107832203-aea22e00-6d44-11eb-9a65-e46947a2dd8a.gif)
