### PR TITLE
Fix undefined error in telemetry service

### DIFF
--- a/src/sql/platform/telemetry/common/adsTelemetryService.ts
+++ b/src/sql/platform/telemetry/common/adsTelemetryService.ts
@@ -16,8 +16,8 @@ class TelemetryEventImpl implements ITelemetryEvent {
 		private _eventName: string,
 		private _properties?: ITelemetryEventProperties,
 		private _measurements?: ITelemetryEventMeasures) {
-		_properties = _properties || {};
-		_measurements = _measurements || {};
+		this._properties = _properties || {};
+		this._measurements = _measurements || {};
 	}
 
 	public send(): void {


### PR DESCRIPTION
Not using this means it just was setting the local var - not the property on the class (they're actually separate vars) so it would be undefined if either of those weren't passed in the constructor. 