### PR TITLE
Import Extension: Updating prose version to fix double backslash bug

### DIFF
--- a/extensions/import/config.json
+++ b/extensions/import/config.json
@@ -1,7 +1,7 @@
 {
 	"downloadUrl": "https://sqlopsextensions.blob.core.windows.net/extensions/import/service/{#version#}/{#fileName#}",
 	"useDefaultLinuxRuntime": true,
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"downloadFileNames": {
 		"Windows_64": "win-x64.zip",
 		"Windows_86": "win-x86.zip",


### PR DESCRIPTION
This PR fixes #13819 
