### PR TITLE
See and Edit Selected Links in Callout Dialog 

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
@@ -45,6 +45,7 @@ export class LinkCalloutDialog extends Modal {
 		dialogPosition: DialogPosition,
 		dialogProperties: IDialogProperties,
 		private readonly _defaultLabel: string = '',
+		private readonly _defaultLinkLabel: string = '',
 		@IContextViewService private readonly _contextViewService: IContextViewService,
 		@IThemeService themeService: IThemeService,
 		@ILayoutService layoutService: ILayoutService,
@@ -134,6 +135,7 @@ export class LinkCalloutDialog extends Modal {
 				placeholder: constants.linkAddressPlaceholder,
 				ariaLabel: constants.linkAddressLabel
 			});
+		this._linkUrlInputBox.value = this._defaultLinkLabel;
 		DOM.append(linkAddressRow, linkAddressInputContainer);
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
@@ -45,7 +45,7 @@ export class LinkCalloutDialog extends Modal {
 		dialogPosition: DialogPosition,
 		dialogProperties: IDialogProperties,
 		private readonly _defaultLabel: string = '',
-		private readonly _defaultLinkLabel: string = '',
+		private readonly _defaultLinkUrl: string = '',
 		@IContextViewService private readonly _contextViewService: IContextViewService,
 		@IThemeService themeService: IThemeService,
 		@ILayoutService layoutService: ILayoutService,
@@ -135,7 +135,7 @@ export class LinkCalloutDialog extends Modal {
 				placeholder: constants.linkAddressPlaceholder,
 				ariaLabel: constants.linkAddressLabel
 			});
-		this._linkUrlInputBox.value = this._defaultLinkLabel;
+		this._linkUrlInputBox.value = this._defaultLinkUrl;
 		DOM.append(linkAddressRow, linkAddressInputContainer);
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -320,7 +320,11 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 	}
 
 	private getCurrentLinkAddress(): string {
-		return document.getSelection().anchorNode.parentNode['href'] || '';
+		if (document.getSelection().anchorNode.parentNode['protocol'] === 'file:') {
+			return document.getSelection().anchorNode.parentNode['pathname'] || '';
+		} else {
+			return document.getSelection().anchorNode.parentNode['href'] || '';
+		}
 	}
 
 	private getCellEditorControl(): IEditor | undefined {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -296,7 +296,8 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 
 		if (type === MarkdownButtonType.LINK_PREVIEW) {
 			const defaultLabel = this.getCurrentSelectionText();
-			this._linkCallout = this._instantiationService.createInstance(LinkCalloutDialog, this.insertLinkHeading, dialogPosition, dialogProperties, defaultLabel);
+			const defaultLinkLabel = this.getCurrentLinkAddress();
+			this._linkCallout = this._instantiationService.createInstance(LinkCalloutDialog, this.insertLinkHeading, dialogPosition, dialogProperties, defaultLabel, defaultLinkLabel);
 			this._linkCallout.render();
 			calloutOptions = await this._linkCallout.open();
 		}
@@ -316,6 +317,10 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 			}
 			return '';
 		}
+	}
+
+	private getCurrentLinkAddress(): string {
+		return document.getSelection().anchorNode.parentNode['href'] || '';
 	}
 
 	private getCellEditorControl(): IEditor | undefined {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -296,8 +296,8 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 
 		if (type === MarkdownButtonType.LINK_PREVIEW) {
 			const defaultLabel = this.getCurrentSelectionText();
-			const defaultLinkLabel = this.getCurrentLinkAddress();
-			this._linkCallout = this._instantiationService.createInstance(LinkCalloutDialog, this.insertLinkHeading, dialogPosition, dialogProperties, defaultLabel, defaultLinkLabel);
+			const defaultLinkUrl = this.getCurrentLinkUrl();
+			this._linkCallout = this._instantiationService.createInstance(LinkCalloutDialog, this.insertLinkHeading, dialogPosition, dialogProperties, defaultLabel, defaultLinkUrl);
 			this._linkCallout.render();
 			calloutOptions = await this._linkCallout.open();
 		}
@@ -319,7 +319,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 		}
 	}
 
-	private getCurrentLinkAddress(): string {
+	private getCurrentLinkUrl(): string {
 		if (document.getSelection().anchorNode.parentNode['protocol'] === 'file:') {
 			return document.getSelection().anchorNode.parentNode['pathname'] || '';
 		} else {

--- a/src/sql/workbench/contrib/notebook/test/calloutDialog/linkCalloutDialog.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/calloutDialog/linkCalloutDialog.test.ts
@@ -12,7 +12,6 @@ import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKe
 import { Deferred } from 'sql/base/common/promise';
 import { escapeLabel, escapeUrl } from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/utils';
 import { IDialogProperties } from 'sql/workbench/browser/modal/modal';
-import * as DOM from 'vs/base/browser/dom';
 
 suite('Link Callout Dialog', function (): void {
 	let layoutService: ILayoutService;

--- a/src/sql/workbench/contrib/notebook/test/calloutDialog/linkCalloutDialog.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/calloutDialog/linkCalloutDialog.test.ts
@@ -29,7 +29,7 @@ suite('Link Callout Dialog', function (): void {
 	});
 
 	test('Should return empty markdown on cancel', async function (): Promise<void> {
-		let linkCalloutDialog = new LinkCalloutDialog('Title', 'below', defaultDialogProperties, 'defaultLabel',
+		let linkCalloutDialog = new LinkCalloutDialog('Title', 'below', defaultDialogProperties, 'defaultLabel', 'defaultLinkLabel',
 			undefined, themeService, layoutService, telemetryService, contextKeyService, undefined, undefined, undefined);
 		linkCalloutDialog.render();
 
@@ -50,7 +50,7 @@ suite('Link Callout Dialog', function (): void {
 	test('Should return expected values on insert', async function (): Promise<void> {
 		const defaultLabel = 'defaultLabel';
 		const sampleUrl = 'https://www.aka.ms/azuredatastudio';
-		let linkCalloutDialog = new LinkCalloutDialog('Title', 'below', defaultDialogProperties, defaultLabel,
+		let linkCalloutDialog = new LinkCalloutDialog('Title', 'below', defaultDialogProperties, defaultLabel, sampleUrl,
 			undefined, themeService, layoutService, telemetryService, contextKeyService, undefined, undefined, undefined);
 		linkCalloutDialog.render();
 
@@ -73,7 +73,7 @@ suite('Link Callout Dialog', function (): void {
 	test('Should return expected values on insert when escape necessary', async function (): Promise<void> {
 		const defaultLabel = 'default[]Label';
 		const sampleUrl = 'https://www.aka.ms/azuredatastudio()';
-		let linkCalloutDialog = new LinkCalloutDialog('Title', 'below', defaultDialogProperties, defaultLabel,
+		let linkCalloutDialog = new LinkCalloutDialog('Title', 'below', defaultDialogProperties, defaultLabel, sampleUrl,
 			undefined, themeService, layoutService, telemetryService, contextKeyService, undefined, undefined, undefined);
 		linkCalloutDialog.render();
 

--- a/src/sql/workbench/contrib/notebook/test/calloutDialog/linkCalloutDialog.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/calloutDialog/linkCalloutDialog.test.ts
@@ -12,6 +12,7 @@ import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKe
 import { Deferred } from 'sql/base/common/promise';
 import { escapeLabel, escapeUrl } from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/utils';
 import { IDialogProperties } from 'sql/workbench/browser/modal/modal';
+import * as DOM from 'vs/base/browser/dom';
 
 suite('Link Callout Dialog', function (): void {
 	let layoutService: ILayoutService;
@@ -106,4 +107,27 @@ suite('Link Callout Dialog', function (): void {
 		assert.equal(escapeUrl('<>&()'), '&lt;&gt;&amp;%28%29', 'URL test known escaped characters failed');
 		assert.equal(escapeUrl('<>&()[]'), '&lt;&gt;&amp;%28%29[]', 'URL test all escaped characters failed');
 	});
+
+	test('Should return file link properly', async function (): Promise<void> {
+		const defaultLabel = 'defaultLabel';
+		const sampleUrl = 'C:/Test/Test.ipynb';
+		let linkCalloutDialog = new LinkCalloutDialog('Title', 'below', defaultDialogProperties, defaultLabel, sampleUrl,
+			undefined, themeService, layoutService, telemetryService, contextKeyService, undefined, undefined, undefined);
+		linkCalloutDialog.render();
+
+		let deferred = new Deferred<ILinkCalloutDialogOptions>();
+		// When I first open the callout dialog
+		linkCalloutDialog.open().then(value => {
+			deferred.resolve(value);
+		});
+		linkCalloutDialog.url = sampleUrl;
+
+		// And insert the dialog
+		linkCalloutDialog.insert();
+		let result = await deferred.promise;
+		assert.equal(result.insertUnescapedLinkLabel, defaultLabel, 'Label not returned correctly');
+		assert.equal(result.insertUnescapedLinkUrl, sampleUrl, 'URL not returned correctly');
+		assert.equal(result.insertEscapedMarkdown, `[${defaultLabel}](${sampleUrl})`, 'Markdown not returned correctly');
+	});
+
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses #14724. 
It will show the user the currently selected link within the Callout dialog so that the user can see the current link and edit it.

![Link-in-CallOut](https://user-images.githubusercontent.com/23587151/113638053-d4540100-962a-11eb-95ec-407cd286cda8.gif)

