### PR TITLE
Remove Online Services Settings option

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -460,6 +460,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 				}
 			}
 		});
+		/** {{SQL CARBON EDIT}} Remove unused options (we don't have online services)
 		MenuRegistry.appendMenuItem(MenuId.MenubarPreferencesMenu, {
 			group: '1_settings',
 			command: {
@@ -476,7 +477,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 			},
 			order: 2
 		});
-
+		**/
 		this.registerSettingsEditorActions();
 
 		this.extensionService.whenInstalledExtensionsRegistered()


### PR DESCRIPTION
This option doesn't do anything as we don't have any settings for online services so just removing it

Before : 

![image](https://user-images.githubusercontent.com/28519865/110525519-84d0f280-80c9-11eb-9481-18dfb0436305.png)

After :

![image](https://user-images.githubusercontent.com/28519865/110525414-679c2400-80c9-11eb-8a2f-b769c98b08cd.png)
