### PR TITLE
Add event for connection error

### DIFF
--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -6,6 +6,7 @@
 // Telemetry Event Names
 
 export const DatabaseConnected = 'DatabaseConnected';
+export const DatabaseConnectionError = 'DatabaseConnectionError';
 export const DatabaseDisconnected = 'DatabaseDisconnected';
 export const DeleteConnection = 'DeleteConnection';
 export const AddServerGroup = 'AddServerGroup';


### PR DESCRIPTION
Adding new event for capturing number of connection failures

- Inlined functions to clean things up
- Made the elapsed time values measurements and added the unit to the end. This means events before this goes out will need to be changed to correlate with the new events but seeing as we don't currently use those values anyways that doesn't seem to be a huge problem to me