### PR TITLE
check whether element is undefined

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerWidget.component.ts
@@ -184,6 +184,6 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 	}
 
 	public getTableHeight(): string {
-		return `calc(100% - ${this._input.height}px)`;
+		return this._input ? `calc(100% - ${this._input.height}px)` : '100%';
 	}
 }


### PR DESCRIPTION
in #14621, the user attached a log file indicates that `this._input` could be undefined. I couldn't reproduce it myself, but it doesn't hurt to add an extra check.
