### PR TITLE
Add data-workspace unit tests to test-extensions-unit scripts

### DIFF
--- a/scripts/test-extensions-unit.bat
+++ b/scripts/test-extensions-unit.bat
@@ -113,6 +113,10 @@ echo *** starting sql-database-projects tests ***
 echo ********************************************
 call "%INTEGRATION_TEST_ELECTRON_PATH%" --extensionDevelopmentPath=%~dp0\..\extensions\sql-database-projects --extensionTestsPath=%~dp0\..\extensions\sql-database-projects\out\test --user-data-dir=%VSCODEUSERDATADIR% --extensions-dir=%VSCODEEXTENSIONSDIR% --remote-debugging-port=9222 --disable-telemetry --disable-crash-reporter --disable-updates --nogpu
 
+echo ********************************************
+echo *** starting data-workspace tests ***
+echo ********************************************
+call "%INTEGRATION_TEST_ELECTRON_PATH%" --extensionDevelopmentPath=%~dp0\..\extensions\data-workspace --extensionTestsPath=%~dp0\..\extensions\data-workspace\out\test --user-data-dir=%VSCODEUSERDATADIR% --extensions-dir=%VSCODEEXTENSIONSDIR% --remote-debugging-port=9222 --disable-telemetry --disable-crash-reporter --disable-updates --nogpu
 
 if %errorlevel% neq 0 exit /b %errorlevel%
 

--- a/scripts/test-extensions-unit.sh
+++ b/scripts/test-extensions-unit.sh
@@ -109,6 +109,11 @@ echo *** starting sql-database-projects tests ***
 echo ********************************************
 "$INTEGRATION_TEST_ELECTRON_PATH" $LINUX_NO_SANDBOX --extensionDevelopmentPath=$ROOT/extensions/sql-database-projects --extensionTestsPath=$ROOT/extensions/sql-database-projects/out/test --user-data-dir=$VSCODEUSERDATADIR --extensions-dir=$VSCODEEXTDIR --disable-telemetry --disable-crash-reporter --disable-updates --nogpu
 
+echo ********************************************
+echo *** starting data-workspace tests ***
+echo ********************************************
+"$INTEGRATION_TEST_ELECTRON_PATH" $LINUX_NO_SANDBOX --extensionDevelopmentPath=$ROOT/extensions/data-workspace --extensionTestsPath=$ROOT/extensions/data-workspace/out/test --user-data-dir=$VSCODEUSERDATADIR --extensions-dir=$VSCODEEXTDIR --disable-telemetry --disable-crash-reporter --disable-updates --nogpu
+
 if [[ "$NO_CLEANUP" == "" ]]; then
 	rm -r $VSCODEUSERDATADIR
 	rm -r $VSCODEEXTDIR


### PR DESCRIPTION
Adding this so that the data-workspace code coverage gets included in the code coverage reports in PRs. @Charles-Gagnon let me know if anything else needs to be updated to include them. 
