### PR TITLE
fix relative paths in wysiwyg

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -245,7 +245,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();
 				result = result ?? linkCalloutResult?.insertUnescapedLinkUrl;
-				// Callout is responsible for returning escaped strings. We replace %20 for whitespaces to allow spaces in the link's display text
+				// Callout is responsible for returning escaped strings.
 				document.execCommand('insertHTML', false, `<a href="${escape(result)}">${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
 				return;
 			}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -235,17 +235,11 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				needsTransform = false;
 			} else {
 				let result = undefined;
-				const isFile = URI.parse(linkCalloutResult?.insertUnescapedLinkUrl).scheme.includes('file');
+				const isFile = URI.parse(linkCalloutResult?.insertUnescapedLinkUrl).scheme === 'file';
 				if (!path.isAbsolute(linkCalloutResult?.insertUnescapedLinkUrl) && isFile) {
-					// Counts the number of ..\ intermediate directories when user enters a relative path
-					let midDirectories = (linkCalloutResult?.insertUnescapedLinkUrl.match(/..\\/g) || []).length;
-					let dirName = path.dirname(this.cellModel?.notebookModel?.notebookUri.fsPath);
-					const relativePath = linkCalloutResult?.insertUnescapedLinkUrl.replace(/\.\\/g, '/');
-					while (midDirectories > 1) {
-						dirName = path.dirname(dirName);
-						midDirectories--;
-					}
-					result = path.join(dirName, relativePath);
+					const notebookDirName = path.dirname(this.cellModel?.notebookModel?.notebookUri.fsPath);
+					const relativePath = linkCalloutResult?.insertUnescapedLinkUrl.replace(/(\.\\ | \.\/)/g, '/');
+					result = path.resolve(notebookDirName, relativePath);
 				}
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -21,7 +21,6 @@ import { TextModel } from 'vs/editor/common/model/textModel';
 import { IEditor } from 'vs/editor/common/editorCommon';
 import * as path from 'vs/base/common/path';
 import { URI } from 'vs/base/common/uri';
-import { encode } from 'iconv-lite-umd';
 
 export const MARKDOWN_TOOLBAR_SELECTOR: string = 'markdown-toolbar-component';
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -243,9 +243,9 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				}
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();
-				result = result ? result : linkCalloutResult?.insertUnescapedLinkUrl;
+				result = result ?? linkCalloutResult?.insertUnescapedLinkUrl;
 				// Callout is responsible for returning escaped strings
-				document.execCommand('insertHTML', false, `<a href="${result}">${linkCalloutResult?.insertUnescapedLinkLabel}</a>`);
+				document.execCommand('insertHTML', false, `<a href="${escape(result)}">${escape(linkCalloutResult?.insertUnescapedLinkLabel).replace(/%20/g, ' ')}</a>`);
 				return;
 			}
 		}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -21,6 +21,7 @@ import { TextModel } from 'vs/editor/common/model/textModel';
 import { IEditor } from 'vs/editor/common/editorCommon';
 import * as path from 'vs/base/common/path';
 import { URI } from 'vs/base/common/uri';
+import { escape } from 'vs/base/common/strings';
 
 export const MARKDOWN_TOOLBAR_SELECTOR: string = 'markdown-toolbar-component';
 
@@ -245,7 +246,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				this.output?.nativeElement?.focus();
 				result = result ?? linkCalloutResult?.insertUnescapedLinkUrl;
 				// Callout is responsible for returning escaped strings. We replace %20 for whitespaces to allow spaces in the link's display text
-				document.execCommand('insertHTML', false, `<a href="${encodeURI(result)}">${escape(linkCalloutResult?.insertUnescapedLinkLabel).replace(/%20/g, ' ')}</a>`);
+				document.execCommand('insertHTML', false, `<a href="${escape(result)}">${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
 				return;
 			}
 		}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -235,11 +235,11 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 			if (this.cellModel.currentMode !== CellEditModes.WYSIWYG) {
 				needsTransform = false;
 			} else {
-				let linkUrl = linkCalloutResult?.insertUnescapedLinkUrl;
+				let linkUrl = linkCalloutResult.insertUnescapedLinkUrl;
 				const isFile = URI.parse(linkUrl).scheme === 'file';
 				if (isFile && !path.isAbsolute(linkUrl)) {
 					const notebookDirName = path.dirname(this.cellModel?.notebookModel?.notebookUri.fsPath);
-					const relativePath = (linkCalloutResult?.insertUnescapedLinkUrl).replace(/\\/g, path.posix.sep);
+					const relativePath = (linkUrl).replace(/\\/g, path.posix.sep);
 					linkUrl = path.resolve(notebookDirName, relativePath);
 				}
 				// Otherwise, re-focus on the output element, and insert the link directly.

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -235,12 +235,12 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 				needsTransform = false;
 			} else {
 				let result = undefined;
-				const isFile = !URI.parse(linkCalloutResult?.insertUnescapedLinkUrl).scheme.includes('http');
+				const isFile = URI.parse(linkCalloutResult?.insertUnescapedLinkUrl).scheme.includes('file');
 				if (!path.isAbsolute(linkCalloutResult?.insertUnescapedLinkUrl) && isFile) {
+					// Counts the number of ..\ intermediate directories when user enters a relative path
 					let midDirectories = (linkCalloutResult?.insertUnescapedLinkUrl.match(/..\\/g) || []).length;
 					let dirName = path.dirname(this.cellModel?.notebookModel?.notebookUri.fsPath);
 					const relativePath = linkCalloutResult?.insertUnescapedLinkUrl.replace(/\.\\/g, '/');
-
 					while (midDirectories > 1) {
 						dirName = path.dirname(dirName);
 						midDirectories--;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -235,18 +235,16 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 			if (this.cellModel.currentMode !== CellEditModes.WYSIWYG) {
 				needsTransform = false;
 			} else {
-				let result = undefined;
-				const isFile = URI.parse(linkCalloutResult?.insertUnescapedLinkUrl).scheme === 'file';
-				if (isFile && !path.isAbsolute(linkCalloutResult?.insertUnescapedLinkUrl)) {
+				let linkUrl = linkCalloutResult?.insertUnescapedLinkUrl;
+				const isFile = URI.parse(linkUrl).scheme === 'file';
+				if (isFile && !path.isAbsolute(linkUrl)) {
 					const notebookDirName = path.dirname(this.cellModel?.notebookModel?.notebookUri.fsPath);
 					const relativePath = (linkCalloutResult?.insertUnescapedLinkUrl).replace(/\\/g, path.posix.sep);
-					result = path.resolve(notebookDirName, relativePath);
+					linkUrl = path.resolve(notebookDirName, relativePath);
 				}
 				// Otherwise, re-focus on the output element, and insert the link directly.
 				this.output?.nativeElement?.focus();
-				result = result ?? linkCalloutResult?.insertUnescapedLinkUrl;
-				// Callout is responsible for returning escaped strings.
-				document.execCommand('insertHTML', false, `<a href="${escape(result)}">${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
+				document.execCommand('insertHTML', false, `<a href="${escape(linkUrl)}">${escape(linkCalloutResult?.insertUnescapedLinkLabel)}</a>`);
 				return;
 			}
 		}


### PR DESCRIPTION
Convert relative paths to absolute paths based on the notebook uri before converting to markdown
This PR fixes #14736
![Screen Shot 2021-03-16 at 12 45 20 PM](https://user-images.githubusercontent.com/34872381/111370449-7d739100-8655-11eb-80c0-3846be718b85.png)

