### PR TITLE
Activate extensions contributing deployment providers

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -1016,6 +1016,11 @@
           "when": "mi-type=arc-mi"
         }
       }
+    ],
+    "resourceDeploymentOptionsSources": [
+      {
+        "id": "arc.controllers"
+      }
     ]
   },
   "dependencies": {

--- a/extensions/azdata/package.json
+++ b/extensions/azdata/package.json
@@ -107,7 +107,12 @@
           "when": "azdata.found"
         }
       ]
-    }
+    },
+    "resourceDeploymentOptionsSources": [
+      {
+        "id": "arc.controller.config.profiles"
+      }
+    ]
   },
   "dependencies": {
     "request": "^2.88.2",

--- a/extensions/azurecore/package.json
+++ b/extensions/azurecore/package.json
@@ -317,6 +317,11 @@
         }
       ]
     },
+    "resourceDeploymentValueProviders": [
+      {
+        "id": "subscription-id-to-tenant-id"
+      }
+    ],
     "hasAzureResourceProviders": true
   },
   "dependencies": {

--- a/extensions/resource-deployment/src/ui/modelViewUtils.ts
+++ b/extensions/resource-deployment/src/ui/modelViewUtils.ts
@@ -422,7 +422,7 @@ async function hookUpValueProviders(context: WizardPageContext): Promise<void> {
 					console.error(`Could not find target component ${field.valueProvider.triggerField} when hooking up value providers for ${field.label}`);
 					return;
 				}
-				const provider = valueProviderService.getValueProvider(field.valueProvider.providerId);
+				const provider = await valueProviderService.getValueProvider(field.valueProvider.providerId);
 				const updateFields = async () => {
 					const targetComponentValue = await targetComponent.getValue();
 					const newFieldValue = await provider.getValue(targetComponentValue?.toString() ?? '');
@@ -619,7 +619,7 @@ async function processOptionsTypeField(context: FieldContext): Promise<void> {
 	throwUnless('optionsType' in context.fieldInfo.options, loc.optionsTypeNotFound);
 	if (context.fieldInfo.options.source?.providerId) {
 		try {
-			context.fieldInfo.options.source.provider = optionsSourcesService.getOptionsSource(context.fieldInfo.options.source.providerId);
+			context.fieldInfo.options.source.provider = await optionsSourcesService.getOptionsSource(context.fieldInfo.options.source.providerId);
 		}
 		catch (e) {
 			disableControlButtons(context.container);


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/14749

We need to be able to handle extensions which may not have been activated yet but still contribute a provider - this is a common pattern already used in VS Code (for example with tree views)

Package JSON defines the ID so that the RD extension can know which extension contributes what provider - and then the extension is in charge of ensuring that it's registered before the activate function returns. 