### PR TITLE
fix filter button visibility issue

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -37,7 +37,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
 	private columnDef!: FilterableColumn<T>;
 	private buttonStyles?: IButtonStyles;
 	private disposableStore = new DisposableStore();
-	public enabled: boolean = true;
+	private _enabled: boolean = true;
 
 	constructor() {
 	}
@@ -434,5 +434,19 @@ export class HeaderFilter<T extends Slick.SlickData> {
 
 		e.preventDefault();
 		e.stopPropagation();
+	}
+
+	public get enabled(): boolean {
+		return this._enabled;
+	}
+
+	public set enabled(value: boolean) {
+		if (this._enabled !== value) {
+			this._enabled = value;
+			// force the table header to redraw.
+			this.grid.getColumns().forEach((column) => {
+				this.grid.updateColumnHeader(column.id);
+			});
+		}
 	}
 }

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -430,6 +430,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 			this.renderGridDataRowsRange(startIndex, count);
 		});
 		this.dataProvider.dataRows = collection;
+		this.setFilterState();
 		this.table.updateRowCount();
 		await this.setupState();
 	}
@@ -525,7 +526,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 			};
 			this.table.rerenderGrid();
 		}));
-		if (this.configurationService.getValue<boolean>('workbench')['enablePreviewFeatures']) {
+		if (this.enableFilteringFeature) {
 			this.filterPlugin = new HeaderFilter();
 			attachButtonStyler(this.filterPlugin, this.themeService);
 			this.table.registerPlugin(this.filterPlugin);
@@ -686,13 +687,23 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 	public updateResult(resultSet: ResultSetSummary) {
 		this._resultSet = resultSet;
 		if (this.table && this.visible) {
-			if (this.configurationService.getValue<boolean>('workbench')['enablePreviewFeatures'] && this.options.inMemoryDataProcessing && this.options.inMemoryDataCountThreshold < resultSet.rowCount) {
-				this.filterPlugin.enabled = false;
-			}
 			this.dataProvider.length = resultSet.rowCount;
+			this.setFilterState();
 			this.table.updateRowCount();
 		}
 		this._onDidChange.fire(undefined);
+	}
+
+	private get enableFilteringFeature(): boolean {
+		return this.configurationService.getValue<boolean>('workbench')['enablePreviewFeatures'];
+	}
+
+	private setFilterState(): void {
+		if (this.enableFilteringFeature) {
+			const rowCount = this.table.getData().getLength();
+			this.filterPlugin.enabled = this.options.inMemoryDataProcessing
+				&& (this.options.inMemoryDataCountThreshold === undefined || this.options.inMemoryDataCountThreshold >= rowCount);
+		}
 	}
 
 	private generateContext(cell?: Slick.Cell): IGridActionContext {


### PR DESCRIPTION
This PR fixes #14962

there are 2 actual issues:
1. when we switch tabs and come back to the original query editor or switch between messages/charts/results inside the editor, the filter button will be visible even though row count exceeds the max allow rows.
    fix: add a call to update the filter's state in onDidInsert which is called when the view is restored
2. when the result is coming in batches, the header won't be refreshed.
    fix: updated the enabled property setter to force redrawing of the table header, so that the latest enabled state is used.