### PR TITLE
Cleaning up PG Compute and Storage code and adding reset for Cores

### DIFF
--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -74,16 +74,16 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		const content = this.modelView.modelBuilder.divContainer().component();
 		root.addItem(content, { CSSStyles: { 'margin': '20px' } });
 
-		content.addItem(this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		content.addItem(this.modelView.modelBuilder.text().withProps({
 			value: loc.computeAndStorage,
 			CSSStyles: { ...cssStyles.title }
 		}).component());
 
-		const infoComputeStorage_p1 = this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		const infoComputeStorage_p1 = this.modelView.modelBuilder.text().withProps({
 			value: loc.postgresComputeAndStorageDescriptionPartOne,
 			CSSStyles: { ...cssStyles.text, 'margin-block-start': '0px', 'margin-block-end': '0px', 'max-width': 'auto' }
 		}).component();
-		const infoComputeStorage_p2 = this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		const infoComputeStorage_p2 = this.modelView.modelBuilder.text().withProps({
 			value: loc.postgresComputeAndStorageDescriptionPartTwo,
 			CSSStyles: { ...cssStyles.text, 'margin-block-start': '0px', 'margin-block-end': '0px' }
 		}).component();
@@ -94,7 +94,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			CSSStyles: { 'margin-block-start': '0px', 'margin-block-end': '0px' }
 		}).component();
 
-		const infoComputeStorage_p3 = this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		const infoComputeStorage_p3 = this.modelView.modelBuilder.text().withProps({
 			value: loc.computeAndStorageDescriptionPartThree,
 			CSSStyles: { ...cssStyles.text, 'margin-block-start': '0px', 'margin-block-end': '0px' }
 		}).component();
@@ -105,17 +105,17 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			CSSStyles: { 'margin-block-start': '0px', 'margin-block-end': '0px' }
 		}).component();
 
-		const infoComputeStorage_p4 = this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		const infoComputeStorage_p4 = this.modelView.modelBuilder.text().withProps({
 			value: loc.computeAndStorageDescriptionPartFour,
 			CSSStyles: { ...cssStyles.text, 'margin-block-start': '0px', 'margin-block-end': '0px' }
 		}).component();
 
-		const infoComputeStorage_p5 = this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		const infoComputeStorage_p5 = this.modelView.modelBuilder.text().withProps({
 			value: loc.computeAndStorageDescriptionPartFive,
 			CSSStyles: { ...cssStyles.text, 'margin-block-start': '0px', 'margin-block-end': '0px' }
 		}).component();
 
-		const infoComputeStorage_p6 = this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		const infoComputeStorage_p6 = this.modelView.modelBuilder.text().withProps({
 			value: loc.computeAndStorageDescriptionPartSix,
 			CSSStyles: { ...cssStyles.text, 'margin-block-start': '0px', 'margin-block-end': '0px' }
 		}).component();
@@ -137,7 +137,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		// Worker nodes section
 		this.workerContainer = this.modelView.modelBuilder.divContainer().component();
-		this.workerContainer.addItem(this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		this.workerContainer.addItem(this.modelView.modelBuilder.text().withProps({
 			value: loc.workerNodes,
 			CSSStyles: { ...cssStyles.title, 'margin-top': '25px' }
 		}).component());
@@ -146,7 +146,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		// Coordinator node section
 		this.coordinatorContainer = this.modelView.modelBuilder.divContainer().component();
-		this.coordinatorContainer.addItem(this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		this.coordinatorContainer.addItem(this.modelView.modelBuilder.text().withProps({
 			value: loc.coordinatorNode,
 			CSSStyles: { ...cssStyles.title, 'margin-top': '25px' }
 		}).component());
@@ -162,7 +162,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 	protected get toolbarContainer(): azdata.ToolbarContainer {
 		// Save Edits
-		this.saveButton = this.modelView.modelBuilder.button().withProperties<azdata.ButtonProperties>({
+		this.saveButton = this.modelView.modelBuilder.button().withProps({
 			label: loc.saveText,
 			iconPath: IconPathHelper.save,
 			enabled: false
@@ -235,7 +235,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			}));
 
 		// Discard
-		this.discardButton = this.modelView.modelBuilder.button().withProperties<azdata.ButtonProperties>({
+		this.discardButton = this.modelView.modelBuilder.button().withProps({
 			label: loc.discardText,
 			iconPath: IconPathHelper.discard,
 			enabled: false
@@ -265,7 +265,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 	private initializeConfigurationBoxes(): void {
 		// Worker node count
-		this.workerBox = this.modelView.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
+		this.workerBox = this.modelView.modelBuilder.inputBox().withProps({
 			readOnly: false,
 			inputType: 'number',
 			placeHolder: loc.loading,
@@ -283,7 +283,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		);
 
 		// Worker nodes cores request
-		this.workerCoresRequestBox = this.modelView.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
+		this.workerCoresRequestBox = this.modelView.modelBuilder.inputBox().withProps({
 			readOnly: false,
 			min: 1,
 			inputType: 'number',
@@ -303,7 +303,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		);
 
 		// Worker nodes cores limit
-		this.workerCoresLimitBox = this.modelView.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
+		this.workerCoresLimitBox = this.modelView.modelBuilder.inputBox().withProps({
 			readOnly: false,
 			min: 1,
 			inputType: 'number',
@@ -323,7 +323,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		);
 
 		// Worker nodes memory request
-		this.workerMemoryRequestBox = this.modelView.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
+		this.workerMemoryRequestBox = this.modelView.modelBuilder.inputBox().withProps({
 			readOnly: false,
 			min: 0.25,
 			inputType: 'number',
@@ -343,7 +343,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		);
 
 		// Worker nodes memory limit
-		this.workerMemoryLimitBox = this.modelView.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
+		this.workerMemoryLimitBox = this.modelView.modelBuilder.inputBox().withProps({
 			readOnly: false,
 			min: 0.25,
 			inputType: 'number',
@@ -363,7 +363,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		);
 
 		// Coordinator node cores request
-		this.coordinatorCoresRequestBox = this.modelView.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
+		this.coordinatorCoresRequestBox = this.modelView.modelBuilder.inputBox().withProps({
 			readOnly: false,
 			min: 1,
 			inputType: 'number',
@@ -383,7 +383,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		);
 
 		// Coordinator node cores limit
-		this.coordinatorCoresLimitBox = this.modelView.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
+		this.coordinatorCoresLimitBox = this.modelView.modelBuilder.inputBox().withProps({
 			readOnly: false,
 			min: 1,
 			inputType: 'number',
@@ -403,7 +403,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		);
 
 		// Coordinator node memory request
-		this.coordinatorMemoryRequestBox = this.modelView.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
+		this.coordinatorMemoryRequestBox = this.modelView.modelBuilder.inputBox().withProps({
 			readOnly: false,
 			min: 0.25,
 			inputType: 'number',
@@ -423,7 +423,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		);
 
 		// Coordinator node memory limit
-		this.coordinatorMemoryLimitBox = this.modelView.modelBuilder.inputBox().withProperties<azdata.InputBoxProperties>({
+		this.coordinatorMemoryLimitBox = this.modelView.modelBuilder.inputBox().withProps({
 			readOnly: false,
 			min: 0.25,
 			inputType: 'number',
@@ -470,7 +470,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			alignItems: 'center'
 		}).component();
 
-		const keyComponent = this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		const keyComponent = this.modelView.modelBuilder.text().withProps({
 			value: loc.workerNodeCount,
 			CSSStyles: { ...cssStyles.text, 'margin-block-start': '0px', 'margin-block-end': '0px' }
 		}).component();
@@ -478,7 +478,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		const keyContainer = this.modelView.modelBuilder.flexContainer().withLayout({ alignItems: 'center' }).component();
 		keyContainer.addItem(keyComponent, { CSSStyles: { 'margin-right': '0px', 'margin-bottom': '15px' } });
 
-		const information = this.modelView.modelBuilder.button().withProperties<azdata.ButtonProperties>({
+		const information = this.modelView.modelBuilder.button().withProps({
 			iconPath: IconPathHelper.information,
 			title: loc.workerNodesInformation,
 			width: '15px',
@@ -522,7 +522,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			alignItems: 'center'
 		}).component();
 
-		const keyComponent = this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		const keyComponent = this.modelView.modelBuilder.text().withProps({
 			value: key,
 			CSSStyles: { ...cssStyles.text, 'margin-block-start': '0px', 'margin-block-end': '0px' }
 		}).component();
@@ -583,7 +583,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			alignItems: 'center'
 		}).component();
 
-		const titleComponent = this.modelView.modelBuilder.text().withProperties<azdata.TextComponentProperties>({
+		const titleComponent = this.modelView.modelBuilder.text().withProps({
 			value: title,
 			CSSStyles: { ...cssStyles.title, 'font-weight': 'bold', 'margin-block-start': '0px', 'margin-block-end': '0px' }
 		}).component();
@@ -591,7 +591,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		const titleContainer = this.modelView.modelBuilder.flexContainer().withLayout({ alignItems: 'center' }).component();
 		titleContainer.addItem(titleComponent, { CSSStyles: { 'margin-right': '0px', 'margin-bottom': '15px' } });
 
-		const information = this.modelView.modelBuilder.button().withProperties<azdata.ButtonProperties>({
+		const information = this.modelView.modelBuilder.button().withProps({
 			iconPath: IconPathHelper.information,
 			title: description,
 			width: '15px',

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -170,7 +170,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		this.disposables.push(
 			this.saveButton.onDidClick(async () => {
-				this.saveButton!.enabled = false;
+				this.saveButton.enabled = false;
 				try {
 					await vscode.window.withProgress(
 						{
@@ -212,7 +212,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 							} catch (err) {
 								// If an error occurs while editing the instance then re-enable the save button since
 								// the edit wasn't successfully applied
-								this.saveButton!.enabled = true;
+								this.saveButton.enabled = true;
 								throw err;
 							} finally {
 								session?.dispose();
@@ -227,7 +227,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 					vscode.window.showInformationMessage(loc.instanceUpdated(this._postgresModel.info.name));
 
-					this.discardButton!.enabled = false;
+					this.discardButton.enabled = false;
 
 				} catch (error) {
 					vscode.window.showErrorMessage(loc.instanceUpdateFailed(this._postgresModel.info.name, error));
@@ -243,17 +243,17 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		this.disposables.push(
 			this.discardButton.onDidClick(async () => {
-				this.discardButton!.enabled = false;
+				this.discardButton.enabled = false;
 				try {
-					this.workerBox!.value = this.currentConfiguration.workers!.toString();
-					this.workerCoresRequestBox!.value = this.currentConfiguration.workerCoresRequest;
-					this.workerCoresLimitBox!.value = this.currentConfiguration.workerCoresLimit;
-					this.workerMemoryRequestBox!.value = this.currentConfiguration.workerMemoryRequest;
-					this.workerMemoryLimitBox!.value = this.currentConfiguration.workerMemoryLimit;
+					this.workerBox.value = this.currentConfiguration.workers!.toString();
+					this.workerCoresRequestBox.value = this.currentConfiguration.workerCoresRequest;
+					this.workerCoresLimitBox.value = this.currentConfiguration.workerCoresLimit;
+					this.workerMemoryRequestBox.value = this.currentConfiguration.workerMemoryRequest;
+					this.workerMemoryLimitBox.value = this.currentConfiguration.workerMemoryLimit;
 				} catch (error) {
 					vscode.window.showErrorMessage(loc.pageDiscardFailed(error));
 				} finally {
-					this.saveButton!.enabled = false;
+					this.saveButton.enabled = false;
 				}
 			}));
 
@@ -274,10 +274,10 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		this.disposables.push(
 			this.workerBox.onTextChanged(() => {
-				if (!this.saveValueToEdit(this.workerBox!, this.currentConfiguration.workers!.toString())) {
+				if (!this.saveValueToEdit(this.workerBox, this.currentConfiguration.workers!.toString())) {
 					this.saveArgs.workers = undefined;
 				} else {
-					this.saveArgs.workers = parseInt(this.workerBox!.value!);
+					this.saveArgs.workers = parseInt(this.workerBox.value!);
 				}
 			})
 		);
@@ -292,12 +292,12 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		this.disposables.push(
 			this.workerCoresRequestBox.onTextChanged(() => {
-				if (!(this.saveValueToEdit(this.workerCoresRequestBox!, this.currentConfiguration.workerCoresRequest!))) {
+				if (!(this.saveValueToEdit(this.workerCoresRequestBox, this.currentConfiguration.workerCoresRequest!))) {
 					this.saveArgs.workerCoresRequest = undefined;
-				} else if (this.workerCoresRequestBox!.value === '') {
+				} else if (this.workerCoresRequestBox.value === '') {
 					this.saveArgs.workerCoresRequest = '""';
 				} else {
-					this.saveArgs.workerCoresRequest = this.workerCoresRequestBox!.value;
+					this.saveArgs.workerCoresRequest = this.workerCoresRequestBox.value;
 				}
 			})
 		);
@@ -312,12 +312,12 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		this.disposables.push(
 			this.workerCoresLimitBox.onTextChanged(() => {
-				if (!(this.saveValueToEdit(this.workerCoresLimitBox!, this.currentConfiguration.workerCoresLimit!))) {
+				if (!(this.saveValueToEdit(this.workerCoresLimitBox, this.currentConfiguration.workerCoresLimit!))) {
 					this.saveArgs.workerCoresLimit = undefined;
-				} else if (this.workerCoresLimitBox!.value === '') {
+				} else if (this.workerCoresLimitBox.value === '') {
 					this.saveArgs.workerCoresLimit = '""';
 				} else {
-					this.saveArgs.workerCoresLimit = this.workerCoresLimitBox!.value;
+					this.saveArgs.workerCoresLimit = this.workerCoresLimitBox.value;
 				}
 			})
 		);
@@ -332,12 +332,12 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		this.disposables.push(
 			this.workerMemoryRequestBox.onTextChanged(() => {
-				if (!(this.saveValueToEdit(this.workerMemoryRequestBox!, this.currentConfiguration.workerMemoryRequest!))) {
+				if (!(this.saveValueToEdit(this.workerMemoryRequestBox, this.currentConfiguration.workerMemoryRequest!))) {
 					this.saveArgs.workerMemoryRequest = undefined;
-				} else if (this.workerMemoryRequestBox!.value === '') {
+				} else if (this.workerMemoryRequestBox.value === '') {
 					this.saveArgs.workerMemoryRequest = '""';
 				} else {
-					this.saveArgs.workerMemoryRequest = this.workerMemoryRequestBox!.value + 'Gi';
+					this.saveArgs.workerMemoryRequest = this.workerMemoryRequestBox.value + 'Gi';
 				}
 			})
 		);
@@ -352,12 +352,12 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		this.disposables.push(
 			this.workerMemoryLimitBox.onTextChanged(() => {
-				if (!(this.saveValueToEdit(this.workerMemoryLimitBox!, this.currentConfiguration.workerMemoryLimit!))) {
+				if (!(this.saveValueToEdit(this.workerMemoryLimitBox, this.currentConfiguration.workerMemoryLimit!))) {
 					this.saveArgs.workerMemoryLimit = undefined;
-				} else if (this.workerMemoryLimitBox!.value === '') {
+				} else if (this.workerMemoryLimitBox.value === '') {
 					this.saveArgs.workerMemoryLimit = '""';
 				} else {
-					this.saveArgs.workerMemoryLimit = this.workerMemoryLimitBox!.value + 'Gi';
+					this.saveArgs.workerMemoryLimit = this.workerMemoryLimitBox.value + 'Gi';
 				}
 			})
 		);
@@ -372,12 +372,12 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		this.disposables.push(
 			this.coordinatorCoresRequestBox.onTextChanged(() => {
-				if (!(this.saveValueToEdit(this.coordinatorCoresRequestBox!, this.currentConfiguration.coordinatorCoresRequest!))) {
+				if (!(this.saveValueToEdit(this.coordinatorCoresRequestBox, this.currentConfiguration.coordinatorCoresRequest!))) {
 					this.saveArgs.coordinatorCoresRequest = undefined;
-				} else if (this.coordinatorCoresRequestBox!.value === '') {
+				} else if (this.coordinatorCoresRequestBox.value === '') {
 					this.saveArgs.coordinatorCoresRequest = '""';
 				} else {
-					this.saveArgs.coordinatorCoresRequest = this.coordinatorCoresRequestBox!.value;
+					this.saveArgs.coordinatorCoresRequest = this.coordinatorCoresRequestBox.value;
 				}
 			})
 		);
@@ -392,12 +392,12 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		this.disposables.push(
 			this.coordinatorCoresLimitBox.onTextChanged(() => {
-				if (!(this.saveValueToEdit(this.coordinatorCoresLimitBox!, this.currentConfiguration.coordinatorCoresLimit!))) {
+				if (!(this.saveValueToEdit(this.coordinatorCoresLimitBox, this.currentConfiguration.coordinatorCoresLimit!))) {
 					this.saveArgs.coordinatorCoresLimit = undefined;
-				} else if (this.coordinatorCoresLimitBox!.value === '') {
+				} else if (this.coordinatorCoresLimitBox.value === '') {
 					this.saveArgs.coordinatorCoresLimit = '""';
 				} else {
-					this.saveArgs.coordinatorCoresLimit = this.coordinatorCoresLimitBox!.value;
+					this.saveArgs.coordinatorCoresLimit = this.coordinatorCoresLimitBox.value;
 				}
 			})
 		);
@@ -412,12 +412,12 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		this.disposables.push(
 			this.coordinatorMemoryRequestBox.onTextChanged(() => {
-				if (!(this.saveValueToEdit(this.coordinatorMemoryRequestBox!, this.currentConfiguration.coordinatorMemoryRequest!))) {
+				if (!(this.saveValueToEdit(this.coordinatorMemoryRequestBox, this.currentConfiguration.coordinatorMemoryRequest!))) {
 					this.saveArgs.coordinatorMemoryRequest = undefined;
-				} else if (this.coordinatorMemoryRequestBox!.value === '') {
+				} else if (this.coordinatorMemoryRequestBox.value === '') {
 					this.saveArgs.coordinatorMemoryRequest = '""';
 				} else {
-					this.saveArgs.coordinatorMemoryRequest = this.coordinatorMemoryRequestBox!.value + 'Gi';
+					this.saveArgs.coordinatorMemoryRequest = this.coordinatorMemoryRequestBox.value + 'Gi';
 				}
 			})
 		);
@@ -432,12 +432,12 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		this.disposables.push(
 			this.coordinatorMemoryLimitBox.onTextChanged(() => {
-				if (!(this.saveValueToEdit(this.coordinatorMemoryLimitBox!, this.currentConfiguration.coordinatorMemoryLimit!))) {
+				if (!(this.saveValueToEdit(this.coordinatorMemoryLimitBox, this.currentConfiguration.coordinatorMemoryLimit!))) {
 					this.saveArgs.coordinatorMemoryLimit = undefined;
-				} else if (this.coordinatorMemoryLimitBox!.value === '') {
+				} else if (this.coordinatorMemoryLimitBox.value === '') {
 					this.saveArgs.coordinatorMemoryLimit = '""';
 				} else {
-					this.saveArgs.coordinatorMemoryLimit = this.coordinatorMemoryLimitBox!.value + 'Gi';
+					this.saveArgs.coordinatorMemoryLimit = this.coordinatorMemoryLimitBox.value + 'Gi';
 				}
 			})
 		);
@@ -453,10 +453,10 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		return [
 			this.createWorkerNodesSectionContainer(),
 			this.createCoresMemorySection(loc.configurationPerNode, loc.postgresConfigurationInformation),	// use loc.workerNodesConfigurationInformation when coordinator section is included
-			this.createConfigurationSectionContainer(loc.coresRequest, this.workerCoresRequestBox!),
-			this.createConfigurationSectionContainer(loc.coresLimit, this.workerCoresLimitBox!),
-			this.createConfigurationSectionContainer(loc.memoryRequest, this.workerMemoryRequestBox!),
-			this.createConfigurationSectionContainer(loc.memoryLimit, this.workerMemoryLimitBox!)
+			this.createConfigurationSectionContainer(loc.coresRequest, this.workerCoresRequestBox),
+			this.createConfigurationSectionContainer(loc.coresLimit, this.workerCoresLimitBox),
+			this.createConfigurationSectionContainer(loc.memoryRequest, this.workerMemoryRequestBox),
+			this.createConfigurationSectionContainer(loc.memoryLimit, this.workerMemoryLimitBox)
 
 		];
 	}
@@ -490,7 +490,7 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		flexContainer.addItem(keyContainer, keyFlex);
 
 		const inputContainer = this.modelView.modelBuilder.flexContainer().withLayout({ alignItems: 'center' }).component();
-		inputContainer.addItem(this.workerBox!, { CSSStyles: { 'margin-bottom': '15px', 'min-width': '50px', 'max-width': '225px' } });
+		inputContainer.addItem(this.workerBox, { CSSStyles: { 'margin-bottom': '15px', 'min-width': '50px', 'max-width': '225px' } });
 
 		flexContainer.addItem(inputContainer, inputFlex);
 
@@ -505,10 +505,10 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 
 		return [
 			this.createCoresMemorySection(loc.configuration, loc.coordinatorNodeConfigurationInformation),
-			this.createConfigurationSectionContainer(loc.coresRequest, this.coordinatorCoresRequestBox!),
-			this.createConfigurationSectionContainer(loc.coresLimit, this.coordinatorCoresLimitBox!),
-			this.createConfigurationSectionContainer(loc.memoryRequest, this.coordinatorMemoryRequestBox!),
-			this.createConfigurationSectionContainer(loc.memoryLimit, this.coordinatorMemoryLimitBox!)
+			this.createConfigurationSectionContainer(loc.coresRequest, this.coordinatorCoresRequestBox),
+			this.createConfigurationSectionContainer(loc.coresLimit, this.coordinatorCoresLimitBox),
+			this.createConfigurationSectionContainer(loc.memoryRequest, this.coordinatorMemoryRequestBox),
+			this.createConfigurationSectionContainer(loc.memoryLimit, this.coordinatorMemoryLimitBox)
 
 		];
 	}
@@ -558,8 +558,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		} else if ((!component.valid)) {
 			return false;
 		} else {
-			this.saveButton!.enabled = true;
-			this.discardButton!.enabled = true;
+			this.saveButton.enabled = true;
+			this.discardButton.enabled = true;
 			return true;
 		}
 	}
@@ -569,9 +569,9 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 		let scale = this._postgresModel.config?.spec.scale;
 		this.currentConfiguration.workers = scale?.workers ?? scale?.shards ?? 0;
 
-		this.workerBox!.min = this.currentConfiguration.workers;
-		this.workerBox!.placeHolder = '';
-		this.workerBox!.value = this.currentConfiguration.workers.toString();
+		this.workerBox.min = this.currentConfiguration.workers;
+		this.workerBox.placeHolder = '';
+		this.workerBox.value = this.currentConfiguration.workers.toString();
 		this.saveArgs.workers = undefined;
 	}
 
@@ -615,8 +615,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.currentConfiguration.workerCoresRequest = '';
 		}
 
-		this.workerCoresRequestBox!.placeHolder = '';
-		this.workerCoresRequestBox!.value = this.currentConfiguration.workerCoresRequest;
+		this.workerCoresRequestBox.placeHolder = '';
+		this.workerCoresRequestBox.value = this.currentConfiguration.workerCoresRequest;
 		this.saveArgs.workerCoresRequest = undefined;
 
 		// Cores Limit
@@ -625,8 +625,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.currentConfiguration.workerCoresLimit = '';
 		}
 
-		this.workerCoresLimitBox!.placeHolder = '';
-		this.workerCoresLimitBox!.value = this.currentConfiguration.workerCoresLimit;
+		this.workerCoresLimitBox.placeHolder = '';
+		this.workerCoresLimitBox.value = this.currentConfiguration.workerCoresLimit;
 		this.saveArgs.workerCoresLimit = undefined;
 	}
 
@@ -639,8 +639,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.currentConfiguration.workerMemoryRequest = convertToGibibyteString(currentMemorySize);
 		}
 
-		this.workerMemoryRequestBox!.placeHolder = '';
-		this.workerMemoryRequestBox!.value = this.currentConfiguration.workerMemoryRequest;
+		this.workerMemoryRequestBox.placeHolder = '';
+		this.workerMemoryRequestBox.value = this.currentConfiguration.workerMemoryRequest;
 		this.saveArgs.workerMemoryRequest = undefined;
 
 		//Memory Limit
@@ -651,8 +651,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.currentConfiguration.workerMemoryLimit = convertToGibibyteString(currentMemorySize);
 		}
 
-		this.workerMemoryLimitBox!.placeHolder = '';
-		this.workerMemoryLimitBox!.value = this.currentConfiguration.workerMemoryLimit;
+		this.workerMemoryLimitBox.placeHolder = '';
+		this.workerMemoryLimitBox.value = this.currentConfiguration.workerMemoryLimit;
 		this.saveArgs.workerMemoryLimit = undefined;
 	}
 
@@ -663,8 +663,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.currentConfiguration.coordinatorCoresRequest = '';
 		}
 
-		this.coordinatorCoresRequestBox!.placeHolder = '';
-		this.coordinatorCoresRequestBox!.value = this.currentConfiguration.coordinatorCoresRequest;
+		this.coordinatorCoresRequestBox.placeHolder = '';
+		this.coordinatorCoresRequestBox.value = this.currentConfiguration.coordinatorCoresRequest;
 		this.saveArgs.coordinatorCoresRequest = undefined;
 
 		// TODO get current cpu size for coordinator
@@ -673,8 +673,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.currentConfiguration.coordinatorCoresLimit = '';
 		}
 
-		this.coordinatorCoresLimitBox!.placeHolder = '';
-		this.coordinatorCoresLimitBox!.value = this.currentConfiguration.coordinatorCoresLimit;
+		this.coordinatorCoresLimitBox.placeHolder = '';
+		this.coordinatorCoresLimitBox.value = this.currentConfiguration.coordinatorCoresLimit;
 		this.saveArgs.coordinatorCoresLimit = undefined;
 	}
 
@@ -687,8 +687,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.currentConfiguration.coordinatorCoresRequest = convertToGibibyteString(currentMemorySize);
 		}
 
-		this.coordinatorMemoryRequestBox!.placeHolder = '';
-		this.coordinatorMemoryRequestBox!.value = this.currentConfiguration.coordinatorMemoryRequest;
+		this.coordinatorMemoryRequestBox.placeHolder = '';
+		this.coordinatorMemoryRequestBox.value = this.currentConfiguration.coordinatorMemoryRequest;
 		this.saveArgs.coordinatorMemoryRequest = undefined;
 
 		// TODO get current memory size for coordinator
@@ -699,8 +699,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.currentConfiguration.coordinatorCoresLimit = convertToGibibyteString(currentMemorySize);
 		}
 
-		this.coordinatorMemoryLimitBox!.placeHolder = '';
-		this.coordinatorMemoryLimitBox!.value = this.currentConfiguration.coordinatorMemoryLimit;
+		this.coordinatorMemoryLimitBox.placeHolder = '';
+		this.coordinatorMemoryLimitBox.value = this.currentConfiguration.coordinatorMemoryLimit;
 		this.saveArgs.coordinatorMemoryLimit = undefined;
 	}
 

--- a/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresComputeAndStoragePage.ts
@@ -294,6 +294,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.workerCoresRequestBox.onTextChanged(() => {
 				if (!(this.saveValueToEdit(this.workerCoresRequestBox!, this.currentConfiguration.workerCoresRequest!))) {
 					this.saveArgs.workerCoresRequest = undefined;
+				} else if (this.workerCoresRequestBox!.value === '') {
+					this.saveArgs.workerCoresRequest = '""';
 				} else {
 					this.saveArgs.workerCoresRequest = this.workerCoresRequestBox!.value;
 				}
@@ -312,6 +314,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.workerCoresLimitBox.onTextChanged(() => {
 				if (!(this.saveValueToEdit(this.workerCoresLimitBox!, this.currentConfiguration.workerCoresLimit!))) {
 					this.saveArgs.workerCoresLimit = undefined;
+				} else if (this.workerCoresLimitBox!.value === '') {
+					this.saveArgs.workerCoresLimit = '""';
 				} else {
 					this.saveArgs.workerCoresLimit = this.workerCoresLimitBox!.value;
 				}
@@ -370,6 +374,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.coordinatorCoresRequestBox.onTextChanged(() => {
 				if (!(this.saveValueToEdit(this.coordinatorCoresRequestBox!, this.currentConfiguration.coordinatorCoresRequest!))) {
 					this.saveArgs.coordinatorCoresRequest = undefined;
+				} else if (this.coordinatorCoresRequestBox!.value === '') {
+					this.saveArgs.coordinatorCoresRequest = '""';
 				} else {
 					this.saveArgs.coordinatorCoresRequest = this.coordinatorCoresRequestBox!.value;
 				}
@@ -388,6 +394,8 @@ export class PostgresComputeAndStoragePage extends DashboardPage {
 			this.coordinatorCoresLimitBox.onTextChanged(() => {
 				if (!(this.saveValueToEdit(this.coordinatorCoresLimitBox!, this.currentConfiguration.coordinatorCoresLimit!))) {
 					this.saveArgs.coordinatorCoresLimit = undefined;
+				} else if (this.coordinatorCoresLimitBox!.value === '') {
+					this.saveArgs.coordinatorCoresLimit = '""';
 				} else {
 					this.saveArgs.coordinatorCoresLimit = this.coordinatorCoresLimitBox!.value;
 				}


### PR DESCRIPTION
This PR 
1. Adds reset ability to Cores request and limit
2. Removes unnecessary '!'
3. Uses withProps instead of withProperties
