### PR TITLE
fix the dashboard toolbar not load issue

### DIFF
--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -289,10 +289,14 @@ export class LabeledMenuItemActionItem extends MenuEntryActionViewItem {
 				}
 
 				if (this.label) {
-					this.label.classList.add('codicon', this._defaultCSSClassToAdd, ...iconClass.split(' '));
+					const iconClasses = iconClass.split(' ');
+					if (this._defaultCSSClassToAdd) {
+						iconClasses.push(this._defaultCSSClassToAdd);
+					}
+					this.label.classList.add('codicon', ...iconClasses);
 					this._labeledItemClassDispose = toDisposable(() => {
 						if (this.label) {
-							this.label.classList.remove('codicon', this._defaultCSSClassToAdd, ...iconClass.split(' '));
+							this.label.classList.remove('codicon', ...iconClasses);
 						}
 					});
 				}


### PR DESCRIPTION
this PR fixes #14281 
I noticed in latest insider build, when you have sql-database-project extension installed, the dashboard's toolbar doesn't have all the expected items with error messages in the console.

![image](https://user-images.githubusercontent.com/13777222/108817816-54d40c00-756d-11eb-91ad-d5a2986508f0.png)
![image](https://user-images.githubusercontent.com/13777222/108817868-61586480-756d-11eb-889a-4434e02cbbf1.png)

turns out this is caused by the recent vscode merge, we added a class in the vscode's file, and in the recent vscode merge, we changed the implementation of how to add css classes to the node (the old addClass method is deprecated)
old:
https://github.com/microsoft/azuredatastudio/blob/release/1.26/src/vs/platform/actions/browser/menuEntryActionViewItem.ts#L359

new:
https://github.com/microsoft/azuredatastudio/blob/main/src/vs/platform/actions/browser/menuEntryActionViewItem.ts#L292

the new one doesn't allow empty css class names, and caused the error above.

the fix is to check whether the class is empty and only add it to the list if it is not empty.

with the fix, the toolbar is loading as expected:
![image](https://user-images.githubusercontent.com/13777222/108818366-1db22a80-756e-11eb-8a83-92e712b6ecbd.png)

more information on this class:
this was added here by Chris for notebook toolbar (it passes in a default class name 'notebook-button', but I couldn't find the definition of it in our code base) @chlafreniere , if the class name doesn't actually exist, could you please remove it?
https://github.com/microsoft/azuredatastudio/blob/main/src/sql/workbench/contrib/notebook/browser/notebook.component.ts#L512

currently only dashboard and notebook are using this class.