### PR TITLE
Fix for bug 14282 in Restore Dialog

### DIFF
--- a/src/sql/workbench/services/restore/browser/restoreDialog.ts
+++ b/src/sql/workbench/services/restore/browser/restoreDialog.ts
@@ -634,9 +634,12 @@ export class RestoreDialog extends Modal {
 	}
 
 	private onSourceDatabaseChanged(selectedDatabase: string) {
-		this.viewModel.sourceDatabaseName = selectedDatabase;
-		this.viewModel.selectedBackupSets = undefined;
-		this.validateRestore(true);
+		// This check is to avoid any unnecessary even firing (to remove flickering)
+		if (this.viewModel.sourceDatabaseName !== selectedDatabase) {
+			this.viewModel.sourceDatabaseName = selectedDatabase;
+			this.viewModel.selectedBackupSets = undefined;
+			this.validateRestore(true);
+		}
 	}
 
 	private onRestoreFromChanged(selectedRestoreFrom: string) {

--- a/src/sql/workbench/services/restore/browser/restoreServiceImpl.ts
+++ b/src/sql/workbench/services/restore/browser/restoreServiceImpl.ts
@@ -319,8 +319,9 @@ export class RestoreDialogController implements IRestoreDialogController {
 
 					if (this._currentProvider === ConnectionConstants.mssqlProviderName) {
 						let restoreDialog = this._restoreDialogs[this._currentProvider] as RestoreDialog;
-						restoreDialog.viewModel.resetRestoreOptions(connection.databaseName!);
 						this.getMssqlRestoreConfigInfo().then(() => {
+							// database list is filled only after getMssqlRestoreConfigInfo() calling before will always set to empty value
+							restoreDialog.viewModel.resetRestoreOptions(connection.databaseName!, restoreDialog.viewModel.databaseList);
 							restoreDialog.open(connection.serverName, this._ownerUri!);
 							restoreDialog.validateRestore();
 						}, restoreConfigError => {

--- a/src/sql/workbench/services/restore/browser/restoreViewModel.ts
+++ b/src/sql/workbench/services/restore/browser/restoreViewModel.ts
@@ -245,13 +245,13 @@ export class RestoreViewModel {
 	/**
 	* Reset restore options to the default value
 	*/
-	public resetRestoreOptions(databaseName: string): void {
+	public resetRestoreOptions(databaseName: string, databaseList: string[] = []): void {
 		this.sourceDatabaseName = databaseName ? databaseName : '';
 		this.updateTargetDatabaseName(databaseName);
-		this.updateSourceDatabaseNames([], this.sourceDatabaseName);
+		this.databaseList = databaseList;
+		this.updateSourceDatabaseNames(this.databaseList, this.sourceDatabaseName);
 		this.updateFilePath('');
 		this.updateLastBackupTaken('');
-		this.databaseList = [];
 		this.selectedBackupSets = undefined;
 		for (let key in this._optionsMap) {
 			this._optionsMap[key].defaultValue = this.getDisplayValue(this._optionsMap[key].optionMetadata, this._optionsMap[key].optionMetadata.defaultValue);


### PR DESCRIPTION
This PR is a fix for #14282.
it contains changes to avoid flickering and ensuring the target DB is always selected correctly even if corresponding source is not present.

Both issues seem to be caused by repeated selection event of source drop down - 
- flickering due to repeated setting of values in the page
- and improper setting of database because target db is set to be overwritten by source and hence repeated select events on source were causing target to change as well.

I am not very sure as to how this started because I don't see any changes to this code. Hence I would like to test more before checkin. starting the PR anyways to get some suggestions.

