### PR TITLE
Update PowerShell extension to v2021.2.2

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1450,7 +1450,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": "*"
+									"value": "1.29.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1450,7 +1450,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": "1.29.0"
+									"value": ">=1.29.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1413,14 +1413,14 @@
 					},
 					"versions": [
 						{
-							"version": "2020.4.0",
-							"lastUpdated": "4/28/2020",
+							"version": "2021.2.2",
+							"lastUpdated": "2/26/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/ms-vscode.PowerShell-2020.4.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/ms-vscode.PowerShell-2021.2.2.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1413,14 +1413,14 @@
 					},
 					"versions": [
 						{
-							"version": "2021.2.2",
-							"lastUpdated": "2/26/2021",
+							"version": "2020.4.0",
+							"lastUpdated": "4/28/2020",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/ms-vscode.PowerShell-2021.2.2.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/ms-vscode.PowerShell-2020.4.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1413,14 +1413,14 @@
 					},
 					"versions": [
 						{
-							"version": "2020.4.0",
-							"lastUpdated": "4/28/2020",
+							"version": "2021.2.2",
+							"lastUpdated": "2/26/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/ms-vscode.PowerShell-2020.4.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/powershell/ms-vscode.PowerShell-2021.2.2.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/PowerShell/vscode-powershell/issues/2993.

You'll need to upload [the VSIX asset](https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/PowerShell/2021.2.2/vspackage) to your own blob storage
