### PR TITLE
Don't log disposed changeDetector errors

### DIFF
--- a/src/sql/base/browser/lifecycle.ts
+++ b/src/sql/base/browser/lifecycle.ts
@@ -17,7 +17,10 @@ export function subscriptionToDisposable(sub: Subscription): IDisposable {
 }
 
 export class AngularDisposable extends Disposable implements OnDestroy {
+	public isDisposed = false;
+
 	ngOnDestroy() {
 		this.dispose();
+		this.isDisposed = true;
 	}
 }

--- a/src/sql/workbench/browser/modelComponents/modelComponentWrapper.component.ts
+++ b/src/sql/workbench/browser/modelComponents/modelComponentWrapper.component.ts
@@ -110,7 +110,7 @@ export class ModelComponentWrapper extends AngularDisposable implements AfterVie
 		let selector = componentRegistry.getCtorFromId(this.descriptor.type);
 
 		if (selector === undefined) {
-			this.logService.error('No selector defined for type {0}', this.descriptor.type);
+			this.logService.error('No selector defined for type ', this.descriptor.type);
 			return;
 		}
 
@@ -128,7 +128,13 @@ export class ModelComponentWrapper extends AngularDisposable implements AfterVie
 			this._componentInstance.modelStore = this.modelStore;
 			this._changeref.detectChanges();
 		} catch (e) {
-			this.logService.error('Error rendering component: {0}', e);
+			// There's a possible race condition here where a component that is added is then immediately removed,
+			// which then makes it so that while the changeRef isn't destroyed when we call detectChanges above
+			// it becomes destroyed during the detectChanges call and thus eventually throws. So to avoid a pointless
+			// error message in the console we just make sure that we aren't disposed before printing it out
+			if (!this.isDisposed) {
+				this.logService.error('Error rendering component: ', e);
+			}
 			return;
 		}
 		let el = <HTMLElement>componentRef.location.nativeElement;

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -1118,7 +1118,7 @@ export class NotebookModel extends Disposable implements INotebookModel {
 			}
 			await this.shutdownActiveSession();
 		} catch (err) {
-			this.logService.error('An error occurred when closing the notebook: {0}', getErrorMessage(err));
+			this.logService.error('An error occurred when closing the notebook: ', getErrorMessage(err));
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/microsoft/azuredatastudio/issues/14917

I looked into this and there isn't really any way we can actually fix this - basically it's because of a race condition where : 

1. We create a ComponentWrapper
2. It gets initialized and calls detectChanges - at this point it isn't disposed and then goes off into Angular code
3. The container holder the component wrapper is then cleared (pretty quickly after the component is created)
4. The change detector is then marked as disposed since the component was removed
5. Finally the detectChanges call from 2 gets to a point where it checks that the changedetector isn't disposed and now throws because it sees that it is

So instead I just make it ignore any errors that happen after it's disposed - that would be an expected scenario at that point anyways I'd say.

I also cleaned up some of the logging messages - the log service doesn't use tokens ({0}) for formatting, it just appends the parameters passed to it at the end of the string. Previously the error would look like this : 

`Error rendering component: {0} ViewDestroyedError: ...`