### PR TITLE
Clean up dialog event hide reasons

### DIFF
--- a/src/sql/workbench/browser/modal/calloutDialog.ts
+++ b/src/sql/workbench/browser/modal/calloutDialog.ts
@@ -51,7 +51,7 @@ export abstract class CalloutDialog<T> extends Modal {
 	public abstract open(): Promise<T>;
 
 	public cancel(): void {
-		this.hide();
+		this.hide('cancel');
 		this.dispose();
 	}
 

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -104,6 +104,8 @@ const defaultOptions: IModalOptions = {
 
 const tabbableElementsQuerySelector = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]';
 
+export type HideReason = 'close' | 'cancel' | 'done' | 'ok';
+
 export abstract class Modal extends Disposable implements IThemable {
 	protected _useDefaultMessageBoxLocation: boolean = true;
 	protected _messageElement?: HTMLElement;
@@ -317,7 +319,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	 * Overridable to change behavior of escape key
 	 */
 	protected onClose(e?: StandardKeyboardEvent) {
-		this.hide();
+		this.hide('close');
 	}
 
 	/**
@@ -330,7 +332,7 @@ export abstract class Modal extends Disposable implements IThemable {
 		if (target.closest('.modal-content')) {
 			return;
 		} else {
-			this.hide();
+			this.hide('close');
 		}
 	}
 
@@ -338,7 +340,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	 * Overridable to change behavior of enter key
 	 */
 	protected onAccept(e?: StandardKeyboardEvent) {
-		this.hide();
+		this.hide('ok');
 	}
 
 	private handleBackwardTab(e: KeyboardEvent) {
@@ -499,7 +501,7 @@ export abstract class Modal extends Disposable implements IThemable {
 	/**
 	 * Hides the modal and removes key listeners
 	 */
-	protected hide(reason?: string, currentPageName?: string): void {
+	protected hide(reason?: HideReason, currentPageName?: string): void {
 		this._modalShowingContext.get()!.pop();
 		this._bodyContainer!.remove();
 		this.disposableStore.clear();

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -104,7 +104,7 @@ const defaultOptions: IModalOptions = {
 
 const tabbableElementsQuerySelector = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]';
 
-export type HideReason = 'close' | 'cancel' | 'done' | 'ok';
+export type HideReason = 'close' | 'cancel' | 'ok';
 
 export abstract class Modal extends Disposable implements IThemable {
 	protected _useDefaultMessageBoxLocation: boolean = true;

--- a/src/sql/workbench/browser/modal/optionsDialog.ts
+++ b/src/sql/workbench/browser/modal/optionsDialog.ts
@@ -6,7 +6,7 @@
 import 'vs/css!./media/optionsDialog';
 import * as DialogHelper from './dialogHelper';
 import { SelectBox } from 'sql/base/browser/ui/selectBox/selectBox';
-import { IModalOptions, Modal } from './modal';
+import { HideReason, IModalOptions, Modal } from './modal';
 import * as OptionsDialogHelper from './optionsDialogHelper';
 
 import * as azdata from 'azdata';
@@ -176,16 +176,16 @@ export class OptionsDialog extends Modal {
 		if (OptionsDialogHelper.validateInputs(this._optionElements)) {
 			OptionsDialogHelper.updateOptions(this._optionValues, this._optionElements);
 			this._onOk.fire();
-			this.close();
+			this.close('ok');
 		}
 	}
 
 	public cancel() {
-		this.close();
+		this.close('cancel');
 	}
 
-	public close() {
-		this.hide();
+	public close(hideReason: HideReason = 'close') {
+		this.hide(hideReason);
 		this._optionElements = {};
 		this._onCloseEvent.fire();
 	}

--- a/src/sql/workbench/contrib/backup/browser/backupDialog.ts
+++ b/src/sql/workbench/contrib/backup/browser/backupDialog.ts
@@ -82,7 +82,7 @@ export class BackupDialog extends Modal {
 	 * Clean up the module and DOM element and close the dialog
 	 */
 	public close() {
-		this.hide();
+		this.hide('close');
 	}
 
 	public dispose(): void {

--- a/src/sql/workbench/contrib/charts/browser/configureChartDialog.ts
+++ b/src/sql/workbench/contrib/charts/browser/configureChartDialog.ts
@@ -52,6 +52,6 @@ export class ConfigureChartDialog extends Modal {
 	}
 
 	public close() {
-		this.hide();
+		this.hide('close');
 	}
 }

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog.ts
@@ -184,7 +184,7 @@ export class ImageCalloutDialog extends CalloutDialog<IImageCalloutDialogOptions
 	}
 
 	public insert(): void {
-		this.hide();
+		this.hide('ok');
 		this._selectionComplete.resolve({
 			insertEscapedMarkdown: `![](${escapeUrl(this._imageUrlInputBox.value)})`,
 			imagePath: this._imageUrlInputBox.value,

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
@@ -144,7 +144,7 @@ export class LinkCalloutDialog extends CalloutDialog<ILinkCalloutDialogOptions> 
 	}
 
 	public insert(): void {
-		this.hide();
+		this.hide('ok');
 		let escapedLabel = escapeLabel(this._linkTextInputBox.value);
 		let escapedUrl = escapeUrl(this._linkUrlInputBox.value);
 

--- a/src/sql/workbench/contrib/webview/browser/webViewDialog.ts
+++ b/src/sql/workbench/contrib/webview/browser/webViewDialog.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Button } from 'sql/base/browser/ui/button/button';
-import { Modal } from 'sql/workbench/browser/modal/modal';
+import { HideReason, Modal } from 'sql/workbench/browser/modal/modal';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { Event, Emitter } from 'vs/base/common/event';
@@ -136,11 +136,11 @@ export class WebViewDialog extends Modal {
 
 	public ok(): void {
 		this._onOk.fire();
-		this.close();
+		this.close('ok');
 	}
 
-	public close() {
-		this.hide();
+	public close(hideReason: HideReason = 'close') {
+		this.hide(hideReason);
 		this._onClosed.fire();
 	}
 

--- a/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
@@ -22,7 +22,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import * as azdata from 'azdata';
 
 import { Button } from 'sql/base/browser/ui/button/button';
-import { Modal } from 'sql/workbench/browser/modal/modal';
+import { HideReason, Modal } from 'sql/workbench/browser/modal/modal';
 import { AccountViewModel } from 'sql/platform/accounts/common/accountViewModel';
 import { AddAccountAction } from 'sql/platform/accounts/common/accountActions';
 import { AccountListRenderer, AccountListDelegate } from 'sql/workbench/services/accountManagement/browser/accountListRenderer';
@@ -272,12 +272,12 @@ export class AccountDialog extends Modal {
 
 	/* Overwrite enter key behavior */
 	protected onAccept() {
-		this.close();
+		this.close('ok');
 	}
 
-	public close() {
+	public close(hideReason: HideReason = 'close') {
 		this._onCloseEmitter.fire();
-		this.hide();
+		this.hide(hideReason);
 	}
 
 	public open() {

--- a/src/sql/workbench/services/accountManagement/browser/autoOAuthDialog.ts
+++ b/src/sql/workbench/services/accountManagement/browser/autoOAuthDialog.ts
@@ -142,7 +142,7 @@ export class AutoOAuthDialog extends Modal {
 		this._copyAndOpenButton!.enabled = true;
 		this._onCloseEvent.fire();
 		this.spinner = false;
-		this.hide();
+		this.hide('close');
 	}
 
 	public open(title: string, message: string, userCode: string, uri: string) {

--- a/src/sql/workbench/services/connection/browser/connectionDialogService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogService.ts
@@ -201,7 +201,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	private handleOnCancel(params: INewConnectionParams): void {
 		if (this.ignoreNextConnect) {
 			this._connectionDialog.resetConnection();
-			this._connectionDialog.close();
+			this._connectionDialog.close('cancel');
 			this.ignoreNextConnect = false;
 			this._dialogDeferredPromise.resolve(undefined);
 			return;
@@ -229,7 +229,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	private async handleDefaultOnConnect(params: INewConnectionParams, connection: IConnectionProfile): Promise<void> {
 		if (this.ignoreNextConnect) {
 			this._connectionDialog.resetConnection();
-			this._connectionDialog.close();
+			this._connectionDialog.close('ok');
 			this.ignoreNextConnect = false;
 			this._connecting = false;
 			this._dialogDeferredPromise.resolve(connection);
@@ -253,7 +253,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			const connectionResult = await this._connectionManagementService.connectAndSaveProfile(connection, uri, options, params && params.input);
 			this._connecting = false;
 			if (connectionResult && connectionResult.connected) {
-				this._connectionDialog.close();
+				this._connectionDialog.close('ok');
 				if (this._dialogDeferredPromise) {
 					this._dialogDeferredPromise.resolve(connectionResult.connectionProfile);
 				}

--- a/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionDialogWidget.ts
@@ -6,7 +6,7 @@
 import 'vs/css!./media/connectionDialog';
 import { Button } from 'sql/base/browser/ui/button/button';
 import { SelectBox } from 'sql/base/browser/ui/selectBox/selectBox';
-import { Modal } from 'sql/workbench/browser/modal/modal';
+import { HideReason, Modal } from 'sql/workbench/browser/modal/modal';
 import { IConnectionManagementService, INewConnectionParams } from 'sql/platform/connection/common/connectionManagement';
 import * as DialogHelper from 'sql/workbench/browser/modal/dialogHelper';
 import { TreeCreationUtils } from 'sql/workbench/services/objectExplorer/browser/treeCreationUtils';
@@ -360,13 +360,13 @@ export class ConnectionDialogWidget extends Modal {
 		const wasConnecting = this._connecting;
 		this._onCancel.fire();
 		if (!this._databaseDropdownExpanded && !wasConnecting) {
-			this.close();
+			this.close('cancel');
 		}
 	}
 
-	public close() {
+	public close(hideReason: HideReason = 'close') {
 		this.resetConnection();
-		this.hide();
+		this.hide(hideReason);
 	}
 
 	private createRecentConnectionList(): void {

--- a/src/sql/workbench/services/dialog/browser/customDialogService.ts
+++ b/src/sql/workbench/services/dialog/browser/customDialogService.ts
@@ -44,7 +44,7 @@ export class CustomDialogService {
 	}
 
 	public closeWizard(wizard: Wizard): void {
-		this._wizardModals.get(wizard)?.cancel();
+		this._wizardModals.get(wizard)?.close();
 	}
 
 	public getWizardModal(wizard: Wizard): WizardModal | undefined {

--- a/src/sql/workbench/services/dialog/browser/dialogModal.ts
+++ b/src/sql/workbench/services/dialog/browser/dialogModal.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/dialogModal';
-import { Modal, IModalOptions } from 'sql/workbench/browser/modal/modal';
+import { Modal, IModalOptions, HideReason } from 'sql/workbench/browser/modal/modal';
 import { Dialog, DialogButton } from 'sql/workbench/services/dialog/common/dialogTypes';
 import { DialogPane } from 'sql/workbench/services/dialog/browser/dialogPane';
 
@@ -138,7 +138,7 @@ export class DialogModal extends Modal {
 			if (await this._dialog.validateClose()) {
 				this._onDone.fire();
 				this.dispose();
-				this.hide('close');
+				this.hide('done');
 			}
 			clearTimeout(buttonSpinnerHandler);
 			this._doneButton.element.classList.remove('validating');
@@ -146,10 +146,14 @@ export class DialogModal extends Modal {
 		}
 	}
 
-	public cancel(): void {
+	public close(): void {
+		this.cancel('close');
+	}
+
+	public cancel(hideReason: HideReason = 'cancel'): void {
 		this._onCancel.fire();
 		this.dispose();
-		this.hide('cancel');
+		this.hide(hideReason);
 	}
 
 	/**

--- a/src/sql/workbench/services/dialog/browser/dialogModal.ts
+++ b/src/sql/workbench/services/dialog/browser/dialogModal.ts
@@ -138,7 +138,7 @@ export class DialogModal extends Modal {
 			if (await this._dialog.validateClose()) {
 				this._onDone.fire();
 				this.dispose();
-				this.hide('done');
+				this.hide('ok');
 			}
 			clearTimeout(buttonSpinnerHandler);
 			this._doneButton.element.classList.remove('validating');

--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -274,7 +274,7 @@ export class WizardModal extends Modal {
 			}
 			this._onDone.fire();
 			this.dispose();
-			this.hide('done');
+			this.hide('ok');
 		}
 	}
 

--- a/src/sql/workbench/services/dialog/browser/wizardModal.ts
+++ b/src/sql/workbench/services/dialog/browser/wizardModal.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/dialogModal';
-import { Modal, IModalOptions } from 'sql/workbench/browser/modal/modal';
+import { Modal, IModalOptions, HideReason } from 'sql/workbench/browser/modal/modal';
 import { Wizard, DialogButton, WizardPage } from 'sql/workbench/services/dialog/common/dialogTypes';
 import { DialogPane } from 'sql/workbench/services/dialog/browser/dialogPane';
 import { bootstrapAngular } from 'sql/workbench/services/bootstrap/browser/bootstrapService';
@@ -278,11 +278,14 @@ export class WizardModal extends Modal {
 		}
 	}
 
-	public cancel(): void {
+	public close(): void {
+		this.cancel('close');
+	}
+	public cancel(hideReason: HideReason = 'cancel'): void {
 		const currentPage = this._wizard.pages[this._wizard.currentPage];
 		this._onCancel.fire();
 		this.dispose();
-		this.hide('cancel', currentPage.pageName ?? this._wizard.currentPage.toString());
+		this.hide(hideReason, currentPage.pageName ?? this._wizard.currentPage.toString());
 	}
 
 	private async validateNavigation(newPage: number): Promise<boolean> {

--- a/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
+++ b/src/sql/workbench/services/errorMessage/browser/errorMessageDialog.ts
@@ -5,7 +5,7 @@
 
 import 'vs/css!./media/errorMessageDialog';
 import { Button } from 'sql/base/browser/ui/button/button';
-import { Modal } from 'sql/workbench/browser/modal/modal';
+import { HideReason, Modal } from 'sql/workbench/browser/modal/modal';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 
 import Severity from 'vs/base/common/severity';
@@ -137,11 +137,11 @@ export class ErrorMessageDialog extends Modal {
 
 	public ok(): void {
 		this._onOk.fire();
-		this.close();
+		this.close('ok');
 	}
 
-	public close() {
-		this.hide();
+	public close(hideReason: HideReason = 'close') {
+		this.hide(hideReason);
 	}
 
 	public open(severity: Severity, headerTitle: string, message: string, messageDetails?: string, actions?: IAction[]) {

--- a/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
+++ b/src/sql/workbench/services/fileBrowser/browser/fileBrowserDialog.ts
@@ -8,7 +8,7 @@ import { Button } from 'sql/base/browser/ui/button/button';
 import { InputBox, OnLoseFocusParams } from 'sql/base/browser/ui/inputBox/inputBox';
 import { SelectBox } from 'sql/base/browser/ui/selectBox/selectBox';
 import * as DialogHelper from 'sql/workbench/browser/modal/dialogHelper';
-import { Modal } from 'sql/workbench/browser/modal/modal';
+import { HideReason, Modal } from 'sql/workbench/browser/modal/modal';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { FileNode } from 'sql/workbench/services/fileBrowser/common/fileNode';
 import { FileBrowserTreeView } from 'sql/workbench/services/fileBrowser/browser/fileBrowserTreeView';
@@ -185,7 +185,7 @@ export class FileBrowserDialog extends Modal {
 
 	private ok() {
 		this._onOk.fire(this._selectedFilePath);
-		this.close();
+		this.close('ok');
 	}
 
 	private handleOnValidate(succeeded: boolean, errorMessage: string) {
@@ -197,12 +197,12 @@ export class FileBrowserDialog extends Modal {
 		}
 	}
 
-	private close(): void {
+	private close(hideReason: HideReason = 'close'): void {
 		if (this._fileBrowserTreeView) {
 			this._fileBrowserTreeView.dispose();
 		}
 		this._onOk.dispose();
-		this.hide();
+		this.hide(hideReason);
 		this._viewModel.closeFileBrowser().catch(err => onUnexpectedError(err));
 	}
 

--- a/src/sql/workbench/services/insights/browser/insightsDialogView.ts
+++ b/src/sql/workbench/services/insights/browser/insightsDialogView.ts
@@ -414,7 +414,7 @@ export class InsightsDialogView extends Modal {
 
 
 	public close() {
-		this.hide();
+		this.hide('close');
 		dispose(this._taskButtonDisposables);
 		this._taskButtonDisposables = [];
 	}

--- a/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog.ts
+++ b/src/sql/workbench/services/resourceProvider/browser/firewallRuleDialog.ts
@@ -265,11 +265,11 @@ export class FirewallRuleDialog extends Modal {
 
 	public cancel() {
 		this._onCancel.fire();
-		this.close();
+		this.hide('cancel');
 	}
 
 	public close() {
-		this.hide();
+		this.hide('close');
 	}
 
 	public createFirewallRule() {

--- a/src/sql/workbench/services/restore/browser/restoreDialog.ts
+++ b/src/sql/workbench/services/restore/browser/restoreDialog.ts
@@ -29,7 +29,7 @@ import { CheckboxSelectColumn } from 'sql/base/browser/ui/table/plugins/checkbox
 import { Table } from 'sql/base/browser/ui/table/table';
 import { TableDataView } from 'sql/base/browser/ui/table/tableDataView';
 import * as DialogHelper from 'sql/workbench/browser/modal/dialogHelper';
-import { Modal } from 'sql/workbench/browser/modal/modal';
+import { HideReason, Modal } from 'sql/workbench/browser/modal/modal';
 import { attachTableStyler, attachInputBoxStyler, attachSelectBoxStyler, attachEditableDropdownStyler, attachCheckboxStyler } from 'sql/platform/theme/common/styler';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { RestoreViewModel, RestoreOptionParam, SouceDatabaseNamesParam } from 'sql/workbench/services/restore/browser/restoreViewModel';
@@ -688,12 +688,12 @@ export class RestoreDialog extends Modal {
 
 	public cancel() {
 		this._onCancel.fire();
-		this.close();
+		this.close('cancel');
 	}
 
-	public close() {
+	public close(hideReason: HideReason = 'close') {
 		this.resetDialog();
-		this.hide();
+		this.hide(hideReason);
 		this._onCloseEvent.fire();
 	}
 

--- a/src/sql/workbench/services/serverGroup/browser/serverGroupDialog.ts
+++ b/src/sql/workbench/services/serverGroup/browser/serverGroupDialog.ts
@@ -18,7 +18,7 @@ import { localize } from 'vs/nls';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 import { Button } from 'sql/base/browser/ui/button/button';
-import { Modal } from 'sql/workbench/browser/modal/modal';
+import { HideReason, Modal } from 'sql/workbench/browser/modal/modal';
 import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
 import { ServerGroupViewModel } from 'sql/workbench/services/serverGroup/common/serverGroupViewModel';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
@@ -360,11 +360,11 @@ export class ServerGroupDialog extends Modal {
 
 	public cancel() {
 		this._onCancel.fire();
-		this.close();
+		this.close('cancel');
 	}
 
-	public close() {
-		this.hide();
+	public close(hideReason: HideReason = 'close') {
+		this.hide(hideReason);
 		this.withRenderedDialog.groupNameInputBox.hideMessage();
 		this._onCloseEvent.fire();
 	}


### PR DESCRIPTION
There were a lot of places where we either weren't capturing the hide reason or had an incorrect reason. This mostly cleans them up.

The whole cancel/close/ok thing is a huge mess across all these dialogs - I didn't want to start trying to make sense of that all and so just kept my changes extremely minimal (hence why you see weird stuff like calling close with 'cancel')