### PR TITLE
Notebooks: Fix re-installing pip + smoke tests

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -167,7 +167,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 				await this.installPythonPackage(backgroundOperation, this._usingExistingPython, this._pythonInstallationPath, this.outputChannel);
 				// reinstall pip to make sure !pip command works
 				if (!this._usingExistingPython) {
-					let packages: PythonPkgDetails[] = await this.getInstalledPipPackages();
+					let packages: PythonPkgDetails[] = await this.getInstalledPipPackages(this._pythonExecutable);
 					let pip: PythonPkgDetails = packages.find(x => x.name === 'pip');
 					let cmd = `"${this._pythonExecutable}" -m pip install --force-reinstall pip=="${pip.version}"`;
 					await this.executeBufferedCommand(cmd);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Notebook smoke tests were failing because `this.getInstalledPipPackages()` was returning an empty array, causing `pip.version` to throw an error. An empty array was returned because the Python Path config setting hasn't been set yet (didn't run into this issue locally since I had Python Path set).
