### PR TITLE
Fix duplicated nodes

### DIFF
--- a/extensions/notebook/src/book/bookModel.ts
+++ b/extensions/notebook/src/book/bookModel.ts
@@ -155,6 +155,7 @@ export class BookModel {
 			}
 		);
 		this._bookItems.push(notebookItem);
+		this._rootNode = notebookItem;
 		if (this.openAsUntitled && !this._allNotebooks.get(pathDetails.base)) {
 			this._allNotebooks.set(pathDetails.base, notebookItem);
 		} else {

--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -39,7 +39,7 @@ export interface BookTreeItemFormat {
 }
 
 export class BookTreeItem extends vscode.TreeItem {
-	private _sections: JupyterBookSection[];
+	private _sections: JupyterBookSection[] | undefined;
 	private _uri: string | undefined;
 	private _previousUri: string;
 	private _nextUri: string;

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -65,7 +65,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			// Only reveal if...
 			if (e.visible && // If the view is currently visible - if not then we'll just wait until this is called when the view is made visible
 				book && // The notebook is part of a book in the viewlet (otherwise nothing to reveal)
-				this._openAsUntitled ? notebookPath?.scheme === 'untitled' : notebookPath?.scheme !== 'untitled') // The notebook is of the correct type for this tree view
+				(this._openAsUntitled ? notebookPath?.scheme === 'untitled' : notebookPath?.scheme !== 'untitled')) // The notebook is of the correct type for this tree view
 			{
 				await this.revealDocumentInTreeView(notebookPath);
 			}

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -64,10 +64,9 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			const book = this.books.find(book => notebookPath?.fsPath.replace(/\\/g, '/').indexOf(book.bookPath) >= -1);
 			// Only reveal if...
 			if (e.visible && // If the view is currently visible - if not then we'll just wait until this is called when the view is made visible
-				book && ( // The notebook is part of a book in the viewlet (otherwise nothing to reveal)
-					(!this._openAsUntitled && notebookPath?.scheme !== 'untitled') || // This view is for titled notebooks and the notebook is not untitled
-					(this._openAsUntitled && notebookPath?.scheme === 'untitled') // The view is for untitled notebooks and the notebook is untitled
-				)) {
+				book && // The notebook is part of a book in the viewlet (otherwise nothing to reveal)
+				this._openAsUntitled ? notebookPath?.scheme === 'untitled' : notebookPath?.scheme !== 'untitled') // The notebook is of the correct type for this tree view
+			{
 				await this.revealDocumentInTreeView(notebookPath);
 			}
 		});

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -60,9 +60,10 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			// in the tree view
 			let openDocument = azdata.nb.activeNotebookEditor;
 			let notebookPath = openDocument?.document.uri;
+			// Find the book that this notebook belongs to
 			const book = this.books.find(book => notebookPath?.fsPath.replace(/\\/g, '/').indexOf(book.bookPath) >= -1);
 			// Only reveal if...
-			if (e.visible && // If the view is currently visible to save execution time
+			if (e.visible && // If the view is currently visible - if not then we'll just wait until this is called when the view is made visible
 				book && ( // The notebook is part of a book in the viewlet (otherwise nothing to reveal)
 					(!this._openAsUntitled && notebookPath?.scheme !== 'untitled') || // This view is for titled notebooks and the notebook is not untitled
 					(this._openAsUntitled && notebookPath?.scheme === 'untitled') // The view is for untitled notebooks and the notebook is untitled
@@ -78,8 +79,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			await Promise.all(getPinnedNotebooks().map(async (notebook) => {
 				try {
 					await this.createAndAddBookModel(notebook.notebookPath, true, notebook.bookPath);
-				} catch (err) {
-					console.log('caught error');
+				} catch {
 					// no-op, not all workspace folders are going to be valid books
 				}
 			}));
@@ -87,8 +87,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			await Promise.all(workspaceFolders.map(async (workspaceFolder) => {
 				try {
 					await this.loadNotebooksInFolder(workspaceFolder.uri.fsPath);
-				} catch (err) {
-					console.log('error');
+				} catch {
 					// no-op, not all workspace folders are going to be valid books
 				}
 			}));

--- a/extensions/notebook/src/extension.ts
+++ b/extensions/notebook/src/extension.ts
@@ -150,9 +150,9 @@ export async function activate(extensionContext: vscode.ExtensionContext): Promi
 
 	azdata.nb.onDidChangeActiveNotebookEditor(e => {
 		if (e.document.uri.scheme === 'untitled') {
-			providedBookTreeViewProvider.revealActiveDocumentInViewlet(e.document.uri, false);
+			providedBookTreeViewProvider.revealDocumentInTreeView(e.document.uri, false);
 		} else {
-			bookTreeViewProvider.revealActiveDocumentInViewlet(e.document.uri, false);
+			bookTreeViewProvider.revealDocumentInTreeView(e.document.uri, false);
 		}
 	});
 

--- a/extensions/notebook/src/test/book/book.test.ts
+++ b/extensions/notebook/src/test/book/book.test.ts
@@ -253,7 +253,7 @@ describe('BooksTreeViewTests', function () {
 				let notebook2Path = path.join(rootFolderPath, 'Book', 'content', 'notebook2.ipynb');
 				let notebookUri = vscode.Uri.file(notebook2Path);
 
-				let revealActiveDocumentInViewletSpy = sinon.spy(bookTreeViewProvider, 'revealActiveDocumentInViewlet');
+				let revealActiveDocumentInViewletSpy = sinon.spy(bookTreeViewProvider, 'revealDocumentInTreeView');
 				await azdata.nb.showNotebookDocument(notebookUri);
 				should(azdata.nb.notebookDocuments.find(doc => doc.fileName === notebookUri.fsPath)).not.be.undefined();
 				should(revealActiveDocumentInViewletSpy.calledOnce).be.true('revealActiveDocumentInViewlet should have been called');
@@ -336,7 +336,7 @@ describe('BooksTreeViewTests', function () {
 				const untitledNotebook1Uri = vscode.Uri.parse(`untitled:notebook1.ipynb`);
 				const untitledNotebook2Uri = vscode.Uri.parse(`untitled:notebook2.ipynb`);
 
-				let revealActiveDocumentInViewletSpy = sinon.spy(providedbookTreeViewProvider, 'revealActiveDocumentInViewlet');
+				let revealActiveDocumentInViewletSpy = sinon.spy(providedbookTreeViewProvider, 'revealDocumentInTreeView');
 				await azdata.nb.showNotebookDocument(untitledNotebook1Uri);
 				should(azdata.nb.notebookDocuments.find(doc => doc.fileName === untitledNotebook1Uri.fsPath)).not.be.undefined();
 				should(revealActiveDocumentInViewletSpy.calledOnce).be.true('revealActiveDocumentInViewlet should have been called');


### PR DESCRIPTION
The main issue here was the getChildren function line 631 - when passed undefined we should pass only the root nodes of the tree view. We were getting all the children of those root nodes though and so would end up with a bunch of duplicated tree items. 

Along the way I tried to clean up some things : 

1. Create tree view and visibility changed handler in the constructor instead of each time we load a book. There should only ever be one per tree data provider so making more is likely to result in issues (I was seeing some odd stuff with the callbacks not being hooked up correctly)
2. Renamed some functions to be clearer about what they're doing