### PR TITLE
fix issue that user is not able to interact with checkbox in declarative table using keyboard

### DIFF
--- a/src/sql/base/browser/ui/checkbox/checkbox.ts
+++ b/src/sql/base/browser/ui/checkbox/checkbox.ts
@@ -9,6 +9,7 @@ import { Color } from 'vs/base/common/color';
 import { Event, Emitter } from 'vs/base/common/event';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { Widget } from 'vs/base/browser/ui/widget';
+import { EventHelper } from 'vs/base/browser/dom';
 
 export interface ICheckboxOptions {
 	label: string;
@@ -46,12 +47,12 @@ export class Checkbox extends Widget {
 		});
 
 		this.onkeydown(this._el, e => {
-			if (e.equals(KeyCode.Enter)) {
+			if (e.equals(KeyCode.Enter) || e.equals(KeyCode.Space)) {
 				this.checked = !this.checked;
 				// Manually fire the event since we stop the event propagation which means
 				// the onchange event won't fire.
 				this._onChange.fire(this.checked);
-				e.stopPropagation();
+				EventHelper.stop(e, true);
 			}
 		});
 

--- a/src/sql/base/browser/ui/checkbox/checkbox.ts
+++ b/src/sql/base/browser/ui/checkbox/checkbox.ts
@@ -7,9 +7,7 @@ import 'vs/css!./media/checkbox';
 
 import { Color } from 'vs/base/common/color';
 import { Event, Emitter } from 'vs/base/common/event';
-import { KeyCode } from 'vs/base/common/keyCodes';
 import { Widget } from 'vs/base/browser/ui/widget';
-import { EventHelper } from 'vs/base/browser/dom';
 
 export interface ICheckboxOptions {
 	label: string;
@@ -46,15 +44,6 @@ export class Checkbox extends Widget {
 			this._onChange.fire(this.checked);
 		});
 
-		this.onkeydown(this._el, e => {
-			if (e.equals(KeyCode.Enter) || e.equals(KeyCode.Space)) {
-				this.checked = !this.checked;
-				// Manually fire the event since we stop the event propagation which means
-				// the onchange event won't fire.
-				this._onChange.fire(this.checked);
-				EventHelper.stop(e, true);
-			}
-		});
 
 		this._label = document.createElement('span');
 		this._label.style.verticalAlign = 'middle';

--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
@@ -323,6 +323,10 @@ export default class DeclarativeTableComponent extends ContainerBase<any, azdata
 	}
 
 	public onKey(e: KeyboardEvent, row: number) {
+		// Ignore the bubble up events
+		if (e.target !== e.currentTarget) {
+			return;
+		}
 		const event = new StandardKeyboardEvent(e);
 		if (event.equals(KeyCode.Enter) || event.equals(KeyCode.Space)) {
 			this.onRowSelected(row);


### PR DESCRIPTION
1. Remove the enter key handler, as per accessibility requirement, we shouldn't need to handle Enter key. https://webaim.org/techniques/keyboard/
![image](https://user-images.githubusercontent.com/13777222/112399069-ca451080-8cc2-11eb-83f2-7ae415bbfb11.png)

2. Fix the issue that user is not able to interact with the checkboxes inside the declarative table using space key. The fix is: for declarative table's row, only handle the keyboard event when the event is originated on the element itself.
