### PR TITLE
Notebooks: fix smoke test

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -182,7 +182,7 @@ CommandsRegistry.registerCommand({
 		for (let editor of editors) {
 			if (editor instanceof NotebookInput) {
 				let model: INotebookModel = editor.notebookModel;
-				if (model.providerId === 'jupyter') {
+				if (model.providerId === 'jupyter' && model.clientSession.isReady) {
 					// Jupyter server needs to be restarted so that the correct Python installation is used
 					if (!jupyterServerRestarted) {
 						let jupyterNotebookManager: INotebookManager = model.notebookManagers.find(x => x.providerId === 'jupyter');


### PR DESCRIPTION
Notebook smoke test failure was caused by my previous PR https://github.com/microsoft/azuredatastudio/pull/14765.
The test timed out after Python download because the Jupyter server was being started twice. Added a check to make sure there is an active Jupyter session running before restarting the server.