### PR TITLE
Add loading component to Postgres Connection String Page 

### DIFF
--- a/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresConnectionStringsPage.ts
@@ -12,6 +12,7 @@ import { PostgresModel } from '../../../models/postgresModel';
 
 export class PostgresConnectionStringsPage extends DashboardPage {
 	private keyValueContainer?: KeyValueContainer;
+	private connectionStringsLoading!: azdata.LoadingComponent;
 
 	constructor(protected modelView: azdata.ModelView, private _postgresModel: PostgresModel) {
 		super(modelView);
@@ -59,7 +60,14 @@ export class PostgresConnectionStringsPage extends DashboardPage {
 
 		this.keyValueContainer = new KeyValueContainer(this.modelView.modelBuilder, this.getConnectionStrings());
 		this.disposables.push(this.keyValueContainer);
-		content.addItem(this.keyValueContainer.container);
+
+		this.connectionStringsLoading = this.modelView.modelBuilder.loadingComponent()
+			.withItem(this.keyValueContainer.container)
+			.withProperties<azdata.LoadingComponentProperties>({
+				loading: !this._postgresModel.configLastUpdated
+			}).component();
+
+		content.addItem(this.connectionStringsLoading, { CSSStyles: cssStyles.text });
 		this.initialized = true;
 		return root;
 	}
@@ -87,6 +95,8 @@ export class PostgresConnectionStringsPage extends DashboardPage {
 	}
 
 	private handleServiceUpdated() {
+		this.connectionStringsLoading.loading = true;
 		this.keyValueContainer?.refresh(this.getConnectionStrings());
+		this.connectionStringsLoading.loading = false;
 	}
 }


### PR DESCRIPTION
Adds loading component to Connection String Page

This PR fixes #14390 
![csaddloading](https://user-images.githubusercontent.com/69922333/109346041-ed94b100-7825-11eb-9ecc-fc9c583204e7.gif)
