### PR TITLE
Fix API issues for external extensions

### DIFF
--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3902,9 +3902,8 @@ declare module 'azdata' {
 		 * Create a wizard with the given title and width
 		 * @param title The title of the wizard
 		 * @param name The name used to identify the wizard in telemetry
-		 * @param width The width of the wizard, default value is 'narrow'
 		 */
-		export function createWizard(title: string, name?: string, width?: DialogWidth): Wizard;
+		export function createWizard(title: string, name?: string): Wizard;
 
 		/**
 		 * Used to control whether a message in a dialog/wizard is displayed as an error,

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3902,6 +3902,7 @@ declare module 'azdata' {
 		 * Create a wizard with the given title and width
 		 * @param title The title of the wizard
 		 * @param name The name used to identify the wizard in telemetry
+		 * @param width The width of the wizard, default value is 'narrow'
 		 */
 		export function createWizard(title: string, name?: string, width?: DialogWidth): Wizard;
 

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3903,7 +3903,7 @@ declare module 'azdata' {
 		 * @param title The title of the wizard
 		 * @param name The name used to identify the wizard in telemetry
 		 */
-		export function createWizard(title: string, name?: string): Wizard;
+		export function createWizard(title: string, name?: string, width?: DialogWidth): Wizard;
 
 		/**
 		 * Used to control whether a message in a dialog/wizard is displayed as an error,

--- a/src/sql/azdata.d.ts
+++ b/src/sql/azdata.d.ts
@@ -3916,6 +3916,11 @@ declare module 'azdata' {
 		}
 
 		/**
+		 * The width of a dialog, either from a predetermined size list or a specific size (such as px)
+		 */
+		export type DialogWidth = 'narrow' | 'medium' | 'wide' | number | string;
+
+		/**
 		 * A message shown in a dialog. If the level is not set it defaults to error.
 		 */
 		export type DialogMessage = {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -621,6 +621,13 @@ declare module 'azdata' {
 		 */
 		export function createModelViewDialog(title: string, dialogName?: string, width?: DialogWidth, dialogStyle?: DialogStyle, dialogPosition?: DialogPosition, renderHeader?: boolean, renderFooter?: boolean, dialogProperties?: IDialogProperties): Dialog;
 
+		/**
+		 * Create a wizard with the given title and width
+		 * @param title The title of the wizard
+		 * @param name The name used to identify the wizard in telemetry
+		 * @param width The width of the wizard, default value is 'narrow'
+		 */
+		export function createWizard(title: string, name?: string, width?: DialogWidth): Wizard;
 
 		export interface Button {
 			/**

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -584,8 +584,6 @@ declare module 'azdata' {
 			pageName?: string;
 		}
 
-		export type DialogWidth = 'narrow' | 'medium' | 'wide' | number | string;
-
 		/**
 		 * These dialog styles affect how the dialog displays in the application.
 		 * normal: Positioned top and centered.
@@ -620,14 +618,6 @@ declare module 'azdata' {
 		 * @param dialogProperties Positional data prior to opening of dialog, default is undefined.
 		 */
 		export function createModelViewDialog(title: string, dialogName?: string, width?: DialogWidth, dialogStyle?: DialogStyle, dialogPosition?: DialogPosition, renderHeader?: boolean, renderFooter?: boolean, dialogProperties?: IDialogProperties): Dialog;
-
-		/**
-		 * Create a wizard with the given title and width
-		 * @param title The title of the wizard
-		 * @param name The name used to identify the wizard in telemetry
-		 * @param width The width of the wizard, default value is 'narrow'
-		 */
-		export function createWizard(title: string, name?: string, width?: DialogWidth): Wizard;
 
 		export interface Button {
 			/**


### PR DESCRIPTION
Will think about how we can prevent this from happening in the future, although I'm pretty sure that DefinitelyType would have caught this when we tried to update the types and so we could have fixed it there. This mostly broke because of an extension was still using the deprecated azdata package to get the typings. But it'd be nice to catch it early on if we can. 