### PR TITLE
Add try catch block to model refresh in compute/storage pages

### DIFF
--- a/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaComputeAndStoragePage.ts
@@ -140,8 +140,11 @@ export class MiaaComputeAndStoragePage extends DashboardPage {
 							} finally {
 								session?.dispose();
 							}
-
-							await this._miaaModel.refresh();
+							try {
+								await this._miaaModel.refresh();
+							} catch (error) {
+								vscode.window.showErrorMessage(loc.refreshFailed(error));
+							}
 						}
 					);
 

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -216,8 +216,11 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 								throw err;
 							} finally {
 								session?.dispose();
+							} try {
+								await this._postgresModel.refresh();
+							} catch (error) {
+								vscode.window.showErrorMessage(loc.refreshFailed(error));
 							}
-							await this._postgresModel.refresh();
 						}
 					);
 

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -216,7 +216,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 								throw err;
 							} finally {
 								session?.dispose();
-							} try {
+							}
+							try {
 								await this._postgresModel.refresh();
 							} catch (error) {
 								vscode.window.showErrorMessage(loc.refreshFailed(error));


### PR DESCRIPTION
Have model refresh calls placed in separate try/catch - we should still show the "instance updated" message even if the refresh failed (but want to still display an error about the refresh failing).
