### PR TITLE
Fix "Query Canceled by User" when querying encrypted fields Bug

### DIFF
--- a/extensions/mssql/src/features.ts
+++ b/extensions/mssql/src/features.ts
@@ -76,7 +76,7 @@ export class AccountFeature implements StaticFeature {
 			window.showErrorMessage(unauthorizedMessage);
 			return undefined;
 		}
-		const securityToken = await azdata.accounts.getAccountSecurityToken(account, tenant, azdata.AzureResource.AzureKeyVault);
+		const securityToken = await azdata.accounts.getAccountSecurityToken(account, tenant.id, azdata.AzureResource.AzureKeyVault);
 
 		if (!securityToken?.token) {
 			window.showErrorMessage(unauthorizedMessage);


### PR DESCRIPTION
Some time back when the `azdata.accounts.getAccountSecurityToken()` method was introduced, [some changes](https://github.com/microsoft/azuredatastudio/commit/587abd43c2d92d83af1214399172fe8734597915#diff-e519fbe7133b0f3ebdab4872678a1ad87ce1a8736ee4e2988ae0637a2a318c2b) were made to make use of this new method. Within one of the AE workflows, the `tenant` object was passed to this method instead of the `tenant.id` string value, which caused an exception and led to this bug.

![image](https://user-images.githubusercontent.com/4079568/110190861-5063ea80-7dda-11eb-9555-4dce51a79eb1.png)

This PR aims to correct this mistake, fix the bug and Closes #12611.