### PR TITLE
Fix BDC deployment removing all security settings from config

### DIFF
--- a/extensions/resource-deployment/src/services/azdataService.ts
+++ b/extensions/resource-deployment/src/services/azdataService.ts
@@ -61,7 +61,7 @@ export class AzdataService implements IAzdataService {
 		const env: NodeJS.ProcessEnv = {};
 		// azdata requires this environment variables to be set
 		env['ACCEPT_EULA'] = 'yes';
-		await this.platformService.runCommand(`azdata bdc config init --source ${profileName} --target ${profileName} --force`, { workingDirectory: this.platformService.storagePath(), additionalEnvironmentVariables: env });
+		await this.platformService.runCommand(`azdata bdc config init --source ${profileName} --path ${profileName} --force`, { workingDirectory: this.platformService.storagePath(), additionalEnvironmentVariables: env });
 		const configObjects = await Promise.all([
 			this.getJsonObjectFromFile(path.join(this.platformService.storagePath(), profileName, 'bdc.json')),
 			this.getJsonObjectFromFile(path.join(this.platformService.storagePath(), profileName, 'control.json'))

--- a/extensions/resource-deployment/src/services/bigDataClusterDeploymentProfile.ts
+++ b/extensions/resource-deployment/src/services/bigDataClusterDeploymentProfile.ts
@@ -270,10 +270,10 @@ export class BigDataClusterDeploymentProfile {
 	}
 
 	public setAuthenticationMode(mode: string): void {
-		// If basic authentication is picked, the security section must be removed
+		// If basic authentication is picked, the activeDirectory security section must be removed
 		// otherwise azdata will throw validation error
-		if (mode === AuthenticationMode.Basic && 'security' in this._controlConfig) {
-			delete this._controlConfig.security;
+		if (mode === AuthenticationMode.Basic && 'security' in this._controlConfig && 'activeDirectory' in this._controlConfig.security) {
+			delete this._controlConfig.security.activeDirectory;
 		}
 	}
 


### PR DESCRIPTION
We only need to remove the activeDirectory settings (which is what causes the validaiton error). Other settings should be preserved. 

Also updated --target to --path, --target is deprecated and will be removed in a future release. 