### PR TITLE
Fix search results display (#14265)

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet.ts
@@ -38,7 +38,6 @@ import { getOutOfWorkspaceEditorResources } from 'vs/workbench/contrib/search/co
 import { NotebookSearchView } from 'sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch';
 import * as path from 'vs/base/common/path';
 import { URI } from 'vs/base/common/uri';
-import { isString } from 'vs/base/common/types';
 import { TreeViewPane } from 'vs/workbench/browser/parts/views/treeView';
 
 export const VIEWLET_ID = 'workbench.view.notebooks';
@@ -264,7 +263,11 @@ export class NotebookExplorerViewPaneContainer extends ViewPaneContainer {
 		this.validateQuery(query).then(() => {
 			if (this.views.length > 1) {
 				let filesToIncludeFiltered: string = '';
-				this.views.forEach(async (v) => {
+				// search book results first and then notebooks
+				const pinnedNotebookIndex = this.views.findIndex(view => view.id === 'pinnedBooksView');
+				const viewPanes = this.views;
+				viewPanes.push(viewPanes.splice(pinnedNotebookIndex, 1)[0]);
+				viewPanes.forEach(async (v) => {
 					if (v instanceof TreeViewPane) {
 						const { treeView } = (<ITreeViewDescriptor>Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).getView(v.id));
 						if (treeView.dataProvider) {
@@ -272,32 +275,34 @@ export class NotebookExplorerViewPaneContainer extends ViewPaneContainer {
 							items?.forEach(root => {
 								this.updateViewletsState();
 								if (root.contextValue === 'providedBook' || root.contextValue === 'savedBook') {
-									let rootFolder = URI.file(root.resourceUri.path);
+									const rootFolder = URI.file(root.resourceUri.path);
 									let folderToSearch = { folder: rootFolder };
 									if (root.tooltip.toString().includes('content')) {
 										let pattern = {};
 										pattern['content/**'] = true;
 										folderToSearch['includePattern'] = pattern;
 									}
-									query.folderQueries = query.folderQueries.filter((folder) => {
-										if (!!folder.includePattern && !folder.includePattern.toString().startsWith('content')) {
-											//verify if pinned notebook is not opened in Books Viewlet
-											return path.relative(folder.folder.fsPath, folderToSearch.folder.fsPath) !== '..';
-										} else {
-											return true;
-										}
-									});
 									query.folderQueries.push(folderToSearch);
 									filesToIncludeFiltered = filesToIncludeFiltered + path.join(folderToSearch.folder.fsPath, '**', '*.md') + ',' + path.join(folderToSearch.folder.fsPath, '**', '*.ipynb') + ',';
 								} else {
 									let pattern = {};
-									let rootFolder = URI.file(path.dirname(root.resourceUri.path));
-									let pathToNotebook = isString(root.tooltip) ? root.tooltip : root.tooltip.value;
-									let baseName = path.join('**', path.basename(pathToNotebook));
+									const rootFolder = URI.file(path.dirname(root.resourceUri.path));
+									const baseName = path.join('**', path.basename(root.resourceUri.path)).replace(/\\/g, '/');
+									let isOpenedInBooksView = false;
 									pattern[baseName] = true;
-									let folderToSearch = { folder: rootFolder, includePattern: pattern };
-									query.folderQueries.push(folderToSearch);
-									filesToIncludeFiltered = filesToIncludeFiltered + rootFolder + ',';
+									query.folderQueries.forEach((folder) => {
+										//check for books
+										if ((folder.includePattern === undefined || folder.includePattern['content/**']) && !isOpenedInBooksView) {
+											//verify if pinned notebook is not opened in Books Viewlet
+											const relativePath = path.relative(folder.folder.fsPath, rootFolder.fsPath);
+											isOpenedInBooksView = !relativePath.startsWith('..') || !relativePath.startsWith('.');
+										}
+									});
+									if (!isOpenedInBooksView) {
+										const folderToSearch = { folder: rootFolder, includePattern: pattern };
+										query.folderQueries.push(folderToSearch);
+										filesToIncludeFiltered = filesToIncludeFiltered + rootFolder + ',';
+									}
 								}
 							});
 


### PR DESCRIPTION
Previously, we used to identify the root of a tree item with the resourceUri but since we were sending always the root of the book instead of the actual path of a notebook it would cause the following issue: #13688.

In order to fix how the results were display, I keep track of the opened books in the Provided Book Tree View and the actual Book Tree View. For this reason, I iterate over the Pinned Books View last.
The folder.includePattern is undefined for the new version of Jupyter Books, it's content/** for the legacy version of Books and it is the name of afile + extensionfor individual notebooks (either pinned or standalone notebooks in the Books View).
I added this check to identify which queries were books and check if the tree item (saved notebook or pinned notebook) belongs to a book that has been added to the query before. If they haven't been added, then I proceed to add it to the query.

This PR fixes #14259