### PR TITLE
Use {arg} to reference selected text in query shortcuts

### DIFF
--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -380,7 +380,12 @@ export class RunQueryShortcutAction extends Action {
 			// otherwise, either run the statement or the script depending on parameter
 			let parameterText: string = editor.getSelectionText();
 			return this.escapeStringParamIfNeeded(editor, shortcutText, parameterText).then((escapedParam) => {
-				let queryString = `${shortcutText} ${escapedParam}`;
+				let queryString = '';
+				if (shortcutText.includes('{arg}')) {
+					queryString = shortcutText.replace('{arg}', escapedParam);
+				} else {
+					queryString = `${shortcutText} ${escapedParam}`;
+				}
 				editor.input.runQueryString(queryString);
 			}).then(success => null, err => {
 				// swallow errors for now

--- a/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/keyboardQueryActions.ts
@@ -382,7 +382,7 @@ export class RunQueryShortcutAction extends Action {
 			return this.escapeStringParamIfNeeded(editor, shortcutText, parameterText).then((escapedParam) => {
 				let queryString = '';
 				if (shortcutText.includes('{arg}')) {
-					queryString = shortcutText.replace('{arg}', escapedParam);
+					queryString = shortcutText.replace(/{arg}/g, escapedParam);
 				} else {
 					queryString = `${shortcutText} ${escapedParam}`;
 				}

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -468,7 +468,7 @@ for (let i = 0; i < 9; i++) {
 		'type': 'string',
 		'default': defaultVal,
 		'description': localize('queryShortcutDescription',
-			"Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter",
+			"Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}",
 			queryIndex)
 	};
 }

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -468,7 +468,7 @@ for (let i = 0; i < 9; i++) {
 		'type': 'string',
 		'default': defaultVal,
 		'description': localize('queryShortcutDescription',
-			"Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}",
+			"Set keybinding workbench.action.query.shortcut{0} to run the shortcut text as a procedure call or query execution. Any selected text in the query editor will be passed as a parameter at the end of your query, or you can reference it with {arg}",
 			queryIndex)
 	};
 }


### PR DESCRIPTION

My goal is to add the ability to insert the parameter anywhere in the query. I'm modifying the execution of query shortcuts by first checking if `{arg}` is present, if true just replace it with the parameter if not add the parameter at the end of the query just like it's been working until now.

This PR fixes #14893
