### PR TITLE
Add mocha dependencies

### DIFF
--- a/extensions/integration-tests/package.json
+++ b/extensions/integration-tests/package.json
@@ -35,9 +35,11 @@
   },
   "devDependencies": {
     "@types/chai": "3.4.34",
+    "@types/mocha": "^5.2.5",
     "@types/node": "^10.14.8",
     "azure-keyvault": "^3.0.4",
     "chai": "3.5.0",
+    "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.17.0",
     "mocha-multi-reporters": "^1.1.7",
     "ms-rest-azure": "^2.6.0",

--- a/extensions/integration-tests/yarn.lock
+++ b/extensions/integration-tests/yarn.lock
@@ -187,6 +187,11 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.4.34.tgz#d5335792823bb09cddd5e38c3d211b709183854d"
   integrity sha1-1TNXkoI7sJzd1eOMPSEbcJGDhU0=
 
+"@types/mocha@^5.2.5":
+  version "5.2.7"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
+  integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
+
 "@types/node@^10.14.8":
   version "10.14.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.17.tgz#b96d4dd3e427382482848948041d3754d40fd5ce"

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -374,8 +374,10 @@
     "xmldom": "^0.3.0"
   },
   "devDependencies": {
+    "@types/mocha": "^5.2.5",
     "@types/sinon": "^9.0.4",
     "@types/xmldom": "^0.1.29",
+    "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.17.0",
     "mocha-multi-reporters": "^1.1.7",
     "should": "^13.2.1",

--- a/extensions/sql-database-projects/yarn.lock
+++ b/extensions/sql-database-projects/yarn.lock
@@ -269,6 +269,11 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@types/mocha@^5.2.5":
+  version "5.2.7"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
+  integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
+
 "@types/sinon@^9.0.4":
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.4.tgz#e934f904606632287a6e7f7ab0ce3f08a0dad4b1"


### PR DESCRIPTION
The only thing this is really doing is adding the correct typings - without direct references to the 5.2.5 version it falls back to using the base ADS one which is much older so the typings are very out of date.

Adding the mocha reference isn't strictly necessary since we get it through the vscodetestcover package anyways (hence why you don't see any changes in the yarn.lock). But it's good to be explicit here since we tend to reference the mocha package in the tests so that we're sure to be using the correct version. 