### PR TITLE
fix sorting issue in azure resource grid

### DIFF
--- a/extensions/azurecore/src/azureDataGridProvider.ts
+++ b/extensions/azurecore/src/azureDataGridProvider.ts
@@ -76,7 +76,7 @@ export class AzureDataGridProvider implements azdata.DataGridProvider {
 			{ id: 'icon', type: 'image', field: 'iconPath', name: '', width: 25, sortable: false, filterable: false, resizable: false, tooltip: loc.typeIcon },
 			{ id: 'name', type: 'text', field: 'name', name: loc.name, width: 150 },
 			{ id: 'type', type: 'text', field: 'typeDisplayName', name: loc.resourceType, width: 150 },
-			{ id: 'type', type: 'text', field: 'resourceGroup', name: loc.resourceGroup, width: 150 },
+			{ id: 'resourceGroup', type: 'text', field: 'resourceGroup', name: loc.resourceGroup, width: 150 },
 			{ id: 'location', type: 'text', field: 'locationDisplayName', name: loc.location, width: 150 },
 			{ id: 'subscriptionId', type: 'text', field: 'subscriptionName', name: loc.subscription, width: 150 }
 		];


### PR DESCRIPTION
sorting on the resource type column will result in the resource group column to be sorted(see screenshot), turns out caused by duplicate id being used.

![sort](https://user-images.githubusercontent.com/13777222/109251131-cb585000-779f-11eb-9bf3-894eda1eddf0.gif)


