### PR TITLE
Create book dialog improvements

### DIFF
--- a/extensions/notebook/src/book/bookTocManager.ts
+++ b/extensions/notebook/src/book/bookTocManager.ts
@@ -91,7 +91,7 @@ export class BookTocManager implements IBookTocManager {
 				const contentStat = (await fs.promises.stat(path.join(directory, content)));
 				const parsedFile = path.parse(content);
 				if (contentStat.isFile() && allowedFileExtensions.includes(parsedFile.ext)) {
-					let filePath = directory === rootDirectory ? path.posix.join(path.sep, parsedFile.name) : path.posix.join(path.sep, path.relative(rootDirectory, directory), parsedFile.name);
+					let filePath = directory === rootDirectory ? path.posix.join(path.posix.sep, parsedFile.name) : path.posix.join(path.posix.sep, path.relative(rootDirectory, directory), parsedFile.name);
 					const section: JupyterBookSection = {
 						title: parsedFile.name,
 						file: filePath
@@ -100,7 +100,7 @@ export class BookTocManager implements IBookTocManager {
 				} else if (contentStat.isDirectory()) {
 					let files = await fs.promises.readdir(path.join(directory, content));
 					let initFile = this.getInitFile(files);
-					let filePath = directory === rootDirectory ? path.posix.join(path.sep, parsedFile.name, initFile.name) : path.posix.join(path.sep, path.relative(rootDirectory, directory), parsedFile.name, initFile.name);
+					let filePath = directory === rootDirectory ? path.posix.join(path.posix.sep, parsedFile.name, initFile.name) : path.posix.join(path.posix.sep, path.relative(rootDirectory, directory), parsedFile.name, initFile.name);
 					let section: JupyterBookSection = {};
 					section = {
 						title: parsedFile.name,
@@ -314,7 +314,7 @@ export class BookTocManager implements IBookTocManager {
 	 * @param book The target book.
 	*/
 	async addSection(section: BookTreeItem, book: BookTreeItem): Promise<void> {
-		const uri = path.sep.concat(path.relative(section.rootContentPath, section.book.contentPath));
+		const uri = path.posix.join(path.posix.sep, path.relative(section.rootContentPath, section.book.contentPath));
 		let moveFile = path.join(path.parse(uri).dir, path.parse(uri).name);
 		let fileName = undefined;
 		try {
@@ -380,7 +380,7 @@ export class BookTocManager implements IBookTocManager {
 			}
 		}
 		fileName = fileName === undefined ? notebookPath.name : path.parse(fileName).name;
-		this.newSection.file = path.posix.join(path.sep, fileName);
+		this.newSection.file = path.posix.join(path.posix.sep, fileName);
 		this.newSection.title = notebook.book.title;
 		if (book.version === BookVersion.v1) {
 			// here we only convert if is v1 because we are already using the v2 notation for every book that we read.

--- a/extensions/notebook/src/book/bookTocManager.ts
+++ b/extensions/notebook/src/book/bookTocManager.ts
@@ -62,6 +62,8 @@ export class BookTocManager implements IBookTocManager {
 
 		// If it doesnt find a file named as 'index.md' then use the first file we find.
 		if (initFileIndex !== -1) {
+			initFile = path.parse(files[initFileIndex]);
+		} else {
 			files.some((f) => {
 				const parsedPath = path.parse(f);
 				if (allowedFileExtensions.includes(parsedPath.ext)) {
@@ -98,30 +100,16 @@ export class BookTocManager implements IBookTocManager {
 				} else if (contentStat.isDirectory()) {
 					let files = await fs.promises.readdir(path.join(directory, content));
 					let initFile = this.getInitFile(files);
-					if (initFile) {
-						const indexToRemove = files.findIndex(f => f === initFile.base);
-						if (indexToRemove !== -1) {
-							files.splice(indexToRemove, 1);
-						}
-						let filePath = directory === rootDirectory ? path.posix.join(path.sep, parsedFile.name, initFile.name) : path.posix.join(path.sep, path.relative(rootDirectory, directory), parsedFile.name, initFile.name);
-						let section: JupyterBookSection = {};
-						// if files is empty then treat it as a notebook
-						if (files.length > 0) {
-							section = {
-								title: parsedFile.name,
-								file: filePath,
-								expand_sections: true,
-								numbered: false,
-								sections: await this.createTocFromDir(files, path.join(directory, content), rootDirectory)
-							};
-						} else {
-							section = {
-								title: parsedFile.name,
-								file: filePath,
-							};
-						}
-						toc.push(section);
-					}
+					let filePath = directory === rootDirectory ? path.posix.join(path.sep, parsedFile.name, initFile.name) : path.posix.join(path.sep, path.relative(rootDirectory, directory), parsedFile.name, initFile.name);
+					let section: JupyterBookSection = {};
+					section = {
+						title: parsedFile.name,
+						file: filePath,
+						expand_sections: true,
+						numbered: false,
+						sections: await this.createTocFromDir(files, path.join(directory, content), rootDirectory)
+					};
+					toc.push(section);
 				}
 			}
 			catch (error) {

--- a/extensions/notebook/src/book/bookTocManager.ts
+++ b/extensions/notebook/src/book/bookTocManager.ts
@@ -90,9 +90,10 @@ export class BookTocManager implements IBookTocManager {
 			const contentStat = (await fs.promises.stat(path.join(directory, content)));
 			const parsedFile = path.parse(content);
 			if (contentStat.isFile() && allowedFileExtensions.includes(parsedFile.ext)) {
+				let filePath = directory === rootDirectory ? path.join(path.sep, parsedFile.name) : path.join(path.sep, path.relative(rootDirectory, directory), parsedFile.name);
 				const section: JupyterBookSection = {
 					title: parsedFile.name,
-					file: directory === rootDirectory ? path.join(path.sep, parsedFile.name) : path.join(path.sep, path.relative(rootDirectory, directory), parsedFile.name),
+					file: filePath.replace(/\\/g, '/')
 				};
 				toc.push(section);
 			} else if (contentStat.isDirectory()) {
@@ -103,9 +104,10 @@ export class BookTocManager implements IBookTocManager {
 					if (indexToRemove !== -1) {
 						files.splice(indexToRemove, 1);
 					}
+					let filePath = directory === rootDirectory ? path.join(path.sep, parsedFile.name, initFile.name) : path.join(path.sep, path.relative(rootDirectory, directory), parsedFile.name, initFile.name);
 					const section: JupyterBookSection = {
 						title: parsedFile.name,
-						file: directory === rootDirectory ? path.join(path.sep, parsedFile.name, initFile.name) : path.join(path.sep, path.relative(rootDirectory, directory), parsedFile.name, initFile.name),
+						file: filePath.replace(/\\/g, '/'),
 						expand_sections: true,
 						numbered: false,
 						sections: await this.createTocFromDir(files, path.join(directory, content), rootDirectory)

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -162,20 +162,19 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			canPickMany: false,
 			placeHolder: loc.labelBookFolder
 		});
-
+		const updateBook = this.books.find(book => book.bookPath === pickedBook.detail).bookItems[0];
 		if (pickedBook && movingElement) {
-			const updateBook = this.books.find(book => book.bookPath === pickedBook.detail).bookItems[0];
 			if (updateBook) {
 				let bookSections = updateBook.sections;
-				while (bookSections?.length > 0) {
+				while (bookSections) {
 					bookOptions = [{ label: loc.labelAddToLevel, detail: pickedSection ? pickedSection.detail : '' }];
 					bookSections.forEach(section => {
 						if (section.sections) {
 							bookOptions.push({ label: section.title ? section.title : section.file, detail: section.file });
 						}
 					});
-					bookSections = [];
-					if (bookOptions.length > 1) {
+					bookSections = undefined;
+					if (bookOptions.length >= 1) {
 						pickedSection = await vscode.window.showQuickPick(bookOptions, {
 							canPickMany: false,
 							placeHolder: loc.labelBookSection
@@ -194,16 +193,15 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 					}
 				}
 			}
-			return { quickPickSection: pickedSection, book: updateBook };
 		}
-		return undefined;
+		return pickedSection ? { quickPickSection: pickedSection, book: updateBook } : undefined;
 	}
 
 	async editBook(movingElement: BookTreeItem): Promise<void> {
 		const selectionResults = await this.getSelectionQuickPick(movingElement);
-		const pickedSection = selectionResults.quickPickSection;
-		const updateBook = selectionResults.book;
-		if (pickedSection && updateBook) {
+		if (selectionResults) {
+			const pickedSection = selectionResults.quickPickSection;
+			const updateBook = selectionResults.book;
 			const targetSection = pickedSection.detail !== undefined ? updateBook.findChildSection(pickedSection.detail) : undefined;
 			if (movingElement.tableOfContents.sections) {
 				if (movingElement.contextValue === 'savedNotebook') {

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -162,8 +162,9 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			canPickMany: false,
 			placeHolder: loc.labelBookFolder
 		});
-		const updateBook = this.books.find(book => book.bookPath === pickedBook.detail).bookItems[0];
+
 		if (pickedBook && movingElement) {
+			const updateBook = this.books.find(book => book.bookPath === pickedBook.detail).bookItems[0];
 			if (updateBook) {
 				let bookSections = updateBook.sections;
 				while (bookSections) {
@@ -193,8 +194,9 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 					}
 				}
 			}
+			return pickedSection ? { quickPickSection: pickedSection, book: updateBook } : undefined;
 		}
-		return pickedSection ? { quickPickSection: pickedSection, book: updateBook } : undefined;
+		return undefined;
 	}
 
 	async editBook(movingElement: BookTreeItem): Promise<void> {

--- a/extensions/notebook/src/common/localizedConstants.ts
+++ b/extensions/notebook/src/common/localizedConstants.ts
@@ -94,5 +94,6 @@ export const saveLocation = localize('saveLocation', "Save location");
 export const contentFolder = localize('contentFolder', "Content folder (Optional)");
 export const msgContentFolderError = localize('msgContentFolderError', "Content folder path does not exist");
 export const msgSaveFolderError = localize('msgSaveFolderError', "Save location path does not exist");
+export function msgCreateBookWarningMsg(file: string): string { return localize('msgCreateBookWarningMsg', "Error while trying to access: {0}", file); }
 
 

--- a/extensions/notebook/src/dialog/createBookDialog.ts
+++ b/extensions/notebook/src/dialog/createBookDialog.ts
@@ -28,7 +28,7 @@ export class CreateBookDialog {
 	}
 
 	protected createHorizontalContainer(view: azdata.ModelView, items: azdata.Component[]): azdata.FlexContainer {
-		return view.modelBuilder.flexContainer().withItems(items, { CSSStyles: { 'margin-right': '10px', 'margin-bottom': '10px' } }).withLayout({ flexFlow: 'row' }).component();
+		return view.modelBuilder.flexContainer().withItems(items, { CSSStyles: { 'margin-right': '5px', 'margin-bottom': '10px' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
 	}
 
 	public async selectFolder(): Promise<string | undefined> {
@@ -140,7 +140,7 @@ export class CreateBookDialog {
 						},
 					],
 					title: ''
-				}]).withLayout({ width: '100%' }).component();
+				}]).component();
 			await this.view.initializeModel(this.formModel);
 		});
 		this.dialog.okButton.label = loc.create;

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
-import * as path from 'path';
+//import * as path from 'path';
 
 import { JupyterController } from './jupyter/jupyterController';
 import { AppContext } from './common/appContext';
@@ -31,7 +31,7 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	IconPathHelper.setExtensionContext(extensionContext);
 
 	const appContext = new AppContext(extensionContext);
-	const createBookPath: string = path.posix.join(extensionContext.extensionPath, 'resources', 'notebooks', 'JupyterBooksCreate.ipynb');
+	//const createBookPath: string = path.posix.join(extensionContext.extensionPath, 'resources', 'notebooks', 'JupyterBooksCreate.ipynb');
 	/**
 	 *  									***** IMPORTANT *****
 	 * If changes are made to bookTreeView.openBook, please ensure backwards compatibility with its current state.
@@ -60,14 +60,16 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	}));
 
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.createBook', async () => {
-		let untitledFileName: vscode.Uri = vscode.Uri.parse(`untitled:${createBookPath}`);
-		await vscode.workspace.openTextDocument(createBookPath).then((document) => {
-			azdata.nb.showNotebookDocument(untitledFileName, {
-				connectionProfile: null,
-				initialContent: document.getText(),
-				initialDirtyState: false
-			});
-		});
+		// let untitledFileName: vscode.Uri = vscode.Uri.parse(`untitled:${createBookPath}`);
+		// await vscode.workspace.openTextDocument(createBookPath).then((document) => {
+		// 	azdata.nb.showNotebookDocument(untitledFileName, {
+		// 		connectionProfile: null,
+		// 		initialContent: document.getText(),
+		// 		initialDirtyState: false
+		// 	});
+		// });
+
+		await bookTreeViewProvider.createBook();
 	}));
 
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.moveTo', async (book: BookTreeItem) => {

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -6,7 +6,6 @@
 import * as vscode from 'vscode';
 import * as azdata from 'azdata';
 import * as nls from 'vscode-nls';
-//import * as path from 'path';
 
 import { JupyterController } from './jupyter/jupyterController';
 import { AppContext } from './common/appContext';
@@ -31,7 +30,6 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	IconPathHelper.setExtensionContext(extensionContext);
 
 	const appContext = new AppContext(extensionContext);
-	//const createBookPath: string = path.posix.join(extensionContext.extensionPath, 'resources', 'notebooks', 'JupyterBooksCreate.ipynb');
 	/**
 	 *  									***** IMPORTANT *****
 	 * If changes are made to bookTreeView.openBook, please ensure backwards compatibility with its current state.
@@ -60,15 +58,6 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 	}));
 
 	extensionContext.subscriptions.push(vscode.commands.registerCommand('notebook.command.createBook', async () => {
-		// let untitledFileName: vscode.Uri = vscode.Uri.parse(`untitled:${createBookPath}`);
-		// await vscode.workspace.openTextDocument(createBookPath).then((document) => {
-		// 	azdata.nb.showNotebookDocument(untitledFileName, {
-		// 		connectionProfile: null,
-		// 		initialContent: document.getText(),
-		// 		initialDirtyState: false
-		// 	});
-		// });
-
 		await bookTreeViewProvider.createBook();
 	}));
 

--- a/extensions/notebook/src/test/book/bookTocManager.test.ts
+++ b/extensions/notebook/src/test/book/bookTocManager.test.ts
@@ -95,8 +95,8 @@ describe('BookTocManagerTests', function () {
 				file: path.join(subfolder, 'notebook3')
 			}];
 			await bookTocManager.createBook(bookFolderPath, root2FolderPath);
-			should(equalTOC(bookTocManager.tableofContents[2].sections, expectedSection)).be.true;
-			should((bookTocManager.tableofContents[2] as IJupyterBookSectionV2).file).be.equal(path.join(subfolder, 'readme'));
+			should(equalTOC(bookTocManager.tableofContents[1].sections, expectedSection)).be.true;
+			should(bookTocManager.tableofContents[1].file).be.equal(path.join(path.sep, subfolder, 'readme'));
 		});
 
 		it('should ignore invalid file extensions', async () => {

--- a/extensions/notebook/src/test/book/bookTocManager.test.ts
+++ b/extensions/notebook/src/test/book/bookTocManager.test.ts
@@ -59,7 +59,7 @@ describe('BookTocManagerTests', function () {
 			rootFolderPath = path.join(os.tmpdir(), `BookTestData_${uuid.v4()}`);
 			bookFolderPath = path.join(os.tmpdir(), `BookTestData_${uuid.v4()}`);
 			root2FolderPath = path.join(os.tmpdir(), `BookTestData_${uuid.v4()}`);
-			notebooks = ['notebook1.ipynb', 'notebook2.ipynb', 'notebook3.ipynb', 'index.md', 'readme.md'];
+			notebooks = ['notebook1.ipynb', 'notebook2.ipynb', 'notebook3.ipynb', 'index.md'];
 
 			await fs.mkdir(rootFolderPath);
 			await fs.writeFile(path.join(rootFolderPath, notebooks[0]), '');
@@ -72,7 +72,7 @@ describe('BookTocManagerTests', function () {
 			await fs.writeFile(path.join(root2FolderPath, notebooks[0]), '');
 			await fs.writeFile(path.join(root2FolderPath, subfolder, notebooks[1]), '');
 			await fs.writeFile(path.join(root2FolderPath, subfolder, notebooks[2]), '');
-			await fs.writeFile(path.join(root2FolderPath, subfolder, notebooks[4]), '');
+			await fs.writeFile(path.join(root2FolderPath, subfolder, notebooks[3]), '');
 			await fs.writeFile(path.join(root2FolderPath, notebooks[3]), '');
 		});
 
@@ -96,7 +96,7 @@ describe('BookTocManagerTests', function () {
 			}];
 			await bookTocManager.createBook(bookFolderPath, root2FolderPath);
 			should(equalTOC(bookTocManager.tableofContents[1].sections, expectedSection)).be.true;
-			should(bookTocManager.tableofContents[1].file).be.equal(path.join(path.sep, subfolder, 'readme'));
+			should(bookTocManager.tableofContents[1].file).be.equal(path.join(path.sep, subfolder, 'index'));
 		});
 
 		it('should ignore invalid file extensions', async () => {


### PR DESCRIPTION
- Add support for generating table of contents for folder with multiple subdirectories.
- Show dialog instead of loading the createJupyterBook notebook when running the create book command.
- Modify quickPick to allow moving sections to a book with no sections.
- Replace backlash to slash for windows paths.

https://user-images.githubusercontent.com/34872381/109088003-68918680-76c3-11eb-9a33-476dd19c40c2.mov


