### PR TITLE
Add telemetry for deployment type being selected

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -132,7 +132,7 @@
     ],
     "resourceDeploymentTypes": [
       {
-        "name": "arc.control.create",
+        "name": "arc-controller",
         "displayName": "%resource.type.azure.arc.display.name%",
         "description": "%resource.type.azure.arc.description%",
         "platforms": "*",
@@ -144,6 +144,7 @@
         ],
         "providers": [
           {
+            "name": "arc-controller",
             "notebookWizard": {
               "notebook": "./notebooks/arcDeployment/deploy.arc.data.controller.ipynb",
               "type": "new-arc-control-plane",
@@ -626,7 +627,7 @@
         ]
       },
       {
-        "name": "arc.postgres",
+        "name": "arc-postgres",
         "displayName": "%resource.type.arc.postgres.display.name%",
         "description": "%resource.type.arc.postgres.description%",
         "platforms": "*",
@@ -637,6 +638,7 @@
         ],
         "providers": [
           {
+            "name": "arc-postgres",
             "notebookWizard": {
               "notebook": "./notebooks/arcDeployment/deploy.postgres.existing.arc.ipynb",
               "doneAction": {
@@ -912,6 +914,7 @@
           "SQL Server"
         ],
         "provider": {
+          "name": "azure-sql-mi_arc-mi",
           "notebookWizard": {
             "notebook": "./notebooks/arcDeployment/deploy.sql.existing.arc.ipynb",
             "doneAction": {

--- a/extensions/arc/src/extension.ts
+++ b/extensions/arc/src/extension.ts
@@ -24,7 +24,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<arc.IE
 	vscode.window.registerTreeDataProvider('azureArc', treeDataProvider);
 
 	vscode.commands.registerCommand('arc.createController', async () => {
-		await vscode.commands.executeCommand('azdata.resource.deploy', 'arc.control.create', ['arc.control.create']);
+		await vscode.commands.executeCommand('azdata.resource.deploy', 'arc-controller', ['arc-controller']);
 	});
 
 	vscode.commands.registerCommand('arc.connectToController', async () => {

--- a/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/controller/controllerDashboardOverviewPage.ts
@@ -150,7 +150,7 @@ export class ControllerDashboardOverviewPage extends DashboardPage {
 				const node = this._controllerModel.treeDataProvider.getControllerNode(this._controllerModel);
 				await vscode.commands.executeCommand('azdata.resource.deploy',
 					'azure-sql-mi', // Default option
-					['azure-sql-mi', 'arc.postgres'], // Type filter
+					['azure-sql-mi', 'arc-postgres'], // Type filter
 					{ 'azure-sql-mi': { 'mi-type': ['arc-mi'] } }, // Options filter
 					{ 'CONTROLLER_NAME': node?.label });
 			}));

--- a/extensions/asde-deployment/package.json
+++ b/extensions/asde-deployment/package.json
@@ -59,6 +59,7 @@
         ],
         "providers": [
           {
+            "name": "sql-edge_local",
             "dialog": {
               "notebook": "./notebooks/edge/deploy-sql-edge-local.ipynb",
               "title": "%sql-edge-local-title%",
@@ -152,6 +153,7 @@
             "when": "type=local"
           },
           {
+            "name": "sql-edge_remote",
             "dialog": {
               "notebook": "./notebooks/edge/deploy-sql-edge-remote.ipynb",
               "title": "%sql-edge-remote-title%",
@@ -269,6 +271,7 @@
             "when": "type=remote"
           },
           {
+            "name": "sql-edge_azure-create-new",
             "dialog": {
               "notebook": "./notebooks/edge/deploy-sql-edge-azure.ipynb",
               "title": "%sql-edge-azure-title%",
@@ -399,6 +402,7 @@
             "when": "type=azure-create-new"
           },
           {
+            "name": "sql-edge_azure-single-device",
             "dialog": {
               "notebook": "./notebooks/edge/deploy-sql-edge-single-device.ipynb",
               "title": "%sql-edge-azure-single-device-title%",
@@ -489,6 +493,7 @@
             "when": "type=azure-single-device"
           },
           {
+            "name": "sql-edge_azure-multi-device",
             "dialog": {
               "notebook": "./notebooks/edge/deploy-sql-edge-multi-device.ipynb",
               "title": "%sql-edge-azure-multi-device-title%",

--- a/extensions/resource-deployment/extension.webpack.config.js
+++ b/extensions/resource-deployment/extension.webpack.config.js
@@ -9,9 +9,15 @@
 
 const withDefaults = require('../shared.webpack.config');
 
+const externals = {
+	'applicationinsights-native-metrics': 'commonjs applicationinsights-native-metrics',
+	'@opentelemetry/tracing': 'commonjs @opentelemetry/tracing'
+};
+
 module.exports = withDefaults({
 	context: __dirname,
 	entry: {
 		main: './src/main.ts'
-	}
+	},
+	externals: externals
 });

--- a/extensions/resource-deployment/package.json
+++ b/extensions/resource-deployment/package.json
@@ -93,6 +93,7 @@
         ],
         "providers": [
           {
+            "name": "sql-image_2017",
             "dialog": {
               "notebook": "./notebooks/docker/2017/deploy-sql2017-image.ipynb",
               "title": "%docker-sql-2017-title%",
@@ -144,6 +145,7 @@
             "when": "version=sql2017"
           },
           {
+            "name": "sql-image_2019",
             "dialog": {
               "notebook": "./notebooks/docker/2019/deploy-sql2019-image.ipynb",
               "title": "%docker-sql-2019-title%",
@@ -248,6 +250,7 @@
         ],
         "providers": [
           {
+            "name": "sql-bdc_new-aks_bdc2019",
             "bdcWizard": {
               "type": "new-aks",
               "notebook": "./notebooks/bdc/2019/deploy-bdc-aks.ipynb"
@@ -268,6 +271,7 @@
             "when": "target=new-aks&&version=bdc2019"
           },
           {
+            "name": "sql-bdc_existing-aks_bdc2019",
             "bdcWizard": {
               "type": "existing-aks",
               "notebook": "./notebooks/bdc/2019/deploy-bdc-existing-aks.ipynb"
@@ -285,6 +289,7 @@
             "when": "target=existing-aks&&version=bdc2019"
           },
           {
+            "name": "sql-bdc_existing-kubeadm_bdc2019",
             "bdcWizard": {
               "type": "existing-kubeadm",
               "notebook": "./notebooks/bdc/2019/deploy-bdc-existing-kubeadm.ipynb"
@@ -302,6 +307,7 @@
             "when": "target=existing-kubeadm&&version=bdc2019"
           },
           {
+            "name": "sql-bdc_existing-aro_bdc2019",
             "bdcWizard": {
               "type": "existing-aro",
               "notebook": "./notebooks/bdc/2019/deploy-bdc-existing-aro.ipynb"
@@ -319,6 +325,7 @@
             "when": "target=existing-aro&&version=bdc2019"
           },
           {
+            "name": "sql-bdc_existing-openshift_bdc2019",
             "bdcWizard": {
               "type": "existing-openshift",
               "notebook": "./notebooks/bdc/2019/deploy-bdc-existing-openshift.ipynb"
@@ -391,11 +398,13 @@
         ],
         "providers": [
           {
+            "name": "sql-windows-setup_2017",
             "downloadUrl": "https://go.microsoft.com/fwlink/?linkid=853016",
             "requiredTools": [],
             "when": "version=sql2017"
           },
           {
+            "name": "sql-windows-setup_2019",
             "downloadUrl": "https://go.microsoft.com/fwlink/?linkid=866662",
             "requiredTools": [],
             "when": "version=sql2019"
@@ -449,6 +458,7 @@
         ],
         "providers": [
           {
+            "name": "sql-azure-setup_single-database",
             "azureSQLDBWizard": {
               "notebook": "./notebooks/azuredb/create-sqldb.ipynb"
             },
@@ -460,11 +470,13 @@
             "when": "resource-type=single-database"
           },
           {
+            "name": "sql-azure-setup_elastic-pool",
             "webPageUrl": "https://portal.azure.com/#create/Microsoft.SQLElasticDatabasePool",
             "requiredTools": [],
             "when": "resource-type=elastic-pool"
           },
           {
+            "name": "sql-azure-setup_database-server",
             "webPageUrl": "https://portal.azure.com/#create/Microsoft.SQLServer",
             "requiredTools": [],
             "when": "resource-type=database-server"
@@ -504,6 +516,7 @@
         ],
         "providers": [
           {
+            "name": "azure-sql-vm",
             "azureSQLVMWizard": {
               "notebook": "./notebooks/azurevm/create-sqlvm.ipynb"
             },
@@ -549,6 +562,7 @@
         ],
         "providers": [
           {
+            "name": "azure-sql-mi_azure-sql-mi",
             "webPageUrl": "https://portal.azure.com/#create/Microsoft.SQLManagedInstance",
             "requiredTools": [],
             "when": "mi-type=azure-sql-mi"
@@ -604,6 +618,7 @@
     ]
   },
   "dependencies": {
+    "@microsoft/ads-extension-telemetry": "^1.1.3",
     "axios": "^0.19.2",
     "linux-release-info": "^2.0.0",
     "promisify-child-process": "^3.1.1",

--- a/extensions/resource-deployment/src/interfaces.ts
+++ b/extensions/resource-deployment/src/interfaces.ts
@@ -146,6 +146,7 @@ export function instanceOfAzureSQLDBDeploymentProvider(obj: any): obj is AzureSQ
 }
 
 export interface DeploymentProviderBase {
+	name: string;
 	requiredTools: ToolRequirementInfo[];
 	when: string;
 }

--- a/extensions/resource-deployment/src/services/telemetryService.ts
+++ b/extensions/resource-deployment/src/services/telemetryService.ts
@@ -3,9 +3,10 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as vscode from 'vscode';
 import AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
 
-const packageJson = require('../../package.json');
+const packageJson = vscode.extensions.getExtension('Microsoft.resource-deployment')!.packageJSON;
 
 export const TelemetryReporter = new AdsTelemetryReporter(packageJson.name, packageJson.version, packageJson.aiKey);
 

--- a/extensions/resource-deployment/src/services/telemetryService.ts
+++ b/extensions/resource-deployment/src/services/telemetryService.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import AdsTelemetryReporter from '@microsoft/ads-extension-telemetry';
+
+const packageJson = require('../../package.json');
+
+export const TelemetryReporter = new AdsTelemetryReporter(packageJson.name, packageJson.version, packageJson.aiKey);
+
+export enum TelemetryView {
+	ResourceTypeWizard = 'ResourceTypeWizard'
+}
+
+export enum TelemetryAction {
+	SelectedDeploymentType = 'SelectedDeploymentType'
+}
+

--- a/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
@@ -14,6 +14,7 @@ import { getErrorMessage } from '../common/utils';
 import { ResourceTypePage } from './resourceTypePage';
 import { ResourceTypeWizard } from './resourceTypeWizard';
 import { OptionValuesFilter as OptionValuesFilter } from '../services/resourceTypeService';
+import { TelemetryAction, TelemetryReporter, TelemetryView } from '../services/telemetryService';
 
 const localize = nls.loadMessageBundle();
 
@@ -81,6 +82,11 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 			this.wizard.wizardObject.message = {
 				text: ''
 			};
+			TelemetryReporter.createActionEvent(TelemetryView.ResourceTypeWizard, TelemetryAction.SelectedDeploymentType)
+				.withAdditionalProperties({
+					'resourceType': this._resourceType.name,
+					'provider': this.getCurrentProvider().name
+				}).send();
 			return true;
 		});
 	}

--- a/extensions/resource-deployment/yarn.lock
+++ b/extensions/resource-deployment/yarn.lock
@@ -189,6 +189,13 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
+"@microsoft/ads-extension-telemetry@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@microsoft/ads-extension-telemetry/-/ads-extension-telemetry-1.1.3.tgz#54160eefa21f2a536622b0617f3c3f2018cf9c87"
+  integrity sha512-+h6hM9oOA6Zj/N0nCGPzRgydR0YHiHpNJoNlv6a/ziWXO3RYSbQX+3U/PpT3gEA6+8RwByf6RVICo7uIGBy1LQ==
+  dependencies:
+    vscode-extension-telemetry "^0.1.6"
+
 "@microsoft/azdata-test@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@microsoft/azdata-test/-/azdata-test-1.4.0.tgz#a809187ae8a065c518e3a3e2d350883e592853bc"
@@ -288,12 +295,37 @@ append-transform@^2.0.0:
   dependencies:
     default-require-extensions "^3.0.0"
 
+applicationinsights@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.7.4.tgz#e7d96435594d893b00cf49f70a5927105dbb8749"
+  integrity sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==
+  dependencies:
+    cls-hooked "^4.2.2"
+    continuation-local-storage "^3.2.1"
+    diagnostic-channel "0.2.0"
+    diagnostic-channel-publishers "^0.3.3"
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+async-hook-jl@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
+  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
+  dependencies:
+    stack-chain "^1.3.7"
+
+async-listener@^0.6.0:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"
+  integrity sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==
+  dependencies:
+    semver "^5.3.0"
+    shimmer "^1.1.0"
 
 axios@^0.19.2:
   version "0.19.2"
@@ -344,6 +376,15 @@ circular-json@^0.3.1:
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
   integrity sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==
 
+cls-hooked@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
+  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
+  dependencies:
+    async-hook-jl "^1.7.6"
+    emitter-listener "^1.0.1"
+    semver "^5.4.1"
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -365,6 +406,14 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+continuation-local-storage@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz#11f613f74e914fe9b34c92ad2d28fe6ae1db7ffb"
+  integrity sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==
+  dependencies:
+    async-listener "^0.6.0"
+    emitter-listener "^1.1.1"
 
 convert-source-map@^1.7.0:
   version "1.7.0"
@@ -420,6 +469,18 @@ default-require-extensions@^3.0.0:
   dependencies:
     strip-bom "^4.0.0"
 
+diagnostic-channel-publishers@^0.3.3:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.5.tgz#a84a05fd6cc1d7619fdd17791c17e540119a7536"
+  integrity sha512-AOIjw4T7Nxl0G2BoBPhkQ6i7T4bUd9+xvdYizwvG7vVAM1dvr+SDrcUudlmzwH0kbEwdR2V1EcnKT0wAeYLQNQ==
+
+diagnostic-channel@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz#cc99af9612c23fb1fff13612c72f2cbfaa8d5a17"
+  integrity sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=
+  dependencies:
+    semver "^5.3.0"
+
 diff@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
@@ -429,6 +490,13 @@ diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+emitter-listener@^1.0.1, emitter-listener@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
+  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
+  dependencies:
+    shimmer "^1.2.0"
 
 es6-promise@^4.0.3:
   version "4.2.8"
@@ -834,7 +902,7 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-semver@^5.4.1, semver@^5.6.0:
+semver@^5.3.0, semver@^5.4.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -848,6 +916,11 @@ semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+shimmer@^1.1.0, shimmer@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
 should-equal@^2.0.0:
   version "2.0.0"
@@ -921,6 +994,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+stack-chain@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
+  integrity sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=
+
 strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
@@ -977,6 +1055,13 @@ typemoq@^2.1.0:
     circular-json "^0.3.1"
     lodash "^4.17.4"
     postinstall-build "^5.0.1"
+
+vscode-extension-telemetry@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.6.tgz#048b70c93243413036a8315cda493b8e7342980c"
+  integrity sha512-rbzSg7k4NnsCdF4Lz0gI4jl3JLXR0hnlmfFgsY8CSDYhXgdoIxcre8jw5rjkobY0xhSDhbG7xCjP8zxskySJ/g==
+  dependencies:
+    applicationinsights "1.7.4"
 
 vscode-nls@^4.0.0:
   version "4.1.1"

--- a/samples/sample-resource-deployment/package.json
+++ b/samples/sample-resource-deployment/package.json
@@ -34,6 +34,7 @@
         },
         "providers": [
           {
+            "name": "validations-wizard",
             "notebookWizard": {
               "notebook": "%deployment-notebook-1%",
               "runNotebook": false,
@@ -129,6 +130,7 @@
         },
         "providers": [
           {
+            "name": "test-wizard",
             "notebookWizard": {
               "notebook": "%deployment-notebook-1%",
               "type": "new-arc-control-plane",
@@ -462,6 +464,7 @@
         ],
         "providers": [
           {
+            "name": "edition_evaluation",
             "dialog": {
               "notebook": "%deployment-notebook-1%",
               "title": "%dialog-title-1%",
@@ -520,6 +523,7 @@
             "when": "edition=evaluation"
           },
           {
+            "name": "edition_standard",
             "dialog": {
               "notebook": "%deployment-notebook-2%",
               "title": "%dialog-title-2%",


### PR DESCRIPTION
Currently we can get data on the types of wizards and other dialogs being opened but this has a few limitations : 

1. It doesn't have anything for types that don't use wizards (such as those opening links directly)
2. It doesn't have any information about the specific provider being selected - so for example we couldn't tell whether a BDC instance was being deployed to OpenShift, AKS, Kubeadm, etc.

So this is adding a new custom event that will include that information and is fired every time the user leaves the ToolsAndEulaPage (which is always the first page they visit).

This does mean that if they go back and forth it'll generate a new event each time - but I see this as the same as someone opening the dialog and restarting a deployment multiple times and so that's still good to capture. 

I also took the opportunity to rename the arc resource types to match the naming scheme of all the other ones (dash separated instead of dot separated names)