### PR TITLE
fix multiple button issue

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -99,6 +99,10 @@ export class HeaderFilter<T extends Slick.SlickData> {
 		if ((<FilterableColumn<T>>column).filterable === false) {
 			return;
 		}
+		if (args.node.classList.contains('slick-header-with-filter')) {
+			// the the filter button has already being added to the header
+			return;
+		}
 		args.node.classList.add('slick-header-with-filter');
 		const $el = jQuery(`<button aria-label="${ShowFilterText}" title="${ShowFilterText}"></button>`)
 			.addClass('slick-header-menubutton')


### PR DESCRIPTION
This PR fixes #14437

turns out the issue has always been there, but since it has been using a fixed position, we can only see one icon:
this is the dom structure I captured on the stable build.
![image](https://user-images.githubusercontent.com/13777222/109205055-efde0900-775a-11eb-92ba-e5b4aec1bd7f.png)

recently I fixed the text and button overlapping issue and the button is no longer using fixed position and the issue surfaced itself.

the fix is to add a check before we create the button.

with the fix:
![image](https://user-images.githubusercontent.com/13777222/109205417-6549d980-775b-11eb-91e4-3b36fe200818.png)

