### PR TITLE
Cleanup findAndExpandParentNode

### DIFF
--- a/extensions/notebook/src/book/bookTreeItem.ts
+++ b/extensions/notebook/src/book/bookTreeItem.ts
@@ -206,11 +206,11 @@ export class BookTreeItem extends vscode.TreeItem {
 		this._tableOfContentsPath = tocPath;
 	}
 
-	public get children(): BookTreeItem[] {
+	public get children(): BookTreeItem[] | undefined {
 		return this.book.children;
 	}
 
-	public set children(children: BookTreeItem[]) {
+	public set children(children: BookTreeItem[] | undefined) {
 		this.book.children = children;
 	}
 


### PR DESCRIPTION
Functionally should behave the same, but removed a lot of unnecessary logic, reorganized it to be more readable and added comments. 