### PR TITLE
Notebooks: Ensure WYSIWYG Mode for Keyboard Shortcuts

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -61,7 +61,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 
 	@HostListener('document:keydown', ['$event'])
 	onkeydown(e: KeyboardEvent) {
-		if (this.isActive()) {
+		if (this.isActive() && this.isWYSIWYGMode()) {
 			// select the active .
 			if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
 				preventDefaultAndExecCommand(e, 'selectAll');
@@ -460,6 +460,10 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			this.cellModel.active = false;
 			this._model.updateActiveCell(undefined);
 		}
+	}
+
+	private isWYSIWYGMode(): boolean {
+		return this.cellModel && this.cellModel.showPreview && !this.cellModel.showMarkdown && this.cellModel.isEditMode;
 	}
 }
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -22,7 +22,7 @@ import { IMarkdownRenderResult } from 'vs/editor/browser/core/markdownRenderer';
 
 import { NotebookMarkdownRenderer } from 'sql/workbench/contrib/notebook/browser/outputs/notebookMarkdown';
 import { CellView } from 'sql/workbench/contrib/notebook/browser/cellViews/interfaces';
-import { ICellModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
+import { CellEditModes, ICellModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { NotebookModel } from 'sql/workbench/services/notebook/browser/models/notebookModel';
 import { ISanitizer, defaultSanitizer } from 'sql/workbench/services/notebook/browser/outputs/sanitizer';
 import { CodeComponent } from 'sql/workbench/contrib/notebook/browser/cellViews/code.component';
@@ -61,7 +61,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 
 	@HostListener('document:keydown', ['$event'])
 	onkeydown(e: KeyboardEvent) {
-		if (this.isActive() && this.isWYSIWYGMode()) {
+		if (this.isActive() && this.cellModel?.currentMode === CellEditModes.WYSIWYG) {
 			// select the active .
 			if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
 				preventDefaultAndExecCommand(e, 'selectAll');
@@ -460,10 +460,6 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			this.cellModel.active = false;
 			this._model.updateActiveCell(undefined);
 		}
-	}
-
-	private isWYSIWYGMode(): boolean {
-		return this.cellModel && this.cellModel.showPreview && !this.cellModel.showMarkdown && this.cellModel.isEditMode;
 	}
 }
 

--- a/src/sql/workbench/services/notebook/browser/models/cell.ts
+++ b/src/sql/workbench/services/notebook/browser/models/cell.ts
@@ -12,7 +12,7 @@ import { localize } from 'vs/nls';
 import * as notebookUtils from 'sql/workbench/services/notebook/browser/models/notebookUtils';
 import { CellTypes, CellType, NotebookChangeType } from 'sql/workbench/services/notebook/common/contracts';
 import { NotebookModel } from 'sql/workbench/services/notebook/browser/models/notebookModel';
-import { ICellModel, IOutputChangedEvent, CellExecutionState, ICellModelOptions, ITableUpdatedEvent } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
+import { ICellModel, IOutputChangedEvent, CellExecutionState, ICellModelOptions, ITableUpdatedEvent, CellEditModes } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { IConnectionManagementService } from 'sql/platform/connection/common/connectionManagement';
 import { IConnectionProfile } from 'sql/platform/connection/common/interfaces';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
@@ -876,6 +876,19 @@ export class CellModel extends Disposable implements ICellModel {
 				this.addOutput(output);
 			}
 		}
+	}
+
+	public get currentMode(): CellEditModes {
+		if (this._cellType === CellTypes.Code) {
+			return CellEditModes.CODE;
+		}
+		if (this._showMarkdown && this._showPreview) {
+			return CellEditModes.SPLIT;
+		} else if (this._showMarkdown && !this._showPreview) {
+			return CellEditModes.MARKDOWN;
+		}
+		// defaulting to WYSIWYG
+		return CellEditModes.WYSIWYG;
 	}
 
 	private setLanguageFromContents(cell: nb.ICellContents): void {

--- a/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
+++ b/src/sql/workbench/services/notebook/browser/models/modelInterfaces.ts
@@ -530,6 +530,7 @@ export interface ICellModel {
 	sendChangeToNotebook(change: NotebookChangeType): void;
 	cellSourceChanged: boolean;
 	readonly savedConnectionName: string | undefined;
+	readonly currentMode: CellEditModes;
 }
 
 export interface IModelFactory {
@@ -584,4 +585,11 @@ export interface INotebookContentsEditable {
 	metadata: nb.INotebookMetadata;
 	nbformat: number;
 	nbformat_minor: number;
+}
+
+export enum CellEditModes {
+	'CODE',
+	'MARKDOWN',
+	'SPLIT',
+	'WYSIWYG'
 }


### PR DESCRIPTION
Fixes #14404.

We were incorrectly capturing keyboard shortcuts even outside of WYSIWYG mode, causing some functionality to not work (such as tab moves focus).