### PR TITLE
Still load other projects even if one doesn't exist

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -20,6 +20,7 @@ export const EnterWorkspaceConfirmation = localize('dataworkspace.enterWorkspace
 export const WorkspaceContainsNotAddedProjects = localize('dataworkspace.workspaceContainsNotAddedProjects', "The current workspace contains one or more projects that have not been added to the workspace. Use the 'Open existing' dialog to add projects to the projects pane.");
 export const LaunchOpenExisitingDialog = localize('dataworkspace.launchOpenExistingDialog', "Launch Open existing dialog");
 export const DoNotShowAgain = localize('dataworkspace.doNotShowAgain', "Do not show again");
+export const ProjectsFailedToLoad = (numberOfProjects: number) => { return localize('dataworkspace.projectsFailedToLoad', "{0} project(s) failed to load. Please open console for more information", numberOfProjects); };
 
 // config settings
 export const projectsConfigurationKey = 'projects';

--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -20,7 +20,7 @@ export const EnterWorkspaceConfirmation = localize('dataworkspace.enterWorkspace
 export const WorkspaceContainsNotAddedProjects = localize('dataworkspace.workspaceContainsNotAddedProjects', "The current workspace contains one or more projects that have not been added to the workspace. Use the 'Open existing' dialog to add projects to the projects pane.");
 export const LaunchOpenExisitingDialog = localize('dataworkspace.launchOpenExistingDialog', "Launch Open existing dialog");
 export const DoNotShowAgain = localize('dataworkspace.doNotShowAgain', "Do not show again");
-export const ProjectsFailedToLoad = (numberOfProjects: number) => { return localize('dataworkspace.projectsFailedToLoad', "{0} project(s) failed to load. Please open console for more information", numberOfProjects); };
+export const ProjectsFailedToLoad = localize('dataworkspace.projectsFailedToLoad', "Some projects failed to load. Please open console for more information");
 
 // config settings
 export const projectsConfigurationKey = 'projects';

--- a/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
+++ b/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
@@ -76,7 +76,7 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
 			}
 
 			if (errorCount > 0) {
-				vscode.window.showErrorMessage(ProjectsFailedToLoad(errorCount));
+				vscode.window.showErrorMessage(ProjectsFailedToLoad);
 			}
 
 			TelemetryReporter.sendMetricsEvent(typeMetric, 'OpenWorkspaceProjectTypes');

--- a/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
+++ b/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
@@ -45,6 +45,7 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
 
 			const typeMetric: Record<string, number> = {};
 
+			let errors: string[] = [];
 			for (const project of projects) {
 				try {
 					const projectProvider = await this._workspaceService.getProjectProvider(project);
@@ -69,8 +70,13 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
 						});
 					});
 				} catch (e) {
-					vscode.window.showErrorMessage(e.message);
+					errors.push(e.message);
 				}
+			}
+
+			if (errors.length > 0) {
+				const errorMessage: string = errors.join('\n');
+				vscode.window.showErrorMessage(errorMessage);
 			}
 
 			TelemetryReporter.sendMetricsEvent(typeMetric, 'OpenWorkspaceProjectTypes');

--- a/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
+++ b/extensions/data-workspace/src/common/workspaceTreeDataProvider.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { IWorkspaceService } from './interfaces';
-import { UnknownProjectsError } from './constants';
+import { ProjectsFailedToLoad, UnknownProjectsError } from './constants';
 import { WorkspaceTreeItem } from 'dataworkspace';
 import { TelemetryReporter } from './telemetry';
 
@@ -45,7 +45,7 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
 
 			const typeMetric: Record<string, number> = {};
 
-			let errors: string[] = [];
+			let errorCount = 0;
 			for (const project of projects) {
 				try {
 					const projectProvider = await this._workspaceService.getProjectProvider(project);
@@ -70,13 +70,13 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
 						});
 					});
 				} catch (e) {
-					errors.push(e.message);
+					errorCount++;
+					console.error(e.message);
 				}
 			}
 
-			if (errors.length > 0) {
-				const errorMessage: string = errors.join('\n');
-				vscode.window.showErrorMessage(errorMessage);
+			if (errorCount > 0) {
+				vscode.window.showErrorMessage(ProjectsFailedToLoad(errorCount));
 			}
 
 			TelemetryReporter.sendMetricsEvent(typeMetric, 'OpenWorkspaceProjectTypes');


### PR DESCRIPTION
This PR fixes #14565. An error message will show that the project can't be found, but other projects that can be found will still be loaded.

![image](https://user-images.githubusercontent.com/31145923/110190088-74bdc800-7dd6-11eb-8905-4af7de3d8f91.png)

