### PR TITLE
fix query plan doc failed to load issue

### DIFF
--- a/src/sql/workbench/contrib/queryPlan/common/queryPlanInput.ts
+++ b/src/sql/workbench/contrib/queryPlan/common/queryPlanInput.ts
@@ -3,13 +3,13 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { EditorInput, EditorModel, IEditorInput } from 'vs/workbench/common/editor';
-import { URI } from 'vs/base/common/uri';
-import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/untitledTextEditorInput';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILanguageAssociation } from 'sql/workbench/services/languageAssociation/common/languageAssociation';
+import { URI } from 'vs/base/common/uri';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { EditorInput, EditorModel, IEditorInput } from 'vs/workbench/common/editor';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
+import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/untitledTextEditorInput';
 
 export class QueryPlanConverter implements ILanguageAssociation {
 	static readonly languages = ['sqlplan'];

--- a/src/sql/workbench/contrib/queryPlan/common/queryPlanInput.ts
+++ b/src/sql/workbench/contrib/queryPlan/common/queryPlanInput.ts
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { EditorInput, EditorModel, IEditorInput } from 'vs/workbench/common/editor';
-import { IFileService } from 'vs/platform/files/common/files';
 import { URI } from 'vs/base/common/uri';
 import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/untitledTextEditorInput';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILanguageAssociation } from 'sql/workbench/services/languageAssociation/common/languageAssociation';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 
 export class QueryPlanConverter implements ILanguageAssociation {
 	static readonly languages = ['sqlplan'];
@@ -40,7 +40,7 @@ export class QueryPlanInput extends EditorInput {
 
 	constructor(
 		private _uri: URI,
-		@IFileService private readonly fileService: IFileService
+		@ITextFileService private readonly fileService: ITextFileService
 	) {
 		super();
 	}
@@ -67,7 +67,7 @@ export class QueryPlanInput extends EditorInput {
 
 	public async resolve(refresh?: boolean): Promise<EditorModel | null> {
 		if (!this._xml) {
-			this._xml = (await this.fileService.readFile(this._uri)).value.toString();
+			this._xml = (await this.fileService.read(this._uri, { acceptTextOnly: true })).value;
 		}
 		return null;
 	}


### PR DESCRIPTION
This PR fixes #14632 

turns out this feature never worked, I went all the way back to 0.33 release of sqlops studio :)

root cause:
if we use fileservice to read the text file, it is returned as binary and we use the toString method of it, the text is not the same as if we read it using textfileservice.

![image](https://user-images.githubusercontent.com/13777222/113250446-621f9d00-9275-11eb-9ddb-82ba02d459fa.png)


html-query-plan packages uses XSLT to transform the xml to html, and during rendering, it will look for the node with css class 'qp-root', but due to the malformed xml string, the html was not created successfully, and result in the error of can not read property getBoundingClientRect of null.

fix:

use textfileservice to read the file content.

with the fix:
![image](https://user-images.githubusercontent.com/13777222/113250819-11f50a80-9276-11eb-9ba7-c24549062773.png)



