### PR TITLE
Info prompt for results encoding when saving to JSON

### DIFF
--- a/src/sql/workbench/contrib/query/browser/actions.ts
+++ b/src/sql/workbench/contrib/query/browser/actions.ts
@@ -10,7 +10,7 @@ import { Table } from 'sql/base/browser/ui/table/table';
 import { QueryEditor } from './queryEditor';
 import { CellSelectionModel } from 'sql/base/browser/ui/table/plugins/cellSelectionModel.plugin';
 import { IGridDataProvider } from 'sql/workbench/services/query/common/gridDataProvider';
-import { INotificationService } from 'vs/platform/notification/common/notification';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 import { GridTableState } from 'sql/workbench/common/editor/query/gridTableState';
 import * as Constants from 'sql/workbench/contrib/extensions/common/constants';
@@ -67,6 +67,12 @@ export class SaveResultAction extends Action {
 	}
 
 	public async run(context: IGridActionContext): Promise<boolean> {
+		this.notificationService.prompt(Severity.Info, localize('jsonEncodingPrompt', "Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created."),
+			[{
+				label: localize('jsonEncodingOk', "OK"),
+				run: () => { }
+			}]);
+
 		if (!context.gridDataProvider.canSerialize) {
 			this.notificationService.warn(localize('saveToFileNotSupported', "Save to file is not supported by the backing data source"));
 			return false;

--- a/src/sql/workbench/contrib/query/browser/actions.ts
+++ b/src/sql/workbench/contrib/query/browser/actions.ts
@@ -70,7 +70,7 @@ export class SaveResultAction extends Action {
 		this.notificationService.notify({
 			severity: Severity.Info,
 			message: localize('jsonEncoding', "Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created."),
-			neverShowAgain: { id: 'ignoreJsonEncoding', scope: NeverShowAgainScope.WORKSPACE }
+			neverShowAgain: { id: 'ignoreJsonEncoding', scope: NeverShowAgainScope.GLOBAL }
 		});
 
 		if (!context.gridDataProvider.canSerialize) {

--- a/src/sql/workbench/contrib/query/browser/actions.ts
+++ b/src/sql/workbench/contrib/query/browser/actions.ts
@@ -10,7 +10,7 @@ import { Table } from 'sql/base/browser/ui/table/table';
 import { QueryEditor } from './queryEditor';
 import { CellSelectionModel } from 'sql/base/browser/ui/table/plugins/cellSelectionModel.plugin';
 import { IGridDataProvider } from 'sql/workbench/services/query/common/gridDataProvider';
-import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { INotificationService, Severity, NeverShowAgainScope } from 'vs/platform/notification/common/notification';
 import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
 import { GridTableState } from 'sql/workbench/common/editor/query/gridTableState';
 import * as Constants from 'sql/workbench/contrib/extensions/common/constants';
@@ -67,11 +67,11 @@ export class SaveResultAction extends Action {
 	}
 
 	public async run(context: IGridActionContext): Promise<boolean> {
-		this.notificationService.prompt(Severity.Info, localize('jsonEncodingPrompt', "Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created."),
-			[{
-				label: localize('jsonEncodingOk', "OK"),
-				run: () => { }
-			}]);
+		this.notificationService.notify({
+			severity: Severity.Info,
+			message: localize('jsonEncoding', "Results encoding will not be saved when exporting to JSON, remember to save with desired encoding once file is created."),
+			neverShowAgain: { id: 'ignoreJsonEncoding', scope: NeverShowAgainScope.WORKSPACE }
+		});
 
 		if (!context.gridDataProvider.canSerialize) {
 			this.notificationService.warn(localize('saveToFileNotSupported', "Save to file is not supported by the backing data source"));

--- a/src/sql/workbench/contrib/query/browser/actions.ts
+++ b/src/sql/workbench/contrib/query/browser/actions.ts
@@ -80,7 +80,6 @@ export class SaveResultAction extends Action {
 			});
 		}
 
-
 		if (!context.gridDataProvider.canSerialize) {
 			this.notificationService.warn(localize('saveToFileNotSupported', "Save to file is not supported by the backing data source"));
 			return false;


### PR DESCRIPTION
This PR adds a prompt warning users that encoding of the query editor results will not be saved when exporting to JSON (caused by the design of SQL service). This is to let users know of a workaround for the issue #1986 in case results are saved incorrectly. SQL service will need to be updated to handle encoding or the JSON file must be saved with encoding automatically afterwards (currently there is no way to retrieve the encoding of the results editor window when clicking "Save as JSON").
