### PR TITLE
Update Sql Tools for Feb Hotfix

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.68",
+	"version": "3.0.0-release.79",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azuredatastudio",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "distro": "e70265117090eff42a72ce17fa88b732b92e99b0",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
Update SQL Tools Service to revert SqlClient driver to 2.0.0 due to regression in macOS/Linux connectivity.