### PR TITLE
selected cell summary for status bar

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -36,6 +36,7 @@ import { ChartView } from 'sql/workbench/contrib/charts/browser/chartView';
 import { ToggleableAction } from 'sql/workbench/contrib/notebook/browser/notebookActions';
 import { IInsightOptions } from 'sql/workbench/common/editor/query/chartState';
 import { NotebookChangeType } from 'sql/workbench/services/notebook/common/contracts';
+import { IQueryModelService } from 'sql/workbench/services/query/common/queryModel';
 import { ActionsOrientation } from 'vs/base/browser/ui/actionbar/actionbar';
 import { values } from 'vs/base/common/collections';
 import { URI } from 'vs/base/common/uri';
@@ -198,9 +199,10 @@ class DataResourceTable extends GridTableBase<any> {
 		@IInstantiationService protected instantiationService: IInstantiationService,
 		@IEditorService editorService: IEditorService,
 		@IUntitledTextEditorService untitledEditorService: IUntitledTextEditorService,
-		@IConfigurationService configurationService: IConfigurationService
+		@IConfigurationService configurationService: IConfigurationService,
+		@IQueryModelService queryModelService: IQueryModelService
 	) {
-		super(state, createResultSet(source), { actionOrientation: ActionsOrientation.HORIZONTAL }, contextMenuService, instantiationService, editorService, untitledEditorService, configurationService);
+		super(state, createResultSet(source), { actionOrientation: ActionsOrientation.HORIZONTAL }, contextMenuService, instantiationService, editorService, untitledEditorService, configurationService, queryModelService);
 		this._gridDataProvider = this.instantiationService.createInstance(DataResourceDataProvider, source, this.resultSet, this.cellModel);
 		this._chart = this.instantiationService.createInstance(ChartView, false);
 

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -27,7 +27,7 @@ import { localize } from 'vs/nls';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
-import { TimeElapsedStatusBarContributions, RowCountStatusBarContributions, QueryStatusStatusBarContributions } from 'sql/workbench/contrib/query/browser/statusBarItems';
+import { TimeElapsedStatusBarContributions, RowCountStatusBarContributions, QueryStatusStatusBarContributions, QueryResultSelectionSummaryStatusBarContribution } from 'sql/workbench/contrib/query/browser/statusBarItems';
 import { SqlFlavorStatusbarItem, ChangeFlavorAction } from 'sql/workbench/contrib/query/browser/flavorStatus';
 import { IEditorInputFactoryRegistry, Extensions as EditorInputFactoryExtensions } from 'vs/workbench/common/editor';
 import { FileQueryEditorInput } from 'sql/workbench/contrib/query/common/fileQueryEditorInput';
@@ -479,3 +479,4 @@ workbenchRegistry.registerWorkbenchContribution(TimeElapsedStatusBarContribution
 workbenchRegistry.registerWorkbenchContribution(RowCountStatusBarContributions, LifecyclePhase.Restored);
 workbenchRegistry.registerWorkbenchContribution(QueryStatusStatusBarContributions, LifecyclePhase.Restored);
 workbenchRegistry.registerWorkbenchContribution(SqlFlavorStatusbarItem, LifecyclePhase.Restored);
+workbenchRegistry.registerWorkbenchContribution(QueryResultSelectionSummaryStatusBarContribution, LifecyclePhase.Restored);

--- a/src/sql/workbench/contrib/query/browser/statusBarItems.ts
+++ b/src/sql/workbench/contrib/query/browser/statusBarItems.ts
@@ -3,18 +3,17 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { IQueryModelService } from 'sql/workbench/services/query/common/queryModel';
-import { IntervalTimer } from 'vs/base/common/async';
-import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
-import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
-import { localize } from 'vs/nls';
-import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 import { parseNumAsTimeString } from 'sql/platform/connection/common/utils';
-import { Event } from 'vs/base/common/event';
 import { QueryEditorInput } from 'sql/workbench/common/editor/query/queryEditorInput';
-import { IStatusbarService, IStatusbarEntryAccessor, StatusbarAlignment } from 'vs/workbench/services/statusbar/common/statusbar';
-
+import { IQueryModelService } from 'sql/workbench/services/query/common/queryModel';
+import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
+import { IntervalTimer } from 'vs/base/common/async';
+import { Event } from 'vs/base/common/event';
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { localize } from 'vs/nls';
+import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/common/statusbar';
 export class TimeElapsedStatusBarContributions extends Disposable implements IWorkbenchContribution {
 
 	private static readonly ID = 'status.query.timeElapsed';
@@ -251,5 +250,56 @@ export class QueryStatusStatusBarContributions extends Disposable implements IWo
 
 	private show() {
 		this.statusbarService.updateEntryVisibility(QueryStatusStatusBarContributions.ID, true);
+	}
+}
+
+export class QueryResultSelectionSummaryStatusBarContribution extends Disposable implements IWorkbenchContribution {
+	private static readonly ID = 'status.query.selection-summary';
+	private statusItem: IStatusbarEntryAccessor;
+
+	constructor(
+		@IStatusbarService private readonly statusbarService: IStatusbarService,
+		@IEditorService private editorService: IEditorService,
+		@IQueryModelService queryModelService: IQueryModelService
+	) {
+		super();
+		this.statusItem = this._register(
+			this.statusbarService.addEntry({
+				text: '',
+				ariaLabel: ''
+			},
+				QueryResultSelectionSummaryStatusBarContribution.ID,
+				localize('status.query.selection-summary', "Selection Summary"),
+				StatusbarAlignment.RIGHT, 100)
+		);
+		this._register(editorService.onDidActiveEditorChange(() => { this.hide(); }, this));
+		this._register(queryModelService.onRunQueryStart(() => { this.hide(); }));
+		this._register(queryModelService.onCellSelectionChanged((data: string[]) => {
+			this.onCellSelectionChanged(data);
+		}));
+	}
+
+	private hide(): void {
+		this.statusbarService.updateEntryVisibility(QueryResultSelectionSummaryStatusBarContribution.ID, false);
+	}
+
+	private show(): void {
+		this.statusbarService.updateEntryVisibility(QueryResultSelectionSummaryStatusBarContribution.ID, true);
+	}
+
+	private onCellSelectionChanged(data: string[]): void {
+		const numericValues = data?.filter(value => !isNaN(parseFloat(value))).map(value => parseFloat(value));
+		if (numericValues?.length < 2 || !(this.editorService.activeEditor instanceof QueryEditorInput)) {
+			this.hide();
+			return;
+		}
+
+		const sum = numericValues.reduce((previous, current, idx, array) => previous + current);
+		const summaryText = localize('status.query.summaryText', "Average: {0}  Count: {1}  Sum: {2}", sum / numericValues.length, data.length, sum);
+		this.statusItem.update({
+			text: summaryText,
+			ariaLabel: summaryText
+		});
+		this.show();
 	}
 }

--- a/src/sql/workbench/services/query/common/queryModel.ts
+++ b/src/sql/workbench/services/query/common/queryModel.ts
@@ -48,6 +48,9 @@ export interface IQueryEvent {
 export interface IQueryModelService {
 	_serviceBrand: undefined;
 
+	onCellSelectionChanged: Event<string[]>;
+	notifyCellSelectionChanged(selectedValues: string[]): void;
+
 	getQueryRunner(uri: string): QueryRunner | undefined;
 
 	getQueryRows(uri: string, rowStart: number, numberOfRows: number, batchId: number, resultId: number): Promise<ResultSetSubset | undefined>;

--- a/src/sql/workbench/services/query/common/queryModelService.ts
+++ b/src/sql/workbench/services/query/common/queryModelService.ts
@@ -62,6 +62,7 @@ export class QueryModelService implements IQueryModelService {
 	private _onRunQueryComplete: Emitter<string>;
 	private _onQueryEvent: Emitter<IQueryEvent>;
 	private _onEditSessionReady: Emitter<azdata.EditSessionReadyParams>;
+	private _onCellSelectionChangedEmitter = new Emitter<string[]>();
 
 	// EVENTS /////////////////////////////////////////////////////////////
 	public get onRunQueryStart(): Event<string> { return this._onRunQueryStart.event; }
@@ -69,6 +70,7 @@ export class QueryModelService implements IQueryModelService {
 	public get onRunQueryComplete(): Event<string> { return this._onRunQueryComplete.event; }
 	public get onQueryEvent(): Event<IQueryEvent> { return this._onQueryEvent.event; }
 	public get onEditSessionReady(): Event<azdata.EditSessionReadyParams> { return this._onEditSessionReady.event; }
+	public get onCellSelectionChanged(): Event<string[]> { return this._onCellSelectionChangedEmitter.event; }
 
 	// CONSTRUCTOR /////////////////////////////////////////////////////////
 	constructor(
@@ -94,6 +96,14 @@ export class QueryModelService implements IQueryModelService {
 		}
 
 		return dataService;
+	}
+
+	/**
+	 * Notify the event subscribers about the new selected cell values
+	 * @param selectedValues current selected cell values
+	 */
+	public notifyCellSelectionChanged(selectedValues: string[]): void {
+		this._onCellSelectionChangedEmitter.fire(selectedValues);
 	}
 
 	/**

--- a/src/sql/workbench/services/query/test/common/testQueryModelService.ts
+++ b/src/sql/workbench/services/query/test/common/testQueryModelService.ts
@@ -14,6 +14,10 @@ import { IRange } from 'vs/editor/common/core/range';
 export class TestQueryModelService implements IQueryModelService {
 	_serviceBrand: any;
 	onRunQueryUpdate: Event<string>;
+	onCellSelectionChanged: Event<string[]>;
+	notifyCellSelectionChanged(selectedValues: string[]): void {
+		throw new Error('Method not implemented.');
+	}
 	getQueryRunner(uri: string): QueryRunner {
 		throw new Error('Method not implemented.');
 	}


### PR DESCRIPTION
This is part of the query editor enhancement planned for this semester. the summary will show when there are multiple numeric cells selected, the count include all the selected cells, but the average and sum are only considering numeric cells.

This PR fixes #512

![image](https://user-images.githubusercontent.com/13777222/108457560-b91e6500-7227-11eb-81ba-94c019d39807.png)

how the same data look in Excel:
![image](https://user-images.githubusercontent.com/13777222/108457461-8a07f380-7227-11eb-80bb-1aa8d392665c.png)

@chlafreniere I had to restrict this feature to query editor because there is no global event I can subscribe for notebook's query execution events. the sqlSessionManager is using QueryRunner and it is not associated with QueryModelService like query editor. If I get the the event when the notebook sql cell started execution (to clear the previous summary text), this feature can easily be available for notebook as well.

more screenshots:

when no numeric values are selected, the summary is not visible
![image](https://user-images.githubusercontent.com/13777222/108548170-4ac9b900-72a0-11eb-8de8-923edb4711da.png)

when only one numeric value is selected, the summary is not visible
![image](https://user-images.githubusercontent.com/13777222/108548275-7a78c100-72a0-11eb-821b-4b3cb9a315e3.png)

when multiple regions selected, all selected cells are included in the summary
![image](https://user-images.githubusercontent.com/13777222/108548405-a4ca7e80-72a0-11eb-8870-07cbdcdcc454.png)

when switching editor, the summary will be removed
![switch-window](https://user-images.githubusercontent.com/13777222/108548837-3639f080-72a1-11eb-9ce1-4b7cc2709f3b.gif)

when new query execution is started, the summary will be removed
![re-run](https://user-images.githubusercontent.com/13777222/108549120-99c41e00-72a1-11eb-9d5a-50b2770d0175.gif)

multiple result sets in one query window, only the most recent selection will be displayed
![multiple-resultsets](https://user-images.githubusercontent.com/13777222/108549482-0c34fe00-72a2-11eb-9dd0-3919e33d2f2d.gif)

when query editor is closed, the summary will be removed
![close-editor](https://user-images.githubusercontent.com/13777222/108550672-bc573680-72a3-11eb-8849-201d43a9b928.gif)

