### PR TITLE
Updated Postgres Spec for where to find engine version, removed calling calling -ev in edit commands

### DIFF
--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -53,10 +53,8 @@ export class PostgresModel extends ResourceModel {
 
 	/** Returns the major version of Postgres */
 	public get engineVersion(): string | undefined {
-		const kind = this._config?.kind;
-		return kind
-			? kind.substring(kind.lastIndexOf('-') + 1)
-			: undefined;
+		const kind = this._config?.spec.engine.version;
+		return kind;
 	}
 
 	/** Returns the IP address and port of Postgres */

--- a/extensions/arc/src/models/postgresModel.ts
+++ b/extensions/arc/src/models/postgresModel.ts
@@ -53,8 +53,7 @@ export class PostgresModel extends ResourceModel {
 
 	/** Returns the major version of Postgres */
 	public get engineVersion(): string | undefined {
-		const kind = this._config?.spec.engine.version;
-		return kind;
+		return this._config?.spec.engine.version;
 	}
 
 	/** Returns the IP address and port of Postgres */

--- a/extensions/arc/src/test/mocks/fakeAzdataApi.ts
+++ b/extensions/arc/src/test/mocks/fakeAzdataApi.ts
@@ -49,7 +49,6 @@ export class FakeAzdataApi implements azdataExt.IAzdataApi {
 							replaceEngineSettings?: boolean,
 							workers?: number
 						},
-						_engineVersion?: string,
 						_additionalEnvVars?: azdataExt.AdditionalEnvVars
 					): Promise<azdataExt.AzdataOutput<void>> { throw new Error('Method not implemented.'); }
 				}

--- a/extensions/arc/src/test/models/postgresModel.test.ts
+++ b/extensions/arc/src/test/models/postgresModel.test.ts
@@ -41,7 +41,8 @@ export const FakePostgresServerShowOutput: azdataExt.AzdataOutput<azdataExt.Post
 				extensions: [{ name: '' }],
 				settings: {
 					default: { ['']: '' }
-				}
+				},
+				version: ''
 			},
 			scale: {
 				shards: 0,

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -191,7 +191,6 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 										memoryRequest: this.saveArgs.workerMemoryRequest,
 										memoryLimit: this.saveArgs.workerMemoryLimit
 									},
-									this._postgresModel.engineVersion,
 									this._postgresModel.controllerModel.azdataAdditionalEnvVars,
 									session
 								);
@@ -204,7 +203,6 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 										memoryRequest: this.saveArgs.coordinatorMemoryRequest,
 										memoryLimit: this.saveArgs.coordinatorMemoryLimit
 										},
-										this._postgresModel.engineVersion,
 										this._postgresModel.controllerModel.azdataAdditionalEnvVars,
 										session
 									);

--- a/extensions/arc/src/ui/dashboards/postgres/postgresCoordinatorNodeParametersPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresCoordinatorNodeParametersPage.ts
@@ -36,7 +36,6 @@ export class PostgresCoordinatorNodeParametersPage extends PostgresParametersPag
 			await this._azdataApi.azdata.arc.postgres.server.edit(
 				this._postgresModel.info.name,
 				{ engineSettings: engineSettings.toString() },
-				this._postgresModel.engineVersion,
 				this._postgresModel.controllerModel.azdataAdditionalEnvVars,
 				session);
 		*/
@@ -47,7 +46,6 @@ export class PostgresCoordinatorNodeParametersPage extends PostgresParametersPag
 			await this._azdataApi.azdata.arc.postgres.server.edit(
 				this._postgresModel.info.name,
 				{ engineSettings: `''`, replaceEngineSettings: true },
-				this._postgresModel.engineVersion,
 				this._postgresModel.controllerModel.azdataAdditionalEnvVars,
 				session);
 		*/
@@ -58,7 +56,6 @@ export class PostgresCoordinatorNodeParametersPage extends PostgresParametersPag
 			await this._azdataApi.azdata.arc.postgres.server.edit(
 				this._postgresModel.info.name,
 				{ engineSettings: parameterName + '=' },
-				this._postgresModel.engineVersion,
 				this._postgresModel.controllerModel.azdataAdditionalEnvVars,
 				session);
 		*/

--- a/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresOverviewPage.ts
@@ -224,7 +224,6 @@ export class PostgresOverviewPage extends DashboardPage {
 									adminPassword: true,
 									noWait: true
 								},
-								this._postgresModel.engineVersion,
 								Object.assign({ 'AZDATA_PASSWORD': password }, this._controllerModel.azdataAdditionalEnvVars),
 								session
 							);

--- a/extensions/arc/src/ui/dashboards/postgres/postgresWorkerNodeParametersPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresWorkerNodeParametersPage.ts
@@ -39,7 +39,6 @@ export class PostgresWorkerNodeParametersPage extends PostgresParametersPage {
 		await this._azdataApi.azdata.arc.postgres.server.edit(
 			this._postgresModel.info.name,
 			{ engineSettings: engineSettings },
-			this._postgresModel.engineVersion,
 			this._postgresModel.controllerModel.azdataAdditionalEnvVars,
 			session);
 
@@ -49,7 +48,6 @@ export class PostgresWorkerNodeParametersPage extends PostgresParametersPage {
 		await this._azdataApi.azdata.arc.postgres.server.edit(
 			this._postgresModel.info.name,
 			{ engineSettings: `''`, replaceEngineSettings: true },
-			this._postgresModel.engineVersion,
 			this._postgresModel.controllerModel.azdataAdditionalEnvVars,
 			session);
 
@@ -59,7 +57,6 @@ export class PostgresWorkerNodeParametersPage extends PostgresParametersPage {
 		await this._azdataApi.azdata.arc.postgres.server.edit(
 			this._postgresModel.info.name,
 			{ engineSettings: parameterName + '=' },
-			this._postgresModel.engineVersion,
 			this._postgresModel.controllerModel.azdataAdditionalEnvVars,
 			session);
 

--- a/extensions/azdata/src/api.ts
+++ b/extensions/azdata/src/api.ts
@@ -112,12 +112,11 @@ export function getAzdataApi(localAzdataDiscovered: Promise<IAzdataTool | undefi
 							replaceEngineSettings?: boolean;
 							workers?: number;
 						},
-						engineVersion?: string,
 						additionalEnvVars?: azdataExt.AdditionalEnvVars,
 						session?: azdataExt.AzdataSession) => {
 						await localAzdataDiscovered;
 						throwIfNoAzdataOrEulaNotAccepted(azdataToolService.localAzdata, isEulaAccepted(memento));
-						return azdataToolService.localAzdata.arc.postgres.server.edit(name, args, engineVersion, additionalEnvVars, session);
+						return azdataToolService.localAzdata.arc.postgres.server.edit(name, args, additionalEnvVars, session);
 					}
 				}
 			},

--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -146,7 +146,6 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 						replaceEngineSettings?: boolean,
 						workers?: number
 					},
-					engineVersion?: string,
 					additionalEnvVars?: azdataExt.AdditionalEnvVars,
 					session?: azdataExt.AzdataSession): Promise<azdataExt.AzdataOutput<void>> => {
 					const argsArray = ['arc', 'postgres', 'server', 'edit', '-n', name];
@@ -161,7 +160,6 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 					if (args.port) { argsArray.push('--port', args.port.toString()); }
 					if (args.replaceEngineSettings) { argsArray.push('--replace-engine-settings'); }
 					if (args.workers) { argsArray.push('--workers', args.workers.toString()); }
-					if (engineVersion) { argsArray.push('--engine-version', engineVersion); }
 					return this.executeCommand<void>(argsArray, additionalEnvVars, session);
 				}
 			}

--- a/extensions/azdata/src/typings/azdata-ext.d.ts
+++ b/extensions/azdata/src/typings/azdata-ext.d.ts
@@ -173,7 +173,7 @@ declare module 'azdata-ext' {
 		spec: {
 			engine: {
 				extensions: {
-					name: string // "citus"kind: string
+					name: string // "citus"
 				}[],
 				settings: {
 					default: { [key: string]: string } // { "max_connections": "101", "work_mem": "4MB" }

--- a/extensions/azdata/src/typings/azdata-ext.d.ts
+++ b/extensions/azdata/src/typings/azdata-ext.d.ts
@@ -160,7 +160,7 @@ declare module 'azdata-ext' {
 
 	export interface PostgresServerShowResult {
 		apiVersion: string, // "arcdata.microsoft.com/v1alpha1"
-		kind: string, // "postgresql-12"
+		kind: string, // "postgresql"
 		metadata: {
 			creationTimestamp: string, // "2020-08-19T20:25:11Z"
 			generation: number, // 1
@@ -173,11 +173,12 @@ declare module 'azdata-ext' {
 		spec: {
 			engine: {
 				extensions: {
-					name: string // "citus"
+					name: string // "citus"kind: string
 				}[],
 				settings: {
 					default: { [key: string]: string } // { "max_connections": "101", "work_mem": "4MB" }
-				}
+				},
+				version: string // "12"
 			},
 			scale: {
 				shards: number, // 1 (shards was renamed to workers, kept here for backwards compatibility)
@@ -278,7 +279,6 @@ declare module 'azdata-ext' {
 							replaceEngineSettings?: boolean,
 							workers?: number
 						},
-						engineVersion?: string,
 						additionalEnvVars?: AdditionalEnvVars,
 						session?: AzdataSession
 					): Promise<AzdataOutput<void>>


### PR DESCRIPTION
This PR fixes #14729 


Adding fix to work with incoming change with azdata. 