### PR TITLE
Notebook: Mark test as unstable

### DIFF
--- a/extensions/notebook/src/test/book/book.test.ts
+++ b/extensions/notebook/src/test/book/book.test.ts
@@ -752,7 +752,7 @@ describe('BooksTreeViewTests', function () {
 					should(showNotebookSpy.calledWith(vscode.Uri.file(notebookPath))).be.true(`Should have opened the notebook from ${notebookPath} in the editor.`);
 				});
 
-				it('openNotebookAsUntitled should open a notebook as untitled file in the editor', async () => {
+				it('openNotebookAsUntitled should open a notebook as untitled file in the editor @UNSTABLE@', async () => {
 					let notebookPath = run.folderPaths.notebook2File;
 					await bookTreeViewProvider.openNotebookAsUntitled(notebookPath);
 					should(azdata.nb.notebookDocuments.find(doc => doc.uri.scheme === 'untitled')).not.be.undefined();


### PR DESCRIPTION
Mark 'openNotebookAsUntitled should open a notebook as untitled file in the editor' test as unstable.
