### PR TITLE
Fix blank MIAA/PG deployment wizard pages

### DIFF
--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -640,14 +640,31 @@ async function processOptionsTypeField(context: FieldContext): Promise<void> {
 		// If the options are provided for us then set up the callback to load those options async'ly
 		if (optionsSource?.provider) {
 			getRadioOptions = async () => {
-				return { defaultValue: options.defaultValue, values: await optionsSource.provider!.getOptions() };
+				try {
+					return { defaultValue: options.defaultValue, values: await optionsSource.provider!.getOptions() };
+				} catch (err) {
+					context.container.message = {
+						text: getErrorMessage(err),
+						description: '',
+						level: azdata.window.MessageLevel.Error
+					};
+					return { defaultValue: '', values: [] };
+				}
 			};
 		}
 		optionsComponent = await processRadioOptionsTypeField(context, getRadioOptions);
 	} else {
 		throwUnless(context.fieldInfo.options.optionsType === OptionsType.Dropdown, loc.optionsTypeRadioOrDropdown);
 		if (optionsSource?.provider) {
-			context.fieldInfo.options.values = await optionsSource.provider.getOptions();
+			try {
+				context.fieldInfo.options.values = await optionsSource.provider.getOptions();
+			} catch (err) {
+				context.container.message = {
+					text: getErrorMessage(err),
+					description: '',
+					level: azdata.window.MessageLevel.Error
+				};
+			}
 		}
 		optionsComponent = processDropdownOptionsTypeField(context);
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/14712

I have some ideas about how to make it so that errors on pages aren't displayed until you navigate to the page that contains the components - but that's a bigger fix. For now just making it so at least the user is informed of what needs to be done to fix the issue. 

![image](https://user-images.githubusercontent.com/28519865/111004140-4b082200-833d-11eb-9ebd-efe003da7a39.png)
