### PR TITLE
Fix deploy upgrade existing not choosing the correct database

### DIFF
--- a/extensions/dacpac/src/test/testDacFxConfigPages.ts
+++ b/extensions/dacpac/src/test/testDacFxConfigPages.ts
@@ -22,7 +22,7 @@ export class TestDeployConfigPage extends DeployConfigPage {
 	}
 
 	SetDatabaseDropDown(): void {
-		this.databaseDropdown.value = { name: 'DummyDatabase', displayName: 'DummyDatabase' };
+		this.databaseDropdown.value = 'DummyDatabase';
 	}
 
 	SetFileName(): void {

--- a/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
+++ b/extensions/dacpac/src/wizard/api/dacFxConfigPage.ts
@@ -104,12 +104,12 @@ export abstract class DacFxConfigPage extends BasePage {
 
 		// Handle database changes
 		this.databaseDropdown.onValueChanged(() => {
-			const databaseDropdownValue = this.databaseDropdown.value;
+			const databaseDropdownValue: string = this.databaseDropdown.value as string;
 			if (!databaseDropdownValue) {
 				return;
 			}
 
-			this.model.database = databaseDropdownValue as string;
+			this.model.database = databaseDropdownValue;
 			this.fileTextBox.value = this.generateFilePathFromDatabaseAndTimestamp();
 			this.model.filePath = this.fileTextBox.value;
 		});

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -142,12 +142,12 @@ export class DeployConfigPage extends DacFxConfigPage {
 
 		//Handle database changes
 		this.databaseDropdown.onValueChanged(() => {
-			const databaseDropdownValue = this.databaseDropdown.value as azdata.CategoryValue;
+			const databaseDropdownValue = this.databaseDropdown.value;
 			if (!databaseDropdownValue) {
 				return;
 			}
 
-			this.model.database = databaseDropdownValue.name;
+			this.model.database = databaseDropdownValue as string;
 		});
 
 		this.databaseLoader = this.view.modelBuilder.loadingComponent().withItem(this.databaseDropdown).withProperties({

--- a/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
+++ b/extensions/dacpac/src/wizard/pages/deployConfigPage.ts
@@ -142,12 +142,12 @@ export class DeployConfigPage extends DacFxConfigPage {
 
 		//Handle database changes
 		this.databaseDropdown.onValueChanged(() => {
-			const databaseDropdownValue = this.databaseDropdown.value;
+			const databaseDropdownValue: string = this.databaseDropdown.value as string;
 			if (!databaseDropdownValue) {
 				return;
 			}
 
-			this.model.database = databaseDropdownValue as string;
+			this.model.database = databaseDropdownValue;
 		});
 
 		this.databaseLoader = this.view.modelBuilder.loadingComponent().withItem(this.databaseDropdown).withProperties({


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #14634. The database dropdowns got changed from CategoryValues to strings in https://github.com/microsoft/azuredatastudio/pull/8909 and this missed getting updated. The model.database was getting set to undefined here since databaseDropdownValue.name was undefined, so it defaulted to the first value in the database dropdown. 
