### PR TITLE
Expose getProjectProvider in dataworkspace.d.ts

### DIFF
--- a/extensions/data-workspace/src/common/dataWorkspaceExtension.ts
+++ b/extensions/data-workspace/src/common/dataWorkspaceExtension.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { IExtension } from 'dataworkspace';
+import { IExtension, IProjectProvider } from 'dataworkspace';
 import { WorkspaceService } from '../services/workspaceService';
 import { defaultProjectSaveLocation } from './projectLocationHelper';
 
@@ -14,6 +14,10 @@ export class DataWorkspaceExtension implements IExtension {
 
 	getProjectsInWorkspace(ext?: string): vscode.Uri[] {
 		return this.workspaceService.getProjectsInWorkspace(ext);
+	}
+
+	getProjectProvider(projectFile: vscode.Uri): Promise<IProjectProvider | undefined> {
+		return this.workspaceService.getProjectProvider(projectFile);
 	}
 
 	addProjectsToWorkspace(projectFiles: vscode.Uri[], workspaceFilePath?: vscode.Uri): Promise<void> {

--- a/extensions/data-workspace/src/dataworkspace.d.ts
+++ b/extensions/data-workspace/src/dataworkspace.d.ts
@@ -20,6 +20,12 @@ declare module 'dataworkspace' {
 		getProjectsInWorkspace(ext?: string): vscode.Uri[];
 
 		/**
+		 * Returns the project provider for this file if there is one registered
+		 * @param projectFile project file to filter on
+		 */
+		getProjectProvider(projectFile: vscode.Uri): Promise<IProjectProvider | undefined>;
+
+		/**
 		 * Add projects to the workspace
 		 * @param projectFiles Uris of project files to add,
 		 * @param workspaceFilePath workspace file to create if no workspace is open


### PR DESCRIPTION
This exposes getProjectProvider in dataworkspace.d.ts as requested by @nahk-ivanov. 

Example usage to get sqlproj project provider:
```
const dataWorkspaceApi = vscode.extensions.getExtension('Microsoft.data-workspace').exports as dataworkspace.IExtension;
const provider = await dataWorkspaceApi.getProjectProvider(vscode.Uri.file('test.sqlproj'));

```