### PR TITLE
Fix how data workspace handles untitled workspaces

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -41,7 +41,7 @@ export const ProjectNamePlaceholder = localize('dataworkspace.projectNamePlaceho
 export const ProjectLocationTitle = localize('dataworkspace.projectLocationTitle', "Location");
 export const ProjectLocationPlaceholder = localize('dataworkspace.projectLocationPlaceholder', "Select location to create project");
 export const AddProjectToCurrentWorkspace = localize('dataworkspace.AddProjectToCurrentWorkspace', "This project will be added to the current workspace.");
-export const NewWorkspaceWillBeCreated = localize('dataworkspace.NewWorkspaceWillBeCreated', "A new workspace will be created for this project.");
+export const NewWorkspaceWillBeCreated = localize('dataworkspace.NewWorkspaceWillBeCreated', "A workspace will be created for this project.");
 export const WorkspaceLocationTitle = localize('dataworkspace.workspaceLocationTitle', "Workspace location");
 export const ProjectParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.projectParentDirectoryNotExistError', "The selected project location '{0}' does not exist or is not a directory.", location); };
 export const ProjectDirectoryAlreadyExistError = (projectName: string, location: string): string => { return localize('dataworkspace.projectDirectoryAlreadyExistError', "There is already a directory named '{0}' in the selected location: '{1}'.", projectName, location); };

--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -15,7 +15,7 @@ export const AllProjectTypes = localize('AllProjectTypes', "All Project Types");
 export const ProviderNotFoundForProjectTypeError = (projectType: string): string => { return localize('UnknownProjectTypeError', "No provider was found for project type with id: '{0}'", projectType); };
 export const WorkspaceRequiredMessage = localize('dataworkspace.workspaceRequiredMessage', "A workspace is required in order to use the project feature.");
 export const OpenWorkspace = localize('dataworkspace.openWorkspace', "Open Workspace…");
-export const CreateWorkspaceConfirmation = localize('dataworkspace.createWorkspaceConfirmation', "A new workspace will be created and opened in order to open project. The Extension Host will restart and if there is a folder currently open, it will be closed.");
+export const CreateWorkspaceConfirmation = localize('dataworkspace.createWorkspaceConfirmation', "A workspace will be created and opened in order to open project. The Extension Host will restart and if there is a folder currently open, it will be closed.");
 export const EnterWorkspaceConfirmation = localize('dataworkspace.enterWorkspaceConfirmation', "To open this workspace, the Extension Host will restart and if there is a workspace or folder currently open, it will be closed.");
 export const WorkspaceContainsNotAddedProjects = localize('dataworkspace.workspaceContainsNotAddedProjects', "The current workspace contains one or more projects that have not been added to the workspace. Use the 'Open existing' dialog to add projects to the projects pane.");
 export const LaunchOpenExisitingDialog = localize('dataworkspace.launchOpenExistingDialog', "Launch Open existing dialog");

--- a/extensions/data-workspace/src/common/utils.ts
+++ b/extensions/data-workspace/src/common/utils.ts
@@ -31,6 +31,9 @@ async function getFileStatus(path: string): Promise<fs.Stats | undefined> {
 	}
 }
 
+/**
+ * if the current workspace is untitled, the returned URI of vscode.workspace.workspaceFile will use the `untitled` scheme
+ */
 export function isCurrentWorkspaceUntitled(): boolean {
 	return !!vscode.workspace.workspaceFile && vscode.workspace.workspaceFile.scheme.toLowerCase() === 'untitled';
 }

--- a/extensions/data-workspace/src/common/utils.ts
+++ b/extensions/data-workspace/src/common/utils.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fs from 'fs';
+import * as vscode from 'vscode';
 
 export async function directoryExist(directoryPath: string): Promise<boolean> {
 	const stats = await getFileStatus(directoryPath);
@@ -28,6 +29,10 @@ async function getFileStatus(path: string): Promise<fs.Stats | undefined> {
 			throw e;
 		}
 	}
+}
+
+export function isCurrentWorkspaceUntitled(): boolean {
+	return !!vscode.workspace.workspaceFile && vscode.workspace.workspaceFile.scheme.toLowerCase() === 'untitled';
 }
 
 export interface IPackageInfo {

--- a/extensions/data-workspace/src/dialogs/dialogBase.ts
+++ b/extensions/data-workspace/src/dialogs/dialogBase.ts
@@ -94,13 +94,12 @@ export abstract class DialogBase {
 			CSSStyles: { 'margin-top': '3px', 'margin-bottom': '0px' }
 		}).component();
 
-		const untitledWorkspaceCurrentlyOpen = !!vscode.workspace.workspaceFile && isCurrentWorkspaceUntitled();
-		const initialWorkspaceInputBoxValue = !!vscode.workspace.workspaceFile && !untitledWorkspaceCurrentlyOpen ? vscode.workspace.workspaceFile.fsPath : '';
+		const initialWorkspaceInputBoxValue = !!vscode.workspace.workspaceFile && !isCurrentWorkspaceUntitled() ? vscode.workspace.workspaceFile.fsPath : '';
 
 		this.workspaceInputBox = view.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
 			ariaLabel: constants.WorkspaceLocationTitle,
 			width: constants.DefaultInputWidth,
-			enabled: !vscode.workspace.workspaceFile || untitledWorkspaceCurrentlyOpen, // want it editable if no saved workspace is open
+			enabled: !vscode.workspace.workspaceFile || isCurrentWorkspaceUntitled(), // want it editable if no saved workspace is open
 			value: initialWorkspaceInputBoxValue,
 			title: initialWorkspaceInputBoxValue // hovertext for if file path is too long to be seen in textbox
 		}).component();

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -57,9 +57,9 @@ export class WorkspaceService implements IWorkspaceService {
 
 		if (isCurrentWorkspaceUntitled()) {
 			vscode.workspace.updateWorkspaceFolders(vscode.workspace.workspaceFolders!.length, null, { uri: projectFolder });
-			await azdata.workspace.saveWorkspace(workspaceFile!);
+			await azdata.workspace.saveAndEnterWorkspace(workspaceFile!);
 		} else {
-			await azdata.workspace.createWorkspace(projectFolder, workspaceFile);
+			await azdata.workspace.createAndEnterWorkspace(projectFolder, workspaceFile);
 		}
 	}
 

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -74,10 +74,10 @@ export class WorkspaceService implements IWorkspaceService {
 	}
 
 	/**
-	 * Verify that a workspace is open or that if one isn't, it's ok to create a workspace
+	 * Verify that a workspace is open or that if one isn't, it's ok to create a workspace and restart the extension host
 	 */
 	async validateWorkspace(): Promise<boolean> {
-		if (!vscode.workspace.workspaceFile) {
+		if (!vscode.workspace.workspaceFile || isCurrentWorkspaceUntitled()) {
 			const result = await vscode.window.showWarningMessage(constants.CreateWorkspaceConfirmation, constants.OkButtonText, constants.CancelButtonText);
 			if (result === constants.OkButtonText) {
 				return true;

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -13,6 +13,7 @@ import { IWorkspaceService } from '../common/interfaces';
 import { ProjectProviderRegistry } from '../common/projectProviderRegistry';
 import Logger from '../common/logger';
 import { TelemetryReporter, TelemetryViews, calculateRelativity, TelemetryActions } from '../common/telemetry';
+import { isCurrentWorkspaceUntitled } from '../common/utils';
 
 const WorkspaceConfigurationName = 'dataworkspace';
 const ProjectsConfigurationName = 'projects';
@@ -51,9 +52,15 @@ export class WorkspaceService implements IWorkspaceService {
 		// save temp project
 		await this._context.globalState.update(TempProject, [projectFileFsPath]);
 
-		// create a new workspace
+		// create workspace
 		const projectFolder = vscode.Uri.file(path.dirname(projectFileFsPath));
-		await azdata.workspace.createWorkspace(projectFolder, workspaceFile);
+
+		if (isCurrentWorkspaceUntitled()) {
+			vscode.workspace.updateWorkspaceFolders(vscode.workspace.workspaceFolders!.length, null, { uri: projectFolder });
+			await azdata.workspace.saveWorkspace(workspaceFile!);
+		} else {
+			await azdata.workspace.createWorkspace(projectFolder, workspaceFile);
+		}
 	}
 
 	get isProjectProviderAvailable(): boolean {
@@ -102,7 +109,7 @@ export class WorkspaceService implements IWorkspaceService {
 		}
 
 		// a workspace needs to be open to add projects
-		if (!vscode.workspace.workspaceFile) {
+		if (!vscode.workspace.workspaceFile || isCurrentWorkspaceUntitled()) {
 			await this.CreateNewWorkspaceForProject(projectFiles[0].fsPath, workspaceFilePath);
 
 			// this won't get hit since the extension host will get restarted, but helps with testing

--- a/extensions/data-workspace/src/test/workspaceService.test.ts
+++ b/extensions/data-workspace/src/test/workspaceService.test.ts
@@ -246,13 +246,13 @@ suite('WorkspaceService Tests', function (): void {
 		const onWorkspaceProjectsChangedDisposable = service.onDidWorkspaceProjectsChange(() => {
 			onWorkspaceProjectsChangedStub();
 		});
-		const createWorkspaceStub = sinon.stub(azdata.workspace, 'createWorkspace').resolves(undefined);
+		const createWorkspaceStub = sinon.stub(azdata.workspace, 'createAndEnterWorkspace').resolves(undefined);
 
 		await service.addProjectsToWorkspace([
 			vscode.Uri.file('/test/folder/proj1.sqlproj')
 		]);
 
-		should.strictEqual(createWorkspaceStub.calledOnce, true, 'createWorkspace should have been called once');
+		should.strictEqual(createWorkspaceStub.calledOnce, true, 'createAndEnterWorkspace should have been called once');
 		should.strictEqual(onWorkspaceProjectsChangedStub.notCalled, true, 'the onDidWorkspaceProjectsChange event should not have been fired');
 		onWorkspaceProjectsChangedDisposable.dispose();
 	});
@@ -269,7 +269,7 @@ suite('WorkspaceService Tests', function (): void {
 			onWorkspaceProjectsChangedStub();
 		});
 		stubGetConfigurationValue(getConfigurationStub, updateConfigurationStub);
-		sinon.stub(azdata.workspace, 'createWorkspace').resolves(undefined);
+		sinon.stub(azdata.workspace, 'createAndEnterWorkspace').resolves(undefined);
 		sinon.stub(vscode.workspace, 'workspaceFolders').value(['folder1']);
 		mockGlobalState.setup(x => x.get(TypeMoq.It.isAny())).returns(() => [processPath('folder1/proj2.sqlproj')]);
 

--- a/extensions/data-workspace/src/test/workspaceService.test.ts
+++ b/extensions/data-workspace/src/test/workspaceService.test.ts
@@ -11,6 +11,7 @@ import * as should from 'should';
 import * as path from 'path';
 import * as TypeMoq from 'typemoq';
 import * as constants from '../common/constants';
+import * as utils from '../common/utils';
 import { WorkspaceService } from '../services/workspaceService';
 import { ProjectProviderRegistry } from '../common/projectProviderRegistry';
 import { createProjectProvider } from './projectProviderRegistry.test';
@@ -253,6 +254,25 @@ suite('WorkspaceService Tests', function (): void {
 		]);
 
 		should.strictEqual(createWorkspaceStub.calledOnce, true, 'createAndEnterWorkspace should have been called once');
+		should.strictEqual(onWorkspaceProjectsChangedStub.notCalled, true, 'the onDidWorkspaceProjectsChange event should not have been fired');
+		onWorkspaceProjectsChangedDisposable.dispose();
+	});
+
+	test('test addProjectsToWorkspace when untitled workspace is open', async () => {
+		stubWorkspaceFile(undefined);
+		const onWorkspaceProjectsChangedStub = sinon.stub();
+		const onWorkspaceProjectsChangedDisposable = service.onDidWorkspaceProjectsChange(() => {
+			onWorkspaceProjectsChangedStub();
+		});
+		const saveWorkspaceStub = sinon.stub(azdata.workspace, 'saveAndEnterWorkspace').resolves(undefined);
+		sinon.stub(utils, 'isCurrentWorkspaceUntitled').returns(true);
+		sinon.stub(vscode.workspace, 'workspaceFolders').value(['folder1']);
+
+		await service.addProjectsToWorkspace([
+			vscode.Uri.file('/test/folder/proj1.sqlproj')
+		]);
+
+		should.strictEqual(saveWorkspaceStub.calledOnce, true, 'saveAndEnterWorkspace should have been called once');
 		should.strictEqual(onWorkspaceProjectsChangedStub.notCalled, true, 'the onDidWorkspaceProjectsChange event should not have been fired');
 		onWorkspaceProjectsChangedDisposable.dispose();
 	});

--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -244,6 +244,13 @@ export function getDataWorkspaceExtensionApi(): dataworkspace.IExtension {
 	return extension.exports;
 }
 
+/**
+ * if the current workspace is untitled, the returned URI of vscode.workspace.workspaceFile will use the `untitled` scheme
+ */
+export function isCurrentWorkspaceUntitled(): boolean {
+	return !!vscode.workspace.workspaceFile && vscode.workspace.workspaceFile.scheme.toLowerCase() === 'untitled';
+}
+
 /*
  * Returns the default deployment options from DacFx
  */

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -15,7 +15,7 @@ import { cssStyles } from '../common/uiConstants';
 import { ImportDataModel } from '../models/api/import';
 import { Deferred } from '../common/promise';
 import { getConnectionName } from './utils';
-import { exists } from '../common/utils';
+import { exists, isCurrentWorkspaceUntitled } from '../common/utils';
 
 export class CreateProjectFromDatabaseDialog {
 	public dialog: azdata.window.Dialog;
@@ -356,11 +356,14 @@ export class CreateProjectFromDatabaseDialog {
 	 * @param view
 	 */
 	private createWorkspaceContainerRow(view: azdata.ModelView): azdata.FlexContainer {
+		const untitledWorkspaceCurrentlyOpen = !!vscode.workspace.workspaceFile && isCurrentWorkspaceUntitled();
+		const initialWorkspaceInputBoxValue = !!vscode.workspace.workspaceFile && !untitledWorkspaceCurrentlyOpen ? vscode.workspace.workspaceFile.fsPath : '';
+
 		this.workspaceInputBox = view.modelBuilder.inputBox().withProperties({
 			ariaLabel: constants.workspaceLocationTitle,
-			enabled: !vscode.workspace.workspaceFile, // want it editable if no workspace is open
-			value: vscode.workspace.workspaceFile?.fsPath ?? '',
-			title: vscode.workspace.workspaceFile?.fsPath ?? '', // hovertext for if file path is too long to be seen in textbox
+			enabled: !vscode.workspace.workspaceFile || untitledWorkspaceCurrentlyOpen, // want it editable if no saved workspace is open
+			value: initialWorkspaceInputBoxValue,
+			title: initialWorkspaceInputBoxValue, // hovertext for if file path is too long to be seen in textbox
 			width: '100%'
 		}).component();
 
@@ -397,9 +400,8 @@ export class CreateProjectFromDatabaseDialog {
 		}).component();
 
 		let workspaceContainerRow;
-		if (vscode.workspace.workspaceFile) {
+		if (vscode.workspace.workspaceFile && !isCurrentWorkspaceUntitled()) {
 			workspaceContainerRow = view.modelBuilder.flexContainer().withItems([workspaceLabel, this.workspaceInputBox], { flex: '0 0 auto', CSSStyles: { 'margin-right': '10px', 'margin-top': '0px' } }).withLayout({ flexFlow: 'column' }).component();
-
 		} else {
 			// have browse button to help select where the workspace file should be created
 			const workspaceInput = view.modelBuilder.flexContainer().withItems([this.workspaceInputBox], { CSSStyles: { 'margin-right': '10px', 'margin-bottom': '10px', 'width': '100%' } }).withLayout({ flexFlow: 'row', alignItems: 'center' }).component();
@@ -416,7 +418,7 @@ export class CreateProjectFromDatabaseDialog {
 	 * @param name
 	 */
 	public updateWorkspaceInputbox(location: string, name: string): void {
-		if (!vscode.workspace.workspaceFile) {
+		if (!vscode.workspace.workspaceFile || isCurrentWorkspaceUntitled()) {
 			const fileLocation = location && name ? path.join(location, `${name}.code-workspace`) : '';
 			this.workspaceInputBox!.value = fileLocation;
 			this.workspaceInputBox!.title = fileLocation;

--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -356,12 +356,11 @@ export class CreateProjectFromDatabaseDialog {
 	 * @param view
 	 */
 	private createWorkspaceContainerRow(view: azdata.ModelView): azdata.FlexContainer {
-		const untitledWorkspaceCurrentlyOpen = !!vscode.workspace.workspaceFile && isCurrentWorkspaceUntitled();
-		const initialWorkspaceInputBoxValue = !!vscode.workspace.workspaceFile && !untitledWorkspaceCurrentlyOpen ? vscode.workspace.workspaceFile.fsPath : '';
+		const initialWorkspaceInputBoxValue = !!vscode.workspace.workspaceFile && !isCurrentWorkspaceUntitled() ? vscode.workspace.workspaceFile.fsPath : '';
 
 		this.workspaceInputBox = view.modelBuilder.inputBox().withProperties({
 			ariaLabel: constants.workspaceLocationTitle,
-			enabled: !vscode.workspace.workspaceFile || untitledWorkspaceCurrentlyOpen, // want it editable if no saved workspace is open
+			enabled: !vscode.workspace.workspaceFile || isCurrentWorkspaceUntitled(), // want it editable if no saved workspace is open
 			value: initialWorkspaceInputBoxValue,
 			title: initialWorkspaceInputBoxValue, // hovertext for if file path is too long to be seen in textbox
 			width: '100%'

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -955,12 +955,6 @@ declare module 'azdata' {
 		 * @param workspacefile
 		 */
 		export function saveWorkspace(workspaceFile: vscode.Uri): Promise<void>;
-
-		/**
-		 * returns whether or not the workspace is untitled
-		 * @param workspacefile
-		 */
-		export function isUntitledWorkspace(workspaceFile: vscode.Uri): boolean;
 	}
 
 	export interface TableComponentProperties {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -949,6 +949,18 @@ declare module 'azdata' {
 		 * @param workspacefile
 		 */
 		export function enterWorkspace(workspaceFile: vscode.Uri): Promise<void>;
+
+		/**
+		 * Saves and enters the workspace with the provided path
+		 * @param workspacefile
+		 */
+		export function saveWorkspace(workspaceFile: vscode.Uri): Promise<void>;
+
+		/**
+		 * returns whether or not the workspace is untitled
+		 * @param workspacefile
+		 */
+		export function isUntitledWorkspace(workspaceFile: vscode.Uri): boolean;
 	}
 
 	export interface TableComponentProperties {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -942,7 +942,7 @@ declare module 'azdata' {
 		/**
 		 * Creates and enters a workspace at the specified location
 		 */
-		export function createWorkspace(location: vscode.Uri, workspaceFile?: vscode.Uri): Promise<void>;
+		export function createAndEnterWorkspace(location: vscode.Uri, workspaceFile?: vscode.Uri): Promise<void>;
 
 		/**
 		 * Enters the workspace with the provided path
@@ -954,7 +954,7 @@ declare module 'azdata' {
 		 * Saves and enters the workspace with the provided path
 		 * @param workspacefile
 		 */
-		export function saveWorkspace(workspaceFile: vscode.Uri): Promise<void>;
+		export function saveAndEnterWorkspace(workspaceFile: vscode.Uri): Promise<void>;
 	}
 
 	export interface TableComponentProperties {

--- a/src/sql/workbench/api/browser/mainThreadWorkspace.ts
+++ b/src/sql/workbench/api/browser/mainThreadWorkspace.ts
@@ -9,13 +9,16 @@ import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { IWorkspaceEditingService } from 'vs/workbench/services/workspaces/common/workspaceEditing';
+import { isUntitledWorkspace } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadWorkspace)
 export class MainThreadWorkspace extends Disposable implements MainThreadWorkspaceShape {
 
 	constructor(
 		extHostContext: IExtHostContext,
-		@IWorkspaceEditingService private workspaceEditingService: IWorkspaceEditingService
+		@IWorkspaceEditingService private workspaceEditingService: IWorkspaceEditingService,
+		@IWorkbenchEnvironmentService protected readonly environmentService: IWorkbenchEnvironmentService,
 	) {
 		super();
 	}
@@ -29,5 +32,14 @@ export class MainThreadWorkspace extends Disposable implements MainThreadWorkspa
 	$enterWorkspace(workspaceFile: URI): Promise<void> {
 		workspaceFile = URI.revive(workspaceFile);
 		return this.workspaceEditingService.enterWorkspace(workspaceFile);
+	}
+
+	$saveWorkspace(workspaceFile: URI): Promise<void> {
+		workspaceFile = URI.revive(workspaceFile);
+		return this.workspaceEditingService.saveAndEnterWorkspace(workspaceFile);
+	}
+
+	$isUntitledWorkspace(workspaceFile: URI): boolean {
+		return isUntitledWorkspace(workspaceFile, this.environmentService);
 	}
 }

--- a/src/sql/workbench/api/browser/mainThreadWorkspace.ts
+++ b/src/sql/workbench/api/browser/mainThreadWorkspace.ts
@@ -9,7 +9,6 @@ import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { IWorkspaceEditingService } from 'vs/workbench/services/workspaces/common/workspaceEditing';
-import { isUntitledWorkspace } from 'vs/platform/workspaces/common/workspaces';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadWorkspace)

--- a/src/sql/workbench/api/browser/mainThreadWorkspace.ts
+++ b/src/sql/workbench/api/browser/mainThreadWorkspace.ts
@@ -39,7 +39,4 @@ export class MainThreadWorkspace extends Disposable implements MainThreadWorkspa
 		return this.workspaceEditingService.saveAndEnterWorkspace(workspaceFile);
 	}
 
-	$isUntitledWorkspace(workspaceFile: URI): boolean {
-		return isUntitledWorkspace(workspaceFile, this.environmentService);
-	}
 }

--- a/src/sql/workbench/api/browser/mainThreadWorkspace.ts
+++ b/src/sql/workbench/api/browser/mainThreadWorkspace.ts
@@ -22,7 +22,7 @@ export class MainThreadWorkspace extends Disposable implements MainThreadWorkspa
 		super();
 	}
 
-	$createWorkspace(folder: URI, workspaceFile?: URI): Promise<void> {
+	$createAndEnterWorkspace(folder: URI, workspaceFile?: URI): Promise<void> {
 		folder = URI.revive(folder);
 		workspaceFile = URI.revive(workspaceFile);
 		return this.workspaceEditingService.createAndEnterWorkspace([{ uri: folder }], workspaceFile);
@@ -33,7 +33,7 @@ export class MainThreadWorkspace extends Disposable implements MainThreadWorkspa
 		return this.workspaceEditingService.enterWorkspace(workspaceFile);
 	}
 
-	$saveWorkspace(workspaceFile: URI): Promise<void> {
+	$saveAndEnterWorkspace(workspaceFile: URI): Promise<void> {
 		workspaceFile = URI.revive(workspaceFile);
 		return this.workspaceEditingService.saveAndEnterWorkspace(workspaceFile);
 	}

--- a/src/sql/workbench/api/common/extHostWorkspace.ts
+++ b/src/sql/workbench/api/common/extHostWorkspace.ts
@@ -17,15 +17,15 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape {
 		this._proxy = _mainContext.getProxy(SqlMainContext.MainThreadWorkspace);
 	}
 
-	$createWorkspace(folder: URI, workspaceFile: URI): Promise<void> {
-		return this._proxy.$createWorkspace(folder, workspaceFile);
+	$createAndEnterWorkspace(folder: URI, workspaceFile: URI): Promise<void> {
+		return this._proxy.$createAndEnterWorkspace(folder, workspaceFile);
 	}
 
 	$enterWorkspace(workspaceFile: URI): Promise<void> {
 		return this._proxy.$enterWorkspace(workspaceFile);
 	}
 
-	$saveWorkspace(workspaceFile: URI): Promise<void> {
-		return this._proxy.$saveWorkspace(workspaceFile);
+	$saveAndEnterWorkspace(workspaceFile: URI): Promise<void> {
+		return this._proxy.$saveAndEnterWorkspace(workspaceFile);
 	}
 }

--- a/src/sql/workbench/api/common/extHostWorkspace.ts
+++ b/src/sql/workbench/api/common/extHostWorkspace.ts
@@ -28,8 +28,4 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape {
 	$saveWorkspace(workspaceFile: URI): Promise<void> {
 		return this._proxy.$saveWorkspace(workspaceFile);
 	}
-
-	$isUntitledWorkspace(workspaceFile: URI): boolean {
-		return this._proxy.$isUntitledWorkspace(workspaceFile);
-	}
 }

--- a/src/sql/workbench/api/common/extHostWorkspace.ts
+++ b/src/sql/workbench/api/common/extHostWorkspace.ts
@@ -24,4 +24,12 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape {
 	$enterWorkspace(workspaceFile: URI): Promise<void> {
 		return this._proxy.$enterWorkspace(workspaceFile);
 	}
+
+	$saveWorkspace(workspaceFile: URI): Promise<void> {
+		return this._proxy.$saveWorkspace(workspaceFile);
+	}
+
+	$isUntitledWorkspace(workspaceFile: URI): boolean {
+		return this._proxy.$isUntitledWorkspace(workspaceFile);
+	}
 }

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -472,6 +472,12 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				},
 				enterWorkspace(workspaceFile: vscode.Uri): Promise<void> {
 					return extHostWorkspace.$enterWorkspace(workspaceFile);
+				},
+				saveWorkspace(workspaceFile: vscode.Uri): Promise<void> {
+					return extHostWorkspace.$saveWorkspace(workspaceFile);
+				},
+				isUntitledWorkspace(workspaceFile: vscode.Uri): boolean {
+					return extHostWorkspace.$isUntitledWorkspace(workspaceFile);
 				}
 			};
 

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -467,14 +467,14 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				createModelViewEditor(title: string, options?: azdata.ModelViewEditorOptions, name?: string): azdata.workspace.ModelViewEditor {
 					return extHostModelViewDialog.createModelViewEditor(title, extension, name, options);
 				},
-				createWorkspace(location: vscode.Uri, workspaceFile: vscode.Uri): Promise<void> {
-					return extHostWorkspace.$createWorkspace(location, workspaceFile);
+				createAndEnterWorkspace(location: vscode.Uri, workspaceFile: vscode.Uri): Promise<void> {
+					return extHostWorkspace.$createAndEnterWorkspace(location, workspaceFile);
 				},
 				enterWorkspace(workspaceFile: vscode.Uri): Promise<void> {
 					return extHostWorkspace.$enterWorkspace(workspaceFile);
 				},
-				saveWorkspace(workspaceFile: vscode.Uri): Promise<void> {
-					return extHostWorkspace.$saveWorkspace(workspaceFile);
+				saveAndEnterWorkspace(workspaceFile: vscode.Uri): Promise<void> {
+					return extHostWorkspace.$saveAndEnterWorkspace(workspaceFile);
 				}
 			};
 

--- a/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.api.impl.ts
@@ -475,9 +475,6 @@ export function createAdsApiFactory(accessor: ServicesAccessor): IAdsExtensionAp
 				},
 				saveWorkspace(workspaceFile: vscode.Uri): Promise<void> {
 					return extHostWorkspace.$saveWorkspace(workspaceFile);
-				},
-				isUntitledWorkspace(workspaceFile: vscode.Uri): boolean {
-					return extHostWorkspace.$isUntitledWorkspace(workspaceFile);
 				}
 			};
 

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -759,15 +759,15 @@ export interface ExtHostBackgroundTaskManagementShape {
 }
 
 export interface ExtHostWorkspaceShape {
-	$createWorkspace(folder: vscode.Uri, workspaceFile: vscode.Uri): Promise<void>;
+	$createAndEnterWorkspace(folder: vscode.Uri, workspaceFile: vscode.Uri): Promise<void>;
 	$enterWorkspace(workspaceFile: vscode.Uri): Promise<void>;
-	$saveWorkspace(workspaceFile: vscode.Uri): Promise<void>;
+	$saveAndEnterWorkspace(workspaceFile: vscode.Uri): Promise<void>;
 }
 
 export interface MainThreadWorkspaceShape {
-	$createWorkspace(folder: vscode.Uri, workspaceFile: vscode.Uri): Promise<void>;
+	$createAndEnterWorkspace(folder: vscode.Uri, workspaceFile: vscode.Uri): Promise<void>;
 	$enterWorkspace(workspaceFile: vscode.Uri): Promise<void>;
-	$saveWorkspace(workspaceFile: vscode.Uri): Promise<void>;
+	$saveAndEnterWorkspace(workspaceFile: vscode.Uri): Promise<void>;
 }
 
 export interface MainThreadBackgroundTaskManagementShape extends IDisposable {

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -761,11 +761,15 @@ export interface ExtHostBackgroundTaskManagementShape {
 export interface ExtHostWorkspaceShape {
 	$createWorkspace(folder: vscode.Uri, workspaceFile: vscode.Uri): Promise<void>;
 	$enterWorkspace(workspaceFile: vscode.Uri): Promise<void>;
+	$saveWorkspace(workspaceFile: vscode.Uri): Promise<void>;
+	$isUntitledWorkspace(workspacefile: vscode.Uri): boolean;
 }
 
 export interface MainThreadWorkspaceShape {
 	$createWorkspace(folder: vscode.Uri, workspaceFile: vscode.Uri): Promise<void>;
 	$enterWorkspace(workspaceFile: vscode.Uri): Promise<void>;
+	$saveWorkspace(workspaceFile: vscode.Uri): Promise<void>;
+	$isUntitledWorkspace(workspacefile: vscode.Uri): boolean;
 }
 
 export interface MainThreadBackgroundTaskManagementShape extends IDisposable {

--- a/src/sql/workbench/api/common/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/common/sqlExtHost.protocol.ts
@@ -762,14 +762,12 @@ export interface ExtHostWorkspaceShape {
 	$createWorkspace(folder: vscode.Uri, workspaceFile: vscode.Uri): Promise<void>;
 	$enterWorkspace(workspaceFile: vscode.Uri): Promise<void>;
 	$saveWorkspace(workspaceFile: vscode.Uri): Promise<void>;
-	$isUntitledWorkspace(workspacefile: vscode.Uri): boolean;
 }
 
 export interface MainThreadWorkspaceShape {
 	$createWorkspace(folder: vscode.Uri, workspaceFile: vscode.Uri): Promise<void>;
 	$enterWorkspace(workspaceFile: vscode.Uri): Promise<void>;
 	$saveWorkspace(workspaceFile: vscode.Uri): Promise<void>;
-	$isUntitledWorkspace(workspacefile: vscode.Uri): boolean;
 }
 
 export interface MainThreadBackgroundTaskManagementShape extends IDisposable {


### PR DESCRIPTION
This PR fixes #14310. Previously, untitled workspaces weren't handled because the projects are added as relative paths to the workspace, but it wasn't the correct path for untitled workspaces since they weren't saved and still in a temp location. After discussing with Raden, the fix here is to handle untitled workspaces like no workspace open scenarios and ask the user for a location to create the workspace. 

 before: 
![image](https://user-images.githubusercontent.com/31145923/108121907-56c33a00-7058-11eb-9207-4930668ccea3.png)

fixed:
![image](https://user-images.githubusercontent.com/31145923/109725780-826d1680-7b66-11eb-8b82-cb122d71bf84.png)
the created workspace will have the newly created project folder and anything else, like folders, that were previously in the untitled workspace. 
![image](https://user-images.githubusercontent.com/31145923/109725878-a16ba880-7b66-11eb-95b9-9d0e2d80ba58.png)
