### PR TITLE
Disable monaco generation

### DIFF
--- a/build/lib/compilation.js
+++ b/build/lib/compilation.js
@@ -12,12 +12,12 @@ const bom = require("gulp-bom");
 const sourcemaps = require("gulp-sourcemaps");
 const tsb = require("gulp-tsb");
 const path = require("path");
-// import * as monacodts from '../monaco/api';
+// import * as monacodts from '../monaco/api'; {{SQL CARBON EDIT}} Remove Monaco generator
 const nls = require("./nls");
 const reporter_1 = require("./reporter");
 const util = require("./util");
-// import * as fancyLog from 'fancy-log';
-// import * as ansiColors from 'ansi-colors';
+// import * as fancyLog from 'fancy-log'; {{SQL CARBON EDIT}} Remove Monaco generator
+// import * as ansiColors from 'ansi-colors'; {{SQL CARBON EDIT}} Remove Monaco generator
 const os = require("os");
 const watch = require('./watch');
 const reporter = reporter_1.createReporter();

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -12,12 +12,12 @@ import * as bom from 'gulp-bom';
 import * as sourcemaps from 'gulp-sourcemaps';
 import * as tsb from 'gulp-tsb';
 import * as path from 'path';
-import * as monacodts from '../monaco/api';
+// import * as monacodts from '../monaco/api'; {{SQL CARBON EDIT}} Remove Monaco generator
 import * as nls from './nls';
 import { createReporter } from './reporter';
 import * as util from './util';
-import * as fancyLog from 'fancy-log';
-import * as ansiColors from 'ansi-colors';
+// import * as fancyLog from 'fancy-log'; {{SQL CARBON EDIT}} Remove Monaco generator
+// import * as ansiColors from 'ansi-colors'; {{SQL CARBON EDIT}} Remove Monaco generator
 import * as os from 'os';
 import ts = require('typescript');
 
@@ -89,13 +89,15 @@ export function compileTask(src: string, out: string, build: boolean): () => Nod
 
 		const compile = createCompile(src, build, true);
 		const srcPipe = gulp.src(`${src}/**`, { base: `${src}` });
+		/* {{SQL CARBON EDIT}} Remove Monaco generator
 		let generator = new MonacoGenerator(false);
 		if (src === 'src') {
 			generator.execute();
 		}
+		*/
 
 		return srcPipe
-			.pipe(generator.stream)
+			//.pipe(generator.stream) {{SQL CARBON EDIT}} Remove Monaco generator
 			.pipe(compile())
 			.pipe(gulp.dest(out));
 	};
@@ -109,16 +111,17 @@ export function watchTask(out: string, build: boolean): () => NodeJS.ReadWriteSt
 		const src = gulp.src('src/**', { base: 'src' });
 		const watchSrc = watch('src/**', { base: 'src', readDelay: 200 });
 
-		let generator = new MonacoGenerator(true);
-		generator.execute();
+		// let generator = new MonacoGenerator(true); {{SQL CARBON EDIT}} Remove Monaco generator
+		// generator.execute(); {{SQL CARBON EDIT}} Remove Monaco generator
 
 		return watchSrc
-			.pipe(generator.stream)
+			// .pipe(generator.stream) {{SQL CARBON EDIT}} Remove Monaco generator
 			.pipe(util.incremental(compile, src, true))
 			.pipe(gulp.dest(out));
 	};
 }
 
+/* {{SQL CARBON EDIT}} Remove Monaco generator
 const REPO_SRC_FOLDER = path.join(__dirname, '../../src');
 
 class MonacoGenerator {
@@ -206,3 +209,4 @@ class MonacoGenerator {
 		}
 	}
 }
+*/


### PR DESCRIPTION
Something in the monaco.d.ts generation is making it so that local compiles are generating modifications to the file. VS Code has made some modifications to this since the point we're merged up to so it wasn't immediately obvious if this was something they fixed on their end.

But in the end we don't have any reason to generate/update this file so disabling it not only solves that annoyance but also improves build times so seems like a win all around. 