### PR TITLE
update dacpac to 1.8.0 and sql database projects to 0.7.1 in insiders

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1219,14 +1219,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.7.0",
-							"lastUpdated": "2/09/2021",
+							"version": "1.8.0",
+							"lastUpdated": "3/11/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.7.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.8.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -3371,14 +3371,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.7.0",
-							"lastUpdated": "2/22/2021",
+							"version": "0.7.1",
+							"lastUpdated": "3/11/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-database-projects/sql-database-projects-0.7.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-database-projects/sql-database-projects-0.7.1.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
@@ -3404,7 +3404,7 @@
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
-									"value": ">=1.25.0"
+									"value": ">=1.27.0"
 								},
 								{
 									"key": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1219,14 +1219,14 @@
 					},
 					"versions": [
 						{
-							"version": "1.7.0",
-							"lastUpdated": "2/09/2021",
+							"version": "1.8.0",
+							"lastUpdated": "3/11/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.7.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/dacpac/dacpac-1.8.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
- Updating dacpac extension version in stable and insiders(doesn't need the latest ADS)
- Updating sql database projects in insiders to same version as already updated in RC #14627

Build with dacpac vsix: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=96404&view=artifacts&pathAsName=false&type=publishedArtifacts