### PR TITLE
Node configuration needs to show different size for data and logs volume for postgresql.

### DIFF
--- a/extensions/arc/src/localizedConstants.ts
+++ b/extensions/arc/src/localizedConstants.ts
@@ -184,6 +184,9 @@ export function instanceDeleted(name: string): string { return localize('arc.ins
 export function instanceUpdated(name: string): string { return localize('arc.instanceUpdated', "Instance '{0}' updated", name); }
 export function copiedToClipboard(name: string): string { return localize('arc.copiedToClipboard', "{0} copied to clipboard", name); }
 export function clickTheTroubleshootButton(resourceType: string): string { return localize('arc.clickTheTroubleshootButton', "Click the troubleshoot button to open the Azure Arc {0} troubleshooting notebook.", resourceType); }
+export function dataStorage(value: string): string { return localize('arc.dataStorage', "{0} data", value); }
+export function logStorage(value: string): string { return localize('arc.logStorage', "{0} log", value); }
+export function backupsStorage(value: string): string { return localize('arc.backupsStorage', "{0} backups", value); }
 export function numVCores(vCores: string | undefined): string {
 	if (vCores && +vCores > 0) {
 		if (+vCores === 1) {

--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -75,7 +75,8 @@ export class PostgresModel extends ResourceModel {
 		const ramLimit = this._config.spec.scheduling?.default?.resources?.limits?.memory;
 		const cpuRequest = this._config.spec.scheduling?.default?.resources?.requests?.cpu;
 		const ramRequest = this._config.spec.scheduling?.default?.resources?.requests?.memory;
-		const storage = this._config.spec.storage?.data?.size;
+		const dataStorage = this._config.spec.storage?.data?.size;
+		const logStorage = this._config.spec.storage?.logs?.size;
 
 		// scale.shards was renamed to scale.workers. Check both for backwards compatibility.
 		const scale = this._config.spec.scale;
@@ -93,8 +94,8 @@ export class PostgresModel extends ResourceModel {
 			configuration.push(`${ramLimit ?? ramRequest!} ${loc.ram}`);
 		}
 
-		if (storage) {
-			configuration.push(`${storage} ${loc.storagePerNode}`);
+		if (dataStorage || logStorage) {
+			configuration.push(`${dataStorage ?? 0} data ${logStorage ?? 0} log ${loc.storagePerNode}`);
 		}
 
 		return configuration.join(', ');

--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -77,7 +77,7 @@ export class PostgresModel extends ResourceModel {
 		const ramRequest = this._config.spec.scheduling?.default?.resources?.requests?.memory;
 		const dataStorage = this._config.spec.storage?.data?.size;
 		const logStorage = this._config.spec.storage?.logs?.size;
-		const backupStorage = this._config.spec.storage?.backups?.size;
+		const backupsStorage = this._config.spec.storage?.backups?.size;
 
 		// scale.shards was renamed to scale.workers. Check both for backwards compatibility.
 		const scale = this._config.spec.scale;
@@ -97,15 +97,15 @@ export class PostgresModel extends ResourceModel {
 
 		let storage: string[] = [];
 		if (dataStorage) {
-			storage.push(` ${dataStorage} data`);
+			storage.push(loc.dataStorage(dataStorage));
 		}
 		if (logStorage) {
-			storage.push(`${logStorage ?? 0} log`);
+			storage.push(loc.logStorage(logStorage));
 		}
-		if (backupStorage) {
-			storage.push(`${backupStorage ?? 0} backups`);
+		if (backupsStorage) {
+			storage.push(loc.backupsStorage(backupsStorage));
 		}
-		if (dataStorage || logStorage || backupStorage) {
+		if (dataStorage || logStorage || backupsStorage) {
 			storage.push(`${loc.storagePerNode}`);
 			configuration.push(storage.join(' '));
 		}

--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -77,6 +77,7 @@ export class PostgresModel extends ResourceModel {
 		const ramRequest = this._config.spec.scheduling?.default?.resources?.requests?.memory;
 		const dataStorage = this._config.spec.storage?.data?.size;
 		const logStorage = this._config.spec.storage?.logs?.size;
+		const backupStorage = this._config.spec.storage?.backups?.size;
 
 		// scale.shards was renamed to scale.workers. Check both for backwards compatibility.
 		const scale = this._config.spec.scale;
@@ -94,8 +95,19 @@ export class PostgresModel extends ResourceModel {
 			configuration.push(`${ramLimit ?? ramRequest!} ${loc.ram}`);
 		}
 
-		if (dataStorage || logStorage) {
-			configuration.push(`${dataStorage ?? 0} data ${logStorage ?? 0} log ${loc.storagePerNode}`);
+		let storage: string[] = [];
+		if (dataStorage) {
+			storage.push(` ${dataStorage} data`);
+		}
+		if (logStorage) {
+			storage.push(`${logStorage ?? 0} log`);
+		}
+		if (backupStorage) {
+			storage.push(`${backupStorage ?? 0} backups`);
+		}
+		if (dataStorage || logStorage || backupStorage) {
+			storage.push(`${loc.storagePerNode}`);
+			configuration.push(storage.join(' '));
 		}
 
 		return configuration.join(', ');


### PR DESCRIPTION
Expected - Azure portal should show different size for data and logs volume.
Actual - Azure portal shows data volume size.
Update:
<img width="318" alt="volstor" src="https://user-images.githubusercontent.com/69922333/109355207-bf1dd280-7833-11eb-9072-29e230b74c43.PNG">

