### PR TITLE
Resource deployment clean up

### DIFF
--- a/extensions/resource-deployment/src/ui/deployAzureSQLDBWizard/deployAzureSQLDBWizardModel.ts
+++ b/extensions/resource-deployment/src/ui/deployAzureSQLDBWizard/deployAzureSQLDBWizardModel.ts
@@ -65,9 +65,6 @@ export class DeployAzureSQLDBWizardModel extends ResourceTypeModel {
 		await this.scriptToNotebook();
 	}
 
-	onCancel(): void {
-	}
-
 	private getPages(): ResourceTypePage[] {
 		const pages: ResourceTypePage[] = [];
 		pages.push(new AzureSettingsPage(this));

--- a/extensions/resource-deployment/src/ui/deployAzureSQLDBWizard/pages/azureSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/deployAzureSQLDBWizard/pages/azureSettingsPage.ts
@@ -243,7 +243,7 @@ export class AzureSettingsPage extends BasePage {
 
 	private async populateAzureSubscriptionsDropdown() {
 		this._azureSubscriptionsDropdown.loading = true;
-		let subService = await apiService.azurecoreApi;
+		let subService = apiService.azurecoreApi;
 		let currentAccountDropdownValue = (this._azureAccountsDropdown.value as azdata.CategoryValue);
 		if (currentAccountDropdownValue === undefined) {
 			this._azureSubscriptionsDropdown.loading = false;

--- a/extensions/resource-deployment/src/ui/deployAzureSQLVMWizard/deployAzureSQLVMWizardModel.ts
+++ b/extensions/resource-deployment/src/ui/deployAzureSQLVMWizard/deployAzureSQLVMWizardModel.ts
@@ -80,10 +80,6 @@ export class DeployAzureSQLVMWizardModel extends ResourceTypeModel {
 		await this.scriptToNotebook();
 	}
 
-	onCancel(): void {
-		throw new Error('Method not implemented.');
-	}
-
 	private getPages(): ResourceTypePage[] {
 		const pages: ResourceTypePage[] = [];
 		pages.push(new AzureSettingsPage(this));

--- a/extensions/resource-deployment/src/ui/deployAzureSQLVMWizard/pages/azureSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/deployAzureSQLVMWizard/pages/azureSettingsPage.ts
@@ -12,6 +12,8 @@ import * as localizedConstants from '../../../localizedConstants';
 import { BasePage } from './basePage';
 import { DeployAzureSQLVMWizardModel } from '../deployAzureSQLVMWizardModel';
 
+const supportedRegions = ['eastus', 'eastus2', 'westus', 'centralus', 'northcentralus', 'southcentralus', 'northeurope', 'westeurope', 'eastasia', 'southeastasia', 'japaneast', 'japanwest', 'australiaeast', 'australiasoutheast', 'australiacentral', 'brazilsouth', 'southindia', 'centralindia', 'westindia', 'canadacentral', 'canadaeast', 'westus2', 'westcentralus', 'uksouth', 'ukwest', 'koreacentral', 'koreasouth', 'francecentral', 'southafricanorth', 'uaenorth', 'switzerlandnorth', 'germanywestcentral', 'norwayeast'];
+
 export class AzureSettingsPage extends BasePage {
 	// <- means depends on
 	//dropdown for azure accounts
@@ -101,6 +103,9 @@ export class AzureSettingsPage extends BasePage {
 		this._azureAccountsDropdown = view.modelBuilder.dropDown().withProperties({}).component();
 
 		this._azureAccountsDropdown.onValueChanged(async (value) => {
+			if (!this._azureAccountsDropdown.value) {
+				return;
+			}
 			this._model.azureAccount = this._accountsMap.get(value.selected)!;
 			this.populateAzureSubscriptionsDropdown();
 		});
@@ -161,8 +166,10 @@ export class AzureSettingsPage extends BasePage {
 	private async createAzureSubscriptionsDropdown(view: azdata.ModelView) {
 		this._azureSubscriptionsDropdown = view.modelBuilder.dropDown().withProperties({}).component();
 
-		this._azureSubscriptionsDropdown.onValueChanged(async (value) => {
-
+		this._azureSubscriptionsDropdown.onValueChanged(async value => {
+			if (!this._azureSubscriptionsDropdown.value) {
+				return;
+			}
 			let currentSubscriptionValue = this._azureSubscriptionsDropdown.value as azdata.CategoryValue;
 			this._model.azureSubscription = currentSubscriptionValue.name;
 			this._model.azureSubscriptionDisplayName = currentSubscriptionValue.displayName;
@@ -180,7 +187,7 @@ export class AzureSettingsPage extends BasePage {
 
 	private async populateAzureSubscriptionsDropdown() {
 		this._azureSubscriptionsDropdown.loading = true;
-		let subService = await apiService.azurecoreApi;
+		let subService = apiService.azurecoreApi;
 		let currentAccountDropdownValue = (this._azureAccountsDropdown.value as azdata.CategoryValue);
 		if (currentAccountDropdownValue === undefined) {
 			this._azureSubscriptionsDropdown.loading = false;
@@ -237,7 +244,7 @@ export class AzureSettingsPage extends BasePage {
 
 	private async populateResourceGroupDropdown() {
 		this._resourceGroupDropdown.loading = true;
-		let subService = await apiService.azurecoreApi;
+		let subService = apiService.azurecoreApi;
 		let currentSubscriptionValue = this._azureSubscriptionsDropdown.value as azdata.CategoryValue;
 		if (currentSubscriptionValue === undefined || currentSubscriptionValue.displayName === '') {
 
@@ -275,7 +282,10 @@ export class AzureSettingsPage extends BasePage {
 			required: true
 		}).component();
 
-		this._azureRegionsDropdown.onValueChanged((value) => {
+		this._azureRegionsDropdown.onValueChanged(value => {
+			if (!this._azureRegionsDropdown.value) {
+				return;
+			}
 			this._model.azureRegion = (this._azureRegionsDropdown.value as azdata.CategoryValue).name;
 		});
 	}
@@ -283,15 +293,13 @@ export class AzureSettingsPage extends BasePage {
 	private async populateAzureRegionsDropdown() {
 		this._azureRegionsDropdown.loading = true;
 
-		let supportedRegions = 'eastus, eastus2, westus, centralus, northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia, japaneast, japanwest, australiaeast, australiasoutheast, australiacentral, brazilsouth, southindia, centralindia, westindia, canadacentral, canadaeast, westus2, westcentralus, uksouth, ukwest, koreacentral, koreasouth, francecentral, southafricanorth, uaenorth, switzerlandnorth, germanywestcentral, norwayeast';
-		let supportedRegionsArray = supportedRegions.split(', ');
 		let url = `https://management.azure.com/subscriptions/${this._model.azureSubscription}/locations?api-version=2020-01-01`;
 		const response = await this._model.getRequest(url, false);
 		response.data.value = response.data.value.sort((a: any, b: any) => (a.displayName > b.displayName) ? 1 : -1);
 		this._model.addDropdownValues(
 			this._azureRegionsDropdown,
 			response.data.value.filter((value: any) => {
-				return supportedRegionsArray.includes(value.name);
+				return supportedRegions.includes(value.name);
 			}).map((value: any) => {
 				return {
 					displayName: value.displayName,

--- a/extensions/resource-deployment/src/ui/deployAzureSQLVMWizard/pages/networkSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/deployAzureSQLVMWizard/pages/networkSettingsPage.ts
@@ -124,7 +124,10 @@ export class NetworkSettingsPage extends BasePage {
 			required: true
 		}).component();
 
-		this._virtualNetworkDropdown.onValueChanged((value) => {
+		this._virtualNetworkDropdown.onValueChanged(value => {
+			if (!this._virtualNetworkDropdown.value) {
+				return;
+			}
 			this._model.virtualNetworkName = (this._virtualNetworkDropdown.value as azdata.CategoryValue).name;
 			this.populateSubnetDropdown();
 		});
@@ -224,7 +227,10 @@ export class NetworkSettingsPage extends BasePage {
 			required: true
 		}).component();
 
-		this._subnetDropdown.onValueChanged((value) => {
+		this._subnetDropdown.onValueChanged(value => {
+			if (!this._subnetDropdown.value) {
+				return;
+			}
 			this._model.subnetName = (this._subnetDropdown.value as azdata.CategoryValue).name;
 		});
 
@@ -307,7 +313,10 @@ export class NetworkSettingsPage extends BasePage {
 			width: constants.standardWidth,
 		}).component();
 
-		this._publicIpDropdown.onValueChanged((value) => {
+		this._publicIpDropdown.onValueChanged(value => {
+			if (!this._publicIpDropdown.value) {
+				return;
+			}
 			this._model.publicIpName = (this._publicIpDropdown.value as azdata.CategoryValue).name;
 		});
 

--- a/extensions/resource-deployment/src/ui/deployAzureSQLVMWizard/pages/vmSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/deployAzureSQLVMWizard/pages/vmSettingsPage.ts
@@ -184,7 +184,10 @@ export class VmSettingsPage extends BasePage {
 		this._vmImageDropdown = view.modelBuilder.dropDown().withProperties({
 		}).component();
 
-		this._vmImageDropdown.onValueChanged((value) => {
+		this._vmImageDropdown.onValueChanged(value => {
+			if (!this._vmImageDropdown.value) {
+				return;
+			}
 			this._model.vmImage = (this._vmImageDropdown.value as azdata.CategoryValue).name;
 			this._vmImageSkuDropdown.loading = true;
 			this._vmImageVersionDropdown.loading = true;
@@ -236,7 +239,10 @@ export class VmSettingsPage extends BasePage {
 		this._vmImageSkuDropdown = view.modelBuilder.dropDown().withProperties({
 		}).component();
 
-		this._vmImageSkuDropdown.onValueChanged((value) => {
+		this._vmImageSkuDropdown.onValueChanged(value => {
+			if (!this._vmImageSkuDropdown.value) {
+				return;
+			}
 			this._model.vmImageSKU = (this._vmImageSkuDropdown.value as azdata.CategoryValue).name;
 			this.populateVmImageVersionDropdown();
 		});
@@ -274,7 +280,10 @@ export class VmSettingsPage extends BasePage {
 		this._vmImageVersionDropdown = view.modelBuilder.dropDown().withProperties({
 		}).component();
 
-		this._vmImageVersionDropdown.onValueChanged((value) => {
+		this._vmImageVersionDropdown.onValueChanged(value => {
+			if (!this._vmImageVersionDropdown.value) {
+				return;
+			}
 			this._model.vmImageVersion = (this._vmImageVersionDropdown.value as azdata.CategoryValue).name;
 		});
 	}

--- a/extensions/resource-deployment/src/ui/deployClusterWizard/deployClusterWizardModel.ts
+++ b/extensions/resource-deployment/src/ui/deployClusterWizard/deployClusterWizardModel.ts
@@ -78,8 +78,6 @@ export class DeployClusterWizardModel extends ResourceTypeModel {
 		await this.scriptToNotebook();
 	}
 
-	onCancel(): void { }
-
 	constructor(public bdcProvider: BdcWizardDeploymentProvider, wizard: ResourceTypeWizard) {
 		super(bdcProvider, wizard);
 		this._kubeService = this.wizard._kubeService;

--- a/extensions/resource-deployment/src/ui/notebookWizard/notebookWizardModel.ts
+++ b/extensions/resource-deployment/src/ui/notebookWizard/notebookWizardModel.ts
@@ -55,9 +55,6 @@ export class NotebookWizardModel extends ResourceTypeModel {
 		this.wizard.setPages(this.getPages());
 	}
 
-	public onCancel(): void {
-	}
-
 	/**
 	 * Generates the notebook and returns true if generation was done and so the wizard should be closed.
 	 **/

--- a/extensions/resource-deployment/src/ui/pageLessDeploymentModel.ts
+++ b/extensions/resource-deployment/src/ui/pageLessDeploymentModel.ts
@@ -51,8 +51,4 @@ export class PageLessDeploymentModel extends ResourceTypeModel {
 			vscode.commands.executeCommand(provider.command);
 		}
 	}
-
-	onCancel(): void {
-	}
-
 }

--- a/extensions/resource-deployment/src/ui/resourceTypeModel.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypeModel.ts
@@ -15,7 +15,7 @@ export abstract class ResourceTypeModel extends Model {
 
 	abstract initialize(initialParams?: InitialVariableValues): void;
 	abstract onOk(): Promise<void>;
-	abstract onCancel(): void;
+	public onCancel(): void { }
 	/**
 	 * performs the script generation and returns true if script was generated successfully
 	 **/

--- a/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
@@ -35,10 +35,6 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 	private _isInitialized = false;
 	private _resourceType: ResourceType;
 
-	public set resourceProvider(provider: DeploymentProvider) {
-		this.wizard.provider = provider;
-	}
-
 	public get toolsService(): IToolsService {
 		return this.wizard.toolsService;
 	}
@@ -190,7 +186,7 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 				if (this._resourceType.options) {
 					let resourceTypeOptions: ResourceTypeOptionValue[] = [];
 					const optionsTitle = this.view.modelBuilder.text().withProps({
-						value: 'Options',
+						value: loc.optionsText,
 						CSSStyles: {
 							'font-size': '14px',
 							'padding': '0'
@@ -308,7 +304,6 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 
 		const options = this.getSelectedOptions();
 
-		this.resourceProvider = this._resourceType.getProvider(options)!;
 		return this._resourceType.getProvider(options)!;
 	}
 


### PR DESCRIPTION
Cleaning up a bunch of errors and other stuff I noticed while doing some other stuff

- Define default onCancel in base model class since most implementations don't actually need it (and get rid of one model that was throwing which was causing an exception when cancelling out of the wizard)
- Fix a bunch of the onValueChanged handlers to properly account for undefined values
- Remove unneeded awaits
- Remove unneeded setter for resourceProvider - the wizard is already updated earlier with the new provider so this was just duplicating that being done