### PR TITLE
Resetting subscriptions after AD tenant is changed in migration wizard

### DIFF
--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -523,12 +523,11 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 					);
 					vscode.window.showInformationMessage(localize("sql.migration.starting.migration.message", 'Starting migration for database {0} to {1}', db, this._targetServerInstance.name));
 				}
+				vscode.window.showInformationMessage(constants.MIGRATION_STARTED);
 			} catch (e) {
 				vscode.window.showInformationMessage(e);
 			}
 
 		});
-
-		vscode.window.showInformationMessage(constants.MIGRATION_STARTED);
 	}
 }

--- a/extensions/sql-migration/src/models/stateMachine.ts
+++ b/extensions/sql-migration/src/models/stateMachine.ts
@@ -523,8 +523,8 @@ export class MigrationStateModel implements Model, vscode.Disposable {
 					);
 					vscode.window.showInformationMessage(localize("sql.migration.starting.migration.message", 'Starting migration for database {0} to {1}', db, this._targetServerInstance.name));
 				}
-				vscode.window.showInformationMessage(constants.MIGRATION_STARTED);
 			} catch (e) {
+				console.log(e);
 				vscode.window.showInformationMessage(e);
 			}
 

--- a/extensions/sql-migration/src/wizard/accountsSelectionPage.ts
+++ b/extensions/sql-migration/src/wizard/accountsSelectionPage.ts
@@ -118,6 +118,9 @@ export class AccountsSelectionPage extends MigrationWizardPage {
 			 */
 			if (value.selected) {
 				this.migrationStateModel._azureAccount.properties.tenants = [this.migrationStateModel.getTenant(value.index)];
+				this.migrationStateModel._subscriptions = undefined!;
+				this.migrationStateModel._targetSubscription = undefined!;
+				this.migrationStateModel._databaseBackup.subscription = undefined!;
 			}
 		});
 


### PR DESCRIPTION
I missed a codepath while doing previous PR and forgot to reset the subscriptions when the user changes the Azure tenant. This causes the subscriptions to not refresh when the tenant is changed. 

