### PR TITLE
Notebook Toolbar: Remove Default CSS Class Name (doesn't exist)

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.component.ts
@@ -509,7 +509,7 @@ export class NotebookComponent extends AngularDisposable implements OnInit, OnDe
 				action.tooltip = action.label;
 				action.label = '';
 			}
-			return new LabeledMenuItemActionItem(action, this.keybindingService, this.notificationService, 'notebook-button');
+			return new LabeledMenuItemActionItem(action, this.keybindingService, this.notificationService);
 		}
 		return undefined;
 	}


### PR DESCRIPTION
@alanrenmsft pointed out that the `notebook-button` css class isn't defined anywhere in the codebase. Just a relic from different times 😄 .

In the constructor for LabeledMenuItemActionItem, default CSS class has a default value:

`private readonly _defaultCSSClassToAdd: string = ''`

Stable:
![image](https://user-images.githubusercontent.com/40371649/108904467-5e905a80-75d3-11eb-8a3f-066067649b7e.png)

This change:
![image](https://user-images.githubusercontent.com/40371649/108904512-6fd96700-75d3-11eb-9ecf-91d80944cc91.png)
