### PR TITLE
Fix MIAA connection strings page not populating

### DIFF
--- a/extensions/arc/src/ui/dashboards/miaa/miaaConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaConnectionStringsPage.ts
@@ -8,7 +8,6 @@ import * as loc from '../../../localizedConstants';
 import { IconPathHelper, cssStyles } from '../../../constants';
 import { KeyValueContainer, KeyValue, InputKeyValue, MultilineInputKeyValue } from '../../components/keyValueContainer';
 import { DashboardPage } from '../../components/dashboardPage';
-import { ControllerModel } from '../../../models/controllerModel';
 import { MiaaModel } from '../../../models/miaaModel';
 import { parseIpAndPort } from '../../../common/utils';
 
@@ -17,9 +16,9 @@ export class MiaaConnectionStringsPage extends DashboardPage {
 	private _keyValueContainer!: KeyValueContainer;
 	private _connectionStringsMessage!: azdata.TextComponent;
 
-	constructor(modelView: azdata.ModelView, private _controllerModel: ControllerModel, private _miaaModel: MiaaModel) {
+	constructor(modelView: azdata.ModelView, private _miaaModel: MiaaModel) {
 		super(modelView);
-		this.disposables.push(this._controllerModel.onRegistrationsUpdated(_ =>
+		this.disposables.push(this._miaaModel.onConfigUpdated(_ =>
 			this.eventuallyRunOnInitialized(() => this.updateConnectionStrings())));
 	}
 

--- a/extensions/arc/src/ui/dashboards/miaa/miaaDashboard.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaDashboard.ts
@@ -27,7 +27,7 @@ export class MiaaDashboard extends Dashboard {
 
 	protected async registerTabs(modelView: azdata.ModelView): Promise<(azdata.DashboardTab | azdata.DashboardTabGroup)[]> {
 		const overviewPage = new MiaaDashboardOverviewPage(modelView, this._controllerModel, this._miaaModel);
-		const connectionStringsPage = new MiaaConnectionStringsPage(modelView, this._controllerModel, this._miaaModel);
+		const connectionStringsPage = new MiaaConnectionStringsPage(modelView, this._miaaModel);
 		const computeAndStoragePage = new MiaaComputeAndStoragePage(modelView, this._miaaModel);
 		return [
 			overviewPage.tab,


### PR DESCRIPTION
We're using the MIAA config to populate this page so it's not correct to hook into the controller config update event since that could happen before the MIAA config was populated - which would cause it to display a "No external endpoint configured" message instead of the connection strings.