### PR TITLE
Make task history horizontally scrollable

### DIFF
--- a/src/sql/workbench/contrib/tasks/browser/media/tasksPanel.css
+++ b/src/sql/workbench/contrib/tasks/browser/media/tasksPanel.css
@@ -7,22 +7,27 @@
 	padding: 10px 22px 0 22px;
 }
 
+.task-history .monaco-tree > .monaco-scrollable-element > .monaco-tree-wrapper {
+	overflow-x: auto !important;
+}
+
+.task-history .monaco-tree .monaco-tree-rows > .monaco-tree-row {
+	width: fit-content;
+}
+
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content > .task-group {
 	line-height: 22px;
 	display: flex;
+	width: fit-content;
 }
 
 /* task label and description */
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content > .task-group > .label {
-	text-overflow: ellipsis;
-	overflow: hidden;
 	font-weight: bold;
 }
 
 /* style for server name | database name */
 .monaco-tree .monaco-tree-rows > .monaco-tree-row > .content > .task-group > .description {
-	text-overflow: ellipsis;
-	overflow: hidden;
 	padding-left: 12px
 }
 

--- a/src/sql/workbench/contrib/tasks/browser/tasksView.ts
+++ b/src/sql/workbench/contrib/tasks/browser/tasksView.ts
@@ -103,6 +103,8 @@ export class TaskHistoryView extends ViewPane {
 		const filter = new DefaultFilter();
 		const accessibilityProvider = new DefaultAccessibilityProvider();
 
+		treeContainer.classList.add('task-history');
+
 		return new Tree(treeContainer, {
 			dataSource, renderer, controller, dnd, filter, accessibilityProvider
 		}, {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #14517. This adds a scrollbar and gets rid of the truncation with ... in the task history when the window is made smaller or zoomed in so that the data is viewable without a tooltip. 

before: 
![image](https://user-images.githubusercontent.com/31145923/112238909-c782e680-8c02-11eb-96cb-a3760dece12a.png)

after:
![taskhistoryscroll](https://user-images.githubusercontent.com/31145923/112238682-5ba07e00-8c02-11eb-9fdc-c466487dca9f.gif)
