### PR TITLE
Reload resource deployment types on extension changes

### DIFF
--- a/extensions/resource-deployment/src/services/resourceTypeService.ts
+++ b/extensions/resource-deployment/src/services/resourceTypeService.ts
@@ -29,9 +29,28 @@ export interface OptionValuesFilter {
 }
 
 export interface IResourceTypeService {
+	/**
+	 * Loads the resource types contributed by all extensions, this should only be called on startup or when
+	 * changes to the installed extensions are made.
+	 */
 	loadResourceTypes(): void;
+	/**
+	 * Gets the set of contributed resource types
+	 * @param filterByPlatform Whether to filter to just types valid for the current platform
+	 */
 	getResourceTypes(filterByPlatform?: boolean): ResourceType[];
+	/**
+	 * Validates that the given resource type matches the schema we expect
+	 * @param resourceType The resource type to validate
+	 * @param positionInfo A string to use to identify the resource type (in case it doesn't have a name or other expected properties)
+	 */
 	validateResourceType(resourceType: ResourceType, positionInfo: string): string[];
+	/**
+	 * Starts a deployment for the given resource type
+	 * @param resourceType The resource type to start the deployment for
+	 * @param optionValuesFilter The resource type options to filter the list of selectable options to
+	 * @param initialVariableValues The set of initial key/value pairs to assign to the variables for the deployment
+	 */
 	startDeployment(resourceType: ResourceType, optionValuesFilter?: OptionValuesFilter, initialVariableValues?: InitialVariableValues): void;
 }
 

--- a/extensions/resource-deployment/src/test/services/resourceTypeService.test.ts
+++ b/extensions/resource-deployment/src/test/services/resourceTypeService.test.ts
@@ -12,6 +12,7 @@ import { ResourceTypeService, processWhenClause } from '../../services/resourceT
 import { IPlatformService } from '../../services/platformService';
 import { ToolsService } from '../../services/toolsService';
 import { NotebookService } from '../../services/notebookService';
+import { ResourceType } from '../../interfaces';
 
 describe('Resource Type Service Tests', function (): void {
 
@@ -36,15 +37,18 @@ describe('Resource Type Service Tests', function (): void {
 			mockPlatformService.reset();
 			mockPlatformService.setup(service => service.platform()).returns(() => platformInfo.platform);
 			mockPlatformService.setup(service => service.showErrorMessage(TypeMoq.It.isAnyString()));
+			resourceTypeService.loadResourceTypes();
 			const resourceTypes = resourceTypeService.getResourceTypes(true).map(rt => rt.name);
 			for (let i = 0; i < platformInfo.resourceTypes.length; i++) {
 				assert(resourceTypes.indexOf(platformInfo.resourceTypes[i]) !== -1, `resource type '${platformInfo.resourceTypes[i]}' should be available for platform: ${platformInfo.platform}.`);
 			}
 		});
 
-		const allResourceTypes = resourceTypeService.getResourceTypes(false);
-		const validationErrors = resourceTypeService.validateResourceTypes(allResourceTypes);
-		assert(validationErrors.length === 0, `Validation errors detected in the package.json: ${validationErrors.join(EOL)}.`);
+		resourceTypeService.loadResourceTypes();
+		resourceTypeService.getResourceTypes().forEach((resourceType: ResourceType, index: number) => {
+			const validationErrors = resourceTypeService.validateResourceType(resourceType, `resource type index ${index}`);
+			assert(validationErrors.length === 0, `Validation errors detected in the package.json: ${validationErrors.join(EOL)}.`);
+		});
 	});
 
 	it('Selected options containing all when clauses should return true', () => {


### PR DESCRIPTION
2 main changes here : 

1. We now reload the resource types whenever an extension is installed/uninstalled so that we always have the latest resource type information without needing to restart ADS
2. We no longer stop loading the resource deployment extension if we detect errors in a resource type - instead we'll just skip that resource type. I never thought this made sense to do since just because one type was invalid doesn't mean we should break the entire feature for everyone else.

As part of this I did some slight refactoring of all the functions running this stuff to just makes things easier to use and follow better practices. 