### PR TITLE
add call stack information to the open document error notification

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -1068,7 +1068,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 					const handle = this.notificationService.notify({
 						severity: Severity.Error,
-						message: localize('editorOpenError', "Unable to open '{0}': {1}.", editor.getName(), toErrorMessage(error)),
+						message: localize('editorOpenError', "Unable to open '{0}': {1}.", editor.getName(), toErrorMessage(error, true)), // {{SQL CARBON EDIT}} add verbose parameter to toErrorMessage method
 						actions
 					});
 					console.log(`Unable to open '${editor.getName()}': `, error); // {{SQL CARBON EDIT}} Print full stack trace to console


### PR DESCRIPTION
I've seen several times we have to leave the issues open because we are not able to reproduce the problem and lack of helpful logs. I am adding the original call stack of the exception to the error message, it will be much easier for us to troubleshoot in the future.

examples: https://github.com/microsoft/azuredatastudio/issues/7335 and https://github.com/microsoft/azuredatastudio/issues/14632


I used the query plan editor error that I have fixed yesterday to demonstrate the new error message:
 
![image](https://user-images.githubusercontent.com/13777222/113378756-9e620480-932c-11eb-9b67-69249aaa9232.png)

expand the message:

![image](https://user-images.githubusercontent.com/13777222/113378679-6eb2fc80-932c-11eb-94c5-314330dfedd8.png)
