### PR TITLE
Hide Open in Editor for notebook search

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookSearch.ts
@@ -384,7 +384,7 @@ export class NotebookSearchView extends SearchView {
 	}
 
 	protected async refreshAndUpdateCount(event?: IChangeEvent): Promise<void> {
-		this.updateSearchResultCount(this.viewModel.searchResult.query!.userDisabledExcludesAndIgnoreFiles);
+		this.updateSearchResultCount(this.viewModel.searchResult.query!.userDisabledExcludesAndIgnoreFiles, false);
 		return this.refreshTree(event);
 	}
 

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1641,7 +1641,7 @@ export class SearchView extends ViewPane {
 		this.openerService.open(URI.parse('https://go.microsoft.com/fwlink/?linkid=853977'));
 	};
 
-	protected updateSearchResultCount(disregardExcludesAndIgnores?: boolean): void { // {{SQL CARBON EDIT}}
+	protected updateSearchResultCount(disregardExcludesAndIgnores?: boolean, showOpenInEditor = true): void { // {{SQL CARBON EDIT}} - Hide Open in Editor in Notebooks viewlet
 		const fileCount = this.viewModel.searchResult.fileCount();
 		this.hasSearchResultsKey.set(fileCount > 0);
 
@@ -1656,18 +1656,25 @@ export class SearchView extends ViewPane {
 				resultMsg += nls.localize('useIgnoresAndExcludesDisabled', " - exclude settings and ignore files are disabled");
 			}
 
-			dom.append(messageEl, $('span', undefined, resultMsg + ' - '));
+			if (showOpenInEditor) { // {{SQL CARBON EDIT}} - Hide Open in Editor in Notebooks viewlet
+				dom.append(messageEl, $('span', undefined, resultMsg + ' - '));
+			} else {
+				dom.append(messageEl, $('span', undefined, resultMsg));
+			}
 			const span = dom.append(messageEl, $('span'));
-			const openInEditorLink = dom.append(span, $('a.pointer.prominent', undefined, nls.localize('openInEditor.message', "Open in editor")));
 
-			openInEditorLink.title = appendKeyBindingLabel(
-				nls.localize('openInEditor.tooltip', "Copy current search results to an editor"),
-				this.keybindingService.lookupKeybinding(Constants.OpenInEditorCommandId), this.keybindingService);
+			if (showOpenInEditor) { // {{SQL CARBON EDIT}} - Hide Open in Editor in Notebooks viewlet
+				const openInEditorLink = dom.append(span, $('a.pointer.prominent', undefined, nls.localize('openInEditor.message', "Open in editor")));
 
-			this.messageDisposables.push(dom.addDisposableListener(openInEditorLink, dom.EventType.CLICK, (e: MouseEvent) => {
-				dom.EventHelper.stop(e, false);
-				this.instantiationService.invokeFunction(createEditorFromSearchResult, this.searchResult, this.searchIncludePattern?.getValue(), this.searchExcludePattern?.getValue()); // {{SQL CARBON EDIT}}
-			}));
+				openInEditorLink.title = appendKeyBindingLabel(
+					nls.localize('openInEditor.tooltip', "Copy current search results to an editor"),
+					this.keybindingService.lookupKeybinding(Constants.OpenInEditorCommandId), this.keybindingService);
+
+				this.messageDisposables.push(dom.addDisposableListener(openInEditorLink, dom.EventType.CLICK, (e: MouseEvent) => {
+					dom.EventHelper.stop(e, false);
+					this.instantiationService.invokeFunction(createEditorFromSearchResult, this.searchResult, this.searchIncludePattern?.getValue(), this.searchExcludePattern?.getValue()); // {{SQL CARBON EDIT}}
+				}));
+			}
 
 			this.reLayout();
 		} else if (!msgWasHidden) {

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1641,7 +1641,7 @@ export class SearchView extends ViewPane {
 		this.openerService.open(URI.parse('https://go.microsoft.com/fwlink/?linkid=853977'));
 	};
 
-	protected updateSearchResultCount(disregardExcludesAndIgnores?: boolean, showOpenInEditor = true): void { // {{SQL CARBON EDIT}} - Hide Open in Editor in Notebooks viewlet
+	protected updateSearchResultCount(disregardExcludesAndIgnores?: boolean, showOpenInEditor: boolean = true): void { // {{SQL CARBON EDIT}} - Hide Open in Editor in Notebooks viewlet
 		const fileCount = this.viewModel.searchResult.fileCount();
 		this.hasSearchResultsKey.set(fileCount > 0);
 


### PR DESCRIPTION
Fixes #12423. Hiding search editor link from notebooks viewlet; users have given us feedback that it's confusing that the link doesn't do anything currently, and would rather not see it here.

![image](https://user-images.githubusercontent.com/40371649/108452894-3644dc80-721e-11eb-85f6-2841bd428225.png)

![image](https://user-images.githubusercontent.com/40371649/108452921-41980800-721e-11eb-8843-7bd378147542.png)
