### PR TITLE
[Notebook] Open Kernel Alias (Kusto) notebook with Kernel Alias (Kusto) as selected kernel

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -337,6 +337,7 @@ export class KernelsDropdown extends SelectBox {
 					index = 0;
 				}
 				this.setOptions(kernels, index);
+				this.model.selectedKernelDisplayName = kernels[index];
 			}
 		} else if (this.model.clientSession?.isInErrorState) {
 			kernels.unshift(noKernelName);

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -895,11 +895,8 @@ suite('notebook model', function (): void {
 
 		// Given I have a session that fails to start
 		sessionReady.resolve();
-		let actualSession: IClientSession = undefined;
 
 		let model = new NotebookModel(defaultModelOptions, undefined, logService, undefined, new NullAdsTelemetryService(), queryConnectionService.object, configurationService);
-		model.onClientSessionReady((session) => actualSession = session);
-		await changeContextWithFakeConnectionProfile(model);
 		await model.loadContents();
 
 		await model.requestModelLoad();

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -905,25 +905,6 @@ suite('notebook model', function (): void {
 		assert.equal(model.languageInfo.name, 'fake', 'Notebook language info is not set properly');
 	});
 
-	// To-DO Fix loadModelAndStartClientSession to utilize loadContents as well
-	// If loadContents() is added then we get error:
-	// TypeError: Cannot read property 'createInstance' of undefined on LoadContents()
-	test.skip('Should not change kernel alias as language info', async function () {
-		let model = await loadModelAndStartClientSession(expectedKernelAliasNotebookContentOneCell);
-
-		// Ensure notebook prefix is present in the connection URI
-		queryConnectionService.setup(c => c.getConnectionUri(TypeMoq.It.isAny())).returns(() => `${uriPrefixes.notebook}some/path`);
-		await model.loadContents();
-
-		await model.requestModelLoad();
-
-		await changeContextWithFakeConnectionProfile(model);
-		await changeContextWithFakeConnectionProfile(model);
-
-		// Check to see if current kernel is set to kernel alias
-		assert.equal(model.languageInfo.name, 'fake', 'Notebook language info is not set properly');
-	});
-
 	async function loadModelAndStartClientSession(notebookContent: nb.INotebookContents): Promise<NotebookModel> {
 		let mockContentManager = TypeMoq.Mock.ofType(NotebookEditorContentManager);
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(notebookContent));

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookModel.test.ts
@@ -886,7 +886,7 @@ suite('notebook model', function (): void {
 		assert.equal(output.metadata['multi_connection_mode'], true, 'multi_connection_mode not saved correctly to notebook metadata');
 	});
 
-	test('Should not language info kernel alias name even if kernel spec is SQL', async function () {
+	test('Should keep kernel alias as language info kernel alias name even if kernel spec is seralized as SQL', async function () {
 		let mockContentManager = TypeMoq.Mock.ofType(NotebookEditorContentManager);
 		mockContentManager.setup(c => c.loadContent()).returns(() => Promise.resolve(expectedKernelAliasNotebookContentOneCell));
 		defaultModelOptions.contentManager = mockContentManager.object;

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -288,6 +288,10 @@ export class NotebookModel extends Disposable implements INotebookModel {
 		return this._selectedKernelDisplayName;
 	}
 
+	public set selectedKernelDisplayName(kernel: string) {
+		this._selectedKernelDisplayName = kernel;
+	}
+
 	public set trustedMode(isTrusted: boolean) {
 		this._trustedMode = isTrusted;
 

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -951,6 +951,11 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	private async updateKernelInfoOnKernelChange(kernel: nb.IKernel, kernelAlias?: string) {
 		await this.updateKernelInfo(kernel);
+		this.kernelAliases.forEach(kernel => {
+			if (this._defaultLanguageInfo?.name === kernel.toLowerCase()) {
+				kernelAlias = kernel;
+			}
+		});
 		if (kernel.info) {
 			this.updateLanguageInfo(kernel.info.language_info);
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #13737.

The scenarios covered: 
- Opens kernel alias Notebook properly with kernel set to kernel alias.
- Switches Kernels properly if kernel alias notebook is open first.
- If Kusto Extension is not installed it will open notebook with SQL kernel.
