### PR TITLE
fix the header filter plugin issue

### DIFF
--- a/src/sql/base/browser/ui/table/interfaces.ts
+++ b/src/sql/base/browser/ui/table/interfaces.ts
@@ -29,3 +29,7 @@ export interface ITableConfiguration<T> {
 	columns?: Slick.Column<T>[];
 	sorter?: ITableSorter<T>;
 }
+
+export interface FilterableColumn<T> extends Slick.Column<T> {
+	filterable?: boolean;
+}

--- a/src/sql/base/browser/ui/table/media/slick.grid.css
+++ b/src/sql/base/browser/ui/table/media/slick.grid.css
@@ -186,3 +186,15 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+
+
+.slick-header-column.slick-header-with-filter {
+	display: flex;
+}
+
+.slick-header-with-filter .slick-column-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: inline-block;
+	flex: 1 1 auto;
+}

--- a/src/sql/base/browser/ui/table/media/table.css
+++ b/src/sql/base/browser/ui/table/media/table.css
@@ -37,14 +37,15 @@
 .slick-header-menubutton {
 	background-position: center center;
 	background-repeat: no-repeat;
-	bottom: 0;
 	cursor: pointer;
 	display: inline-block;
-	position: absolute;
-	right: 10px;
-	top: 0;
-	width: 18px;
+	width: 16px;
 	background-image: url('down.svg');
+	flex: 0 0 auto;
+	margin-right: 2px;
+	background-color: transparent;
+	border: 0px;
+	padding: 0px;
 }
 
 .vs-dark .slick-header-menubutton,

--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -5,6 +5,7 @@ import { IButtonStyles } from 'vs/base/browser/ui/button/button';
 import { localize } from 'vs/nls';
 
 import { Button } from 'sql/base/browser/ui/button/button';
+import { FilterableColumn } from 'sql/base/browser/ui/table/interfaces';
 import { escape } from 'sql/base/common/strings';
 import { addDisposableListener } from 'vs/base/browser/dom';
 import { DisposableStore } from 'vs/base/common/lifecycle';
@@ -19,6 +20,8 @@ export interface CommandEventArgs<T extends Slick.SlickData> {
 	column: Slick.Column<T>,
 	command: string
 }
+
+const ShowFilterText: string = localize('headerFilter.showFilter', "Show Filter");
 
 export class HeaderFilter<T extends Slick.SlickData> {
 
@@ -84,25 +87,18 @@ export class HeaderFilter<T extends Slick.SlickData> {
 		if (column.id === '_detail_selector') {
 			return;
 		}
-		if ((<any>column).filterable === false) {
+		if ((<FilterableColumn<T>>column).filterable === false) {
 			return;
 		}
-		const $el = jQuery('<div tabIndex="0"></div>')
+		args.node.classList.add('slick-header-with-filter');
+		const $el = jQuery(`<button aria-label="${ShowFilterText}" title="${ShowFilterText}"></button>`)
 			.addClass('slick-header-menubutton')
 			.data('column', column);
 
-		$el.bind('click', (e: KeyboardEvent) => {
-			this.showFilter(e);
-			e.preventDefault();
-			e.stopPropagation();
-		}).appendTo(args.node);
-		$el.bind('keydown', (e: KeyboardEvent) => {
-			if (e.key === 'Enter' || e.keyCode === 13) {
-				this.showFilter(e);
-				e.preventDefault();
-				e.stopPropagation();
-			}
-		}).appendTo(args.node);
+		$el.click(() => {
+			this.showFilter($el[0]);
+		});
+		$el.appendTo(args.node);
 	}
 
 	private handleBeforeHeaderCellDestroy(e: Event, args: Slick.OnBeforeHeaderCellDestroyEventArgs<T>) {
@@ -165,8 +161,8 @@ export class HeaderFilter<T extends Slick.SlickData> {
 		});
 	}
 
-	private showFilter(e: KeyboardEvent) {
-		const target = withNullAsUndefined(e.target);
+	private showFilter(element: HTMLElement) {
+		const target = withNullAsUndefined(element);
 		const $menuButton = jQuery(target);
 		this.columnDef = $menuButton.data('column');
 

--- a/src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput.ts
+++ b/src/sql/workbench/browser/editor/resourceViewer/resourceViewerInput.ts
@@ -12,12 +12,12 @@ import { DataGridProvider, IDataGridProviderService } from 'sql/workbench/servic
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { ButtonColumn } from 'sql/base/browser/ui/table/plugins/buttonColumn.plugin';
 import { getDataGridFormatter } from 'sql/workbench/services/dataGridProvider/browser/dataGridProviderUtils';
+import { FilterableColumn } from 'sql/base/browser/ui/table/interfaces';
 
-export interface ColumnDefinition extends Slick.Column<azdata.DataGridItem> {
+export interface ColumnDefinition extends FilterableColumn<azdata.DataGridItem> {
 	name: string;
 	// actions is a special internal type for the More Actions column
 	type: azdata.DataGridColumnType | 'actions';
-	filterable?: boolean;
 }
 
 export class ResourceViewerInput extends EditorInput {


### PR DESCRIPTION
I am working on adding the filtering feature to query result tables and noticed some issues with the header filter plugin.
1. the header text and button are overlapping when resized, using css to control the sizing of the elements.
2. we are using custom div as button and a few accessibility feature is missing, e.g. role, accessible name and space key press handling...., I am replacing it with html button element.
3. the jquery bind method has been marked as deprecated, replaced it with click handler.

before
![image](https://user-images.githubusercontent.com/13777222/108299163-c0277380-7152-11eb-86b0-dc5c81d490cd.png)

after
![image](https://user-images.githubusercontent.com/13777222/108299180-ccabcc00-7152-11eb-8286-9c5306032ca4.png)

