### PR TITLE
Log full stack trace for editor opened errors

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -1071,7 +1071,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 						message: localize('editorOpenError', "Unable to open '{0}': {1}.", editor.getName(), toErrorMessage(error)),
 						actions
 					});
-					console.log(`Unable to open '{0}': `, error); // {{SQL CARBON EDIT}} Print full stack trace to console
+					console.log(`Unable to open '${editor.getName()}': `, error); // {{SQL CARBON EDIT}} Print full stack trace to console
 
 					Event.once(handle.onDidClose)(() => actions.primary && dispose(actions.primary));
 				}

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -1071,7 +1071,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 						message: localize('editorOpenError', "Unable to open '{0}': {1}.", editor.getName(), toErrorMessage(error)),
 						actions
 					});
-					console.log(`Unable to open '{0}': `, error); //{{SQL CARBON EDIT}} Print full stack trace to console
+					console.log(`Unable to open '{0}': `, error); // {{SQL CARBON EDIT}} Print full stack trace to console
 
 					Event.once(handle.onDidClose)(() => actions.primary && dispose(actions.primary));
 				}

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -1071,6 +1071,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 						message: localize('editorOpenError', "Unable to open '{0}': {1}.", editor.getName(), toErrorMessage(error)),
 						actions
 					});
+					console.log(`Unable to open '{0}': `, error); //{{SQL CARBON EDIT}} Print full stack trace to console
 
 					Event.once(handle.onDidClose)(() => actions.primary && dispose(actions.primary));
 				}


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/14929, https://github.com/microsoft/azuredatastudio/issues/13797 and https://github.com/microsoft/azuredatastudio/issues/6763

Hard to tell where this is coming from, so log the full stack trace to console so we can actually figure that out. 