### PR TITLE
Fix input box validation

### DIFF
--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -64,7 +64,7 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 						return undefined;
 					} else {
 						return {
-							content: this.inputElement.inputElement.validationMessage || nls.localize('invalidValueError', "Invalid value"),
+							content: this.inputElement.inputElement.validationMessage || this.validationErrorMessage || nls.localize('invalidValueError', "Invalid value"),
 							type: MessageType.ERROR
 						};
 					}
@@ -137,10 +137,8 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 			this._register(input.onDidChange(async e => {
 				if (checkOption()) {
 					this.value = input.value;
+					input.hideErrors = false;
 					await this.validate();
-					if (input.hideErrors) {
-						input.hideErrors = false;
-					}
 					this.fireEvent({
 						eventType: ComponentEventType.onDidChange,
 						args: e
@@ -160,16 +158,13 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 
 	public async validate(): Promise<boolean> {
 		let valid = await super.validate();
-		const otherErrorMsg = valid || this.inputElement.value === '' ? undefined : this.validationErrorMessage;
-		valid = valid && this.inputElement.validate();
+		// Let the input validate handle showing/hiding the error message
+		valid = this.inputElement.validate() && valid;
 
 		// set aria label based on validity of input
 		if (valid) {
 			this.inputElement.setAriaLabel(this.ariaLabel);
 		} else {
-			if (otherErrorMsg) {
-				this.inputElement.showMessage({ type: MessageType.ERROR, content: otherErrorMsg }, true);
-			}
 			if (this.ariaLabel) {
 				this.inputElement.setAriaLabel(nls.localize('period', "{0}. {1}", this.ariaLabel, this.inputElement.inputElement.validationMessage));
 			} else {

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -157,9 +157,9 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 	}
 
 	public async validate(): Promise<boolean> {
-		let valid = await super.validate();
+		await super.validate();
 		// Let the input validate handle showing/hiding the error message
-		valid = this.inputElement.validate() && valid;
+		const valid = this.inputElement.validate();
 
 		// set aria label based on validity of input
 		if (valid) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/13667

The logic to add a custom input validation message is relatively new - added in https://github.com/microsoft/azuredatastudio/pull/8909. But it appears that due to race condition issues I fixed in https://github.com/microsoft/azuredatastudio/pull/13317 we never noticed any problems.

The root problem here is that we were manually calling showMessage while doing our validate - but because this was happening after the call to inputbox.validate then if we were showing an error initially (a common thing to happen since values aren't initialized until later) when the validation became successful the error message was never hidden properly.

Instead of doing this ourselves we should just be relying on the base class to handle all that for us - and use the validate callback that we pass in to tell it whether or not to show the message. 

While doing this I also noticed another issue where for input boxes using default validation (i.e. number inputs checking min/max) we weren't setting hideErrors to false until AFTER doing the validate - which meant that if someone typed in an invalid number initially it wouldn't show an error - that would only happen for any subsequent characters being inserted. We now set it to false as soon as there's any changes before calling validate so that any errors are correctly displayed. 

**IMPORTANT** - Currently the behavior is changed for default error messages such as min/max values and required values not being empty. Previously we would display the custom `validationErrorMessage` defined by the extension - but now with my changes we will ALWAYS use the error message that's coming from the input box (if one exists).

To me I think this makes sense - I don't really see the need for a custom message in those cases so using the default one seems correct. And in fact I think the messages are even improved since previously we'd ALWAYS show the same error message, but now we'll show different ones based on whether the field fails custom validation OR is empty when it's required. A good example of this is the Import dialog where it checks that the file exists in the validation : 

![Import_Validation](https://user-images.githubusercontent.com/28519865/109729561-e7c40600-7b6c-11eb-8c72-886acfcf8a74.gif)


Here's some examples I used to verify functionality : 

Deploy DacPac wizard : 
![Deploy_Validation](https://user-images.githubusercontent.com/28519865/109727678-9fefaf80-7b69-11eb-934e-0d5c83778bf4.gif)

Create DB Proj wizard : 
![DbProj_Validation](https://user-images.githubusercontent.com/28519865/109728728-a2530900-7b6b-11eb-802a-0e16d76c0a19.gif)


Arc PG Dashboard:
![Dashboard_Validation](https://user-images.githubusercontent.com/28519865/109727737-b8f86080-7b69-11eb-967d-13d294586779.gif)

Connection Dialog:
![ConnectionDialog_Validation](https://user-images.githubusercontent.com/28519865/109728745-a848ea00-7b6b-11eb-9fe1-dad59ff2582e.gif)

