### PR TITLE
remove refreshNode method

### DIFF
--- a/src/sql/workbench/api/common/extHostModelViewTree.ts
+++ b/src/sql/workbench/api/common/extHostModelViewTree.ts
@@ -158,21 +158,6 @@ export class ExtHostTreeView<T> extends vsTreeExt.ExtHostTreeView<T> {
 			.then(() => Object.keys(itemsToRefresh).length ? this.modelViewProxy.$refreshDataProvider(this.handle, this.componentId, itemsToRefresh) : null);
 	}
 
-	protected refreshNode(treeItemHandle: vsTreeExt.TreeItemHandle): Promise<vsTreeExt.TreeNode> {
-		const extElement = this.getExtensionElement(treeItemHandle);
-		const existing = this.nodes.get(extElement);
-		//this.clearChildren(extElement); // clear children cache
-		return Promise.resolve(this.componentDataProvider.getTreeItem(extElement))
-			.then(extTreeItem => {
-				if (extTreeItem) {
-					const newNode = this.createTreeNode(extElement, extTreeItem, existing.parent);
-					this.updateNodeCache(extElement, newNode, existing, existing.parent);
-					return newNode;
-				}
-				return null;
-			});
-	}
-
 	protected createTreeNode(element: T, extensionTreeItem: azdata.TreeComponentItem, parent?: vsTreeExt.TreeNode | vsTreeExt.Root): vsTreeExt.TreeNode {
 		let node = super.createTreeNode(element, extensionTreeItem, parent);
 		if (node.item) {

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -502,12 +502,12 @@ export class ExtHostTreeView<T> extends Disposable {
 	// {{SQL CARBON EDIT}}
 	protected getHandlesToRefresh(elements: T[]): TreeItemHandle[] {
 		const elementsToUpdate = new Set<TreeItemHandle>();
-		for (const element of elements) {
-			const elementNode = this.nodes.get(element);
+		const elementNodes = elements.map(element => this.nodes.get(element));
+		for (const elementNode of elementNodes) {
 			if (elementNode && !elementsToUpdate.has(elementNode.item.handle)) {
-				// check if an ancestor of extElement is already in the elements to update list
+				// check if an ancestor of extElement is already in the elements list
 				let currentNode: TreeNode | undefined = elementNode;
-				while (currentNode && currentNode.parent && !elementsToUpdate.has(currentNode.parent.item.handle)) {
+				while (currentNode && currentNode.parent && elementNodes.findIndex(node => currentNode && currentNode.parent && node && node.item.handle === currentNode.parent.item.handle) === -1) {
 					const parentElement: T | undefined = this.elements.get(currentNode.parent.item.handle);
 					currentNode = parentElement ? this.nodes.get(parentElement) : undefined;
 				}


### PR DESCRIPTION
part of the fix for: https://github.com/microsoft/azuredatastudio/issues/14229

we override the refreshNode method of the vscode base class and commented out the clearChildren() call, this will cause the node not being disposed and cause the duplicate id error in the issue description. aside from the commented out code, the only other difference is this.componentDataProvider (in sql implementation) vs this.dataProvider(in vs implementation), but they are the same object, we pass in the componentDataProvider object in the super() constructor call. 
![image](https://user-images.githubusercontent.com/13777222/110024148-e0bf0400-7ce2-11eb-8dd9-8f37c933d660.png)

![image](https://user-images.githubusercontent.com/13777222/110023849-802fc700-7ce2-11eb-8377-e3f9ad5213cf.png)

this will fix the scenario mentioned in the issue but to make the tree fully functional, I have to make another change in vscode: https://github.com/microsoft/vscode/pull/118091
