### PR TITLE
fix revealFileInOS command

### DIFF
--- a/src/vs/workbench/contrib/files/electron-sandbox/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/electron-sandbox/fileActions.contribution.ts
@@ -14,6 +14,8 @@ import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/co
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { KeyMod, KeyCode, KeyChord } from 'vs/base/common/keyCodes';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { getMultiSelectedResources, IExplorerService } from 'vs/workbench/contrib/files/browser/files';
+import { IListService } from 'vs/platform/list/browser/listService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { revealResourcesInOS } from 'vs/workbench/contrib/files/electron-sandbox/fileCommands';
 import { MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
@@ -21,7 +23,6 @@ import { ResourceContextKey } from 'vs/workbench/common/resources';
 import { appendToCommandPalette, appendEditorTitleContextMenuItem } from 'vs/workbench/contrib/files/browser/fileActions.contribution';
 import { SideBySideEditor, EditorResourceAccessor } from 'vs/workbench/common/editor';
 import { ContextKeyOrExpr } from 'vs/platform/contextkey/common/contextkey';
-import { IExplorerService } from 'vs/workbench/contrib/files/browser/files';
 
 const REVEAL_IN_OS_COMMAND_ID = 'revealFileInOS';
 const REVEAL_IN_OS_LABEL = isWindows ? nls.localize('revealInWindows', "Reveal in File Explorer") : isMacintosh ? nls.localize('revealInMac', "Reveal in Finder") : nls.localize('openContainer', "Open Containing Folder");
@@ -35,9 +36,8 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	win: {
 		primary: KeyMod.Shift | KeyMod.Alt | KeyCode.KEY_R
 	},
-	handler: (accessor: ServicesAccessor, _resource: URI | object) => {
-		const explorerService = accessor.get(IExplorerService);
-		const resources = explorerService.getContext(false).map(item => item.resource);
+	handler: (accessor: ServicesAccessor, resource: URI | object) => {
+		const resources = getMultiSelectedResources(resource, accessor.get(IListService), accessor.get(IEditorService), accessor.get(IExplorerService));
 		revealResourcesInOS(resources, accessor.get(INativeHostService), accessor.get(INotificationService), accessor.get(IWorkspaceContextService));
 	}
 });


### PR DESCRIPTION
This PR fixes #14760. This was already fixed in vscode microsoft/vscode@8f410da(and duplicate import fixed in https://github.com/microsoft/vscode/commit/528ca4c9ea884058308eb477572d52b7283b6218), but it might be a bit before the next vscode merge so bringing this in now so it gets in the April release. 
