### PR TITLE
Notebooks: Fix callout dialog being cut off at the bottom of the document

### DIFF
--- a/src/sql/workbench/browser/modal/calloutDialog.ts
+++ b/src/sql/workbench/browser/modal/calloutDialog.ts
@@ -5,7 +5,7 @@
 
 import 'vs/css!./media/calloutDialog';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
-import { IDialogProperties, Modal, DialogWidth } from 'sql/workbench/browser/modal/modal';
+import { IDialogProperties, Modal, DialogWidth, DialogPosition } from 'sql/workbench/browser/modal/modal';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
@@ -20,6 +20,7 @@ export abstract class CalloutDialog<T> extends Modal {
 		title: string,
 		width: DialogWidth,
 		dialogProperties: IDialogProperties,
+		dialogPosition: DialogPosition,
 		@IThemeService themeService: IThemeService,
 		@ILayoutService layoutService: ILayoutService,
 		@IAdsTelemetryService telemetryService: IAdsTelemetryService,
@@ -40,7 +41,7 @@ export abstract class CalloutDialog<T> extends Modal {
 			contextKeyService,
 			{
 				dialogStyle: 'callout',
-				dialogPosition: 'below',
+				dialogPosition: dialogPosition,
 				dialogProperties: dialogProperties,
 				width: width
 			});

--- a/src/sql/workbench/browser/modal/media/calloutDialog.css
+++ b/src/sql/workbench/browser/modal/media/calloutDialog.css
@@ -48,6 +48,12 @@
 	top: -0.2em;
 	transform: rotate(135deg);
 }
+.callout-arrow.from-above:before {
+	border-width: 0.5em;
+	left: 2em;
+	bottom: -0.2em;
+	transform: rotate(-45deg);
+}
 .callout-arrow.from-left:before {
 	background-color: var(--bodybackground);
 	height: 26px;

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -440,9 +440,7 @@ export abstract class Modal extends Disposable implements IThemable {
 					this._modalDialog.style.left = `${this._modalOptions.positionX}px`;
 					this._modalDialog.style.top = `${this._modalOptions.positionY - 235}px`;
 				}
-			}
-
-			if (this._modalOptions.dialogPosition === 'below') {
+			} else if (this._modalOptions.dialogPosition === 'below') {
 				if (this._modalOptions.dialogProperties) {
 					this._modalDialog.style.left = `${this._modalOptions.dialogProperties.xPos - this._modalOptions.dialogProperties.width}px`;
 					this._modalDialog.style.top = `${this._modalOptions.dialogProperties.yPos + (this._modalOptions.dialogProperties.height)}px`;
@@ -450,9 +448,7 @@ export abstract class Modal extends Disposable implements IThemable {
 					this._modalDialog.style.left = `${this._modalOptions.positionX}px`;
 					this._modalDialog.style.top = `${this._modalOptions.positionY}px`;
 				}
-			}
-
-			if (this._modalOptions.dialogPosition === 'left') {
+			} else if (this._modalOptions.dialogPosition === 'left') {
 				if (this._modalOptions.dialogProperties) {
 					this._modalDialog.style.left = `${this._modalOptions.positionX - (dialogWidth + this._modalOptions.dialogProperties.width)}px`;
 					this._modalDialog.style.top = `${this._modalOptions.positionY - this._modalOptions.dialogProperties.height * 2}px`;

--- a/src/sql/workbench/browser/modal/modal.ts
+++ b/src/sql/workbench/browser/modal/modal.ts
@@ -60,7 +60,7 @@ export interface IModalDialogStyles {
 
 export type DialogWidth = 'narrow' | 'medium' | 'wide' | number;
 export type DialogStyle = 'normal' | 'flyout' | 'callout';
-export type DialogPosition = 'left' | 'below';
+export type DialogPosition = 'left' | 'below' | 'above';
 
 export interface IDialogProperties {
 	xPos: number,
@@ -430,6 +430,16 @@ export abstract class Modal extends Disposable implements IThemable {
 			let dialogWidth;
 			if (typeof this._modalOptions.width === 'number') {
 				dialogWidth = this._modalOptions.width;
+			}
+
+			if (this._modalOptions.dialogPosition === 'above') {
+				if (this._modalOptions.dialogProperties) {
+					this._modalDialog.style.left = `${this._modalOptions.dialogProperties.xPos - this._modalOptions.dialogProperties.width}px`;
+					this._modalDialog.style.top = `${this._modalOptions.dialogProperties.yPos - 235}px`;
+				} else {
+					this._modalDialog.style.left = `${this._modalOptions.positionX}px`;
+					this._modalDialog.style.top = `${this._modalOptions.positionY - 235}px`;
+				}
 			}
 
 			if (this._modalOptions.dialogPosition === 'below') {

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/imageCalloutDialog.ts
@@ -24,7 +24,7 @@ import { Deferred } from 'sql/base/common/promise';
 import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
 import { Checkbox } from 'sql/base/browser/ui/checkbox/checkbox';
 import { RadioButton } from 'sql/base/browser/ui/radioButton/radioButton';
-import { DialogWidth } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { DialogPosition, DialogWidth } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { attachModalDialogStyler } from 'sql/workbench/common/styler';
 import { escapeUrl } from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/utils';
 
@@ -51,6 +51,7 @@ export class ImageCalloutDialog extends CalloutDialog<IImageCalloutDialogOptions
 		title: string,
 		width: DialogWidth,
 		dialogProperties: IDialogProperties,
+		dialogPosition: DialogPosition,
 		@IPathService private readonly _pathService: IPathService,
 		@IFileDialogService private readonly _fileDialogService: IFileDialogService,
 		@IContextViewService private readonly _contextViewService: IContextViewService,
@@ -66,6 +67,7 @@ export class ImageCalloutDialog extends CalloutDialog<IImageCalloutDialogOptions
 			title,
 			width,
 			dialogProperties,
+			dialogPosition,
 			themeService,
 			layoutService,
 			telemetryService,

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
@@ -9,7 +9,7 @@ import * as styler from 'vs/platform/theme/common/styler';
 import * as constants from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/constants';
 import { CalloutDialog } from 'sql/workbench/browser/modal/calloutDialog';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
-import { IDialogProperties } from 'sql/workbench/browser/modal/modal';
+import { DialogPosition, IDialogProperties } from 'sql/workbench/browser/modal/modal';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
@@ -43,6 +43,7 @@ export class LinkCalloutDialog extends CalloutDialog<ILinkCalloutDialogOptions> 
 	constructor(
 		title: string,
 		dialogProperties: IDialogProperties,
+		dialogPosition: DialogPosition,
 		private readonly _defaultLabel: string = '',
 		@IContextViewService private readonly _contextViewService: IContextViewService,
 		@IThemeService themeService: IThemeService,
@@ -57,6 +58,7 @@ export class LinkCalloutDialog extends CalloutDialog<ILinkCalloutDialogOptions> 
 			title,
 			DEFAULT_DIALOG_WIDTH,
 			dialogProperties,
+			dialogPosition,
 			themeService,
 			layoutService,
 			telemetryService,

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -278,11 +278,12 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 		const triggerHeight = triggerElement.offsetHeight;
 		const triggerWidth = triggerElement.offsetWidth;
 		const dialogProperties = { xPos: triggerPosX, yPos: triggerPosY, width: triggerWidth, height: triggerHeight };
+		const dialogPosition = window.innerHeight - triggerPosY < 250 ? 'above' : 'below';
 		let calloutOptions;
 
 		if (type === MarkdownButtonType.LINK_PREVIEW) {
 			const defaultLabel = this.getCurrentSelectionText();
-			this._linkCallout = this._instantiationService.createInstance(LinkCalloutDialog, this.insertLinkHeading, dialogProperties, defaultLabel);
+			this._linkCallout = this._instantiationService.createInstance(LinkCalloutDialog, this.insertLinkHeading, dialogProperties, dialogPosition, defaultLabel);
 			this._linkCallout.render();
 			calloutOptions = await this._linkCallout.open();
 		}

--- a/src/sql/workbench/contrib/notebook/test/calloutDialog/linkCalloutDialog.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/calloutDialog/linkCalloutDialog.test.ts
@@ -26,7 +26,7 @@ suite('Link Callout Dialog', function (): void {
 	});
 
 	test('Should return empty markdown on cancel', async function (): Promise<void> {
-		let linkCalloutDialog = new LinkCalloutDialog('Title', undefined, 'defaultLabel',
+		let linkCalloutDialog = new LinkCalloutDialog('Title', undefined, 'below', 'defaultLabel',
 			undefined, themeService, layoutService, telemetryService, contextKeyService, undefined, undefined, undefined);
 		linkCalloutDialog.render();
 
@@ -47,7 +47,7 @@ suite('Link Callout Dialog', function (): void {
 	test('Should return expected values on insert', async function (): Promise<void> {
 		const defaultLabel = 'defaultLabel';
 		const sampleUrl = 'https://www.aka.ms/azuredatastudio';
-		let linkCalloutDialog = new LinkCalloutDialog('Title', undefined, defaultLabel,
+		let linkCalloutDialog = new LinkCalloutDialog('Title', undefined, 'below', defaultLabel,
 			undefined, themeService, layoutService, telemetryService, contextKeyService, undefined, undefined, undefined);
 		linkCalloutDialog.render();
 
@@ -70,7 +70,7 @@ suite('Link Callout Dialog', function (): void {
 	test('Should return expected values on insert when escape necessary', async function (): Promise<void> {
 		const defaultLabel = 'default[]Label';
 		const sampleUrl = 'https://www.aka.ms/azuredatastudio()';
-		let linkCalloutDialog = new LinkCalloutDialog('Title', undefined, defaultLabel,
+		let linkCalloutDialog = new LinkCalloutDialog('Title', undefined, 'below', defaultLabel,
 			undefined, themeService, layoutService, telemetryService, contextKeyService, undefined, undefined, undefined);
 		linkCalloutDialog.render();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes https://github.com/microsoft/azuredatastudio/issues/14558

Show link callout dialog above the toolbar when there is not enough space below the toolbar.

![Screen Shot 2021-03-05 at 12 10 56 PM](https://user-images.githubusercontent.com/23462877/110168334-e46a8d80-7dab-11eb-8dd7-a812a76179ba.png)
![Screen Shot 2021-03-05 at 12 11 07 PM](https://user-images.githubusercontent.com/23462877/110168341-e6345100-7dab-11eb-8700-8260223196b5.png)

