### PR TITLE
Add remote debugging port to launch scripts

### DIFF
--- a/scripts/sql.bat
+++ b/scripts/sql.bat
@@ -36,7 +36,7 @@ set ELECTRON_ENABLE_STACK_DUMPING=1
 :: Use the following to get v8 tracing:
 :: %CODE% --js-flags="--trace-hydrogen --trace-phase=Z --trace-deopt --code-comments --hydrogen-track-positions --redirect-code-traces" . %*
 
-%CODE% . %*
+%CODE% . %* --remote-debugging-port=9222
 
 popd
 

--- a/scripts/sql.sh
+++ b/scripts/sql.sh
@@ -41,7 +41,7 @@ function code() {
 	export ELECTRON_ENABLE_STACK_DUMPING=1
 
 	# Launch Code
-	exec "$CODE" . "$@"
+	exec "$CODE" . "$@" --remote-debugging-port=9222
 }
 
 code "$@"


### PR DESCRIPTION
In order to debug the main process this option needs to be added. I'm adding it to the scripts so that no matter how they're launched (some people run the scripts directly instead of using the debug task) the port will be opened to then later attach to if desired.