### PR TITLE
Fix script loading in sandbox windows

### DIFF
--- a/src/bootstrap-window.js
+++ b/src/bootstrap-window.js
@@ -106,8 +106,8 @@
 			preferScriptTags: sandbox
 		};
 		// use a trusted types policy when loading via script tags
-		if (loaderConfig.preferScriptTags) {
-			loaderConfig.trustedTypesPolicy = window.trustedTypes?.createPolicy('amdLoader', {
+		if (loaderConfig.preferScriptTags && window && window.trustedTypes) { // {{SQL CARBON EDIT}} fix uglify error
+			loaderConfig.trustedTypesPolicy = window.trustedTypes.createPolicy('amdLoader', {
 				createScriptURL(value) {
 					if (value.startsWith(window.location.origin)) {
 						return value;


### PR DESCRIPTION
This PR fixes loading script files in sandboxed windows, such as Issue Reporter or Process Explorer.  The sandbox windows use a custom schema (vscode-file vs. file) and need to have this configured when being bootstrapped.

This is for issue https://github.com/microsoft/azuredatastudio/issues/14623.

<img width="725" alt="Screen Shot 2021-03-15 at 12 32 18 AM" src="https://user-images.githubusercontent.com/599935/111118675-54a0ae00-8526-11eb-9546-b8e74944656c.png">

