### PR TITLE
Fix dropdown error & editor database dropdown validation

### DIFF
--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -13,7 +13,6 @@ import { IMessage, MessageType } from 'vs/base/browser/ui/inputbox/inputBox';
 import { IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { IListStyles, List } from 'vs/base/browser/ui/list/listWidget';
 import { Color } from 'vs/base/common/color';
-import { onUnexpectedError } from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { Disposable } from 'vs/base/common/lifecycle';

--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -221,7 +221,7 @@ export class Dropdown extends Disposable implements IListVirtualDelegate<string>
 		}));
 
 		this._input.onDidChange(e => {
-			if (this._dataSource.values?.length > 0) {
+			if (this._dataSource.values.length > 0) {
 				this._dataSource.filter = e;
 				if (this._isDropDownVisible) {
 					this._updateDropDownList();
@@ -297,25 +297,21 @@ export class Dropdown extends Disposable implements IListVirtualDelegate<string>
 	}
 
 	private _updateDropDownList(): void {
-		try {
-			this._selectList.splice(0, this._selectList.length, this._dataSource.filteredValues.map(v => { return { text: v }; }));
-		} catch (e) {
-			onUnexpectedError(e);
-		}
+		this._selectList.splice(0, this._selectList.length, this._dataSource.filteredValues.map(v => { return { text: v }; }));
 
 		let width = this._inputContainer.clientWidth;
-		if (this._dataSource && this._dataSource.filteredValues) {
-			const longestOption = this._dataSource.filteredValues.reduce((previous, current) => {
-				return previous.length > current.length ? previous : current;
-			}, '');
-			this._widthControlElement.innerText = longestOption;
 
-			const inputContainerWidth = DOM.getContentWidth(this._inputContainer);
-			const longestOptionWidth = DOM.getTotalWidth(this._widthControlElement);
-			width = clamp(longestOptionWidth, inputContainerWidth, 500);
-		}
+		// Find the longest option in the list and set our width to that (max 500px)
+		const longestOption = this._dataSource.filteredValues.reduce((previous, current) => {
+			return previous.length > current.length ? previous : current;
+		}, '');
+		this._widthControlElement.innerText = longestOption;
 
-		const height = Math.min((this._dataSource.filteredValues?.length ?? 0) * this.getHeight(), this._options.maxHeight ?? 500);
+		const inputContainerWidth = DOM.getContentWidth(this._inputContainer);
+		const longestOptionWidth = DOM.getTotalWidth(this._widthControlElement);
+		width = clamp(longestOptionWidth, inputContainerWidth, 500);
+
+		const height = Math.min(this._dataSource.filteredValues.length * this.getHeight(), this._options.maxHeight ?? 500);
 		this._selectListContainer.style.width = `${width}px`;
 		this._selectListContainer.style.height = `${height}px`;
 		this._selectList.layout(height, width);
@@ -361,7 +357,7 @@ export class Dropdown extends Disposable implements IListVirtualDelegate<string>
 	}
 
 	private _inputValidator(value: string): IMessage | null {
-		if (!this._input.hasFocus() && !this._selectList.isDOMFocused() && this._dataSource.values && !this._dataSource.values.some(i => i === value)) {
+		if (!this._input.hasFocus() && this._input.isEnabled() && !this._selectList.isDOMFocused() && !this._dataSource.values.some(i => i === value)) {
 			if (this._options.strictSelection && this._options.errorMessage) {
 				return {
 					content: this._options.errorMessage,

--- a/src/sql/base/parts/editableDropdown/browser/dropdownList.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdownList.ts
@@ -42,9 +42,9 @@ export class DropdownListRenderer implements IListRenderer<IDropdownListItem, ID
 }
 
 export class DropdownDataSource {
-	values: string[];
+	public values: string[] = [];
 
-	filter: string | undefined;
+	public filter: string | undefined = undefined;
 
 	public get filteredValues(): string[] {
 		if (this.filter) {

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -764,7 +764,7 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 	private onDropdownFocus(): void {
 		this.getDatabaseNames().then(databaseNames => {
 			this._dropdown.values = databaseNames;
-		});
+		}).catch(onUnexpectedError);
 	}
 
 	/**
@@ -799,7 +799,7 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 				.then(databaseNames => {
 					this._databaseSelectBox.setOptions(databaseNames);
 					this._databaseSelectBox.selectWithOptionName(databaseName);
-				});
+				}).catch(onUnexpectedError);
 		} else {
 			// Set the value immediately to the initial database so the user can see that, and then
 			// populate the list with just that value to avoid displaying an error while we load

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -768,8 +768,8 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 	}
 
 	/**
-	 * Fetches the list of database names from
-	 * @returns The list of database names for the current editor connection
+	 * Fetches the list of database names from the current editor connection
+	 * @returns The list of database names
 	 */
 	private async getDatabaseNames(): Promise<string[]> {
 		if (!this._editor.input) {

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -44,6 +44,7 @@ import { ConnectionProfile } from 'sql/platform/connection/common/connectionProf
 import { IQueryManagementService } from 'sql/workbench/services/query/common/queryManagement';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IRange } from 'vs/editor/common/core/range';
+import { onUnexpectedError } from 'vs/base/common/errors';
 
 /**
  * Action class that query-based Actions will extend. This base class automatically handles activating and
@@ -800,14 +801,15 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 					this._databaseSelectBox.selectWithOptionName(databaseName);
 				});
 		} else {
-			// Set the value immediately to the initial database so the user can see that, but
-			// keep the control disabled while we load the rest of the database names
+			// Set the value immediately to the initial database so the user can see that, and then
+			// populate the list with just that value to avoid displaying an error while we load
+			// the full list of databases
 			this._dropdown.value = databaseName;
+			this._dropdown.values = [databaseName];
+			this._dropdown.enabled = true;
 			this.getDatabaseNames().then(databaseNames => {
 				this._dropdown.values = databaseNames;
-			}).finally(() => {
-				this._dropdown.enabled = true;
-			});
+			}).catch(onUnexpectedError);
 		}
 	}
 

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -68,6 +68,7 @@ suite('SQL QueryAction Tests', () => {
 		queryModelService.setup(q => q.onRunQueryComplete).returns(() => Event.None);
 		connectionManagementService = TypeMoq.Mock.ofType<TestConnectionManagementService>(TestConnectionManagementService);
 		connectionManagementService.setup(q => q.onDisconnect).returns(() => Event.None);
+		connectionManagementService.setup(q => q.listDatabases(TypeMoq.It.isAny())).returns(() => Promise.resolve({ databaseNames: ['master', 'msdb', 'model'] }));
 		const workbenchinstantiationService = workbenchInstantiationService();
 		const accessor = workbenchinstantiationService.createInstance(ServiceAccessor);
 		const service = accessor.untitledTextEditorService;


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/14916

There's two fixes here : 

1. The dropdown map error - this is coming from this line https://github.com/microsoft/azuredatastudio/blob/main/src/sql/base/parts/editableDropdown/browser/dropdown.ts#L301

At this point the data source didn't have any values set and so filteredValues was undefined. I could have just updated it to also check for undefined like we did elsewhere - but IMO it makes more sense to just have the data source always have a list of values and then just default to an empty list. There isn't really any difference between an empty list and undefined. 

The fixes in dropdown and dropdownList are for this

2. After doing this I noticed that the query editor database name dropdown was highlighted in red after connecting to a server until you clicked on the list. This was because we were waiting to load the database names in the list until the list got focus, and the validation for the dropdown was checking that the value being set was actually in the list. But because we didn't have the list of database names yet the values list was empty so it always showed an error.

So I slightly changed the behavior - whenever we change a connection and set that initial database name we also immediately set the values to just be a single item of that database name. Then we update that once we get the full list of database names.

Showing this in action with a long delay loading the database names : 

![DatabaseLoading](https://user-images.githubusercontent.com/28519865/113335863-629e4f00-92da-11eb-923c-1c6c036dbe16.gif)

I think this dropdown could use some more work though still - such as a loading symbol while the database names are loading. But that should be done as a follow-up enhancement if needed. This PR is focused around fixing the original issue and not regressing behavior. 