### PR TITLE
calloutDialog refactor - new superclasses for insert image and insert link

### DIFF
--- a/src/sql/workbench/browser/modal/calloutDialog.ts
+++ b/src/sql/workbench/browser/modal/calloutDialog.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import 'vs/css!./media/calloutDialog';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { IDialogProperties, Modal, DialogWidth } from 'sql/workbench/browser/modal/modal';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -11,18 +12,9 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
-
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 
-export interface ICalloutDialogOptions {
-	insertTitle?: string,
-	insertMarkup?: string,
-	imagePath?: string,
-	embedImage?: boolean
-}
-export class CalloutDialog extends Modal {
-
-
+export abstract class CalloutDialog extends Modal {
 
 	constructor(
 		title: string,
@@ -54,30 +46,8 @@ export class CalloutDialog extends Modal {
 			});
 	}
 
-	/**
-	 * Opens the dialog and returns a promise for what options the user chooses.
-	 */
-	public open(): void {
-		this.show();
-	}
-
-	public render() {
-		super.render();
-	}
-
-	protected renderBody(container: HTMLElement) {
-	}
+	protected abstract renderBody(container: HTMLElement): void;
 
 	protected layout(height?: number): void {
-	}
-
-	public insert(): void {
-		this.hide();
-		this.dispose();
-	}
-
-	public cancel(): void {
-		this.hide();
-		this.dispose();
 	}
 }

--- a/src/sql/workbench/browser/modal/calloutDialog.ts
+++ b/src/sql/workbench/browser/modal/calloutDialog.ts
@@ -6,13 +6,12 @@
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { IDialogProperties, Modal, DialogWidth } from 'sql/workbench/browser/modal/modal';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { localize } from 'vs/nls';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
-import { attachModalDialogStyler } from 'sql/workbench/common/styler';
+
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 
 export interface ICalloutDialogOptions {
@@ -23,8 +22,7 @@ export interface ICalloutDialogOptions {
 }
 export class CalloutDialog extends Modal {
 
-	private readonly insertButtonText = localize('callout.insertButton', "Insert");
-	private readonly cancelButtonText = localize('callout.cancelButton', "Cancel");
+
 
 	constructor(
 		title: string,
@@ -61,16 +59,10 @@ export class CalloutDialog extends Modal {
 	 */
 	public open(): void {
 		this.show();
-		//return this._selectionComplete.promise;
 	}
 
 	public render() {
 		super.render();
-
-		attachModalDialogStyler(this, this._themeService);
-
-		this.addFooterButton(this.insertButtonText, () => this.insert());
-		this.addFooterButton(this.cancelButtonText, () => this.cancel(), undefined, true);
 	}
 
 	protected renderBody(container: HTMLElement) {

--- a/src/sql/workbench/browser/modal/calloutDialog.ts
+++ b/src/sql/workbench/browser/modal/calloutDialog.ts
@@ -14,7 +14,7 @@ import { ITextResourcePropertiesService } from 'vs/editor/common/services/textRe
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 
-export abstract class CalloutDialog extends Modal {
+export abstract class CalloutDialog<T> extends Modal {
 
 	constructor(
 		title: string,
@@ -47,6 +47,13 @@ export abstract class CalloutDialog extends Modal {
 	}
 
 	protected abstract renderBody(container: HTMLElement): void;
+
+	public abstract open(): Promise<T>;
+
+	public cancel(): void {
+		this.hide();
+		this.dispose();
+	}
 
 	protected layout(height?: number): void {
 	}

--- a/src/sql/workbench/browser/modal/calloutDialog.ts
+++ b/src/sql/workbench/browser/modal/calloutDialog.ts
@@ -3,86 +3,37 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { URI } from 'vs/base/common/uri';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
-import * as DOM from 'vs/base/browser/dom';
-import * as styler from 'vs/platform/theme/common/styler';
-import * as strings from 'vs/base/common/strings';
 import { IDialogProperties, Modal, DialogWidth } from 'sql/workbench/browser/modal/modal';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { localize } from 'vs/nls';
-import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
-import { IFileDialogService, IOpenDialogOptions } from 'vs/platform/dialogs/common/dialogs';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { attachModalDialogStyler } from 'sql/workbench/common/styler';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
-import { Deferred } from 'sql/base/common/promise';
-import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
-import { Checkbox } from 'sql/base/browser/ui/checkbox/checkbox';
-import { RadioButton } from 'sql/base/browser/ui/radioButton/radioButton';
-import { IPathService } from 'vs/workbench/services/path/common/pathService';
-
-export type CalloutType = 'IMAGE' | 'LINK';
 
 export interface ICalloutDialogOptions {
 	insertTitle?: string,
-	calloutType?: CalloutType,
 	insertMarkup?: string,
 	imagePath?: string,
 	embedImage?: boolean
 }
 export class CalloutDialog extends Modal {
-	private _calloutType: CalloutType;
-	private _selectionComplete: Deferred<ICalloutDialogOptions>;
-	// Link
-	private _linkTextLabel: HTMLElement;
-	private _linkTextInputBox: InputBox;
-	private _linkAddressLabel: HTMLElement;
-	private _linkUrlInputBox: InputBox;
-	// Image
-	private _imageLocationLabel: HTMLElement;
-	private _imageLocalRadioButton: RadioButton;
-	private _editorImageLocationGroup: string = 'editorImageLocationGroup';
-	private _imageRemoteRadioButton: RadioButton;
-	private _imageUrlLabel: HTMLElement;
-	private _imageUrlInputBox: InputBox;
-	private _imageBrowseButton: HTMLAnchorElement;
-	private _imageEmbedLabel: HTMLElement;
-	private _imageEmbedCheckbox: Checkbox;
 
 	private readonly insertButtonText = localize('callout.insertButton', "Insert");
 	private readonly cancelButtonText = localize('callout.cancelButton', "Cancel");
-	// Link
-	private readonly linkTextLabel = localize('callout.linkTextLabel', "Text to display");
-	private readonly linkTextPlaceholder = localize('callout.linkTextPlaceholder', "Text to display");
-	private readonly linkAddressLabel = localize('callout.linkAddressLabel', "Address");
-	private readonly linkAddressPlaceholder = localize('callout.linkAddressPlaceholder', "Link to an existing file or web page");
-	// Image
-	private readonly locationLabel = localize('callout.locationLabel', "Image location");
-	private readonly localImageLabel = localize('callout.localImageLabel', "This computer");
-	private readonly remoteImageLabel = localize('callout.remoteImageLabel', "Online");
-	private readonly pathInputLabel = localize('callout.pathInputLabel', "Image URL");
-	private readonly pathPlaceholder = localize('callout.pathPlaceholder', "Enter image path");
-	private readonly urlPlaceholder = localize('callout.urlPlaceholder', "Enter image URL");
-	private readonly browseAltText = localize('callout.browseAltText', "Browse");
-	private readonly embedImageLabel = localize('callout.embedImageLabel', "Attach image to notebook");
 
 	constructor(
-		calloutType: CalloutType,
 		title: string,
 		width: DialogWidth,
 		dialogProperties: IDialogProperties,
-		@IPathService private readonly _pathService: IPathService,
-		@IFileDialogService private readonly _fileDialogService: IFileDialogService,
 		@IThemeService themeService: IThemeService,
 		@ILayoutService layoutService: ILayoutService,
 		@IAdsTelemetryService telemetryService: IAdsTelemetryService,
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@IContextViewService private _contextViewService: IContextViewService,
 		@IClipboardService clipboardService: IClipboardService,
 		@ILogService logService: ILogService,
 		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService
@@ -103,17 +54,14 @@ export class CalloutDialog extends Modal {
 				dialogProperties: dialogProperties,
 				width: width
 			});
-
-		this._selectionComplete = new Deferred<ICalloutDialogOptions>();
-		this._calloutType = calloutType;
 	}
 
 	/**
 	 * Opens the dialog and returns a promise for what options the user chooses.
 	 */
-	public open(): Promise<ICalloutDialogOptions> {
+	public open(): void {
 		this.show();
-		return this._selectionComplete.promise;
+		//return this._selectionComplete.promise;
 	}
 
 	public render() {
@@ -123,204 +71,21 @@ export class CalloutDialog extends Modal {
 
 		this.addFooterButton(this.insertButtonText, () => this.insert());
 		this.addFooterButton(this.cancelButtonText, () => this.cancel(), undefined, true);
-
-		this.registerListeners();
 	}
 
 	protected renderBody(container: HTMLElement) {
-		if (this._calloutType === 'IMAGE') {
-			this.buildInsertImageCallout(container);
-		}
-
-		if (this._calloutType === 'LINK') {
-			this.buildInsertLinkCallout(container);
-		}
-	}
-
-	private buildInsertImageCallout(container: HTMLElement): void {
-		let imageContentColumn = DOM.$('.column.insert-image');
-		DOM.append(container, imageContentColumn);
-
-		let locationRow = DOM.$('.row');
-		DOM.append(imageContentColumn, locationRow);
-
-		this._imageLocationLabel = DOM.$('p');
-		this._imageLocationLabel.innerText = this.locationLabel;
-		DOM.append(locationRow, this._imageLocationLabel);
-
-		let radioButtonGroup = DOM.$('.radio-group');
-		this._imageLocalRadioButton = new RadioButton(radioButtonGroup, {
-			label: this.localImageLabel,
-			enabled: true,
-			checked: true
-		});
-		this._imageRemoteRadioButton = new RadioButton(radioButtonGroup, {
-			label: this.remoteImageLabel,
-			enabled: true,
-			checked: false
-		});
-		this._imageLocalRadioButton.value = localize('local', "Local");
-		this._imageLocalRadioButton.name = this._editorImageLocationGroup;
-		this._imageRemoteRadioButton.value = localize('remote', "Remote");
-		this._imageRemoteRadioButton.name = this._editorImageLocationGroup;
-		DOM.append(locationRow, radioButtonGroup);
-
-		let pathRow = DOM.$('.row');
-		DOM.append(imageContentColumn, pathRow);
-		this._imageUrlLabel = DOM.$('p');
-		if (this._imageLocalRadioButton.checked === true) {
-			this._imageUrlLabel.innerText = this.pathPlaceholder;
-		} else {
-			this._imageUrlLabel.innerText = this.urlPlaceholder;
-		}
-		DOM.append(pathRow, this._imageUrlLabel);
-
-		let inputContainer = DOM.$('.flex-container');
-		this._imageUrlInputBox = new InputBox(
-			inputContainer,
-			this._contextViewService,
-			{
-				placeholder: this.pathPlaceholder,
-				ariaLabel: this.pathInputLabel
-			});
-		let browseButtonContainer = DOM.$('.button-icon');
-		this._imageBrowseButton = DOM.$('a.codicon.masked-icon.browse-local');
-		this._imageBrowseButton.title = this.browseAltText;
-		DOM.append(inputContainer, browseButtonContainer);
-		DOM.append(browseButtonContainer, this._imageBrowseButton);
-
-		this._register(DOM.addDisposableListener(this._imageBrowseButton, DOM.EventType.CLICK, async () => {
-			let selectedUri = await this.handleBrowse();
-			if (selectedUri) {
-				this._imageUrlInputBox.value = selectedUri.fsPath;
-			}
-		}, true));
-
-		this._register(this._imageRemoteRadioButton.onClicked(e => {
-			this._imageBrowseButton.style.display = 'none';
-			this._imageUrlLabel.innerText = this.urlPlaceholder;
-			this._imageUrlInputBox.setPlaceHolder(this.urlPlaceholder);
-		}));
-		this._register(this._imageLocalRadioButton.onClicked(e => {
-			this._imageBrowseButton.style.display = 'block';
-			this._imageUrlLabel.innerText = this.pathPlaceholder;
-			this._imageUrlInputBox.setPlaceHolder(this.pathPlaceholder);
-		}));
-		DOM.append(pathRow, inputContainer);
-
-		let embedRow = DOM.$('.row');
-		DOM.append(imageContentColumn, embedRow);
-		this._imageEmbedLabel = DOM.append(embedRow, DOM.$('.checkbox'));
-		this._imageEmbedCheckbox = new Checkbox(
-			this._imageEmbedLabel,
-			{
-				label: this.embedImageLabel,
-				checked: false,
-				onChange: (viaKeyboard) => { },
-				ariaLabel: this.embedImageLabel
-			});
-		DOM.append(embedRow, this._imageEmbedLabel);
-	}
-
-	private buildInsertLinkCallout(container: HTMLElement): void {
-		let linkContentColumn = DOM.$('.column.insert-link');
-		DOM.append(container, linkContentColumn);
-
-		let linkTextRow = DOM.$('.row');
-		DOM.append(linkContentColumn, linkTextRow);
-
-		this._linkTextLabel = DOM.$('p');
-		this._linkTextLabel.innerText = this.linkTextLabel;
-		DOM.append(linkTextRow, this._linkTextLabel);
-
-		const linkTextInputContainer = DOM.$('.input-field');
-		this._linkTextInputBox = new InputBox(
-			linkTextInputContainer,
-			this._contextViewService,
-			{
-				placeholder: this.linkTextPlaceholder,
-				ariaLabel: this.linkTextLabel
-			});
-		DOM.append(linkTextRow, linkTextInputContainer);
-
-		let linkAddressRow = DOM.$('.row');
-		DOM.append(linkContentColumn, linkAddressRow);
-		this._linkAddressLabel = DOM.$('p');
-		this._linkAddressLabel.innerText = this.linkAddressLabel;
-		DOM.append(linkAddressRow, this._linkAddressLabel);
-
-		const linkAddressInputContainer = DOM.$('.input-field');
-		this._linkUrlInputBox = new InputBox(
-			linkAddressInputContainer,
-			this._contextViewService,
-			{
-				placeholder: this.linkAddressPlaceholder,
-				ariaLabel: this.linkAddressLabel
-			});
-		DOM.append(linkAddressRow, linkAddressInputContainer);
-	}
-
-	private registerListeners(): void {
-		// Theme styler
-		if (this._calloutType === 'IMAGE') {
-			this._register(styler.attachInputBoxStyler(this._imageUrlInputBox, this._themeService));
-			this._register(styler.attachCheckboxStyler(this._imageEmbedCheckbox, this._themeService));
-		}
-		if (this._calloutType === 'LINK') {
-			this._register(styler.attachInputBoxStyler(this._linkTextInputBox, this._themeService));
-			this._register(styler.attachInputBoxStyler(this._linkUrlInputBox, this._themeService));
-		}
 	}
 
 	protected layout(height?: number): void {
 	}
 
-	public insert() {
+	public insert(): void {
 		this.hide();
-		if (this._calloutType === 'IMAGE') {
-			this._selectionComplete.resolve({
-				insertMarkup: `<img src="${strings.escape(this._imageUrlInputBox.value)}">`,
-				imagePath: this._imageUrlInputBox.value,
-				embedImage: this._imageEmbedCheckbox.checked
-			});
-		}
-		if (this._calloutType === 'LINK') {
-			this._selectionComplete.resolve({
-				insertMarkup: `<a href="${strings.escape(this._linkUrlInputBox.value)}">${strings.escape(this._linkTextInputBox.value)}</a>`,
-			});
-		}
 		this.dispose();
 	}
 
-	public cancel() {
+	public cancel(): void {
 		this.hide();
-		this._selectionComplete.resolve({
-			insertMarkup: '',
-			imagePath: undefined,
-			embedImage: undefined
-		});
 		this.dispose();
-	}
-
-	private async getUserHome(): Promise<string> {
-		const userHomeUri = await this._pathService.userHome();
-		return userHomeUri.path;
-	}
-
-	private async handleBrowse(): Promise<URI | undefined> {
-		let options: IOpenDialogOptions = {
-			openLabel: undefined,
-			canSelectFiles: true,
-			canSelectFolders: false,
-			canSelectMany: false,
-			defaultUri: URI.file(await this.getUserHome()),
-			title: undefined
-		};
-		let imageUri: URI[] = await this._fileDialogService.showOpenDialog(options);
-		if (imageUri.length > 0) {
-			return imageUri[0];
-		} else {
-			return undefined;
-		}
 	}
 }

--- a/src/sql/workbench/browser/modal/media/calloutDialog.css
+++ b/src/sql/workbench/browser/modal/media/calloutDialog.css
@@ -27,7 +27,6 @@
 	box-shadow: none;
 }
 
-/* Correct the arrow appearance for HC theme */
 .callout-arrow:before {
 	border-width: 1px;
 	border-style: solid;

--- a/src/sql/workbench/browser/modal/media/calloutDialog.css
+++ b/src/sql/workbench/browser/modal/media/calloutDialog.css
@@ -13,12 +13,6 @@
 	position: absolute;
 }
 
-.modal.callout-dialog .modal-content .insert-image .flex-container {
-	display: flex;
-}
-.modal.callout-dialog .modal-content .insert-image .flex-container > div {
-	flex: 1;
-}
 .modal.callout-dialog .modal-content p {
 	margin: 0;
 }
@@ -26,19 +20,9 @@
 	cursor: pointer;
 	margin-left: 10px;
 }
-.modal.callout-dialog .modal-content .insert-image .monaco-inputbox {
-	min-width: 380px;
-}
 .modal.callout-dialog .modal-content .row  {
 	margin-bottom: 16px;
 }
-.modal.callout-dialog .modal-content .radio-group input {
-	margin-right: 8px;
-}
-.modal.callout-dialog .modal-content .radio-group span {
-	margin-right: 15px;
-}
-
 .hc-black .modal.callout-dialog .modal-dialog {
 	box-shadow: none;
 }
@@ -94,7 +78,6 @@
 	right: -1.2em;
 	width: 2em;
 }
-
 
 .modal.callout-dialog .modal-header {
 	padding: 18px 24px 8px 24px;

--- a/src/sql/workbench/browser/modal/media/modal.css
+++ b/src/sql/workbench/browser/modal/media/modal.css
@@ -24,112 +24,12 @@
 	height: 480px;
 }
 
-.modal.callout-dialog {
-	background-color: transparent;
-}
-.modal.callout-dialog .modal-dialog {
-	border-radius: 2px;
-	box-shadow: 0px 3px 8px rgba(var(--foreground));
-	max-height: 300px;
-	position: absolute;
-}
-
-.modal.callout-dialog .modal-content .insert-image .flex-container {
-	display: flex;
-}
-.modal.callout-dialog .modal-content .insert-image .flex-container > div {
-	flex: 1;
-}
-.modal.callout-dialog .modal-content p {
-	margin: 0;
-}
-.modal.callout-dialog .modal-content .button-icon {
-	cursor: pointer;
-	margin-left: 10px;
-}
-.modal.callout-dialog .modal-content .insert-image .monaco-inputbox {
-	min-width: 380px;
-}
-.modal.callout-dialog .modal-content .row  {
-	margin-bottom: 16px;
-}
-.modal.callout-dialog .modal-content .radio-group input {
-	margin-right: 8px;
-}
-.modal.callout-dialog .modal-content .radio-group span {
-	margin-right: 15px;
-}
-
-.hc-black .modal.callout-dialog .modal-dialog {
-	box-shadow: none;
-}
-
-/* Correct the arrow appearance for HC theme */
-.callout-arrow:before {
-	border-width: 1px;
-	border-style: solid;
-	border-color:
-		transparent
-		transparent
-		var(--bodybackground)
-		var(--bodybackground);
-	box-shadow: -3px 3px 3px 0 rgba(var(--foreground));
-	content: '';
-	display: block;
-	height: 0;
-	position: absolute;
-	width: 0;
-}
-.callout-arrow.from-below:before {
-	border-width: 0.5em;
-	left: 2em;
-	top: -0.2em;
-	transform: rotate(135deg);
-}
-.callout-arrow.from-left:before {
-	background-color: var(--bodybackground);
-	height: 26px;
-	right: -13px;
-	top: 26px;
-	transform: rotate(-135deg);
-	width: 26px;
-}
-
-.hc-black .callout-arrow:before {
-	background-color: var(--bodybackground);
-	border-color:
-		transparent
-		transparent
-		var(--border)
-		var(--border);
-	border-width: 0.1em;
-	box-shadow: none;
-	height: 0.8em;
-	width: 0.8em;
-}
-.hc-black .callout-arrow.from-below:before {
-	top: -0.4em;
-}
-.hc-black .callout-arrow.from-left:before {
-	height: 2em;
-	right: -1.2em;
-	width: 2em;
-}
-
-
 .modal .modal-header {
 	padding: 15px;
 }
 
-.modal.callout-dialog .modal-header {
-	padding: 18px 24px 8px 24px;
-}
-
 .modal .modal-footer {
 	padding: 15px;
-}
-.modal.callout-dialog .modal-footer {
-	padding: 15px 24px 15px 24px;
 }
 
 .modal .codicon.in-progress {
@@ -187,17 +87,6 @@
 .modal.flyout-dialog .modal-body-and-footer {
 	flex: 1 1;
 	overflow: hidden;
-}
-
-.modal.callout-dialog .modal-body {
-	padding: 8px 24px;
-}
-
-.modal.callout-dialog.compact .modal-header {
-	padding: 16px 24px 4px 24px;
-}
-.modal.callout-dialog.compact .modal-body {
-	padding: 4px 24px 16px 24px;
 }
 
 /* modl body content style(excluding dialogErrorMessage section) for angulr component dialog */

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/common/constants.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/common/constants.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { localize } from 'vs/nls';
+
+// Localized texts
+export const insertButtonText = localize('callout.insertButton', "Insert");
+export const cancelButtonText = localize('callout.cancelButton', "Cancel");

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/common/constants.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/common/constants.ts
@@ -7,3 +7,19 @@ import { localize } from 'vs/nls';
 // Localized texts
 export const insertButtonText = localize('callout.insertButton', "Insert");
 export const cancelButtonText = localize('callout.cancelButton', "Cancel");
+// Insert Image
+export const locationLabel = localize('imageCallout.locationLabel', "Image location");
+export const localImageLabel = localize('imageCallout.localImageLabel', "This computer");
+export const remoteImageLabel = localize('imageCallout.remoteImageLabel', "Online");
+export const pathInputLabel = localize('imageCallout.pathInputLabel', "Image URL");
+export const pathPlaceholder = localize('imageCallout.pathPlaceholder', "Enter image path");
+export const urlPlaceholder = localize('imageCallout.urlPlaceholder', "Enter image URL");
+export const browseAltText = localize('imageCallout.browseAltText', "Browse");
+export const embedImageLabel = localize('imageCallout.embedImageLabel', "Attach image to notebook");
+export const locationLocal = localize('imageCallout.local', "Local");
+export const locationRemote = localize('imageCallout.remote', "Remote");
+// Insert Link
+export const linkTextLabel = localize('linkCallout.linkTextLabel', "Text to display");
+export const linkTextPlaceholder = localize('linkCallout.linkTextPlaceholder', "Text to display");
+export const linkAddressLabel = localize('linkCallout.linkAddressLabel', "Address");
+export const linkAddressPlaceholder = localize('linkCallout.linkAddressPlaceholder', "Link to an existing file or web page");

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog.ts
@@ -1,0 +1,230 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'vs/css!./media/calloutDialog';
+import * as DOM from 'vs/base/browser/dom';
+import * as strings from 'vs/base/common/strings';
+import * as styler from 'vs/platform/theme/common/styler';
+import { URI } from 'vs/base/common/uri';
+import { localize } from 'vs/nls';
+import { CalloutDialog, ICalloutDialogOptions } from 'sql/workbench/browser/modal/calloutDialog';
+import { IFileDialogService, IOpenDialogOptions } from 'vs/platform/dialogs/common/dialogs';
+import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
+import { IDialogProperties } from 'sql/workbench/browser/modal/modal';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IPathService } from 'vs/workbench/services/path/common/pathService';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { ILogService } from 'vs/platform/log/common/log';
+import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
+import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
+import { Deferred } from 'sql/base/common/promise';
+import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
+import { Checkbox } from 'sql/base/browser/ui/checkbox/checkbox';
+import { RadioButton } from 'sql/base/browser/ui/radioButton/radioButton';
+import { DialogWidth } from 'sql/workbench/api/common/sqlExtHostTypes';
+
+export class ImageCalloutDialog extends CalloutDialog {
+	private _selectionComplete: Deferred<ICalloutDialogOptions>;
+	private _imageLocationLabel: HTMLElement;
+	private _imageLocalRadioButton: RadioButton;
+	private _editorImageLocationGroup: string = 'editorImageLocationGroup';
+	private _imageRemoteRadioButton: RadioButton;
+	private _imageUrlLabel: HTMLElement;
+	private _imageUrlInputBox: InputBox;
+	private _imageBrowseButton: HTMLAnchorElement;
+	private _imageEmbedLabel: HTMLElement;
+	private _imageEmbedCheckbox: Checkbox;
+	private readonly locationLabel = localize('callout.locationLabel', "Image location");
+	private readonly localImageLabel = localize('callout.localImageLabel', "This computer");
+	private readonly remoteImageLabel = localize('callout.remoteImageLabel', "Online");
+	private readonly pathInputLabel = localize('callout.pathInputLabel', "Image URL");
+	private readonly pathPlaceholder = localize('callout.pathPlaceholder', "Enter image path");
+	private readonly urlPlaceholder = localize('callout.urlPlaceholder', "Enter image URL");
+	private readonly browseAltText = localize('callout.browseAltText', "Browse");
+	private readonly embedImageLabel = localize('callout.embedImageLabel', "Attach image to notebook");
+
+	constructor(
+		title: string,
+		width: DialogWidth,
+		dialogProperties: IDialogProperties,
+		@IPathService private readonly _pathService: IPathService,
+		@IFileDialogService private readonly _fileDialogService: IFileDialogService,
+		@IContextViewService private _contextViewService: IContextViewService,
+		@IThemeService themeService: IThemeService,
+		@ILayoutService layoutService: ILayoutService,
+		@IAdsTelemetryService telemetryService: IAdsTelemetryService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IClipboardService clipboardService: IClipboardService,
+		@ILogService logService: ILogService,
+		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService
+	) {
+		super(
+			title,
+			width,
+			dialogProperties,
+			themeService,
+			layoutService,
+			telemetryService,
+			contextKeyService,
+			clipboardService,
+			logService,
+			textResourcePropertiesService
+		);
+
+		this._selectionComplete = new Deferred<ICalloutDialogOptions>();
+	}
+
+	/**
+	 * Opens the dialog and returns a promise for what options the user chooses.
+	 */
+	public open(): Promise<ICalloutDialogOptions> {
+		//this.show();
+		return this._selectionComplete.promise;
+	}
+
+	public render() {
+		this.registerListeners();
+	}
+
+	protected renderBody(container: HTMLElement) {
+		this.buildInsertImageCallout(container);
+	}
+
+	private buildInsertImageCallout(container: HTMLElement): void {
+		let imageContentColumn = DOM.$('.column.insert-image');
+		DOM.append(container, imageContentColumn);
+
+		let locationRow = DOM.$('.row');
+		DOM.append(imageContentColumn, locationRow);
+
+		this._imageLocationLabel = DOM.$('p');
+		this._imageLocationLabel.innerText = this.locationLabel;
+		DOM.append(locationRow, this._imageLocationLabel);
+
+		let radioButtonGroup = DOM.$('.radio-group');
+		this._imageLocalRadioButton = new RadioButton(radioButtonGroup, {
+			label: this.localImageLabel,
+			enabled: true,
+			checked: true
+		});
+		this._imageRemoteRadioButton = new RadioButton(radioButtonGroup, {
+			label: this.remoteImageLabel,
+			enabled: true,
+			checked: false
+		});
+		this._imageLocalRadioButton.value = localize('local', "Local");
+		this._imageLocalRadioButton.name = this._editorImageLocationGroup;
+		this._imageRemoteRadioButton.value = localize('remote', "Remote");
+		this._imageRemoteRadioButton.name = this._editorImageLocationGroup;
+		DOM.append(locationRow, radioButtonGroup);
+
+		let pathRow = DOM.$('.row');
+		DOM.append(imageContentColumn, pathRow);
+		this._imageUrlLabel = DOM.$('p');
+		if (this._imageLocalRadioButton.checked === true) {
+			this._imageUrlLabel.innerText = this.pathPlaceholder;
+		} else {
+			this._imageUrlLabel.innerText = this.urlPlaceholder;
+		}
+		DOM.append(pathRow, this._imageUrlLabel);
+
+		let inputContainer = DOM.$('.flex-container');
+		this._imageUrlInputBox = new InputBox(
+			inputContainer,
+			this._contextViewService,
+			{
+				placeholder: this.pathPlaceholder,
+				ariaLabel: this.pathInputLabel
+			});
+		let browseButtonContainer = DOM.$('.button-icon');
+		this._imageBrowseButton = DOM.$('a.codicon.masked-icon.browse-local');
+		this._imageBrowseButton.title = this.browseAltText;
+		DOM.append(inputContainer, browseButtonContainer);
+		DOM.append(browseButtonContainer, this._imageBrowseButton);
+
+		this._register(DOM.addDisposableListener(this._imageBrowseButton, DOM.EventType.CLICK, async () => {
+			let selectedUri = await this.handleBrowse();
+			if (selectedUri) {
+				this._imageUrlInputBox.value = selectedUri.fsPath;
+			}
+		}, true));
+
+		this._register(this._imageRemoteRadioButton.onClicked(e => {
+			this._imageBrowseButton.style.display = 'none';
+			this._imageUrlLabel.innerText = this.urlPlaceholder;
+			this._imageUrlInputBox.setPlaceHolder(this.urlPlaceholder);
+		}));
+		this._register(this._imageLocalRadioButton.onClicked(e => {
+			this._imageBrowseButton.style.display = 'block';
+			this._imageUrlLabel.innerText = this.pathPlaceholder;
+			this._imageUrlInputBox.setPlaceHolder(this.pathPlaceholder);
+		}));
+		DOM.append(pathRow, inputContainer);
+
+		let embedRow = DOM.$('.row');
+		DOM.append(imageContentColumn, embedRow);
+		this._imageEmbedLabel = DOM.append(embedRow, DOM.$('.checkbox'));
+		this._imageEmbedCheckbox = new Checkbox(
+			this._imageEmbedLabel,
+			{
+				label: this.embedImageLabel,
+				checked: false,
+				onChange: (viaKeyboard) => { },
+				ariaLabel: this.embedImageLabel
+			});
+		DOM.append(embedRow, this._imageEmbedLabel);
+	}
+
+	private registerListeners(): void {
+		// Theme styler
+		this._register(styler.attachInputBoxStyler(this._imageUrlInputBox, this._themeService));
+		this._register(styler.attachCheckboxStyler(this._imageEmbedCheckbox, this._themeService));
+	}
+
+	public insert() {
+		//this.hide();
+		this._selectionComplete.resolve({
+			insertMarkup: `<img src="${strings.escape(this._imageUrlInputBox.value)}">`,
+			imagePath: this._imageUrlInputBox.value,
+			embedImage: this._imageEmbedCheckbox.checked
+		});
+		//this.dispose();
+	}
+
+	public cancel() {
+		//this.hide();
+		this._selectionComplete.resolve({
+			insertMarkup: '',
+			imagePath: undefined,
+			embedImage: undefined
+		});
+		//this.dispose();
+	}
+
+	private async getUserHome(): Promise<string> {
+		const userHomeUri = await this._pathService.userHome();
+		return userHomeUri.path;
+	}
+
+	private async handleBrowse(): Promise<URI | undefined> {
+		let options: IOpenDialogOptions = {
+			openLabel: undefined,
+			canSelectFiles: true,
+			canSelectFolders: false,
+			canSelectMany: false,
+			defaultUri: URI.file(await this.getUserHome()),
+			title: undefined
+		};
+		let imageUri: URI[] = await this._fileDialogService.showOpenDialog(options);
+		if (imageUri.length > 0) {
+			return imageUri[0];
+		} else {
+			return undefined;
+		}
+	}
+
+}

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog.ts
@@ -8,7 +8,6 @@ import * as DOM from 'vs/base/browser/dom';
 import * as strings from 'vs/base/common/strings';
 import * as styler from 'vs/platform/theme/common/styler';
 import { URI } from 'vs/base/common/uri';
-import { localize } from 'vs/nls';
 import * as constants from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/constants';
 import { CalloutDialog } from 'sql/workbench/browser/modal/calloutDialog';
 import { IFileDialogService, IOpenDialogOptions } from 'vs/platform/dialogs/common/dialogs';
@@ -29,15 +28,15 @@ import { RadioButton } from 'sql/base/browser/ui/radioButton/radioButton';
 import { DialogWidth } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { attachModalDialogStyler } from 'sql/workbench/common/styler';
 
-export interface ICalloutDialogOptions {
+export interface IImageCalloutDialogOptions {
 	insertTitle?: string,
 	insertMarkup?: string,
 	imagePath?: string,
 	embedImage?: boolean
 }
 
-export class ImageCalloutDialog extends CalloutDialog {
-	private _selectionComplete: Deferred<ICalloutDialogOptions> = new Deferred<ICalloutDialogOptions>();
+export class ImageCalloutDialog extends CalloutDialog<IImageCalloutDialogOptions> {
+	private _selectionComplete: Deferred<IImageCalloutDialogOptions> = new Deferred<IImageCalloutDialogOptions>();
 	private _imageLocationLabel: HTMLElement;
 	private _imageLocalRadioButton: RadioButton;
 	private _editorImageLocationGroup: string = 'editorImageLocationGroup';
@@ -47,18 +46,6 @@ export class ImageCalloutDialog extends CalloutDialog {
 	private _imageBrowseButton: HTMLAnchorElement;
 	private _imageEmbedLabel: HTMLElement;
 	private _imageEmbedCheckbox: Checkbox;
-
-
-	private readonly locationLabel = localize('callout.locationLabel', "Image location");
-	private readonly localImageLabel = localize('callout.localImageLabel', "This computer");
-	private readonly remoteImageLabel = localize('callout.remoteImageLabel', "Online");
-	private readonly pathInputLabel = localize('callout.pathInputLabel', "Image URL");
-	private readonly pathPlaceholder = localize('callout.pathPlaceholder', "Enter image path");
-	private readonly urlPlaceholder = localize('callout.urlPlaceholder', "Enter image URL");
-	private readonly browseAltText = localize('callout.browseAltText', "Browse");
-	private readonly embedImageLabel = localize('callout.embedImageLabel', "Attach image to notebook");
-	private readonly locationLocal = localize('local', "Local");
-	private readonly locationRemote = localize('remote', "Remote");
 
 	constructor(
 		title: string,
@@ -92,7 +79,7 @@ export class ImageCalloutDialog extends CalloutDialog {
 	/**
 	 * Opens the dialog and returns a promise for what options the user chooses.
 	 */
-	public open(): Promise<ICalloutDialogOptions> {
+	public open(): Promise<IImageCalloutDialogOptions> {
 		this.show();
 		return this._selectionComplete.promise;
 	}
@@ -113,24 +100,24 @@ export class ImageCalloutDialog extends CalloutDialog {
 		DOM.append(imageContentColumn, locationRow);
 
 		this._imageLocationLabel = DOM.$('p');
-		this._imageLocationLabel.innerText = this.locationLabel;
+		this._imageLocationLabel.innerText = constants.locationLabel;
 		DOM.append(locationRow, this._imageLocationLabel);
 
 		let radioButtonGroup = DOM.$('.radio-group');
 		this._imageLocalRadioButton = new RadioButton(radioButtonGroup, {
-			label: this.localImageLabel,
+			label: constants.localImageLabel,
 			enabled: true,
 			checked: true
 		});
 		this._imageRemoteRadioButton = new RadioButton(radioButtonGroup, {
-			label: this.remoteImageLabel,
+			label: constants.remoteImageLabel,
 			enabled: true,
 			checked: false
 		});
 		this._imageLocalRadioButton.name = this._editorImageLocationGroup;
-		this._imageLocalRadioButton.value = this.locationLocal;
+		this._imageLocalRadioButton.value = constants.locationLocal;
 		this._imageRemoteRadioButton.name = this._editorImageLocationGroup;
-		this._imageRemoteRadioButton.value = this.locationRemote;
+		this._imageRemoteRadioButton.value = constants.locationRemote;
 
 		DOM.append(locationRow, radioButtonGroup);
 
@@ -138,9 +125,9 @@ export class ImageCalloutDialog extends CalloutDialog {
 		DOM.append(imageContentColumn, pathRow);
 		this._imageUrlLabel = DOM.$('p');
 		if (this._imageLocalRadioButton.checked === true) {
-			this._imageUrlLabel.innerText = this.pathPlaceholder;
+			this._imageUrlLabel.innerText = constants.pathPlaceholder;
 		} else {
-			this._imageUrlLabel.innerText = this.urlPlaceholder;
+			this._imageUrlLabel.innerText = constants.urlPlaceholder;
 		}
 		DOM.append(pathRow, this._imageUrlLabel);
 
@@ -149,12 +136,12 @@ export class ImageCalloutDialog extends CalloutDialog {
 			inputContainer,
 			this._contextViewService,
 			{
-				placeholder: this.pathPlaceholder,
-				ariaLabel: this.pathInputLabel
+				placeholder: constants.pathPlaceholder,
+				ariaLabel: constants.pathInputLabel
 			});
 		let browseButtonContainer = DOM.$('.button-icon');
 		this._imageBrowseButton = DOM.$('a.codicon.masked-icon.browse-local');
-		this._imageBrowseButton.title = this.browseAltText;
+		this._imageBrowseButton.title = constants.browseAltText;
 		DOM.append(inputContainer, browseButtonContainer);
 		DOM.append(browseButtonContainer, this._imageBrowseButton);
 
@@ -167,13 +154,13 @@ export class ImageCalloutDialog extends CalloutDialog {
 
 		this._register(this._imageRemoteRadioButton.onClicked(e => {
 			this._imageBrowseButton.style.display = 'none';
-			this._imageUrlLabel.innerText = this.urlPlaceholder;
-			this._imageUrlInputBox.setPlaceHolder(this.urlPlaceholder);
+			this._imageUrlLabel.innerText = constants.urlPlaceholder;
+			this._imageUrlInputBox.setPlaceHolder(constants.urlPlaceholder);
 		}));
 		this._register(this._imageLocalRadioButton.onClicked(e => {
 			this._imageBrowseButton.style.display = 'block';
-			this._imageUrlLabel.innerText = this.pathPlaceholder;
-			this._imageUrlInputBox.setPlaceHolder(this.pathPlaceholder);
+			this._imageUrlLabel.innerText = constants.pathPlaceholder;
+			this._imageUrlInputBox.setPlaceHolder(constants.pathPlaceholder);
 		}));
 		DOM.append(pathRow, inputContainer);
 
@@ -183,10 +170,10 @@ export class ImageCalloutDialog extends CalloutDialog {
 		this._imageEmbedCheckbox = new Checkbox(
 			this._imageEmbedLabel,
 			{
-				label: this.embedImageLabel,
+				label: constants.embedImageLabel,
 				checked: false,
 				onChange: (viaKeyboard) => { },
-				ariaLabel: this.embedImageLabel
+				ariaLabel: constants.embedImageLabel
 			});
 		DOM.append(embedRow, this._imageEmbedLabel);
 	}
@@ -207,13 +194,12 @@ export class ImageCalloutDialog extends CalloutDialog {
 	}
 
 	public cancel(): void {
-		this.hide();
+		super.cancel();
 		this._selectionComplete.resolve({
 			insertMarkup: '',
 			imagePath: undefined,
 			embedImage: undefined
 		});
-		this.dispose();
 	}
 
 	private async getUserHome(): Promise<string> {

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog.ts
@@ -26,6 +26,8 @@ import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
 import { Checkbox } from 'sql/base/browser/ui/checkbox/checkbox';
 import { RadioButton } from 'sql/base/browser/ui/radioButton/radioButton';
 import { DialogWidth } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { attachModalDialogStyler } from 'sql/workbench/common/styler';
+
 
 export class ImageCalloutDialog extends CalloutDialog {
 	private _selectionComplete: Deferred<ICalloutDialogOptions>;
@@ -38,6 +40,8 @@ export class ImageCalloutDialog extends CalloutDialog {
 	private _imageBrowseButton: HTMLAnchorElement;
 	private _imageEmbedLabel: HTMLElement;
 	private _imageEmbedCheckbox: Checkbox;
+	private readonly insertButtonText = localize('callout.insertButton', "Insert");
+	private readonly cancelButtonText = localize('callout.cancelButton', "Cancel");
 	private readonly locationLabel = localize('callout.locationLabel', "Image location");
 	private readonly localImageLabel = localize('callout.localImageLabel', "This computer");
 	private readonly remoteImageLabel = localize('callout.remoteImageLabel', "Online");
@@ -82,11 +86,15 @@ export class ImageCalloutDialog extends CalloutDialog {
 	 * Opens the dialog and returns a promise for what options the user chooses.
 	 */
 	public open(): Promise<ICalloutDialogOptions> {
-		//this.show();
+		this.show();
 		return this._selectionComplete.promise;
 	}
 
 	public render() {
+		super.render();
+		attachModalDialogStyler(this, this._themeService);
+		this.addFooterButton(this.insertButtonText, () => this.insert());
+		this.addFooterButton(this.cancelButtonText, () => this.cancel(), undefined, true);
 		this.registerListeners();
 	}
 
@@ -186,23 +194,23 @@ export class ImageCalloutDialog extends CalloutDialog {
 	}
 
 	public insert() {
-		//this.hide();
+		this.hide();
 		this._selectionComplete.resolve({
 			insertMarkup: `<img src="${strings.escape(this._imageUrlInputBox.value)}">`,
 			imagePath: this._imageUrlInputBox.value,
 			embedImage: this._imageEmbedCheckbox.checked
 		});
-		//this.dispose();
+		this.dispose();
 	}
 
 	public cancel() {
-		//this.hide();
+		this.hide();
 		this._selectionComplete.resolve({
 			insertMarkup: '',
 			imagePath: undefined,
 			embedImage: undefined
 		});
-		//this.dispose();
+		this.dispose();
 	}
 
 	private async getUserHome(): Promise<string> {

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
@@ -21,6 +21,8 @@ import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { Deferred } from 'sql/base/common/promise';
 import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
 import { DialogWidth } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { attachModalDialogStyler } from 'sql/workbench/common/styler';
+
 
 export class LinkCalloutDialog extends CalloutDialog {
 	private _selectionComplete: Deferred<ICalloutDialogOptions>;
@@ -28,6 +30,8 @@ export class LinkCalloutDialog extends CalloutDialog {
 	private _linkTextInputBox: InputBox;
 	private _linkAddressLabel: HTMLElement;
 	private _linkUrlInputBox: InputBox;
+	private readonly insertButtonText = localize('callout.insertButton', "Insert");
+	private readonly cancelButtonText = localize('callout.cancelButton', "Cancel");
 	private readonly linkTextLabel = localize('callout.linkTextLabel', "Text to display");
 	private readonly linkTextPlaceholder = localize('callout.linkTextPlaceholder', "Text to display");
 	private readonly linkAddressLabel = localize('callout.linkAddressLabel', "Address");
@@ -66,11 +70,15 @@ export class LinkCalloutDialog extends CalloutDialog {
 	 * Opens the dialog and returns a promise for what options the user chooses.
 	 */
 	public open(): Promise<ICalloutDialogOptions> {
-		//this.show();
+		this.show();
 		return this._selectionComplete.promise;
 	}
 
 	public render() {
+		super.render();
+		attachModalDialogStyler(this, this._themeService);
+		this.addFooterButton(this.insertButtonText, () => this.insert());
+		this.addFooterButton(this.cancelButtonText, () => this.cancel(), undefined, true);
 		this.registerListeners();
 	}
 
@@ -122,20 +130,20 @@ export class LinkCalloutDialog extends CalloutDialog {
 	}
 
 	public insert() {
-		//this.hide();
+		this.hide();
 		this._selectionComplete.resolve({
 			insertMarkup: `<a href="${strings.escape(this._linkUrlInputBox.value)}">${strings.escape(this._linkTextInputBox.value)}</a>`,
 		});
-		//this.dispose();
+		this.dispose();
 	}
 
 	public cancel() {
-		//this.hide();
+		this.hide();
 		this._selectionComplete.resolve({
 			insertMarkup: '',
 			imagePath: undefined,
 			embedImage: undefined
 		});
-		//this.dispose();
+		this.dispose();
 	}
 }

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
@@ -3,12 +3,14 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import 'vs/css!./media/calloutDialog';
+import 'vs/css!./media/linkCalloutDialog';
 import * as DOM from 'vs/base/browser/dom';
 import * as strings from 'vs/base/common/strings';
 import * as styler from 'vs/platform/theme/common/styler';
 import { localize } from 'vs/nls';
-import { CalloutDialog, ICalloutDialogOptions } from 'sql/workbench/browser/modal/calloutDialog';
+import * as constants from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/constants';
+
+import { CalloutDialog } from 'sql/workbench/browser/modal/calloutDialog';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IDialogProperties } from 'sql/workbench/browser/modal/modal';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -23,15 +25,19 @@ import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
 import { DialogWidth } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { attachModalDialogStyler } from 'sql/workbench/common/styler';
 
+export interface ICalloutDialogOptions {
+	insertTitle?: string,
+	insertMarkup?: string
+}
 
 export class LinkCalloutDialog extends CalloutDialog {
-	private _selectionComplete: Deferred<ICalloutDialogOptions>;
+	private _selectionComplete: Deferred<ICalloutDialogOptions> = new Deferred<ICalloutDialogOptions>();
 	private _linkTextLabel: HTMLElement;
 	private _linkTextInputBox: InputBox;
 	private _linkAddressLabel: HTMLElement;
 	private _linkUrlInputBox: InputBox;
-	private readonly insertButtonText = localize('callout.insertButton', "Insert");
-	private readonly cancelButtonText = localize('callout.cancelButton', "Cancel");
+
+
 	private readonly linkTextLabel = localize('callout.linkTextLabel', "Text to display");
 	private readonly linkTextPlaceholder = localize('callout.linkTextPlaceholder', "Text to display");
 	private readonly linkAddressLabel = localize('callout.linkAddressLabel', "Address");
@@ -41,7 +47,7 @@ export class LinkCalloutDialog extends CalloutDialog {
 		title: string,
 		width: DialogWidth,
 		dialogProperties: IDialogProperties,
-		@IContextViewService private _contextViewService: IContextViewService,
+		@IContextViewService private readonly _contextViewService: IContextViewService,
 		@IThemeService themeService: IThemeService,
 		@ILayoutService layoutService: ILayoutService,
 		@IAdsTelemetryService telemetryService: IAdsTelemetryService,
@@ -62,8 +68,6 @@ export class LinkCalloutDialog extends CalloutDialog {
 			logService,
 			textResourcePropertiesService
 		);
-
-		this._selectionComplete = new Deferred<ICalloutDialogOptions>();
 	}
 
 	/**
@@ -74,19 +78,15 @@ export class LinkCalloutDialog extends CalloutDialog {
 		return this._selectionComplete.promise;
 	}
 
-	public render() {
+	public render(): void {
 		super.render();
 		attachModalDialogStyler(this, this._themeService);
-		this.addFooterButton(this.insertButtonText, () => this.insert());
-		this.addFooterButton(this.cancelButtonText, () => this.cancel(), undefined, true);
+		this.addFooterButton(constants.insertButtonText, () => this.insert());
+		this.addFooterButton(constants.cancelButtonText, () => this.cancel(), undefined, true);
 		this.registerListeners();
 	}
 
 	protected renderBody(container: HTMLElement) {
-		this.buildInsertLinkCallout(container);
-	}
-
-	private buildInsertLinkCallout(container: HTMLElement): void {
 		let linkContentColumn = DOM.$('.column.insert-link');
 		DOM.append(container, linkContentColumn);
 
@@ -129,7 +129,7 @@ export class LinkCalloutDialog extends CalloutDialog {
 		this._register(styler.attachInputBoxStyler(this._linkUrlInputBox, this._themeService));
 	}
 
-	public insert() {
+	public insert(): void {
 		this.hide();
 		this._selectionComplete.resolve({
 			insertMarkup: `<a href="${strings.escape(this._linkUrlInputBox.value)}">${strings.escape(this._linkTextInputBox.value)}</a>`,
@@ -137,12 +137,10 @@ export class LinkCalloutDialog extends CalloutDialog {
 		this.dispose();
 	}
 
-	public cancel() {
+	public cancel(): void {
 		this.hide();
 		this._selectionComplete.resolve({
-			insertMarkup: '',
-			imagePath: undefined,
-			embedImage: undefined
+			insertMarkup: ''
 		});
 		this.dispose();
 	}

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
@@ -7,9 +7,7 @@ import 'vs/css!./media/linkCalloutDialog';
 import * as DOM from 'vs/base/browser/dom';
 import * as strings from 'vs/base/common/strings';
 import * as styler from 'vs/platform/theme/common/styler';
-import { localize } from 'vs/nls';
 import * as constants from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/constants';
-
 import { CalloutDialog } from 'sql/workbench/browser/modal/calloutDialog';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IDialogProperties } from 'sql/workbench/browser/modal/modal';
@@ -25,23 +23,17 @@ import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
 import { DialogWidth } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { attachModalDialogStyler } from 'sql/workbench/common/styler';
 
-export interface ICalloutDialogOptions {
+export interface ILinkCalloutDialogOptions {
 	insertTitle?: string,
 	insertMarkup?: string
 }
 
-export class LinkCalloutDialog extends CalloutDialog {
-	private _selectionComplete: Deferred<ICalloutDialogOptions> = new Deferred<ICalloutDialogOptions>();
+export class LinkCalloutDialog extends CalloutDialog<ILinkCalloutDialogOptions> {
+	private _selectionComplete: Deferred<ILinkCalloutDialogOptions> = new Deferred<ILinkCalloutDialogOptions>();
 	private _linkTextLabel: HTMLElement;
 	private _linkTextInputBox: InputBox;
 	private _linkAddressLabel: HTMLElement;
 	private _linkUrlInputBox: InputBox;
-
-
-	private readonly linkTextLabel = localize('callout.linkTextLabel', "Text to display");
-	private readonly linkTextPlaceholder = localize('callout.linkTextPlaceholder', "Text to display");
-	private readonly linkAddressLabel = localize('callout.linkAddressLabel', "Address");
-	private readonly linkAddressPlaceholder = localize('callout.linkAddressPlaceholder', "Link to an existing file or web page");
 
 	constructor(
 		title: string,
@@ -73,7 +65,7 @@ export class LinkCalloutDialog extends CalloutDialog {
 	/**
 	 * Opens the dialog and returns a promise for what options the user chooses.
 	 */
-	public open(): Promise<ICalloutDialogOptions> {
+	public open(): Promise<ILinkCalloutDialogOptions> {
 		this.show();
 		return this._selectionComplete.promise;
 	}
@@ -94,7 +86,7 @@ export class LinkCalloutDialog extends CalloutDialog {
 		DOM.append(linkContentColumn, linkTextRow);
 
 		this._linkTextLabel = DOM.$('p');
-		this._linkTextLabel.innerText = this.linkTextLabel;
+		this._linkTextLabel.innerText = constants.linkTextLabel;
 		DOM.append(linkTextRow, this._linkTextLabel);
 
 		const linkTextInputContainer = DOM.$('.input-field');
@@ -102,15 +94,15 @@ export class LinkCalloutDialog extends CalloutDialog {
 			linkTextInputContainer,
 			this._contextViewService,
 			{
-				placeholder: this.linkTextPlaceholder,
-				ariaLabel: this.linkTextLabel
+				placeholder: constants.linkTextPlaceholder,
+				ariaLabel: constants.linkTextLabel
 			});
 		DOM.append(linkTextRow, linkTextInputContainer);
 
 		let linkAddressRow = DOM.$('.row');
 		DOM.append(linkContentColumn, linkAddressRow);
 		this._linkAddressLabel = DOM.$('p');
-		this._linkAddressLabel.innerText = this.linkAddressLabel;
+		this._linkAddressLabel.innerText = constants.linkAddressLabel;
 		DOM.append(linkAddressRow, this._linkAddressLabel);
 
 		const linkAddressInputContainer = DOM.$('.input-field');
@@ -118,8 +110,8 @@ export class LinkCalloutDialog extends CalloutDialog {
 			linkAddressInputContainer,
 			this._contextViewService,
 			{
-				placeholder: this.linkAddressPlaceholder,
-				ariaLabel: this.linkAddressLabel
+				placeholder: constants.linkAddressPlaceholder,
+				ariaLabel: constants.linkAddressLabel
 			});
 		DOM.append(linkAddressRow, linkAddressInputContainer);
 	}
@@ -138,10 +130,9 @@ export class LinkCalloutDialog extends CalloutDialog {
 	}
 
 	public cancel(): void {
-		this.hide();
+		super.cancel();
 		this._selectionComplete.resolve({
 			insertMarkup: ''
 		});
-		this.dispose();
 	}
 }

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
@@ -1,0 +1,141 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'vs/css!./media/calloutDialog';
+import * as DOM from 'vs/base/browser/dom';
+import * as strings from 'vs/base/common/strings';
+import * as styler from 'vs/platform/theme/common/styler';
+import { localize } from 'vs/nls';
+import { CalloutDialog, ICalloutDialogOptions } from 'sql/workbench/browser/modal/calloutDialog';
+import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
+import { IDialogProperties } from 'sql/workbench/browser/modal/modal';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { ILogService } from 'vs/platform/log/common/log';
+import { ITextResourcePropertiesService } from 'vs/editor/common/services/textResourceConfigurationService';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
+import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
+import { Deferred } from 'sql/base/common/promise';
+import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
+import { DialogWidth } from 'sql/workbench/api/common/sqlExtHostTypes';
+
+export class LinkCalloutDialog extends CalloutDialog {
+	private _selectionComplete: Deferred<ICalloutDialogOptions>;
+	private _linkTextLabel: HTMLElement;
+	private _linkTextInputBox: InputBox;
+	private _linkAddressLabel: HTMLElement;
+	private _linkUrlInputBox: InputBox;
+	private readonly linkTextLabel = localize('callout.linkTextLabel', "Text to display");
+	private readonly linkTextPlaceholder = localize('callout.linkTextPlaceholder', "Text to display");
+	private readonly linkAddressLabel = localize('callout.linkAddressLabel', "Address");
+	private readonly linkAddressPlaceholder = localize('callout.linkAddressPlaceholder', "Link to an existing file or web page");
+
+	constructor(
+		title: string,
+		width: DialogWidth,
+		dialogProperties: IDialogProperties,
+		@IContextViewService private _contextViewService: IContextViewService,
+		@IThemeService themeService: IThemeService,
+		@ILayoutService layoutService: ILayoutService,
+		@IAdsTelemetryService telemetryService: IAdsTelemetryService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IClipboardService clipboardService: IClipboardService,
+		@ILogService logService: ILogService,
+		@ITextResourcePropertiesService textResourcePropertiesService: ITextResourcePropertiesService
+	) {
+		super(
+			title,
+			width,
+			dialogProperties,
+			themeService,
+			layoutService,
+			telemetryService,
+			contextKeyService,
+			clipboardService,
+			logService,
+			textResourcePropertiesService
+		);
+
+		this._selectionComplete = new Deferred<ICalloutDialogOptions>();
+	}
+
+	/**
+	 * Opens the dialog and returns a promise for what options the user chooses.
+	 */
+	public open(): Promise<ICalloutDialogOptions> {
+		//this.show();
+		return this._selectionComplete.promise;
+	}
+
+	public render() {
+		this.registerListeners();
+	}
+
+	protected renderBody(container: HTMLElement) {
+		this.buildInsertLinkCallout(container);
+	}
+
+	private buildInsertLinkCallout(container: HTMLElement): void {
+		let linkContentColumn = DOM.$('.column.insert-link');
+		DOM.append(container, linkContentColumn);
+
+		let linkTextRow = DOM.$('.row');
+		DOM.append(linkContentColumn, linkTextRow);
+
+		this._linkTextLabel = DOM.$('p');
+		this._linkTextLabel.innerText = this.linkTextLabel;
+		DOM.append(linkTextRow, this._linkTextLabel);
+
+		const linkTextInputContainer = DOM.$('.input-field');
+		this._linkTextInputBox = new InputBox(
+			linkTextInputContainer,
+			this._contextViewService,
+			{
+				placeholder: this.linkTextPlaceholder,
+				ariaLabel: this.linkTextLabel
+			});
+		DOM.append(linkTextRow, linkTextInputContainer);
+
+		let linkAddressRow = DOM.$('.row');
+		DOM.append(linkContentColumn, linkAddressRow);
+		this._linkAddressLabel = DOM.$('p');
+		this._linkAddressLabel.innerText = this.linkAddressLabel;
+		DOM.append(linkAddressRow, this._linkAddressLabel);
+
+		const linkAddressInputContainer = DOM.$('.input-field');
+		this._linkUrlInputBox = new InputBox(
+			linkAddressInputContainer,
+			this._contextViewService,
+			{
+				placeholder: this.linkAddressPlaceholder,
+				ariaLabel: this.linkAddressLabel
+			});
+		DOM.append(linkAddressRow, linkAddressInputContainer);
+	}
+
+	private registerListeners(): void {
+		this._register(styler.attachInputBoxStyler(this._linkTextInputBox, this._themeService));
+		this._register(styler.attachInputBoxStyler(this._linkUrlInputBox, this._themeService));
+	}
+
+	public insert() {
+		//this.hide();
+		this._selectionComplete.resolve({
+			insertMarkup: `<a href="${strings.escape(this._linkUrlInputBox.value)}">${strings.escape(this._linkTextInputBox.value)}</a>`,
+		});
+		//this.dispose();
+	}
+
+	public cancel() {
+		//this.hide();
+		this._selectionComplete.resolve({
+			insertMarkup: '',
+			imagePath: undefined,
+			embedImage: undefined
+		});
+		//this.dispose();
+	}
+}

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/media/calloutDialog.css
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/media/calloutDialog.css
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.modal.callout-dialog {
+	background-color: transparent;
+}
+.modal.callout-dialog .modal-dialog {
+	border-radius: 2px;
+	box-shadow: 0px 3px 8px rgba(var(--foreground));
+	max-height: 300px;
+	position: absolute;
+}
+
+.modal.callout-dialog .modal-content .insert-image .flex-container {
+	display: flex;
+}
+.modal.callout-dialog .modal-content .insert-image .flex-container > div {
+	flex: 1;
+}
+.modal.callout-dialog .modal-content p {
+	margin: 0;
+}
+.modal.callout-dialog .modal-content .button-icon {
+	cursor: pointer;
+	margin-left: 10px;
+}
+.modal.callout-dialog .modal-content .insert-image .monaco-inputbox {
+	min-width: 380px;
+}
+.modal.callout-dialog .modal-content .row  {
+	margin-bottom: 16px;
+}
+.modal.callout-dialog .modal-content .radio-group input {
+	margin-right: 8px;
+}
+.modal.callout-dialog .modal-content .radio-group span {
+	margin-right: 15px;
+}
+
+.hc-black .modal.callout-dialog .modal-dialog {
+	box-shadow: none;
+}
+
+/* Correct the arrow appearance for HC theme */
+.callout-arrow:before {
+	border-width: 1px;
+	border-style: solid;
+	border-color:
+		transparent
+		transparent
+		var(--bodybackground)
+		var(--bodybackground);
+	box-shadow: -3px 3px 3px 0 rgba(var(--foreground));
+	content: '';
+	display: block;
+	height: 0;
+	position: absolute;
+	width: 0;
+}
+.callout-arrow.from-below:before {
+	border-width: 0.5em;
+	left: 2em;
+	top: -0.2em;
+	transform: rotate(135deg);
+}
+.callout-arrow.from-left:before {
+	background-color: var(--bodybackground);
+	height: 26px;
+	right: -13px;
+	top: 26px;
+	transform: rotate(-135deg);
+	width: 26px;
+}
+
+.hc-black .callout-arrow:before {
+	background-color: var(--bodybackground);
+	border-color:
+		transparent
+		transparent
+		var(--border)
+		var(--border);
+	border-width: 0.1em;
+	box-shadow: none;
+	height: 0.8em;
+	width: 0.8em;
+}
+.hc-black .callout-arrow.from-below:before {
+	top: -0.4em;
+}
+.hc-black .callout-arrow.from-left:before {
+	height: 2em;
+	right: -1.2em;
+	width: 2em;
+}
+
+
+.modal.callout-dialog .modal-header {
+	padding: 18px 24px 8px 24px;
+}
+
+.modal.callout-dialog .modal-footer {
+	padding: 15px 24px 15px 24px;
+}
+
+.modal.callout-dialog .modal-body {
+	padding: 8px 24px;
+}
+
+.modal.callout-dialog.compact .modal-header {
+	padding: 16px 24px 4px 24px;
+}
+.modal.callout-dialog.compact .modal-body {
+	padding: 4px 24px 16px 24px;
+}

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/media/imageCalloutDialog.css
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/media/imageCalloutDialog.css
@@ -8,6 +8,7 @@
 }
 .modal.callout-dialog .modal-content .insert-image .flex-container > div {
 	flex: 1;
+	min-width: 380px;
 }
 .modal.callout-dialog .modal-content .radio-group input {
 	margin-right: 8px;

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/media/imageCalloutDialog.css
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/media/imageCalloutDialog.css
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.modal.callout-dialog .modal-content .insert-image .flex-container {
+	display: flex;
+}
+.modal.callout-dialog .modal-content .insert-image .flex-container > div {
+	flex: 1;
+}
+.modal.callout-dialog .modal-content .radio-group input {
+	margin-right: 8px;
+}
+.modal.callout-dialog .modal-content .radio-group span {
+	margin-right: 15px;
+}
+

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/media/linkCalloutDialog.css
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/media/linkCalloutDialog.css
@@ -1,0 +1,5 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+


### PR DESCRIPTION
## calloutDialog refactor: 
Split code specific to image and link into their own super classes. 
Moved callout styles into a new stylesheet.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


