### PR TITLE
Don't allow multiple engine version specifiers

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -47,7 +47,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -535,7 +535,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=*"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1873,7 +1873,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1938,7 +1938,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2003,7 +2003,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2068,7 +2068,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2133,7 +2133,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2198,7 +2198,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2263,7 +2263,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2328,7 +2328,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2393,7 +2393,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2458,7 +2458,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2519,7 +2519,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2584,7 +2584,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2885,7 +2885,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.33.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3711,7 +3711,7 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.20.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -47,7 +47,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1385,7 +1385,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1568,7 +1568,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1751,7 +1751,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1812,7 +1812,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1873,7 +1873,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -1938,7 +1938,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2003,7 +2003,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2068,7 +2068,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2133,7 +2133,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2198,7 +2198,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2263,7 +2263,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2328,7 +2328,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2393,7 +2393,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2458,7 +2458,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.30.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2519,7 +2519,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2584,7 +2584,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2702,7 +2702,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2824,7 +2824,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.29.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -2885,7 +2885,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.33.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3247,7 +3247,7 @@
 								},
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=0.32.1"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3357,7 +3357,7 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.46.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3711,7 +3711,7 @@
 							"properties": [
 								{
 									"key": "Microsoft.VisualStudio.Code.Engine",
-									"value": ">=1.20.0"
+									"value": "*"
 								},
 								{
 									"key": "Microsoft.AzDataEngine",
@@ -3771,12 +3771,12 @@
 									"value": "*"
 								},
 								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
 									"key": "Microsoft.AzDataEngine",
 									"value": ">=1.22.0"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/Microsoft/azuredatastudio"
 								}
 							]
 						}
@@ -3889,12 +3889,12 @@
 									"value": "*"
 								},
 								{
-									"key": "Microsoft.VisualStudio.Services.Links.Source",
-									"value": "https://github.com/Microsoft/azuredatastudio"
-								},
-								{
 									"key": "Microsoft.AzDataEngine",
 									"value": ">=1.25.0"
+								},
+								{
+									"key": "Microsoft.VisualStudio.Services.Links.Source",
+									"value": "https://github.com/Microsoft/azuredatastudio"
 								}
 							]
 						}

--- a/scripts/validateGalleries.js
+++ b/scripts/validateGalleries.js
@@ -172,6 +172,10 @@ function validateVersion(path, extensionName, extensionVersionJson) {
         if (!azdataEngineVersion) {
             throw new Error(`${path} - ${extensionName} - No valid Microsoft.AzdataEngine property found. Value must be either * or >=x.x.x where x.x.x is the minimum Azure Data Studio version the extension requires\n${JSON.stringify(extensionVersionJson.properties)}`)
         }
+        const vscodeEngineVersion = extensionVersionJson.properties.find(property => property.key === 'Microsoft.VisualStudio.Code.Engine');
+        if (vscodeEngineVersion && vscodeEngineVersion.value.startsWith('>=') && azdataEngineVersion.value.startsWith('>=')) {
+            throw new Error(`${path} - ${extensionName} - Both Microsoft.AzDataEngine and Microsoft.VisualStudio.Code.Engine should not have minimum versions. Each Azure Data Studio version is tied to a specific VS Code version and so having both is redundant.`)
+        }
     } else {
         throw new Error(`${path} - ${extensionName} - No properties, extensions must have an AzDataEngine version defined`)
     }


### PR DESCRIPTION
Only allow both engine versions to be * or one * and the other with a version specifier (>=).

Having multiple engine versions is redundant - since each ADS release is tied to a specific VS Code engine version already. 

Most extensions should be specifying an ADS engine version if anything - but we do have some that came from VS Code directly that are easier to have just use the VS Code engine version. 