### PR TITLE
use label instead of handle for aria label

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
+++ b/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
@@ -446,7 +446,7 @@ class ListAccessibilityProvider implements IListAccessibilityProvider<TreeElemen
 		} else if (element instanceof SavedConnectionNode) {
 			return localize('savedConnection', "Saved Connections");
 		} else {
-			return element.element.handle;
+			return element.element.label.label;
 		}
 	}
 


### PR DESCRIPTION
Previously the aria-label is set to the tree node handle, which is definitely wrong, with this PR the aria-label will be the display text.
![image](https://user-images.githubusercontent.com/13777222/111851436-5d033b00-88d0-11eb-87e7-b0408fb623e7.png)

This PR fixes #14172 
