### PR TITLE
Bumped sqltoolsservice version

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.83",
+	"version": "3.0.0-release.87",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",


### PR DESCRIPTION
https://github.com/microsoft/sqltoolsservice/releases/tag/v3.0.0-release.87

Includes the latest Migration Assessments for the SQL Migration extension.