### PR TITLE
Disable auto sync service

### DIFF
--- a/src/vs/platform/userDataSync/common/userDataAutoSyncService.ts
+++ b/src/vs/platform/userDataSync/common/userDataAutoSyncService.ts
@@ -59,6 +59,7 @@ export class UserDataAutoSyncEnablementService extends Disposable implements _IU
 	}
 
 	isEnabled(defaultEnablement?: boolean): boolean {
+		/* {{SQL CARBON EDIT}} Disable unused sync service
 		switch (this.environmentService.sync) {
 			case 'on':
 				return true;
@@ -66,6 +67,8 @@ export class UserDataAutoSyncEnablementService extends Disposable implements _IU
 				return false;
 			default: return this.storageService.getBoolean(enablementKey, StorageScope.GLOBAL, !!defaultEnablement); // {{SQL CARBON EDIT}} strict-null-checks move this to a default case
 		}
+		*/
+		return false;
 	}
 
 	canToggleEnablement(): boolean {

--- a/src/vs/platform/userDataSync/test/common/userDataAutoSyncService.test.ts
+++ b/src/vs/platform/userDataSync/test/common/userDataAutoSyncService.test.ts
@@ -24,7 +24,7 @@ class TestUserDataAutoSyncService extends UserDataAutoSyncService {
 	}
 }
 
-suite('UserDataAutoSyncService', () => {
+suite.skip('UserDataAutoSyncService', () => { // {{SQL CARBON EDIT}} Service is disabled so turn off tests
 
 	const disposableStore = new DisposableStore();
 

--- a/src/vs/workbench/services/userDataSync/browser/userDataAutoSyncEnablementService.ts
+++ b/src/vs/workbench/services/userDataSync/browser/userDataAutoSyncEnablementService.ts
@@ -12,6 +12,7 @@ export class WebUserDataAutoSyncEnablementService extends UserDataAutoSyncEnable
 	private enabled: boolean | undefined = undefined;
 
 	isEnabled(): boolean {
+		/* {{SQL CARBON EDIT}} Disable unused sync service
 		if (this.enabled === undefined) {
 			this.enabled = this.workbenchEnvironmentService.options?.settingsSyncOptions?.enabled;
 		}
@@ -19,6 +20,8 @@ export class WebUserDataAutoSyncEnablementService extends UserDataAutoSyncEnable
 			this.enabled = super.isEnabled(this.workbenchEnvironmentService.options?.enableSyncByDefault);
 		}
 		return this.enabled;
+		*/
+		return false;
 	}
 
 	setEnablement(enabled: boolean) {


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/14616

It's not clear how the service could have been enabled - we don't expose that anywhere as far as I'm aware. But it's possible there's a gap somewhere we haven't found yet so in the meantime just making it so the things that use the service will always be disabled regardless.

There's still a chance that the setting being enabled could cause problems elsewhere - but all the code I saw using this stuff checked the isEnabled state first before showing anything related to sync so this should cover most of the scenarios at the very least.