### PR TITLE
Fix langpack URLs

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1851,15 +1851,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-de/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-de/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-de/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-de/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-de/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-de/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -1916,15 +1916,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-es/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-es/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-es/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-es/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-es/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-es/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -1981,15 +1981,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-fr/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-fr/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-fr/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-fr/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-fr/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-fr/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2046,15 +2046,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-it/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-it/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-it/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-it/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-it/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-it/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2111,15 +2111,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ko/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ko/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ko/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ko/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ko/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ko/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2176,15 +2176,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-pt-BR/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-pt-BR/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-pt-BR/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-pt-BR/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-pt-BR/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-pt-BR/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2241,15 +2241,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ru/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ru/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ru/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ru/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ru/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ru/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2306,15 +2306,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hans/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hans/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hans/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hans/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hans/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hans/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2371,15 +2371,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hant/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hant/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hant/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hant/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hant/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hant/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2436,15 +2436,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ja/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ja/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ja/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ja/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ja/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ja/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -1851,15 +1851,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-de/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-de/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-de/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-de/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-de/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-de/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -1916,15 +1916,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-es/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-es/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-es/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-es/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-es/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-es/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -1981,15 +1981,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-fr/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-fr/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-fr/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-fr/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-fr/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-fr/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2046,15 +2046,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-it/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-it/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-it/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-it/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-it/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-it/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2111,15 +2111,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ko/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ko/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ko/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ko/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ko/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ko/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2176,15 +2176,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-pt-BR/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-pt-BR/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-pt-BR/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-pt-BR/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-pt-BR/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-pt-BR/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2241,15 +2241,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ru/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ru/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ru/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ru/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ru/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ru/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2306,15 +2306,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hans/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hans/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hans/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hans/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hans/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hans/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2371,15 +2371,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hant/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hant/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hant/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hant/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-zh-hant/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-zh-hant/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",
@@ -2436,15 +2436,15 @@
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ja/languagepack.png"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ja/languagepack.png"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ja/README.md"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ja/README.md"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Code.Manifest",
-									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/language-pack-ja/package.json"
+									"source": "https://raw.githubusercontent.com/microsoft/azuredatastudio/main/i18n/ads-language-pack-ja/package.json"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Content.License",


### PR DESCRIPTION
The paths were changed in the repo recently so the gallery currently can't display these. 