### PR TITLE
Fix input box validation showing error even when valid

### DIFF
--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -166,10 +166,10 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 		// set aria label based on validity of input
 		if (valid) {
 			this.inputElement.setAriaLabel(this.ariaLabel);
-			this.inputElement.hideMessage();
 		} else {
 			if (otherErrorMsg) {
 				this.inputElement.showMessage({ type: MessageType.ERROR, content: otherErrorMsg }, true);
+				this.inputElement.inputElement.setAttribute('aria-invalid', 'true');
 			}
 			if (this.ariaLabel) {
 				this.inputElement.setAriaLabel(nls.localize('period', "{0}. {1}", this.ariaLabel, this.inputElement.inputElement.validationMessage));

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -166,6 +166,7 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 		// set aria label based on validity of input
 		if (valid) {
 			this.inputElement.setAriaLabel(this.ariaLabel);
+			this.inputElement.hideMessage();
 		} else {
 			if (otherErrorMsg) {
 				this.inputElement.showMessage({ type: MessageType.ERROR, content: otherErrorMsg }, true);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #13667. I'm not sure why this only started happening in December, but problem was that when a different error message was passed in for the input box and the input was invalid, then the error message was shown but aria-invalid wasn't being set. When the input gets validated again, it only hides the error message if the inputElement has the aria-invalid attribute, but since that wasn't set, the message wasn't getting hidden.
