### PR TITLE
radio button outline style

### DIFF
--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -213,6 +213,7 @@ body.web {
 .monaco-workbench input[type="button"]:focus,
 .monaco-workbench input[type="text"]:focus,
 .monaco-workbench textarea:focus,
+.monaco-workbench input[type="radio"]:focus, /* {{SQL CARBON EDIT}} */
 .monaco-workbench input[type="checkbox"]:focus {
 	outline-width: 1px;
 	outline-style: solid;
@@ -220,6 +221,7 @@ body.web {
 	opacity: 1 !important;
 }
 
+.monaco-workbench input[type="radio"]:focus, /* {{SQL CARBON EDIT}} */
 .monaco-workbench input[type="checkbox"]:focus {
 	outline-offset: 2px;
 }

--- a/src/vs/workbench/browser/style.ts
+++ b/src/vs/workbench/browser/style.ts
@@ -121,7 +121,8 @@ registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) =
 		.monaco-workbench button:focus,
 		.monaco-workbench textarea:focus,
 		.monaco-workbench input[type="search"]:focus,
-		.monaco-workbench input[type="checkbox"]:focus {
+		.monaco-workbench input[type="radio"]:focus, /* {{SQL CARBON EDIT}} */
+		.monaco-workbench input[type="checkbox"]:focus{
 			outline-color: ${focusOutline};
 		}
 		`);


### PR DESCRIPTION
This PR fixes #14546 

right now it is using the browser default color:
![image](https://user-images.githubusercontent.com/13777222/111854010-67c2cd80-88da-11eb-87ea-482433930305.png)

update it use our common colors.

before:
![image](https://user-images.githubusercontent.com/13777222/111853949-321de480-88da-11eb-9c12-190c5c8ba91a.png)

after:
![image](https://user-images.githubusercontent.com/13777222/111853971-46fa7800-88da-11eb-9303-83d4f8d0de5a.png)
