### PR TITLE
Updates how the Postgres Parameter Dashboard adds data to its table and discard values. 

### DIFF
--- a/extensions/arc/src/ui/dashboards/postgres/postgresCoordinatorNodeParametersPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresCoordinatorNodeParametersPage.ts
@@ -66,6 +66,17 @@ export class PostgresCoordinatorNodeParametersPage extends PostgresParametersPag
 
 	protected refreshParametersTable(): void {
 		this._parameters = this._postgresModel.coordinatorNodeEngineSettings.map(engineSetting => this.createParameterComponents(engineSetting));
-		this._parametersTable.data = this._parameters.map(p => [p.parameterName, p.valueContainer, p.description, p.resetButton]);
+
+		this._parametersTable.data = this._parameters.map(p => {
+			if (p.information) {
+				// Container to hold input component and information bubble
+				const valueContainer = this.modelView.modelBuilder.flexContainer().withLayout({ alignItems: 'center' }).component();
+				valueContainer.addItem(p.valueComponent, { CSSStyles: { 'margin-right': '0px' } });
+				valueContainer.addItem(p.information, { CSSStyles: { 'margin-left': '5px' } });
+				return [p.parameterName, valueContainer, p.description, p.resetButton];
+			} else {
+				return [p.parameterName, p.valueComponent, p.description, p.resetButton];
+			}
+		});
 	}
 }

--- a/extensions/arc/src/ui/dashboards/postgres/postgresCoordinatorNodeParametersPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresCoordinatorNodeParametersPage.ts
@@ -7,7 +7,7 @@ import * as azdata from 'azdata';
 import * as loc from '../../../localizedConstants';
 import { IconPathHelper } from '../../../constants';
 import { PostgresParametersPage } from './postgresParameters';
-import { PostgresModel } from '../../../models/postgresModel';
+import { PostgresModel, EngineSettingsModel } from '../../../models/postgresModel';
 
 export class PostgresCoordinatorNodeParametersPage extends PostgresParametersPage {
 
@@ -29,6 +29,10 @@ export class PostgresCoordinatorNodeParametersPage extends PostgresParametersPag
 
 	protected get description(): string {
 		return loc.coordinatorNodeParametersDescription;
+	}
+
+	protected get engineSettings(): EngineSettingsModel[] {
+		return this._postgresModel.coordinatorNodeEngineSettings;
 	}
 
 	protected async saveParameterEdits(): Promise<void> {
@@ -62,21 +66,5 @@ export class PostgresCoordinatorNodeParametersPage extends PostgresParametersPag
 				this._postgresModel.controllerModel.azdataAdditionalEnvVars,
 				session);
 		*/
-	}
-
-	protected refreshParametersTable(): void {
-		this._parameters = this._postgresModel.coordinatorNodeEngineSettings.map(engineSetting => this.createParameterComponents(engineSetting));
-
-		this._parametersTable.data = this._parameters.map(p => {
-			if (p.information) {
-				// Container to hold input component and information bubble
-				const valueContainer = this.modelView.modelBuilder.flexContainer().withLayout({ alignItems: 'center' }).component();
-				valueContainer.addItem(p.valueComponent, { CSSStyles: { 'margin-right': '0px' } });
-				valueContainer.addItem(p.information, { CSSStyles: { 'margin-left': '5px' } });
-				return [p.parameterName, valueContainer, p.description, p.resetButton];
-			} else {
-				return [p.parameterName, p.valueComponent, p.description, p.resetButton];
-			}
-		});
 	}
 }

--- a/extensions/arc/src/ui/dashboards/postgres/postgresParameters.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresParameters.ts
@@ -196,6 +196,7 @@ export abstract class PostgresParametersPage extends DashboardPage {
 					vscode.window.showErrorMessage(loc.pageDiscardFailed(error));
 				} finally {
 					this.saveButton!.enabled = false;
+					this.parameterUpdates!.clear();
 				}
 			})
 		);

--- a/extensions/arc/src/ui/dashboards/postgres/postgresParameters.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresParameters.ts
@@ -381,6 +381,7 @@ export abstract class PostgresParametersPage extends DashboardPage {
 			this.collectChangedComponents(name);
 			return false;
 		} else if (component.value === currentValue) {
+			this.removeFromChangedComponents(name);
 			return false;
 		} else {
 			/* If a valid value has been entered into the input box, enable save and discard buttons
@@ -423,7 +424,7 @@ export abstract class PostgresParametersPage extends DashboardPage {
 							await this._postgresModel.refresh();
 						}
 					);
-
+					this.removeFromChangedComponents(engineSetting.parameterName!);
 					vscode.window.showInformationMessage(loc.instanceUpdated(this._postgresModel.info.name));
 				} catch (error) {
 					vscode.window.showErrorMessage(loc.instanceUpdateFailed(this._postgresModel.info.name, error));
@@ -456,6 +457,7 @@ export abstract class PostgresParametersPage extends DashboardPage {
 						this.discardButton!.enabled = true;
 					} else if (this.parameterUpdates!.has(engineSetting.parameterName!)) {
 						this.parameterUpdates!.delete(engineSetting.parameterName!);
+						this.removeFromChangedComponents(engineSetting.parameterName!);
 					}
 				})
 			);
@@ -487,6 +489,7 @@ export abstract class PostgresParametersPage extends DashboardPage {
 						this.discardButton!.enabled = true;
 					} else if (this.parameterUpdates!.has(engineSetting.parameterName!)) {
 						this.parameterUpdates!.delete(engineSetting.parameterName!);
+						this.removeFromChangedComponents(engineSetting.parameterName!);
 					}
 				})
 			);
@@ -563,6 +566,13 @@ export abstract class PostgresParametersPage extends DashboardPage {
 	private collectChangedComponents(name: string): void {
 		if (!this.changedComponentValues.includes(name)) {
 			this.changedComponentValues.push(name);
+		}
+	}
+
+	private removeFromChangedComponents(name: string): void {
+		if (this.changedComponentValues.includes(name)) {
+			let index = this.changedComponentValues.indexOf(name);
+			this.changedComponentValues.splice(index, 1);
 		}
 	}
 

--- a/extensions/arc/src/ui/dashboards/postgres/postgresParameters.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresParameters.ts
@@ -203,6 +203,7 @@ export abstract class PostgresParametersPage extends DashboardPage {
 				try {
 					this.discardParametersTableChanges();
 				} catch (error) {
+					this.discardButton!.enabled = true;
 					vscode.window.showErrorMessage(loc.pageDiscardFailed(error));
 				} finally {
 					this.changedComponentValues = [];

--- a/extensions/arc/src/ui/dashboards/postgres/postgresWorkerNodeParametersPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresWorkerNodeParametersPage.ts
@@ -64,6 +64,17 @@ export class PostgresWorkerNodeParametersPage extends PostgresParametersPage {
 
 	protected refreshParametersTable(): void {
 		this._parameters = this._postgresModel.workerNodesEngineSettings.map(engineSetting => this.createParameterComponents(engineSetting));
-		this._parametersTable.data = this._parameters.map(p => [p.parameterName, p.valueContainer, p.description, p.resetButton]);
+
+		this._parametersTable.data = this._parameters.map(p => {
+			if (p.information) {
+				// Container to hold input component and information bubble
+				const valueContainer = this.modelView.modelBuilder.flexContainer().withLayout({ alignItems: 'center' }).component();
+				valueContainer.addItem(p.valueComponent, { CSSStyles: { 'margin-right': '0px' } });
+				valueContainer.addItem(p.information, { CSSStyles: { 'margin-left': '5px' } });
+				return [p.parameterName, valueContainer, p.description, p.resetButton];
+			} else {
+				return [p.parameterName, p.valueComponent, p.description, p.resetButton];
+			}
+		});
 	}
 }

--- a/extensions/arc/src/ui/dashboards/postgres/postgresWorkerNodeParametersPage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresWorkerNodeParametersPage.ts
@@ -8,7 +8,7 @@ import * as azdataExt from 'azdata-ext';
 import * as loc from '../../../localizedConstants';
 import { IconPathHelper } from '../../../constants';
 import { PostgresParametersPage } from './postgresParameters';
-import { PostgresModel } from '../../../models/postgresModel';
+import { PostgresModel, EngineSettingsModel } from '../../../models/postgresModel';
 
 export class PostgresWorkerNodeParametersPage extends PostgresParametersPage {
 
@@ -33,6 +33,10 @@ export class PostgresWorkerNodeParametersPage extends PostgresParametersPage {
 	protected get description(): string {
 		// TODO update to loc.workerNodesParametersDescription
 		return loc.nodeParametersDescription;
+	}
+
+	protected get engineSettings(): EngineSettingsModel[] {
+		return this._postgresModel.workerNodesEngineSettings;
 	}
 
 	protected async saveParameterEdits(engineSettings: string, session: azdataExt.AzdataSession): Promise<void> {
@@ -60,21 +64,5 @@ export class PostgresWorkerNodeParametersPage extends PostgresParametersPage {
 			this._postgresModel.engineVersion,
 			this._postgresModel.controllerModel.azdataAdditionalEnvVars,
 			session);
-	}
-
-	protected refreshParametersTable(): void {
-		this._parameters = this._postgresModel.workerNodesEngineSettings.map(engineSetting => this.createParameterComponents(engineSetting));
-
-		this._parametersTable.data = this._parameters.map(p => {
-			if (p.information) {
-				// Container to hold input component and information bubble
-				const valueContainer = this.modelView.modelBuilder.flexContainer().withLayout({ alignItems: 'center' }).component();
-				valueContainer.addItem(p.valueComponent, { CSSStyles: { 'margin-right': '0px' } });
-				valueContainer.addItem(p.information, { CSSStyles: { 'margin-left': '5px' } });
-				return [p.parameterName, valueContainer, p.description, p.resetButton];
-			} else {
-				return [p.parameterName, p.valueComponent, p.description, p.resetButton];
-			}
-		});
 	}
 }


### PR DESCRIPTION
Currently to discard values put in the table by the user, the table gets refreshed and all components are recreated to show its original values. The data of the table is also reset. This change records which parameters have been altered in the UI and only changes the value of the components without  having to reset the data of the table. 

To do this change I had to no longer save the components within a flex container. The only component that needed to be within a container was textbox that took in numbers in order to be placed with an information bubble. This results in no change in the view of the table on the Parameters Dashboard. 

This PR hopefully can address  # 14366
