### PR TITLE
Throw error if findSection is not found

### DIFF
--- a/extensions/notebook/src/book/bookTocManager.ts
+++ b/extensions/notebook/src/book/bookTocManager.ts
@@ -174,7 +174,9 @@ export class BookTocManager implements IBookTocManager {
 	*/
 	async updateTOC(version: BookVersion, tocPath: string, findSection: JupyterBookSection, addSection?: JupyterBookSection): Promise<void> {
 		const toc: JupyterBookSection[] = yaml.safeLoad((await fs.readFile(tocPath, 'utf8')));
-		this._tocFiles.set(tocPath, toc);
+		if (!this._tocFiles.has(tocPath)) {
+			this._tocFiles.set(tocPath, toc);
+		}
 		let originalToc: IJupyterBookToc = { sections: this.getSections(toc) };
 		const indexFindSection = originalToc.sections.findIndex(section => {
 			return section.title === findSection.title && (section.file && section.file === findSection.file || section.url && section.url === findSection.file);

--- a/extensions/notebook/src/common/localizedConstants.ts
+++ b/extensions/notebook/src/common/localizedConstants.ts
@@ -49,7 +49,7 @@ export function closeBookError(resource: string, error: string): string { return
 export function duplicateFileError(title: string, path: string, newPath: string): string { return localize('duplicateFileError', "File {0} already exists in the destination folder {1} \n The file has been renamed to {2} to prevent data loss.", title, path, newPath); }
 export function editBookError(path: string, error: string): string { return localize('editBookError', "Error while editing book {0}: {1}", path, error); }
 export function selectBookError(error: string): string { return localize('selectBookError', "Error while selecting a book or a section to edit: {0}", error); }
-export function sectionNotFound(section: string): string { return localize('sectionNotFound', "The section: {0} was not found in table of contents.", section); }
+export function sectionNotFound(section: string, tocPath: string): string { return localize('sectionNotFound', "The section: {0} was not found in table of contents: {1}.", section, tocPath); }
 
 // Remote Book dialog constants
 export const url = localize('url', "URL");

--- a/extensions/notebook/src/common/localizedConstants.ts
+++ b/extensions/notebook/src/common/localizedConstants.ts
@@ -51,7 +51,6 @@ export function editBookError(path: string, error: string): string { return loca
 export function selectBookError(error: string): string { return localize('selectBookError', "Error while selecting a book or a section to edit: {0}", error); }
 export function sectionNotFound(section: string): string { return localize('sectionNotFound', "The section: {0} was not found in table of contents.", section); }
 
-
 // Remote Book dialog constants
 export const url = localize('url', "URL");
 export const repoUrl = localize('repoUrl', "Repository URL");

--- a/extensions/notebook/src/common/localizedConstants.ts
+++ b/extensions/notebook/src/common/localizedConstants.ts
@@ -49,6 +49,8 @@ export function closeBookError(resource: string, error: string): string { return
 export function duplicateFileError(title: string, path: string, newPath: string): string { return localize('duplicateFileError', "File {0} already exists in the destination folder {1} \n The file has been renamed to {2} to prevent data loss.", title, path, newPath); }
 export function editBookError(path: string, error: string): string { return localize('editBookError', "Error while editing book {0}: {1}", path, error); }
 export function selectBookError(error: string): string { return localize('selectBookError', "Error while selecting a book or a section to edit: {0}", error); }
+export function sectionNotFound(section: string): string { return localize('sectionNotFound', "The section: {0} was not found in table of contents.", section); }
+
 
 // Remote Book dialog constants
 export const url = localize('url', "URL");

--- a/extensions/notebook/src/test/book/bookTocManager.test.ts
+++ b/extensions/notebook/src/test/book/bookTocManager.test.ts
@@ -341,7 +341,7 @@ describe('BookTocManagerTests', function () {
 						version: run.version,
 						page: {
 							title: run.sectionA.sectionName,
-							file: path.join(path.sep,'sectionA', 'readme'),
+							file: path.join(path.sep, 'sectionA', 'readme'),
 							sections: run.sectionA.sectionFormat
 						}
 					};
@@ -405,8 +405,8 @@ describe('BookTocManagerTests', function () {
 						type: BookTreeItemType.Notebook,
 						version: run.version,
 						page: {
-								'title': 'Notebook 5',
-								'file': path.join(path.sep, 'notebook5')
+							'title': 'Notebook 5',
+							'file': path.join(path.sep, 'notebook5')
 						}
 					};
 

--- a/extensions/notebook/src/test/book/bookTocManager.test.ts
+++ b/extensions/notebook/src/test/book/bookTocManager.test.ts
@@ -339,7 +339,11 @@ describe('BookTocManagerTests', function () {
 						treeItemCollapsibleState: undefined,
 						type: BookTreeItemType.Markdown,
 						version: run.version,
-						page: run.sectionA.sectionFormat
+						page: {
+							title: run.sectionA.sectionName,
+							file: path.join(path.sep,'sectionA', 'readme'),
+							sections: run.sectionA.sectionFormat
+						}
 					};
 
 					// section B is from source book
@@ -354,7 +358,11 @@ describe('BookTocManagerTests', function () {
 						treeItemCollapsibleState: undefined,
 						type: BookTreeItemType.Markdown,
 						version: run.version,
-						page: run.sectionB.sectionFormat
+						page: {
+							title: run.sectionB.sectionName,
+							file: path.join(path.sep, 'sectionB', 'readme'),
+							sections: run.sectionB.sectionFormat
+						}
 					};
 
 					// notebook5 is from source book
@@ -375,12 +383,8 @@ describe('BookTocManagerTests', function () {
 						type: BookTreeItemType.Notebook,
 						version: run.version,
 						page: {
-							sections: [
-								{
-									'title': 'Notebook 5',
-									'file': path.join(path.sep, 'notebook5')
-								}
-							]
+							'title': 'Notebook 5',
+							'file': path.join(path.sep, 'notebook5')
 						}
 					};
 
@@ -401,12 +405,8 @@ describe('BookTocManagerTests', function () {
 						type: BookTreeItemType.Notebook,
 						version: run.version,
 						page: {
-							sections: [
-								{
-									'title': 'Notebook 5',
-									'file': path.join(path.sep, 'notebook5')
-								}
-							]
+								'title': 'Notebook 5',
+								'file': path.join(path.sep, 'notebook5')
 						}
 					};
 
@@ -433,7 +433,7 @@ describe('BookTocManagerTests', function () {
 					sectionA.tableOfContentsPath = run.sourceBook.tocPath;
 					sectionB.tableOfContentsPath = run.sourceBook.tocPath;
 					notebook.tableOfContentsPath = run.sourceBook.tocPath;
-					duplicatedNotebook.tableOfContentsPath = run.sourceBook.tocPath;
+					duplicatedNotebook.tableOfContentsPath = undefined;
 
 					sectionA.sections = run.sectionA.sectionFormat;
 					sectionB.sections = run.sectionB.sectionFormat;
@@ -469,9 +469,9 @@ describe('BookTocManagerTests', function () {
 					}
 
 					// target book
-					await fs.writeFile(run.targetBook.tocPath, '- title: Welcome\n  file: /readme\n- title: Section C\n  file: /sectionC/readme\n  sections:\n  - title: Notebook6\n    file: /sectionC/notebook6');
+					await fs.writeFile(run.targetBook.tocPath, '- title: Welcome\n  file: /readme\n- title: Section C\n  file: /sectionC/readme\n  sections:\n  - title: Notebook 6\n    file: /sectionC/notebook6');
 					// source book
-					await fs.writeFile(run.sourceBook.tocPath, '- title: Notebook 5\n  file: /notebook5\n- title: Section A\n  file: /sectionA/readme\n  sections:\n  - title: Notebook1\n    file: /sectionA/notebook1\n  - title: Notebook2\n    file: /sectionA/notebook2');
+					await fs.writeFile(run.sourceBook.tocPath, '- title: Notebook 5\n  file: /notebook5\n- title: Section A\n  file: /sectionA/readme\n  sections:\n  - title: Notebook1\n    file: /sectionA/notebook1\n  - title: Notebook2\n    file: /sectionA/notebook2\n- title: Section B\n  file: /sectionB/readme\n  sections:\n  - title: Notebook3\n    file: /sectionB/notebook3\n  - title: Notebook4\n    file: /sectionB/notebook4');
 
 					const mockExtensionContext = new MockExtensionContext();
 


### PR DESCRIPTION
This a quick fix for the issue https://github.com/microsoft/azuredatastudio/issues/14322
If the section to be modified is not found, then we throw an error to reset both toc files to their original states.
