### PR TITLE
Update connection event properties

### DIFF
--- a/src/sql/platform/telemetry/common/adsTelemetryService.ts
+++ b/src/sql/platform/telemetry/common/adsTelemetryService.ts
@@ -3,7 +3,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAdsTelemetryService, ITelemetryInfo, ITelemetryEvent, ITelemetryConnectionInfo, ITelemetryEventMeasures, ITelemetryEventProperties } from 'sql/platform/telemetry/common/telemetry';
+import * as azdata from 'azdata';
+import { IAdsTelemetryService, ITelemetryInfo, ITelemetryEvent, ITelemetryEventMeasures, ITelemetryEventProperties } from 'sql/platform/telemetry/common/telemetry';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { assign } from 'vs/base/common/objects';
@@ -43,13 +44,23 @@ class TelemetryEventImpl implements ITelemetryEvent {
 		return this;
 	}
 
-	public withConnectionInfo(connectionInfo: ITelemetryConnectionInfo): ITelemetryEvent {
+	public withConnectionInfo(connectionInfo?: azdata.IConnectionProfile): ITelemetryEvent {
 		assign(this._properties,
 			{
-				authenticationType: connectionInfo.authenticationType,
-				providerName: connectionInfo.providerName,
-				serverType: connectionInfo.serverType,
-				engineType: connectionInfo.engineType
+				authenticationType: connectionInfo?.authenticationType,
+				providerName: connectionInfo?.providerName
+			});
+		return this;
+	}
+
+	public withServerInfo(serverInfo?: azdata.ServerInfo): ITelemetryEvent {
+		assign(this._properties,
+			{
+				connectionType: serverInfo?.isCloud !== undefined ? (serverInfo.isCloud ? 'Azure' : 'Standalone') : '',
+				serverVersion: serverInfo?.serverVersion ?? '',
+				serverEdition: serverInfo?.serverEdition ?? '',
+				serverEngineEdition: serverInfo?.engineEditionId ?? '',
+				isBigDataCluster: serverInfo?.options?.isBigDataCluster ?? false,
 			});
 		return this;
 	}
@@ -64,7 +75,9 @@ class NullTelemetryEventImpl implements ITelemetryEvent {
 
 	public withAdditionalMeasurements(additionalMeasurements: ITelemetryEventMeasures): ITelemetryEvent { return this; }
 
-	public withConnectionInfo(connectionInfo: ITelemetryConnectionInfo): ITelemetryEvent { return this; }
+	public withConnectionInfo(connectionInfo: azdata.IConnectionProfile): ITelemetryEvent { return this; }
+
+	public withServerInfo(serverInfo: azdata.ServerInfo): ITelemetryEvent { return this; }
 }
 
 export class AdsTelemetryService implements IAdsTelemetryService {

--- a/src/sql/platform/telemetry/common/telemetry.ts
+++ b/src/sql/platform/telemetry/common/telemetry.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as azdata from 'azdata';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
 export const IAdsTelemetryService = createDecorator<IAdsTelemetryService>('adsTelemetryService');
@@ -19,16 +20,6 @@ export interface ITelemetryEventProperties {
  */
 export interface ITelemetryEventMeasures {
 	[key: string]: number;
-}
-
-/**
- * Connection info properties to add into an event.
- */
-export interface ITelemetryConnectionInfo {
-	authenticationType?: string;
-	providerName?: string;
-	serverType?: string;
-	engineType?: string;
 }
 
 export interface ITelemetryEvent {
@@ -51,9 +42,15 @@ export interface ITelemetryEvent {
 
 	/**
 	 * Adds additional connection-related information to this event.
-	 * @param connectionInfo The connection info to add. Only the fields in TelemetryConnectionInfo are included, all others are ignored.
+	 * @param connectionInfo The connection info to add.
 	 */
-	withConnectionInfo(connectionInfo: ITelemetryConnectionInfo): ITelemetryEvent;
+	withConnectionInfo(connectionInfo?: azdata.IConnectionProfile): ITelemetryEvent;
+
+	/**
+	 * Adds additional server-related information to this event.
+	 * @param serverInfo The server info to add.
+	 */
+	withServerInfo(serverInfo?: azdata.ServerInfo): ITelemetryEvent;
 }
 
 export interface ITelemetryInfo {

--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -955,14 +955,9 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 
 			connection.connectHandler(true);
 			this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.DatabaseConnected)
-				.withAdditionalProperties({
-					connectionType: connection.serverInfo ? (connection.serverInfo.isCloud ? 'Azure' : 'Standalone') : '',
-					provider: connection.connectionProfile.providerName,
-					serverVersion: connection.serverInfo ? connection.serverInfo.serverVersion : '',
-					serverEdition: connection.serverInfo ? connection.serverInfo.serverEdition : '',
-					serverEngineEdition: connection.serverInfo ? connection.serverInfo.engineEditionId : '',
-					isBigDataCluster: connection.serverInfo?.options?.isBigDataCluster ?? false,
-				}).withAdditionalMeasurements({
+				.withConnectionInfo(connection.connectionProfile)
+				.withServerInfo(connection.serverInfo)
+				.withAdditionalMeasurements({
 					extensionConnectionTimeMs: connection.extensionTimer.elapsed() - connection.serviceTimer.elapsed(),
 					serviceConnectionTimeMs: connection.serviceTimer.elapsed()
 				})
@@ -974,9 +969,7 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 		} else {
 			connection.connectHandler(false, info.errorMessage, info.errorNumber, info.messages);
 			this._telemetryService.createErrorEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.DatabaseConnectionError, info.errorNumber.toString())
-				.withAdditionalProperties({
-					provider: connection.connectionProfile.providerName,
-				})
+				.withConnectionInfo(connection.connectionProfile)
 				.withAdditionalMeasurements({
 					extensionConnectionTimeMs: connection.extensionTimer.elapsed() - connection.serviceTimer.elapsed(),
 					serviceConnectionTimeMs: connection.serviceTimer.elapsed()
@@ -1131,9 +1124,6 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 				if (this._connectionStatusManager.isDefaultTypeUri(fileUri)) {
 					this._connectionGlobalStatus.setStatusToDisconnected(fileUri);
 				}
-
-				// TODO: send telemetry events
-				// Telemetry.sendTelemetryEvent('DatabaseDisconnected');
 			}
 
 			return result;
@@ -1145,19 +1135,21 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 	public disconnect(input: string | interfaces.IConnectionProfile): Promise<void> {
 		let uri: string;
 		let profile: interfaces.IConnectionProfile;
+		let info: ConnectionManagementInfo | undefined;
 		if (typeof input === 'object') {
 			uri = Utils.generateUri(input);
 			profile = input;
+			info = this.getConnectionInfo(uri);
 		} else if (typeof input === 'string') {
 			profile = this.getConnectionProfile(input);
+			info = this.getConnectionInfo(input);
 			uri = input;
 		}
 		return this.doDisconnect(uri, profile).then(result => {
 			if (result) {
 				this._telemetryService.createActionEvent(TelemetryKeys.TelemetryView.Shell, TelemetryKeys.DatabaseDisconnected)
-					.withAdditionalProperties({
-						provider: profile.providerName
-					})
+					.withConnectionInfo(profile)
+					.withServerInfo(info?.serverInfo)
 					.send();
 				this._connectionStatusManager.removeConnection(uri);
 			} else {


### PR DESCRIPTION
After the discussion today I realized we were never capturing the auth type used for connections which will definitely be useful - so adding that.

While I was here I cleaned this all up to use the generic with* helper functions so that other places can use the same properties if desired. This fixed some issues with the original implementation too (such as serverType and engineType not even being valid properties on the connection profiles)