### PR TITLE
Add missing "Data Direction"-option to line charts

### DIFF
--- a/src/sql/workbench/contrib/charts/browser/chartOptions.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartOptions.ts
@@ -148,6 +148,7 @@ export const ChartOptions: IChartOptions = {
 		}
 	],
 	[ChartType.Line]: [
+		dataDirectionOption,
 		dataTypeInput,
 		columnsAsLabelsInput,
 		labelFirstColumnInput,


### PR DESCRIPTION
This PR fixes #4032 by adding the missing option to the line-chart type.

Can be tested by just visualizing a result as a line-chart. The "Data Direction" will now be available.
