### PR TITLE
fix a few issues with the table filter pop up.

### DIFF
--- a/src/sql/base/browser/ui/table/media/table.css
+++ b/src/sql/base/browser/ui/table/media/table.css
@@ -99,6 +99,22 @@
 	white-space: nowrap;
 	width: 200px;
 	display: grid;
+	align-content: flex-start;
+}
+
+.slick-header-menu .filter .filter-option {
+	display: flex;
+	align-items: center;
+}
+
+.slick-header-menu .filter-menu-button-container {
+	display: flex;
+	flex-direction: row;
+	width: 100%;
+}
+
+.slick-header-menu .filter-menu-button {
+	flex: 0 0 auto;
 }
 
 .monaco-table label {


### PR DESCRIPTION
1. click on the dropdown button will cause the header to be clicked, the fix is to stop the click event propagation.
2. add a cell value extractor parameter so that we can handle the scenario when data are object.
3. align the checkbox and text, right now the checkbox is higher than the text.
4. make the buttons layout horizontally 
5. set initial focus to the ok button when the menu is opened, currently the focus stays on the dropdown button and pressing tab won't move the focus to the filter pop up.
6. currently if the options can't take up all the available space, there will be whitespace added between the options, I am changing it to remove the extra space.

before
![image](https://user-images.githubusercontent.com/13777222/108611723-16382900-7396-11eb-88e3-077e2c7222e6.png)

after
![image](https://user-images.githubusercontent.com/13777222/108611721-11737500-7396-11eb-8172-bfb261f40dd0.png)
