### PR TITLE
fix the layout issue in migration assessment dialog

### DIFF
--- a/extensions/sql-migration/src/dialog/assessmentResults/assessmentResultsDialog.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/assessmentResultsDialog.ts
@@ -45,10 +45,6 @@ export class AssessmentResultsDialog {
 						flexFlow: 'row',
 						height: '100%',
 						width: '100%'
-					}).withProps({
-						CSSStyles: {
-							'margin-top': '10px'
-						}
 					}).component();
 					flex.addItem(treeComponent, { flex: '0 0 auto' });
 					flex.addItem(resultComponent, { flex: '1 1 auto' });

--- a/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
@@ -62,7 +62,7 @@ export class SqlDatabaseTree {
 
 		component.addItem(this.createSearchComponent(view), { flex: '0 0 auto' });
 		component.addItem(this.createInstanceComponent(view), { flex: '0 0 auto' });
-		component.addItem(this.createDatabaseComponent(view, dbs), { flex: '1 1 auto' });
+		component.addItem(this.createDatabaseComponent(view, dbs), { flex: '1 1 auto', CSSStyles: { 'overflow-y': 'auto' } });
 		return component;
 	}
 
@@ -193,12 +193,13 @@ export class SqlDatabaseTree {
 		}).withProps({
 			CSSStyles: {
 				'margin-left': '10px',
-				'margin-right': '15px'
+				'margin-right': '15px',
+				'overflow-y': 'hidden'
 			}
 		}).component();
 
 		container.addItem(topContainer, { flex: '0 0 auto' });
-		container.addItem(bottomContainer, { flex: '1 1 auto' });
+		container.addItem(bottomContainer, { flex: '1 1 auto', CSSStyles: { 'overflow-y': 'hidden' } });
 
 		return container;
 	}
@@ -231,8 +232,8 @@ export class SqlDatabaseTree {
 			}
 		}).component();
 
-		container.addItem(impactedObjects, { flex: '0 0 auto', CSSStyles: { 'border-right': 'solid 1px' } });
-		container.addItem(rightContainer, { flex: '1 1 auto' });
+		container.addItem(impactedObjects, { flex: '0 0 auto', CSSStyles: { 'border-right': 'solid 1px', 'overflow-y': 'auto' } });
+		container.addItem(rightContainer, { flex: '1 1 auto', CSSStyles: { 'overflow-y': 'auto' } });
 		return container;
 	}
 


### PR DESCRIPTION
I was testing the migration UI and noticed the scroll is going out of control, the 3 pars, databases/issues/issue details should scroll independently. also, for db list, the scroll should happen inside the list itself, the search box and the server warning list should always be visible as shown in the 'after' screenshot

before
![image](https://user-images.githubusercontent.com/13777222/112273016-18620180-8c3a-11eb-91c6-31b83054872f.png)

after:
![image](https://user-images.githubusercontent.com/13777222/112273566-b786f900-8c3a-11eb-8508-73970f9ad9b1.png)
