### PR TITLE
fix schema compare dropdown not selecting correct db when multiple active connections

### DIFF
--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -91,9 +91,14 @@ export class SchemaCompareMainWindow {
 		let sourceDacpac = context as string;
 		if (profile) {
 			let ownerUri = await azdata.connection.getUriForConnection((profile.id));
+			let usr = profile.userName;
+			if (!usr) {
+				usr = loc.defaultText;
+			}
+
 			this.sourceEndpointInfo = {
 				endpointType: mssql.SchemaCompareEndpointType.Database,
-				serverDisplayName: `${profile.serverName} (${profile.userName})`,
+				serverDisplayName: `${profile.serverName} (${usr})`,
 				serverName: profile.serverName,
 				databaseName: profile.databaseName,
 				ownerUri: ownerUri,

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -93,7 +93,7 @@ export class SchemaCompareMainWindow {
 			let ownerUri = await azdata.connection.getUriForConnection((profile.id));
 			this.sourceEndpointInfo = {
 				endpointType: mssql.SchemaCompareEndpointType.Database,
-				serverDisplayName: `${profile.serverName} ${profile.userName}`,
+				serverDisplayName: `${profile.serverName} (${profile.userName})`,
 				serverName: profile.serverName,
 				databaseName: profile.databaseName,
 				ownerUri: ownerUri,


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/12779 and addresses https://github.com/microsoft/azuredatastudio/issues/14957. This missing parenthesis was causing the string comparison to fail when looking for the previously selected server connection, so it was defaulting to the most recent connection when there were multiple active connections.
https://github.com/microsoft/azuredatastudio/blob/a3cddbc8aadf4106fd9877b111ec64b3d609cc61/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts#L559-L564

![schemaCompareDropdown](https://user-images.githubusercontent.com/31145923/113764348-ad9bd600-96cf-11eb-8bba-d7930828a933.gif)
