### PR TITLE
Fix error when listing MIAA databases

### DIFF
--- a/extensions/arc/src/common/utils.ts
+++ b/extensions/arc/src/common/utils.ts
@@ -198,12 +198,16 @@ export function getErrorMessage(error: any, useMessageWithLink: boolean = false)
 
 /**
  * Parses an address into its separate ip and port values. Address must be in the form <ip>:<port>
+ * or <ip>,<port>
  * @param address The address to parse
  */
 export function parseIpAndPort(address: string): { ip: string, port: string } {
-	const sections = address.split(':');
+	let sections = address.split(':');
 	if (sections.length !== 2) {
-		throw new Error(`Invalid address format for ${address}. Address must be in the form <ip>:<port>`);
+		sections = address.split(',');
+		if (sections.length !== 2) {
+			throw new Error(`Invalid address format for ${address}. Address must be in the form <ip>:<port> or <ip>,<port>`);
+		}
 	}
 	return {
 		ip: sections[0],


### PR DESCRIPTION
Recent changes made it so the endpoint we get back from the controller is in the form `<ip>,<port>` instead of `<ip>:<port>` like it was previously. Making us be able to support both to avoid these kind of issues in the future. 