### PR TITLE
implement styler for infobutton

### DIFF
--- a/src/sql/base/browser/ui/infoButton/infoButton.css
+++ b/src/sql/base/browser/ui/infoButton/infoButton.css
@@ -37,37 +37,9 @@
 }
 
 .info-button {
-	background-color: #fff;
 	border-radius: 2px;
-	box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.13);
 	display: inline-block;
-}
-.info-button[tabindex="0"]:active {
-	background-color: #fff;
-	box-shadow: 0px 3px 8px rgba(0, 0, 0, 0.13);
-}
-.vs-dark .info-button {
-	background-color: #1b1a19;
-	box-shadow: 0px 1px 4px rgba(255, 255, 255, 0.13);
-}
-.vs-dark .info-button[tabindex="0"]:active {
-	background-color: #1b1a19;
-	box-shadow: 0px 3px 8px rgba(255, 255, 255, 0.13);
-}
-.hc-black .info-button {
-	background-color: #000;
-	box-shadow: none;
-}
-.hc-black .info-button[tabindex="0"]:active {
-	background-color: #000;
-}
-.info-button:hover {
-	box-shadow: 0px 3px 8px rgba(0, 0, 0, 0.13);
-}
-.vs-dark .info-button:hover {
-	box-shadow: 0px 3px 8px rgba(255, 255, 255, 0.13);
-}
-.hc-black .info-button[tabindex="0"]:hover {
-	border-style: dashed !important;
-	border-color: rgb(243, 133, 24) !important;
+	background-image: none;
+	border-width: 1px;
+	border-style: solid;
 }

--- a/src/sql/base/browser/ui/infoButton/infoButton.ts
+++ b/src/sql/base/browser/ui/infoButton/infoButton.ts
@@ -3,12 +3,10 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import 'vs/css!./infoButton';
 import { Button as sqlButton } from 'sql/base/browser/ui/button/button';
-import { addDisposableListener, EventType } from 'vs/base/browser/dom';
 import { IButtonOptions, IButtonStyles } from 'vs/base/browser/ui/button/button';
 import { Color } from 'vs/base/common/color';
-
-import 'vs/css!./infoButton';
 
 export interface IInfoButtonOptions extends IButtonOptions {
 	buttonMaxHeight: number,
@@ -83,11 +81,6 @@ export class InfoButton extends sqlButton {
 		this.element.style.background = 'none';
 
 		this.infoButtonOptions = options;
-		this._register(addDisposableListener(this.element, EventType.MOUSE_OVER, e => {
-			if (this._buttonHoverBackground) {
-				this.element.style.backgroundColor = this._buttonHoverBackground.toString();
-			}
-		}));
 	}
 
 	public get title(): string {
@@ -171,9 +164,13 @@ export class InfoButton extends sqlButton {
 		this.applyStyles();
 	}
 
-	applyStyles() {
+	applyStyles(): void {
 		this.element.style.backgroundColor = this._buttonBackground?.toString();
 		this.element.style.color = this._buttonForeground?.toString();
 		this.element.style.borderColor = this._buttonBorder?.toString();
+	}
+
+	setHoverBackground(): void {
+		this.element.style.backgroundColor = this._buttonHoverBackground?.toString();
 	}
 }

--- a/src/sql/base/browser/ui/infoButton/infoButton.ts
+++ b/src/sql/base/browser/ui/infoButton/infoButton.ts
@@ -3,9 +3,12 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import 'vs/css!./infoButton';
 import { Button as sqlButton } from 'sql/base/browser/ui/button/button';
-import { IButtonOptions } from 'vs/base/browser/ui/button/button';
+import { addDisposableListener, EventType } from 'vs/base/browser/dom';
+import { IButtonOptions, IButtonStyles } from 'vs/base/browser/ui/button/button';
+import { Color } from 'vs/base/common/color';
+
+import 'vs/css!./infoButton';
 
 export interface IInfoButtonOptions extends IButtonOptions {
 	buttonMaxHeight: number,
@@ -33,6 +36,11 @@ export class InfoButton extends sqlButton {
 	private _iconHeight?: number;
 	private _iconWidth?: number;
 	private _title?: string;
+
+	private _buttonBackground: Color;
+	private _buttonHoverBackground: Color;
+	private _buttonForeground: Color;
+	private _buttonBorder: Color;
 
 	constructor(container: HTMLElement, options?: IInfoButtonOptions) {
 		super(container, options);
@@ -75,6 +83,11 @@ export class InfoButton extends sqlButton {
 		this.element.style.background = 'none';
 
 		this.infoButtonOptions = options;
+		this._register(addDisposableListener(this.element, EventType.MOUSE_OVER, e => {
+			if (this._buttonHoverBackground) {
+				this.element.style.backgroundColor = this._buttonHoverBackground.toString();
+			}
+		}));
 	}
 
 	public get title(): string {
@@ -148,5 +161,19 @@ export class InfoButton extends sqlButton {
 		this.iconWidth = options.iconWidth;
 		this.iconClass = options.iconClass;
 		this.title = options.title;
+	}
+
+	style(styles: IButtonStyles): void {
+		this._buttonBackground = styles.buttonBackground;
+		this._buttonForeground = styles.buttonForeground;
+		this._buttonBorder = styles.buttonBorder;
+		this._buttonHoverBackground = styles.buttonHoverBackground;
+		this.applyStyles();
+	}
+
+	applyStyles() {
+		this.element.style.backgroundColor = this._buttonBackground?.toString();
+		this.element.style.color = this._buttonForeground?.toString();
+		this.element.style.borderColor = this._buttonBorder?.toString();
 	}
 }

--- a/src/sql/base/browser/ui/infoButton/infoButton.ts
+++ b/src/sql/base/browser/ui/infoButton/infoButton.ts
@@ -6,7 +6,6 @@
 import 'vs/css!./infoButton';
 import { Button as sqlButton } from 'sql/base/browser/ui/button/button';
 import { IButtonOptions, IButtonStyles } from 'vs/base/browser/ui/button/button';
-import { Color } from 'vs/base/common/color';
 
 export interface IInfoButtonOptions extends IButtonOptions {
 	buttonMaxHeight: number,
@@ -35,10 +34,7 @@ export class InfoButton extends sqlButton {
 	private _iconWidth?: number;
 	private _title?: string;
 
-	private _buttonBackground: Color;
-	private _buttonHoverBackground: Color;
-	private _buttonForeground: Color;
-	private _buttonBorder: Color;
+	private _styles: IButtonStyles;
 
 	constructor(container: HTMLElement, options?: IInfoButtonOptions) {
 		super(container, options);
@@ -157,20 +153,17 @@ export class InfoButton extends sqlButton {
 	}
 
 	style(styles: IButtonStyles): void {
-		this._buttonBackground = styles.buttonBackground;
-		this._buttonForeground = styles.buttonForeground;
-		this._buttonBorder = styles.buttonBorder;
-		this._buttonHoverBackground = styles.buttonHoverBackground;
+		this._styles = styles;
 		this.applyStyles();
 	}
 
 	applyStyles(): void {
-		this.element.style.backgroundColor = this._buttonBackground?.toString();
-		this.element.style.color = this._buttonForeground?.toString();
-		this.element.style.borderColor = this._buttonBorder?.toString();
+		this.element.style.backgroundColor = this._styles?.buttonBackground?.toString();
+		this.element.style.color = this._styles?.buttonForeground?.toString();
+		this.element.style.borderColor = this._styles?.buttonBorder?.toString();
 	}
 
 	setHoverBackground(): void {
-		this.element.style.backgroundColor = this._buttonHoverBackground?.toString();
+		this.element.style.backgroundColor = this._styles?.buttonHoverBackground?.toString();
 	}
 }

--- a/src/sql/platform/theme/common/colorRegistry.ts
+++ b/src/sql/platform/theme/common/colorRegistry.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { registerColor } from 'vs/platform/theme/common/colorRegistry';
+import { contrastBorder, registerColor } from 'vs/platform/theme/common/colorRegistry';
 import { Color, RGBA } from 'vs/base/common/color';
 import * as nls from 'vs/nls';
 
@@ -67,8 +67,13 @@ export const notebookFindMatchHighlight = registerColor('notebook.findMatchHighl
 export const notebookFindRangeHighlight = registerColor('notebook.findRangeHighlightBackground', { dark: '#FFA500', light: '#FFA500', hc: null }, nls.localize('notebookFindRangeHighlight', "Color of the range limiting the search. The color must not be opaque so as not to hide underlying decorations."), true);
 
 // Info Box
-export const InfoBoxInformationBackground = registerColor('infoBox.infomationBackground', { light: '#F0F6FF', dark: '#001433', hc: '#000000' }, nls.localize('infoBox.infomationBackground', "InfoBox: The background color when the notification type is information."));
-export const InfoBoxWarningBackground = registerColor('infoBox.warningBackground', { light: '#FFF8F0', dark: '#331B00', hc: '#000000' }, nls.localize('infoBox.warningBackground', "InfoBox: The background color when the notification type is warning."));
-export const InfoBoxErrorBackground = registerColor('infoBox.errorBackground', { light: '#FEF0F1', dark: '#300306', hc: '#000000' }, nls.localize('infoBox.errorBackground', "InfoBox: The background color when the notification type is error."));
-export const InfoBoxSuccessBackground = registerColor('infoBox.successBackground', { light: '#F8FFF0', dark: '#1B3300', hc: '#000000' }, nls.localize('infoBox.successBackground', "InfoBox: The background color when the notification type is success."));
+export const infoBoxInformationBackground = registerColor('infoBox.infomationBackground', { light: '#F0F6FF', dark: '#001433', hc: '#000000' }, nls.localize('infoBox.infomationBackground', "InfoBox: The background color when the notification type is information."));
+export const infoBoxWarningBackground = registerColor('infoBox.warningBackground', { light: '#FFF8F0', dark: '#331B00', hc: '#000000' }, nls.localize('infoBox.warningBackground', "InfoBox: The background color when the notification type is warning."));
+export const infoBoxErrorBackground = registerColor('infoBox.errorBackground', { light: '#FEF0F1', dark: '#300306', hc: '#000000' }, nls.localize('infoBox.errorBackground', "InfoBox: The background color when the notification type is error."));
+export const infoBoxSuccessBackground = registerColor('infoBox.successBackground', { light: '#F8FFF0', dark: '#1B3300', hc: '#000000' }, nls.localize('infoBox.successBackground', "InfoBox: The background color when the notification type is success."));
 
+// Info Button
+export const infoButtonForeground = registerColor('infoButton.foreground', { dark: '#FFFFFF', light: '#000000', hc: '#FFFFFF' }, nls.localize('infoButton.foreground', "Info button foreground color."));
+export const infoButtonBackground = registerColor('infoButton.background', { dark: '#1B1A19', light: '#FFFFFF', hc: '#000000' }, nls.localize('infoButton.background', "Info button background color."));
+export const infoButtonBorder = registerColor('infoButton.border', { dark: '#1B1A19', light: '#FFFFFF', hc: contrastBorder }, nls.localize('infoButton.border', "Info button border color."));
+export const infoButtonHoverBackground = registerColor('infoButton.hoverBackground', { dark: '#282625', light: '#F3F2F1', hc: '#000000' }, nls.localize('infoButton.hoverBackground', "Info button hover background color."));

--- a/src/sql/platform/theme/common/styler.ts
+++ b/src/sql/platform/theme/common/styler.ts
@@ -299,12 +299,30 @@ export interface IInfoBoxStyleOverrides {
 }
 
 export const defaultInfoBoxStyles: IInfoBoxStyleOverrides = {
-	informationBackground: sqlcr.InfoBoxInformationBackground,
-	warningBackground: sqlcr.InfoBoxWarningBackground,
-	errorBackground: sqlcr.InfoBoxErrorBackground,
-	successBackground: sqlcr.InfoBoxSuccessBackground
+	informationBackground: sqlcr.infoBoxInformationBackground,
+	warningBackground: sqlcr.infoBoxWarningBackground,
+	errorBackground: sqlcr.infoBoxErrorBackground,
+	successBackground: sqlcr.infoBoxSuccessBackground
 };
 
 export function attachInfoBoxStyler(widget: IThemable, themeService: IThemeService, style?: IInfoBoxStyleOverrides): IDisposable {
 	return attachStyler(themeService, { ...defaultInfoBoxStyles, ...style }, widget);
+}
+
+export interface IInfoButtonStyleOverrides {
+	buttonBackground: cr.ColorIdentifier,
+	buttonForeground: cr.ColorIdentifier,
+	buttonBorder: cr.ColorIdentifier,
+	buttonHoverBackground: cr.ColorIdentifier
+}
+
+export const defaultInfoButtonStyles: IInfoButtonStyleOverrides = {
+	buttonBackground: sqlcr.infoButtonBackground,
+	buttonForeground: sqlcr.infoButtonForeground,
+	buttonBorder: sqlcr.infoButtonBorder,
+	buttonHoverBackground: sqlcr.infoButtonHoverBackground
+};
+
+export function attachInfoButtonStyler(widget: IThemable, themeService: IThemeService, style?: IInfoButtonStyleOverrides): IDisposable {
+	return attachStyler(themeService, { ...defaultInfoButtonStyles, ...style }, widget);
 }

--- a/src/sql/workbench/browser/modelComponents/button.component.ts
+++ b/src/sql/workbench/browser/modelComponents/button.component.ts
@@ -3,24 +3,26 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import 'vs/css!./media/button';
-import {
-	Component, Input, Inject, ChangeDetectorRef, forwardRef,
-	ViewChild, ElementRef, OnDestroy
-} from '@angular/core';
-
+import { ChangeDetectorRef, Component, ElementRef, forwardRef, Inject, Input, OnDestroy, ViewChild } from '@angular/core';
 import * as azdata from 'azdata';
 
-import { ComponentWithIconBase } from 'sql/workbench/browser/modelComponents/componentWithIconBase';
-
-import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { convertSize } from 'sql/base/browser/dom';
 import { Button } from 'sql/base/browser/ui/button/button';
 import { InfoButton } from 'sql/base/browser/ui/infoButton/infoButton';
-import { IComponentDescriptor, IComponent, IModelStore, ComponentEventType } from 'sql/platform/dashboard/browser/interfaces';
-import { convertSize } from 'sql/base/browser/dom';
+import { ComponentEventType, IComponent, IComponentDescriptor, IModelStore } from 'sql/platform/dashboard/browser/interfaces';
+import { attachInfoButtonStyler } from 'sql/platform/theme/common/styler';
+import { ComponentWithIconBase } from 'sql/workbench/browser/modelComponents/componentWithIconBase';
 import { createIconCssClass } from 'sql/workbench/browser/modelComponents/iconUtils';
-import { ILogService } from 'vs/platform/log/common/log';
 import { IDisposable } from 'vs/base/common/lifecycle';
+import { ILogService } from 'vs/platform/log/common/log';
 import { attachButtonStyler } from 'vs/platform/theme/common/styler';
+import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+
+enum ButtonType {
+	File = 'File',
+	Normal = 'Normal',
+	Informational = 'Informational'
+}
 
 @Component({
 	selector: 'modelview-button',
@@ -43,7 +45,7 @@ export default class ButtonComponent extends ComponentWithIconBase<azdata.Button
 	@Input() modelStore: IModelStore;
 	private _button: Button | InfoButton;
 	public fileType: string = '.sql';
-	private _currentButtonType?: azdata.ButtonType = undefined;
+	private _currentButtonType?: ButtonType = undefined;
 	private _buttonStyler: IDisposable | undefined = undefined;
 
 	@ViewChild('input', { read: ElementRef }) private _inputContainer: ElementRef;
@@ -191,7 +193,11 @@ export default class ButtonComponent extends ComponentWithIconBase<azdata.Button
 	 */
 	private updateStyler(): void {
 		this._buttonStyler?.dispose();
-		this._buttonStyler = this._register(attachButtonStyler(this._button, this.themeService));
+		if (this.buttonType === ButtonType.Informational) {
+			this._buttonStyler = this._register(attachInfoButtonStyler(this._button, this.themeService));
+		} else {
+			this._buttonStyler = this._register(attachButtonStyler(this._button, this.themeService));
+		}
 	}
 
 	protected get defaultIconHeight(): number {
@@ -212,11 +218,11 @@ export default class ButtonComponent extends ComponentWithIconBase<azdata.Button
 		this.setPropertyFromUI<string>(this.setValueProperties, newValue);
 	}
 
-	public get buttonType(): azdata.ButtonType {
+	public get buttonType(): ButtonType {
 		if (this.isFile === true) {
-			return 'File' as azdata.ButtonType;
+			return ButtonType.File;
 		} else {
-			return this.getPropertyOrDefault((props) => props.buttonType, 'Normal' as azdata.ButtonType);
+			return this.getPropertyOrDefault((props) => props.buttonType, ButtonType.Normal);
 		}
 	}
 

--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -156,7 +156,7 @@ export class Button extends Disposable implements IButton {
 		this.applyStyles();
 	}
 
-	private setHoverBackground(): void {
+	protected setHoverBackground(): void { // {{SQL CARBON EDIT}} - mark as protected
 		// {{SQL CARBON EDIT}} - skip if this is an icon button
 		if (this.hasIcon) {
 			return;


### PR DESCRIPTION
This PR fixes #14367 

use this opportunity to add styler for info button and use color registry instead of hard coded colors in css file.

before:
<img width="1049" alt="ML-light" src="https://user-images.githubusercontent.com/12279161/108549189-aba5c100-72a1-11eb-809d-a073d1391290.png">
<img width="1043" alt="ML-dark" src="https://user-images.githubusercontent.com/12279161/108549222-b4969280-72a1-11eb-8eb4-dc1f967b573c.png">
<img width="1042" alt="M-high-contrast" src="https://user-images.githubusercontent.com/12279161/108549246-b9f3dd00-72a1-11eb-995f-d567699ece8a.png">

after:

![image](https://user-images.githubusercontent.com/13777222/108797866-204a5b00-7541-11eb-8e86-19b8923cf394.png)

![image](https://user-images.githubusercontent.com/13777222/108797883-2c361d00-7541-11eb-9497-ee23d66ad2f1.png)

![image](https://user-images.githubusercontent.com/13777222/108797897-39530c00-7541-11eb-9ff0-fcb8e9dcc68c.png)
