### PR TITLE
limit the digits after decimal point

### DIFF
--- a/src/sql/workbench/contrib/query/browser/statusBarItems.ts
+++ b/src/sql/workbench/contrib/query/browser/statusBarItems.ts
@@ -288,14 +288,14 @@ export class QueryResultSelectionSummaryStatusBarContribution extends Disposable
 	}
 
 	private onCellSelectionChanged(data: string[]): void {
-		const numericValues = data?.filter(value => !isNaN(parseFloat(value))).map(value => parseFloat(value));
+		const numericValues = data?.filter(value => !Number.isNaN(Number(value))).map(value => Number(value));
 		if (numericValues?.length < 2 || !(this.editorService.activeEditor instanceof QueryEditorInput)) {
 			this.hide();
 			return;
 		}
 
 		const sum = numericValues.reduce((previous, current, idx, array) => previous + current);
-		const summaryText = localize('status.query.summaryText', "Average: {0}  Count: {1}  Sum: {2}", sum / numericValues.length, data.length, sum);
+		const summaryText = localize('status.query.summaryText', "Average: {0}  Count: {1}  Sum: {2}", Number((sum / numericValues.length).toFixed(3)), data.length, sum);
 		this.statusItem.update({
 			text: summaryText,
 			ariaLabel: summaryText


### PR DESCRIPTION
This PR fixes #14417 
also use more strict number parsing, previously strings like '123abc' will be parsed as 123, now it is not considered to be a number.

average is whole number:
![image](https://user-images.githubusercontent.com/13777222/109057403-8a284900-7696-11eb-93bb-b0a648a42588.png)

less than 3 digits after decimal point:
![image](https://user-images.githubusercontent.com/13777222/109057244-5cdb9b00-7696-11eb-957b-2444d83acd9e.png)

more than 3 digits after decimal point:
![image](https://user-images.githubusercontent.com/13777222/109057361-809ee100-7696-11eb-9137-878f4849bc21.png)

