### PR TITLE
Fix a couple things in create project from db dialog

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/createProjectFromDatabaseDialog.ts
@@ -227,9 +227,11 @@ export class CreateProjectFromDatabaseDialog {
 
 		// populate database dropdown with the databases for this connection
 		if (connectionId) {
+			this.sourceDatabaseDropDown!.loading = true;
 			const databaseValues = await azdata.connection.listDatabases(connectionId);
 
 			this.sourceDatabaseDropDown!.values = databaseValues;
+			this.sourceDatabaseDropDown!.loading = false;
 			this.connectionId = connectionId;
 		}
 

--- a/extensions/sql-database-projects/src/tools/newProjectTool.ts
+++ b/extensions/sql-database-projects/src/tools/newProjectTool.ts
@@ -32,7 +32,11 @@ export function defaultProjectNameNewProj(): string {
  *
  * @param dbName the database name to base the default project name off of
  */
-export function defaultProjectNameFromDb(dbName: string): string {
+export function defaultProjectNameFromDb(dbName: string | undefined): string {
+	if (!dbName) {
+		return '';
+	}
+
 	const projectNameStarter = constants.defaultProjectNameStarter + dbName;
 	const defaultLocation = defaultProjectSaveLocation() ?? vscode.Uri.file(os.homedir());
 	const projectPath: string = path.join(defaultLocation.fsPath, projectNameStarter);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #14500. This adds a loader to the database dropdown while waiting for the list of databases and fixes the project name showing as "DatabaseProjectUndefined" when the dialog is opened from command palette or the projects viewlet. 

before: 
![image](https://user-images.githubusercontent.com/31145923/109735856-480c7500-7b78-11eb-91ac-18f0b29ea11f.png)

fixed:
![image](https://user-images.githubusercontent.com/31145923/109735816-3925c280-7b78-11eb-92b5-b4933fd79d24.png)

