### PR TITLE
Fix filtered resource options persisting across deployments

### DIFF
--- a/extensions/resource-deployment/src/ui/resourceTypeWizard.ts
+++ b/extensions/resource-deployment/src/ui/resourceTypeWizard.ts
@@ -21,6 +21,7 @@ import { DeployAzureSQLDBWizardModel } from './deployAzureSQLDBWizard/deployAzur
 import { ToolsAndEulaPage } from './toolsAndEulaSettingsPage';
 import { OptionValuesFilter, ResourceTypeService } from '../services/resourceTypeService';
 import { PageLessDeploymentModel } from './pageLessDeploymentModel';
+import { deepClone } from '../common/utils';
 
 export class ResourceTypeWizard {
 	private customButtons: azdata.window.Button[] = [];
@@ -65,7 +66,7 @@ export class ResourceTypeWizard {
 		 * Setting the first provider from the first value of the dropdowns.
 		 * If there are no options (dropdowns) then the resource type has only one provider which is set as default here.
 		 */
-		let filteredOptions = resourceType.options;
+		let filteredOptions = deepClone(resourceType.options);
 		const optionsFilter = this._optionValuesFilter?.[this.resourceType.name];
 		if (optionsFilter) {
 			filteredOptions.forEach(option => {

--- a/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
+++ b/extensions/resource-deployment/src/ui/toolsAndEulaSettingsPage.ts
@@ -10,7 +10,7 @@ import { AgreementInfo, DeploymentProvider, HelpText, ITool, ResourceType, Resou
 import { createFlexContainer } from './modelViewUtils';
 import * as loc from '../localizedConstants';
 import { IToolsService } from '../services/toolsService';
-import { getErrorMessage } from '../common/utils';
+import { deepClone, getErrorMessage } from '../common/utils';
 import { ResourceTypePage } from './resourceTypePage';
 import { ResourceTypeWizard } from './resourceTypeWizard';
 import { OptionValuesFilter as OptionValuesFilter } from '../services/resourceTypeService';
@@ -200,7 +200,7 @@ export class ToolsAndEulaPage extends ResourceTypePage {
 					}).component();
 					this._optionsContainer.addItem(optionsTitle);
 					this._resourceType.options.forEach((option, index) => {
-						let optionValues = option.values;
+						let optionValues = deepClone(option.values);
 						const optionValueFilter = this.optionValuesFilter?.[this._resourceType.name]?.[option.name];
 						if (optionValueFilter) {
 							optionValues = optionValues.filter(optionValue => optionValueFilter.includes(optionValue.name));


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/14673

We're modifying the objects when we're doing the filtering so make sure we clone them first since the objects passed in used across multiple deployments