### PR TITLE
Fix publish profile with connection string ending in semicolon not loading

### DIFF
--- a/extensions/sql-database-projects/src/models/dataSources/sqlConnectionStringSource.ts
+++ b/extensions/sql-database-projects/src/models/dataSources/sqlConnectionStringSource.ts
@@ -67,7 +67,8 @@ export class SqlConnectionDataSource extends DataSource {
 		// TODO: do we have a common construct for connection strings?
 		this.connectionString = connectionString;
 
-		for (const component of this.connectionString.split(';')) {
+		const components = this.connectionString.split(';').filter(c => c !== '');
+		for (const component of components) {
 			const split = component.split('=');
 
 			if (split.length !== 2) {

--- a/extensions/sql-database-projects/src/test/baselines/publishProfileSqlLoginBaseline.publish.xml
+++ b/extensions/sql-database-projects/src/test/baselines/publishProfileSqlLoginBaseline.publish.xml
@@ -4,8 +4,7 @@
     <IncludeCompositeObjects>True</IncludeCompositeObjects>
     <TargetDatabaseName>targetDb</TargetDatabaseName>
     <DeployScriptFileName>DatabaseProject1.sql</DeployScriptFileName>
-    <![CDATA[[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Test password, not actually used")]]>
-    <TargetConnectionString>Data Source=testserver;User Id=testUser;Password=abcd123;Integrated Security=false;Persist Security Info=False;Pooling=False;MultipleActiveResultSets=False;Connect Timeout=60;Encrypt=False;TrustServerCertificate=True</TargetConnectionString>
+    <TargetConnectionString>Data Source=testserver;User Id=testUser;Password=PLACEHOLDER;Integrated Security=false;Persist Security Info=False;Pooling=False;MultipleActiveResultSets=False;Connect Timeout=60;Encrypt=False;TrustServerCertificate=True</TargetConnectionString>
     <ProfileVersionNumber>1</ProfileVersionNumber>
   </PropertyGroup>
   <ItemGroup>

--- a/extensions/sql-database-projects/src/test/datasource.test.ts
+++ b/extensions/sql-database-projects/src/test/datasource.test.ts
@@ -9,12 +9,12 @@ import * as testUtils from './testUtils';
 import * as sql from '../models/dataSources/sqlConnectionStringSource';
 import * as dataSources from '../models/dataSources/dataSources';
 
-describe.skip('Data Sources: DataSource operations', function (): void {
+describe('Data Sources: DataSource operations', function (): void {
 	before(async function () : Promise<void> {
 		await baselines.loadBaselines();
 	});
 
-	it('Should read DataSources from datasource.json', async function (): Promise<void> {
+	it.skip('Should read DataSources from datasource.json', async function (): Promise<void> {
 		const dataSourcePath = await testUtils.createTestDataSources(baselines.openDataSourcesBaseline);
 		const dataSourceList = await dataSources.load(dataSourcePath);
 
@@ -30,5 +30,11 @@ describe.skip('Data Sources: DataSource operations', function (): void {
 		should(dataSourceList[2].name).equal('AAD Interactive Data Source');
 		should((dataSourceList[2] as sql.SqlConnectionDataSource).integratedSecurity).equal(false);
 		should((dataSourceList[2] as sql.SqlConnectionDataSource).azureMFA).equal(true);
+	});
+
+	it ('Should be able to create sql data source from connection strings with and without ending semicolon', function (): void {
+		should.doesNotThrow(() => new sql.SqlConnectionDataSource('no ending semicolon', 'Data Source=(LOCAL);Initial Catalog=testdb;User id=sa;Password=PLACEHOLDER'));
+		should.doesNotThrow(() => new sql.SqlConnectionDataSource('ending in semicolon', 'Data Source=(LOCAL);Initial Catalog=testdb;User id=sa;Password=PLACEHOLDER;'));
+		should.throws(() => new sql.SqlConnectionDataSource('invalid extra equals sign', 'Data Source=(LOCAL);Initial Catalog=testdb=extra;User id=sa;Password=PLACEHOLDER'));
 	});
 });


### PR DESCRIPTION
This PR fixes #14789, which was reported in #14754. Also changing another test password to be PLACEHOLDER for consistency.
