### PR TITLE
add attach styler for modal dialog footer buttons

### DIFF
--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -534,7 +534,7 @@ export abstract class Modal extends Disposable implements IThemable {
 		} else {
 			DOM.append(this._rightFooter!, footerButton);
 		}
-
+		attachButtonStyler(button, this._themeService);
 		this._footerButtons.push(button);
 		return button;
 	}


### PR DESCRIPTION
This PR fixes one of the issue in #14367 

the button doesn't have attachButtonStyler run on them.

before:

![image](https://user-images.githubusercontent.com/13777222/108796885-ad3fe500-753e-11eb-9dba-c49a5b7981c9.png)


after:
![image](https://user-images.githubusercontent.com/13777222/108796844-939e9d80-753e-11eb-9da0-d627b1025b6b.png)

![image](https://user-images.githubusercontent.com/13777222/108796866-9dc09c00-753e-11eb-8e3f-3f719c9eab8a.png)
