### PR TITLE
Expose AzureAccount typings to other extensions

### DIFF
--- a/extensions/azurecore/src/account-provider/auths/azureAuth.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuth.ts
@@ -12,10 +12,10 @@ import {
 	AzureAccount,
 	AzureAccountProviderMetadata,
 	AzureAuthType,
-	Deferred,
 	Resource,
 	Tenant
-} from '../interfaces';
+} from 'azurecore';
+import { Deferred } from '../interfaces';
 import * as url from 'url';
 
 import { SimpleTokenCache } from '../simpleTokenCache';
@@ -161,7 +161,7 @@ export abstract class AzureAuth implements vscode.Disposable {
 		const tenant = account.properties.tenants.find(t => t.id === tenantId);
 
 		if (!tenant) {
-			throw new AzureAuthError(localize('azure.tenantNotFound', "Specifed tenant with ID '{0}' not found.", tenantId), `Tenant ${tenantId} not found.`, undefined);
+			throw new AzureAuthError(localize('azure.tenantNotFound', "Specified tenant with ID '{0}' not found.", tenantId), `Tenant ${tenantId} not found.`, undefined);
 		}
 
 		const cachedTokens = await this.getSavedToken(tenant, resource, account.key);

--- a/extensions/azurecore/src/account-provider/auths/azureAuthCodeGrant.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureAuthCodeGrant.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AuthorizationCodePostData, AzureAuth, OAuthTokenResponse } from './azureAuth';
-import { AzureAccountProviderMetadata, AzureAuthType, Deferred, Resource, Tenant } from '../interfaces';
+import { AzureAccountProviderMetadata, AzureAuthType, Resource, Tenant } from 'azurecore';
+import { Deferred } from '../interfaces';
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
 import { SimpleTokenCache } from '../simpleTokenCache';

--- a/extensions/azurecore/src/account-provider/auths/azureDeviceCode.ts
+++ b/extensions/azurecore/src/account-provider/auths/azureDeviceCode.ts
@@ -18,12 +18,9 @@ import {
 	AzureAccountProviderMetadata,
 	AzureAuthType,
 	Tenant,
-	Resource,
-	Deferred,
-	// Tenant,
-	// Subscription
-} from '../interfaces';
-
+	Resource
+} from 'azurecore';
+import { Deferred } from '../interfaces';
 import { SimpleTokenCache } from '../simpleTokenCache';
 import { Logger } from '../../utils/Logger';
 const localize = nls.loadMessageBundle();

--- a/extensions/azurecore/src/account-provider/azureAccountProvider.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProvider.ts
@@ -10,9 +10,9 @@ import * as nls from 'vscode-nls';
 import {
 	AzureAccountProviderMetadata,
 	AzureAuthType,
-	Deferred,
 	AzureAccount
-} from './interfaces';
+} from 'azurecore';
+import { Deferred } from './interfaces';
 
 import { SimpleTokenCache } from './simpleTokenCache';
 import { Logger } from '../utils/Logger';

--- a/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
+++ b/extensions/azurecore/src/account-provider/azureAccountProviderService.ts
@@ -10,7 +10,8 @@ import * as vscode from 'vscode';
 import { SimpleTokenCache } from './simpleTokenCache';
 import providerSettings from './providerSettings';
 import { AzureAccountProvider as AzureAccountProvider } from './azureAccountProvider';
-import { AzureAccountProviderMetadata, ProviderSettings } from './interfaces';
+import { AzureAccountProviderMetadata } from 'azurecore';
+import { ProviderSettings } from './interfaces';
 import * as loc from '../localizedConstants';
 
 let localize = nls.loadMessageBundle();

--- a/extensions/azurecore/src/account-provider/interfaces.ts
+++ b/extensions/azurecore/src/account-provider/interfaces.ts
@@ -3,129 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as azdata from 'azdata';
-
-/**
- * Represents a tenant (an Azure Active Directory instance) to which a user has access
- */
-export interface Tenant {
-	/**
-	 * Globally unique identifier of the tenant
-	 */
-	id: string;
-
-	/**
-	 * Display name of the tenant
-	 */
-	displayName: string;
-
-	/**
-	 * Identifier of the user in the tenant
-	 */
-	userId?: string;
-
-	/**
-	 * The category the user has set their tenant to (e.g. Home Tenant)
-	 */
-	tenantCategory?: string;
-}
-
-/**
- * Represents a resource exposed by an Azure Active Directory
- */
-export interface Resource {
-	/**
-	 * Identifier of the resource
-	 */
-	id: string;
-
-	/**
-	 * Endpoint url used to access the resource
-	 */
-	endpoint: string;
-
-	/**
-	 * Resource ID for azdata
-	 */
-	azureResourceId?: azdata.AzureResource
-}
-
-/**
- * Represents settings for an AAD account provider
- */
-interface Settings {
-	/**
-	 * Host of the authority
-	 */
-	host?: string;
-
-	/**
-	 * Identifier of the client application
-	 */
-	clientId?: string;
-
-	/**
-	 * Information that describes the Microsoft resource management resource
-	 */
-	microsoftResource?: Resource
-
-	/**
-	 * Information that describes the AAD graph resource
-	 */
-	graphResource?: Resource;
-
-	/**
-	 * Information that describes the MS graph resource
-	 */
-	msGraphResource?: Resource;
-
-	/**
-	 * Information that describes the Azure resource management resource
-	 */
-	armResource?: Resource;
-
-	/**
-	 * Information that describes the SQL Azure resource
-	 */
-	sqlResource?: Resource;
-
-	/**
-	 * Information that describes the OSS RDBMS resource
-	 */
-	ossRdbmsResource?: Resource;
-
-	/**
-	 * Information that describes the Azure Key Vault resource
-	 */
-	azureKeyVaultResource?: Resource;
-
-	/**
-	 * Information that describes the Azure Dev Ops resource
-	 */
-	azureDevOpsResource?: Resource;
-
-	/**
-	 * A list of tenant IDs to authenticate against. If defined, then these IDs will be used
-	 * instead of querying the tenants endpoint of the armResource
-	 */
-	adTenants?: string[];
-
-	// AuthorizationCodeGrantFlowSettings //////////////////////////////////
-
-	/**
-	 * An optional site ID that brands the interactive aspect of sign in
-	 */
-	siteId?: string;
-
-	/**
-	 * Redirect URI that is used to signify the end of the interactive aspect of sign it
-	 */
-	redirectUri?: string;
-
-	scopes?: string[]
-
-	portalEndpoint?: string
-}
+import * as azurecore from 'azurecore';
 
 /**
  * Mapping of configuration key with the metadata to instantiate the account provider
@@ -139,60 +17,13 @@ export interface ProviderSettings {
 	/**
 	 * Metadata for the provider
 	 */
-	metadata: AzureAccountProviderMetadata;
-}
-
-/**
- * Extension of account provider metadata to override settings type for Azure account providers
- */
-export interface AzureAccountProviderMetadata extends azdata.AccountProviderMetadata {
-	/**
-	 * Azure specific account provider settings.
-	 */
-	settings: Settings;
-}
-
-export enum AzureAuthType {
-	AuthCodeGrant = 0,
-	DeviceCode = 1
-}
-
-/**
- * Properties specific to an Azure account
- */
-interface AzureAccountProperties {
-	/**
-	 * Auth type of azure used to authenticate this account.
-	 */
-	azureAuthType?: AzureAuthType
-
-	providerSettings: AzureAccountProviderMetadata;
-	/**
-	 * Whether or not the account is a Microsoft account
-	 */
-	isMsAccount: boolean;
-
-	/**
-	 * A list of tenants (aka directories) that the account belongs to
-	 */
-	tenants: Tenant[];
-
+	metadata: azurecore.AzureAccountProviderMetadata;
 }
 
 export interface Subscription {
 	id: string,
 	tenantId: string,
 	displayName: string
-}
-
-/**
- * Override of the Account type to enforce properties that are AzureAccountProperties
- */
-export interface AzureAccount extends azdata.Account {
-	/**
-	 * AzureAccountProperties specifically used for Azure accounts
-	 */
-	properties: AzureAccountProperties;
 }
 
 /**

--- a/extensions/azurecore/src/azureResource/commands.ts
+++ b/extensions/azurecore/src/azureResource/commands.ts
@@ -17,7 +17,7 @@ import { AzureResourceTreeProvider } from './tree/treeProvider';
 import { AzureResourceAccountTreeNode } from './tree/accountTreeNode';
 import { IAzureResourceSubscriptionService, IAzureResourceSubscriptionFilterService, IAzureTerminalService } from '../azureResource/interfaces';
 import { AzureResourceServiceNames } from './constants';
-import { AzureAccount, Tenant } from '../account-provider/interfaces';
+import { AzureAccount, Tenant } from 'azurecore';
 import { FlatAccountTreeNode } from './tree/flatAccountTreeNode';
 import { ConnectionDialogTreeProvider } from './tree/connectionDialogTreeProvider';
 

--- a/extensions/azurecore/src/azureResource/interfaces.ts
+++ b/extensions/azurecore/src/azureResource/interfaces.ts
@@ -8,7 +8,7 @@ import * as msRest from '@azure/ms-rest-js';
 import { Account } from 'azdata';
 
 import { azureResource } from 'azureResource';
-import { AzureAccount, Tenant } from '../account-provider/interfaces';
+import { AzureAccount, Tenant } from 'azurecore';
 
 export interface IAzureResourceSubscriptionService {
 	getSubscriptions(account: Account, credential: msRest.ServiceClientCredentials, tenantId: string): Promise<azureResource.AzureResourceSubscription[]>;

--- a/extensions/azurecore/src/azureResource/services/terminalService.ts
+++ b/extensions/azurecore/src/azureResource/services/terminalService.ts
@@ -9,7 +9,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import * as WS from 'ws';
 
 import { IAzureTerminalService } from '../interfaces';
-import { AzureAccount, Tenant } from '../../account-provider/interfaces';
+import { AzureAccount, Tenant } from 'azurecore';
 
 const localize = nls.loadMessageBundle();
 

--- a/extensions/azurecore/src/azureResource/tree/accountTreeNode.ts
+++ b/extensions/azurecore/src/azureResource/tree/accountTreeNode.ts
@@ -21,7 +21,7 @@ import { AzureResourceMessageTreeNode } from '../messageTreeNode';
 import { AzureResourceErrorMessageUtil } from '../utils';
 import { IAzureResourceTreeChangeHandler } from './treeChangeHandler';
 import { IAzureResourceSubscriptionService, IAzureResourceSubscriptionFilterService } from '../../azureResource/interfaces';
-import { AzureAccount } from '../../account-provider/interfaces';
+import { AzureAccount } from 'azurecore';
 
 export class AzureResourceAccountTreeNode extends AzureResourceContainerTreeNodeBase {
 	public constructor(

--- a/extensions/azurecore/src/azureResource/tree/flatAccountTreeNode.ts
+++ b/extensions/azurecore/src/azureResource/tree/flatAccountTreeNode.ts
@@ -19,7 +19,7 @@ import { AzureResourceItemType, AzureResourceServiceNames } from '../constants';
 import { AzureResourceMessageTreeNode } from '../messageTreeNode';
 import { IAzureResourceTreeChangeHandler } from './treeChangeHandler';
 import { IAzureResourceSubscriptionService, IAzureResourceSubscriptionFilterService } from '../../azureResource/interfaces';
-import { AzureAccount } from '../../account-provider/interfaces';
+import { AzureAccount } from 'azurecore';
 import { AzureResourceService } from '../resourceService';
 import { AzureResourceResourceTreeNode } from '../resourceTreeNode';
 import { AzureResourceErrorMessageUtil } from '../utils';

--- a/extensions/azurecore/src/azurecore.d.ts
+++ b/extensions/azurecore/src/azurecore.d.ts
@@ -18,6 +18,175 @@ declare module 'azurecore' {
 	}
 
 	/**
+	 * Override of the Account type to enforce properties that are AzureAccountProperties
+	 */
+	export interface AzureAccount extends azdata.Account {
+		/**
+		 * AzureAccountProperties specifically used for Azure accounts
+		 */
+		properties: AzureAccountProperties;
+	}
+
+	/**
+	 * Properties specific to an Azure account
+	 */
+	export interface AzureAccountProperties {
+		/**
+		 * Auth type of azure used to authenticate this account.
+		 */
+		azureAuthType?: AzureAuthType
+
+		providerSettings: AzureAccountProviderMetadata;
+		/**
+		 * Whether or not the account is a Microsoft account
+		 */
+		isMsAccount: boolean;
+
+		/**
+		 * A list of tenants (aka directories) that the account belongs to
+		 */
+		tenants: Tenant[];
+
+	}
+
+	export const enum AzureAuthType {
+		AuthCodeGrant = 0,
+		DeviceCode = 1
+	}
+
+	/**
+	 * Extension of account provider metadata to override settings type for Azure account providers
+	 */
+	export interface AzureAccountProviderMetadata extends azdata.AccountProviderMetadata {
+		/**
+		 * Azure specific account provider settings.
+		 */
+		settings: Settings;
+	}
+
+	/**
+	 * Represents settings for an AAD account provider
+	 */
+	interface Settings {
+		/**
+		 * Host of the authority
+		 */
+		host?: string;
+
+		/**
+		 * Identifier of the client application
+		 */
+		clientId?: string;
+
+		/**
+		 * Information that describes the Microsoft resource management resource
+		 */
+		microsoftResource?: Resource
+
+		/**
+		 * Information that describes the AAD graph resource
+		 */
+		graphResource?: Resource;
+
+		/**
+		 * Information that describes the MS graph resource
+		 */
+		msGraphResource?: Resource;
+
+		/**
+		 * Information that describes the Azure resource management resource
+		 */
+		armResource?: Resource;
+
+		/**
+		 * Information that describes the SQL Azure resource
+		 */
+		sqlResource?: Resource;
+
+		/**
+		 * Information that describes the OSS RDBMS resource
+		 */
+		ossRdbmsResource?: Resource;
+
+		/**
+		 * Information that describes the Azure Key Vault resource
+		 */
+		azureKeyVaultResource?: Resource;
+
+		/**
+		 * Information that describes the Azure Dev Ops resource
+		 */
+		azureDevOpsResource?: Resource;
+
+		/**
+		 * A list of tenant IDs to authenticate against. If defined, then these IDs will be used
+		 * instead of querying the tenants endpoint of the armResource
+		 */
+		adTenants?: string[];
+
+		// AuthorizationCodeGrantFlowSettings //////////////////////////////////
+
+		/**
+		 * An optional site ID that brands the interactive aspect of sign in
+		 */
+		siteId?: string;
+
+		/**
+		 * Redirect URI that is used to signify the end of the interactive aspect of sign it
+		 */
+		redirectUri?: string;
+
+		scopes?: string[]
+
+		portalEndpoint?: string
+	}
+
+	/**
+	 * Represents a resource exposed by an Azure Active Directory
+	 */
+	export interface Resource {
+		/**
+		 * Identifier of the resource
+		 */
+		id: string;
+
+		/**
+		 * Endpoint url used to access the resource
+		 */
+		endpoint: string;
+
+		/**
+		 * Resource ID for azdata
+		 */
+		azureResourceId?: azdata.AzureResource
+	}
+
+	/**
+	 * Represents a tenant (an Azure Active Directory instance) to which a user has access
+	 */
+	export interface Tenant {
+		/**
+		 * Globally unique identifier of the tenant
+		 */
+		id: string;
+
+		/**
+		 * Display name of the tenant
+		 */
+		displayName: string;
+
+		/**
+		 * Identifier of the user in the tenant
+		 */
+		userId?: string;
+
+		/**
+		 * The category the user has set their tenant to (e.g. Home Tenant)
+		 */
+		tenantCategory?: string;
+	}
+
+	/**
 	 * Enumeration of the Azure datacenter regions. See https://docs.microsoft.com/dotnet/api/microsoft.azure.management.resourcemanager.fluent.core.region
 	 */
 	export const enum AzureRegion {

--- a/extensions/azurecore/src/test/account-provider/auths/azureAuth.test.ts
+++ b/extensions/azurecore/src/test/account-provider/auths/azureAuth.test.ts
@@ -5,14 +5,10 @@
 
 import * as should from 'should';
 import * as TypeMoq from 'typemoq';
-// import * as azdata from 'azdata';
-// import * as vscode from 'vscode';
-// import * as sinon from 'sinon';
 import 'mocha';
 import { AzureAuthCodeGrant } from '../../../account-provider/auths/azureAuthCodeGrant';
-// import { AzureDeviceCode } from '../../../account-provider/auths/azureDeviceCode';
 import { Token, TokenClaims, AccessToken, RefreshToken, OAuthTokenResponse, TokenPostData } from '../../../account-provider/auths/azureAuth';
-import { Tenant, AzureAccount } from '../../../account-provider/interfaces';
+import { Tenant, AzureAccount } from 'azurecore'
 import providerSettings from '../../../account-provider/providerSettings';
 import { AzureResource } from 'azdata';
 import { AxiosResponse } from 'axios';

--- a/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/database/databaseTreeDataProvider.test.ts
@@ -14,7 +14,7 @@ import { azureResource } from 'azureResource';
 import { AzureResourceDatabaseTreeDataProvider } from '../../../../azureResource/providers/database/databaseTreeDataProvider';
 import { AzureResourceItemType } from '../../../../azureResource/constants';
 import { IAzureResourceService } from '../../../../azureResource/interfaces';
-import { AzureAccount } from '../../../../account-provider/interfaces';
+import { AzureAccount } from 'azurecore';
 import settings from '../../../../account-provider/providerSettings';
 
 // Mock services

--- a/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
+++ b/extensions/azurecore/src/test/azureResource/providers/databaseServer/databaseServerTreeDataProvider.test.ts
@@ -19,7 +19,7 @@ import { IAzureResourceService } from '../../../../azureResource/interfaces';
 let mockDatabaseServerService: TypeMoq.IMock<IAzureResourceService<azureResource.AzureResourceDatabaseServer>>;
 let mockExtensionContext: TypeMoq.IMock<vscode.ExtensionContext>;
 import settings from '../../../../account-provider/providerSettings';
-import { AzureAccount } from '../../../../account-provider/interfaces';
+import { AzureAccount } from 'azurecore';
 
 // Mock test data
 const mockAccount: AzureAccount = {

--- a/extensions/azurecore/src/test/azureResource/resourceService.test.ts
+++ b/extensions/azurecore/src/test/azureResource/resourceService.test.ts
@@ -10,7 +10,7 @@ import { fail } from 'assert';
 
 import { azureResource } from 'azureResource';
 import { AzureResourceService } from '../../azureResource/resourceService';
-import { AzureAccount } from '../../account-provider/interfaces';
+import { AzureAccount } from 'azurecore';
 import settings from '../../account-provider/providerSettings';
 
 // Mock test data

--- a/extensions/azurecore/src/test/azureResource/resourceTreeNode.test.ts
+++ b/extensions/azurecore/src/test/azureResource/resourceTreeNode.test.ts
@@ -14,7 +14,7 @@ import { AzureResourceResourceTreeNode } from '../../azureResource/resourceTreeN
 import { AppContext } from '../../appContext';
 import { AzureResourceServiceNames } from '../../azureResource/constants';
 import settings from '../../account-provider/providerSettings';
-import { AzureAccount } from '../../account-provider/interfaces';
+import { AzureAccount } from 'azurecore';
 
 // Mock test data
 const mockAccount: AzureAccount = {

--- a/extensions/mssql/src/features.ts
+++ b/extensions/mssql/src/features.ts
@@ -12,6 +12,7 @@ import * as azdata from 'azdata';
 import * as Utils from './utils';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
 import { DataItemCache } from './util/dataCache';
+import * as azurecore from 'azurecore';
 
 const localize = nls.loadMessageBundle();
 
@@ -48,7 +49,7 @@ export class AccountFeature implements StaticFeature {
 
 	protected async getToken(request: contracts.RequestSecurityTokenParams): Promise<contracts.RequestSecurityTokenResponse | undefined> {
 		const accountList = await azdata.accounts.getAllAccounts();
-		let account: azdata.Account;
+		let account: azurecore.AzureAccount;
 
 		if (accountList.length < 1) {
 			// TODO: Prompt user to add account
@@ -70,7 +71,7 @@ export class AccountFeature implements StaticFeature {
 			account = accountList[0];
 		}
 
-		const tenant = account.properties.tenants.find((t: { [key: string]: string }) => request.authority.includes(t.id));
+		const tenant = account.properties.tenants.find(tenant => request.authority.includes(tenant.id));
 		const unauthorizedMessage = localize('mssql.insufficientlyPrivelagedAzureAccount', "The configured Azure account for {0} does not have sufficient permissions for Azure Key Vault to access a column master key for Always Encrypted.", account.key.accountId);
 		if (!tenant) {
 			window.showErrorMessage(unauthorizedMessage);

--- a/extensions/mssql/src/typings/refs.d.ts
+++ b/extensions/mssql/src/typings/refs.d.ts
@@ -6,4 +6,5 @@
 /// <reference path='../../../../src/sql/azdata.d.ts'/>
 /// <reference path='../../../../src/sql/azdata.proposed.d.ts'/>
 /// <reference path='../../../../src/vs/vscode.d.ts'/>
+/// <reference path='../../../azurecore/src/azurecore.d.ts' />
 /// <reference path='../../../big-data-cluster/src/bdc.d.ts'/>


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/azuredatastudio/pull/14588, this is adding typings to that code so that we're much less likely to have this kind of issue in the future.

I have some general questions around this implementation anyways (why is MSSQL handling general AKV token stuff?) but that's a much bigger problem to tackle so for now this should help avoid other similar types of regressions. 

(Looking through this code - we're going to have some really annoying issues to deal with if we ever support more account types than just Azure...right now pretty much everything we do assumes that getAllAccounts is returning only Azure accounts)