### PR TITLE
remove the dirty flag

### DIFF
--- a/src/sql/workbench/browser/editor/profiler/profilerInput.ts
+++ b/src/sql/workbench/browser/editor/profiler/profilerInput.ts
@@ -277,10 +277,6 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 		this.data.clearFilter();
 	}
 
-	isDirty(): boolean {
-		return this.state.isRunning || !!this.state.isPaused;
-	}
-
 	dispose() {
 		super.dispose();
 		this._profilerService.disconnectSession(this.id);


### PR DESCRIPTION
This PR fixes #14291 

editorInput used to support confirmSave and let us fully control the content of the process: https://github.com/microsoft/azuredatastudio/blob/eb35dae1d1238e03f1cab3bd45e151f381b22aef/src/sql/parts/profiler/editor/profilerInput.ts#L285

vscode has removed it and handle the confirmation in a common place, since we wanted to ask whether the user want to stopped the session, now it is not possible. it doesn't make sense to mark the editor as dirty anymore, it is safe to close the editor directly. the session stop is done in the dispose method of the input
