### PR TITLE
handle query gallery with tags

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -608,7 +608,7 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 					});
 				}
 			}
-			// ADS doesn't not support extension tags, we need to return empty array to avoid breaking some scenarios. e.g. file extension based recommendations.
+			// ADS doesn't support extension tags, we need to return empty array to avoid breaking some scenarios. e.g. file extension based recommendations.
 			const tagFilters = query.criteria.filter(x => x.filterType === FilterType.Tag);
 			if (tagFilters?.length > 0) {
 				filteredExtensions = [];


### PR DESCRIPTION
This PR will fix #14618

file based extension recommendation uses the ext: {extension} to query the extension gallery (you can do the same in extensions view),
![image](https://user-images.githubusercontent.com/13777222/110559943-f9bc2080-80f9-11eb-89d6-b73ac46b1e5c.png)

when the request is received, ADS will ignore the tag filter and return all the extensions.

the fix is to return empty array when we receive a request with tag filtering since our extension metadata doesn't include any tag information.

I have queued a build to verify the fix: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=96183&view=results 
