### PR TITLE
show page first and then do the layout

### DIFF
--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -189,8 +189,8 @@ export class WizardModal extends Modal {
 		this._dialogPanes.forEach((dialogPane, page) => {
 			if (page === pageToShow) {
 				dialogPaneToShow = dialogPane;
-				dialogPane.layout(true);
 				dialogPane.show(focus);
+				dialogPane.layout(true);
 			} else {
 				dialogPane.hide();
 			}


### PR DESCRIPTION
This PR fixes #14221
the tree component is relying on the content width to set the size of the tree
![image](https://user-images.githubusercontent.com/13777222/108110203-ca108000-7047-11eb-99e5-31d35cb2198b.png)

but it is called before the page becomes visible, when things are not visible, the DOM.getContentXXX will return 0.
the fix is to make it visible first and then call the layout method.
with the fix:
![wizard](https://user-images.githubusercontent.com/13777222/108110328-f2987a00-7047-11eb-962c-a618bbceb53b.gif)

tested the wizards in ADS and didn't find any issue with this change.