### PR TITLE
limit the data size for chart rendering

### DIFF
--- a/src/sql/platform/telemetry/common/telemetryKeys.ts
+++ b/src/sql/platform/telemetry/common/telemetryKeys.ts
@@ -73,6 +73,7 @@ export enum TelemetryAction {
 	RunQuery = 'RunQuery',
 	RunQueryStatement = 'RunQueryStatement',
 	RunQueryString = 'RunQueryString',
+	ShowChart = 'ShowChart',
 	StopAgentJob = 'StopAgentJob',
 	WizardPagesNavigation = 'WizardPagesNavigation'
 }
@@ -80,5 +81,9 @@ export enum TelemetryAction {
 export enum NbTelemetryAction {
 	RunCell = 'RunCell',
 	RunAll = 'RunNotebook'
+}
+
+export enum TelemetryPropertyName {
+	ChartMaxRowCountExceeded = 'chartMaxRowCountExceeded'
 }
 

--- a/src/sql/workbench/contrib/charts/browser/chartView.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartView.ts
@@ -2,15 +2,16 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-
 import 'vs/css!./media/chartView';
 import { Checkbox } from 'sql/base/browser/ui/checkbox/checkbox';
 import { IPanelView } from 'sql/base/browser/ui/panel/panel';
 import { SelectBox } from 'sql/base/browser/ui/selectBox/selectBox';
 import { ITaskbarContent, Taskbar } from 'sql/base/browser/ui/taskbar/taskbar';
 import { Extensions, IInsightData, IInsightRegistry } from 'sql/platform/dashboard/browser/insightRegistry';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { ChartState } from 'sql/workbench/common/editor/query/chartState';
 import { ConfigureChartAction, CopyAction, CreateInsightAction, IChartActionContext, SaveImageAction } from 'sql/workbench/contrib/charts/browser/actions';
+import { IChartsConfiguration } from 'sql/workbench/contrib/charts/browser/interfaces';
 import { ChartType, IInsightOptions, InsightType } from 'sql/workbench/contrib/charts/common/interfaces';
 import { ICellValue, VisualizationOptions } from 'sql/workbench/services/query/common/query';
 import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
@@ -23,13 +24,13 @@ import * as nls from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { INotificationService } from 'vs/platform/notification/common/notification';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { Registry } from 'vs/platform/registry/common/platform';
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { attachInputBoxStyler, attachSelectBoxStyler } from 'vs/platform/theme/common/styler';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ChartOptions, ControlType, IChartOption } from './chartOptions';
 import { Insight } from './insight';
-import { IChartsConfiguration } from 'sql/workbench/contrib/charts/browser/interfaces';
 
 
 const insightRegistry = Registry.as<IInsightRegistry>(Extensions.InsightContribution);
@@ -92,7 +93,9 @@ export class ChartView extends Disposable implements IPanelView {
 		@IThemeService private _themeService: IThemeService,
 		@IInstantiationService private _instantiationService: IInstantiationService,
 		@INotificationService private readonly _notificationService: INotificationService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IStorageService private readonly _storageService: IStorageService,
+		@IAdsTelemetryService private readonly _adsTelemetryService: IAdsTelemetryService
 	) {
 		super();
 		this.taskbarContainer = DOM.$('div.taskbar-container');
@@ -198,7 +201,7 @@ export class ChartView extends Disposable implements IPanelView {
 	public chart(dataId: { batchId: number, resultId: number }) {
 		this.state.dataId = dataId;
 		this._currentData = dataId;
-		this.shouldGraph();
+		this.showGraph();
 	}
 
 	layout(dimension: DOM.Dimension): void {
@@ -212,7 +215,7 @@ export class ChartView extends Disposable implements IPanelView {
 
 	public set queryRunner(runner: QueryRunner) {
 		this._queryRunner = runner;
-		this.shouldGraph();
+		this.showGraph();
 	}
 
 	public setData(rows: ICellValue[][], columns: string[]): void {
@@ -231,7 +234,7 @@ export class ChartView extends Disposable implements IPanelView {
 		}
 	}
 
-	private shouldGraph() {
+	private showGraph() {
 		// Check if we have the necessary information
 		if (this._currentData && this._queryRunner) {
 			// check if we are being asked to graph something that is available
@@ -240,9 +243,23 @@ export class ChartView extends Disposable implements IPanelView {
 				let summary = batch.resultSetSummaries[this._currentData.resultId];
 				if (summary) {
 					const maxRowCount = this._configurationService.getValue<IChartsConfiguration>('charts').maxRowCount;
+					const storageKey = 'charts/ignoreMaxRowCountExceededNotification';
+
 					if (summary.rowCount > maxRowCount) {
-						this._notificationService.info(nls.localize('charting.maxAllowedRowsExceeded', "Maximum row count for charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'charts.maxRowCount'.", maxRowCount));
+						this._adsTelemetryService.sendTelemetryEvent('charts.maxRowCountExceeded');
+						if (!this._storageService.getBoolean(storageKey, StorageScope.GLOBAL, false)) {
+							this._notificationService.prompt(Severity.Info,
+								nls.localize('charting.maxAllowedRowsExceeded', "Maximum row count for charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'charts.maxRowCount'.", maxRowCount),
+								[{
+									label: nls.localize('charts.neverShowAgain', "Don't Show Again"),
+									isSecondary: true,
+									run: () => {
+										this._storageService.store(storageKey, true, StorageScope.GLOBAL, StorageTarget.MACHINE);
+									}
+								}]);
+						}
 					}
+
 					this._queryRunner.getQueryRows(0, Math.min(maxRowCount, summary.rowCount), this._currentData.batchId, this._currentData.resultId).then(d => {
 						let rows = d.rows;
 						let columns = summary.columnInfo.map(c => c.columnName);

--- a/src/sql/workbench/contrib/charts/browser/chartView.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartView.ts
@@ -249,7 +249,7 @@ export class ChartView extends Disposable implements IPanelView {
 						this._adsTelemetryService.sendTelemetryEvent('charts.maxRowCountExceeded');
 						if (!this._storageService.getBoolean(storageKey, StorageScope.GLOBAL, false)) {
 							this._notificationService.prompt(Severity.Info,
-								nls.localize('charting.maxAllowedRowsExceeded', "Maximum row count for charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'charts.maxRowCount'.", maxRowCount),
+								nls.localize('charts.maxAllowedRowsExceeded', "Maximum row count for charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'charts.maxRowCount'.", maxRowCount),
 								[{
 									label: nls.localize('charts.neverShowAgain', "Don't Show Again"),
 									isSecondary: true,

--- a/src/sql/workbench/contrib/charts/browser/charts.contribution.ts
+++ b/src/sql/workbench/contrib/charts/browser/charts.contribution.ts
@@ -12,12 +12,12 @@ const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Con
 const chartsConfiguration: IConfigurationNode = {
 	id: 'charts',
 	type: 'object',
-	title: nls.localize('chartsConfigurationTitle', "Charts"),
+	title: nls.localize('chartsConfigurationTitle', "Built-in Charts"),
 	properties: {
 		'charts.maxRowCount': {
 			type: 'number',
 			default: 300,
-			description: nls.localize('charts.maxRowCountDescription', "Maximum allowed rows for charts to render, this is introduced to prevent the application hang. If exceeded, ADS will only take the first N rows for chart rendering.")
+			description: nls.localize('charts.maxRowCountDescription', "The maximum number of rows for charts to display. Warning: increasing this may impact performance.")
 		}
 	}
 };

--- a/src/sql/workbench/contrib/charts/browser/charts.contribution.ts
+++ b/src/sql/workbench/contrib/charts/browser/charts.contribution.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Extensions, IConfigurationRegistry, IConfigurationNode } from 'vs/platform/configuration/common/configurationRegistry';
+import { Registry } from 'vs/platform/registry/common/platform';
+import * as nls from 'vs/nls';
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
+
+const chartsConfiguration: IConfigurationNode = {
+	id: 'charts',
+	type: 'object',
+	title: nls.localize('chartsConfigurationTitle', "Charts"),
+	properties: {
+		'charts.maxRowCount': {
+			type: 'number',
+			default: 300,
+			description: nls.localize('charts.maxRowCountDescription', "Maximum allowed rows for charts to render, this is introduced to prevent the application hang. If exceeded, ADS will only take the first N rows for chart rendering.")
+		}
+	}
+};
+
+configurationRegistry.registerConfiguration(chartsConfiguration);

--- a/src/sql/workbench/contrib/charts/browser/charts.contribution.ts
+++ b/src/sql/workbench/contrib/charts/browser/charts.contribution.ts
@@ -10,14 +10,14 @@ import * as nls from 'vs/nls';
 const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
 
 const chartsConfiguration: IConfigurationNode = {
-	id: 'charts',
+	id: 'builtinCharts',
 	type: 'object',
-	title: nls.localize('chartsConfigurationTitle', "Built-in Charts"),
+	title: nls.localize('builtinChartsConfigurationTitle', "Built-in Charts"),
 	properties: {
-		'charts.maxRowCount': {
+		'builtinCharts.maxRowCount': {
 			type: 'number',
 			default: 300,
-			description: nls.localize('charts.maxRowCountDescription', "The maximum number of rows for charts to display. Warning: increasing this may impact performance.")
+			description: nls.localize('builtinCharts.maxRowCountDescription', "The maximum number of rows for charts to display. Warning: increasing this may impact performance.")
 		}
 	}
 };

--- a/src/sql/workbench/contrib/charts/browser/interfaces.ts
+++ b/src/sql/workbench/contrib/charts/browser/interfaces.ts
@@ -46,3 +46,7 @@ export interface IInsightCtor {
 	new <Services extends BrandedService[]>(container: HTMLElement, options: IInsightOptions, ...services: Services): IInsight;
 	readonly types: Array<InsightType | ChartType>;
 }
+
+export interface IChartsConfiguration {
+	readonly maxRowCount: number;
+}

--- a/src/sql/workbench/contrib/charts/browser/utils.ts
+++ b/src/sql/workbench/contrib/charts/browser/utils.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IChartsConfiguration } from 'sql/workbench/contrib/charts/browser/interfaces';
+import * as nls from 'vs/nls';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
+
+/**
+ * Gets the max allowed row count for chart rendering.
+ */
+export function getChartMaxRowCount(configurationService: IConfigurationService): number {
+	return configurationService.getValue<IChartsConfiguration>('charts').maxRowCount;
+}
+
+/**
+ * Show a toast notification about the max row count for chart has exceeded.
+ */
+export function notifyMaxRowCountExceeded(storageService: IStorageService, notificationService: INotificationService, configurationService: IConfigurationService): void {
+	const storageKey = 'charts/ignoreMaxRowCountExceededNotification';
+	if (!storageService.getBoolean(storageKey, StorageScope.GLOBAL, false)) {
+		notificationService.prompt(Severity.Info,
+			nls.localize('charts.maxAllowedRowsExceeded', "Maximum row count for charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'charts.maxRowCount'.", getChartMaxRowCount(configurationService)),
+			[{
+				label: nls.localize('charts.neverShowAgain', "Don't Show Again"),
+				isSecondary: true,
+				run: () => {
+					storageService.store(storageKey, true, StorageScope.GLOBAL, StorageTarget.MACHINE);
+				}
+			}]);
+	}
+}

--- a/src/sql/workbench/contrib/charts/browser/utils.ts
+++ b/src/sql/workbench/contrib/charts/browser/utils.ts
@@ -13,7 +13,7 @@ import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storag
  * Gets the max allowed row count for chart rendering.
  */
 export function getChartMaxRowCount(configurationService: IConfigurationService): number {
-	return configurationService.getValue<IChartsConfiguration>('charts').maxRowCount;
+	return configurationService.getValue<IChartsConfiguration>('builtinCharts').maxRowCount;
 }
 
 /**
@@ -23,7 +23,7 @@ export function notifyMaxRowCountExceeded(storageService: IStorageService, notif
 	const storageKey = 'charts/ignoreMaxRowCountExceededNotification';
 	if (!storageService.getBoolean(storageKey, StorageScope.GLOBAL, false)) {
 		notificationService.prompt(Severity.Info,
-			nls.localize('charts.maxAllowedRowsExceeded', "Maximum row count for charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'charts.maxRowCount'.", getChartMaxRowCount(configurationService)),
+			nls.localize('charts.maxAllowedRowsExceeded', "Maximum row count for built-in charts has been exceeded, only the first {0} rows are used. To configure the value, you can open user settings and search for: 'builtinCharts.maxRowCount'.", getChartMaxRowCount(configurationService)),
 			[{
 				label: nls.localize('charts.neverShowAgain', "Don't Show Again"),
 				isSecondary: true,

--- a/src/sql/workbench/contrib/charts/test/browser/chartView.test.ts
+++ b/src/sql/workbench/contrib/charts/test/browser/chartView.test.ts
@@ -11,6 +11,7 @@ import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 
 suite('Chart View', () => {
 	test('initializes without error', () => {
@@ -40,6 +41,7 @@ function createChartView(isQueryEditorChart: boolean): ChartView {
 	const themeService = new TestThemeService();
 	const instantiationService = new TestInstantiationService();
 	const notificationService = new TestNotificationService();
+	const configurationService = new TestConfigurationService();
 	instantiationService.stub(IThemeService, themeService);
-	return new ChartView(isQueryEditorChart, contextViewService, themeService, instantiationService, notificationService);
+	return new ChartView(isQueryEditorChart, contextViewService, themeService, instantiationService, notificationService, configurationService);
 }

--- a/src/sql/workbench/contrib/charts/test/browser/chartView.test.ts
+++ b/src/sql/workbench/contrib/charts/test/browser/chartView.test.ts
@@ -12,7 +12,6 @@ import { TestInstantiationService } from 'vs/platform/instantiation/test/common/
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
-import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 
 suite('Chart View', () => {
 	test('initializes without error', () => {
@@ -43,7 +42,6 @@ function createChartView(isQueryEditorChart: boolean): ChartView {
 	const instantiationService = new TestInstantiationService();
 	const notificationService = new TestNotificationService();
 	const configurationService = new TestConfigurationService();
-	const storageService = new TestStorageService();
 	instantiationService.stub(IThemeService, themeService);
-	return new ChartView(isQueryEditorChart, contextViewService, themeService, instantiationService, notificationService, configurationService, storageService, undefined);
+	return new ChartView(isQueryEditorChart, contextViewService, themeService, instantiationService, notificationService, configurationService);
 }

--- a/src/sql/workbench/contrib/charts/test/browser/chartView.test.ts
+++ b/src/sql/workbench/contrib/charts/test/browser/chartView.test.ts
@@ -12,6 +12,7 @@ import { TestInstantiationService } from 'vs/platform/instantiation/test/common/
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
+import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 
 suite('Chart View', () => {
 	test('initializes without error', () => {
@@ -42,6 +43,7 @@ function createChartView(isQueryEditorChart: boolean): ChartView {
 	const instantiationService = new TestInstantiationService();
 	const notificationService = new TestNotificationService();
 	const configurationService = new TestConfigurationService();
+	const storageService = new TestStorageService();
 	instantiationService.stub(IThemeService, themeService);
-	return new ChartView(isQueryEditorChart, contextViewService, themeService, instantiationService, notificationService, configurationService);
+	return new ChartView(isQueryEditorChart, contextViewService, themeService, instantiationService, notificationService, configurationService, storageService, undefined);
 }

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -44,6 +44,11 @@ import { assign } from 'vs/base/common/objects';
 import { QueryResultId } from 'sql/workbench/services/notebook/browser/models/cell';
 import { equals } from 'vs/base/common/arrays';
 import { IDisposableDataProvider } from 'sql/base/common/dataProvider';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { getChartMaxRowCount, notifyMaxRowCountExceeded } from 'sql/workbench/contrib/charts/browser/utils';
+import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
+import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
+
 @Component({
 	selector: GridOutputComponent.SELECTOR,
 	template: `<div #output class="notebook-cellTable"></div>`
@@ -535,7 +540,11 @@ export class NotebookChartAction extends ToggleableAction {
 	public static SHOWTABLE_LABEL = localize('notebook.showTable', "Show table");
 	public static SHOWTABLE_ICON = 'table';
 
-	constructor(private resourceTable: DataResourceTable) {
+	constructor(private resourceTable: DataResourceTable,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IStorageService private readonly storageService: IStorageService,
+		@INotificationService private readonly notificationService: INotificationService,
+		@IAdsTelemetryService private readonly adsTelemetryService: IAdsTelemetryService) {
 		super(NotebookChartAction.ID, {
 			toggleOnLabel: NotebookChartAction.SHOWTABLE_LABEL,
 			toggleOnClass: NotebookChartAction.SHOWTABLE_ICON,
@@ -549,9 +558,17 @@ export class NotebookChartAction extends ToggleableAction {
 		this.resourceTable.toggleChartVisibility();
 		this.toggle(!this.state.isOn);
 		if (this.state.isOn) {
-			let rowCount = context.table.getData().getLength();
-			let columnCount = context.table.columns.length;
-			this.resourceTable.updateChartData(rowCount, columnCount, context.gridDataProvider);
+			const rowCount = context.table.getData().getLength();
+			const columnCount = context.table.columns.length;
+			const maxRowCount = getChartMaxRowCount(this.configurationService);
+			const maxRowCountExceeded = rowCount > maxRowCount;
+			if (maxRowCountExceeded) {
+				notifyMaxRowCountExceeded(this.storageService, this.notificationService, this.configurationService);
+			}
+			this.adsTelemetryService.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.TelemetryAction.ShowChart).withAdditionalProperties(
+				{ [TelemetryKeys.TelemetryPropertyName.ChartMaxRowCountExceeded]: maxRowCountExceeded }
+			).send();
+			this.resourceTable.updateChartData(Math.min(rowCount, maxRowCount), columnCount, context.gridDataProvider);
 		}
 		return true;
 	}

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -289,8 +289,9 @@ class DataResourceTable extends GridTableBase<any> {
 
 	public updateChartData(rowCount: number, columnCount: number, gridDataProvider: IGridDataProvider): void {
 		if (this.chartDisplayed) {
-			gridDataProvider.getRowData(0, rowCount).then(result => {
-				let range = new Slick.Range(0, 0, rowCount - 1, columnCount - 1);
+			const actualRowCount = Math.min(getChartMaxRowCount(this.configurationService), rowCount);
+			gridDataProvider.getRowData(0, actualRowCount).then(result => {
+				let range = new Slick.Range(0, 0, actualRowCount - 1, columnCount - 1);
 				let columns = gridDataProvider.getColumnHeaders(range);
 				this._chart.setData(result.rows, columns);
 			});

--- a/src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout.ts
+++ b/src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout.ts
@@ -38,9 +38,9 @@ let sqlTocItems: ITOCEntry<string>[] = [{
 			settings: ['profiler.*']
 		},
 		{
-			id: 'data/charts',
-			label: localize('charts', "Charts"),
-			settings: ['charts.*']
+			id: 'data/builtinCharts',
+			label: localize('builtinCharts', "Built-in Charts"),
+			settings: ['builtinCharts.*']
 		}
 	]
 }];

--- a/src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout.ts
+++ b/src/sql/workbench/contrib/preferences/browser/sqlSettingsLayout.ts
@@ -36,6 +36,11 @@ let sqlTocItems: ITOCEntry<string>[] = [{
 			id: 'data/profiler',
 			label: localize('profiler', "Profiler"),
 			settings: ['profiler.*']
+		},
+		{
+			id: 'data/charts',
+			label: localize('charts', "Charts"),
+			settings: ['charts.*']
 		}
 	]
 }];

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -383,7 +383,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		@IInstantiationService protected readonly instantiationService: IInstantiationService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IUntitledTextEditorService private readonly untitledEditorService: IUntitledTextEditorService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IConfigurationService protected readonly configurationService: IConfigurationService,
 		@IQueryModelService private readonly queryModelService: IQueryModelService,
 		@IThemeService private readonly themeService: IThemeService
 	) {

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -512,4 +512,7 @@ import 'sql/workbench/contrib/extensions/browser/extensions.contribution';
 // Azure
 import 'sql/workbench/contrib/azure/browser/azure.contribution';
 
+// Charts
+import 'sql/workbench/contrib/charts/browser/charts.contribution';
+
 //#endregion


### PR DESCRIPTION
This PR fixes #14335 

Right now we are not limiting the size of the data we pass to chartjs to render charts, as described in the issue, this will cause the app to freeze or crash.

I experimented myself locally and I found 300 is a reasonable number that the charts works with no obvious lag.
I've made it configurable so that users can adjust this number based on their local environment, also provided an option to suppress this notification. 

![image](https://user-images.githubusercontent.com/13777222/113361458-e9feb900-9300-11eb-8d0f-a49d6dcaabb5.png)

