### PR TITLE
make tenant list not tab focusable

### DIFF
--- a/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
+++ b/src/sql/workbench/services/accountManagement/browser/accountDialog.ts
@@ -84,6 +84,9 @@ class AccountPanel extends ViewPane {
 		this.tenantList = new List<Tenant>('TenantList', container, new TenantListDelegate(AccountDialog.ACCOUNTLIST_HEIGHT), [this.instantiationService.createInstance(TenantListRenderer)]);
 		this._register(attachListStyler(this.accountList, this.themeService));
 		this._register(attachListStyler(this.tenantList, this.themeService));
+
+		// Temporary workaround for https://github.com/microsoft/azuredatastudio/issues/14808 so that we can close an accessibility issue.
+		this.tenantList.getHTMLElement().tabIndex = -1;
 	}
 
 	protected layoutBody(size: number): void {
@@ -301,9 +304,9 @@ export class AccountDialog extends Modal {
 		this._noaccountViewContainer!.hidden = true;
 		if (Iterable.consume(this._providerViewsMap.values()).length > 0) {
 			const firstView = this._providerViewsMap.values().next().value;
-			if (firstView instanceof AccountPanel) {
-				firstView.setSelection([0]);
-				firstView.focus();
+			if (firstView && firstView.view instanceof AccountPanel) {
+				firstView.view.setSelection([0]);
+				firstView.view.focus();
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes #14170 

this is a temporary fix for the accessibility issue by making the tenant list not keyboard focusable and opened an issue for @cssuh to understand what do we want to do with the tenant list: https://github.com/microsoft/azuredatastudio/issues/14808