### PR TITLE
fix chart's checkbox option type

### DIFF
--- a/src/sql/base/browser/ui/checkbox/media/checkbox.css
+++ b/src/sql/base/browser/ui/checkbox/media/checkbox.css
@@ -22,3 +22,7 @@
 	pointer-events: none;
 	opacity: 0.3;
 }
+
+input[type='checkbox'] {
+	margin: 0px 5px 0px 0px;
+}

--- a/src/sql/workbench/contrib/charts/browser/chartView.ts
+++ b/src/sql/workbench/contrib/charts/browser/chartView.ts
@@ -317,11 +317,13 @@ export class ChartView extends Disposable implements IPanelView {
 	}
 
 	private createOption(option: IChartOption, container: HTMLElement) {
-		const label = DOM.$('div.option-label');
-		label.innerText = option.label;
 		const optionContainer = DOM.$('div.option-container');
 		const optionInput = DOM.$('div.option-input');
-		optionContainer.appendChild(label);
+		if (option.type !== ControlType.checkbox) {
+			const label = DOM.$('div.option-label');
+			label.innerText = option.label;
+			optionContainer.appendChild(label);
+		}
 		optionContainer.appendChild(optionInput);
 		let setFunc: ((val: string) => void) | ((val: number) => void) | ((val: boolean) => void);
 		let entry = option.configEntry as keyof IInsightOptions;
@@ -329,7 +331,7 @@ export class ChartView extends Disposable implements IPanelView {
 		switch (option.type) {
 			case ControlType.checkbox:
 				let checkbox = new Checkbox(optionInput, {
-					label: '',
+					label: option.label,
 					ariaLabel: option.label,
 					checked: value,
 					onChange: () => {

--- a/src/sql/workbench/contrib/charts/browser/media/chartView.css
+++ b/src/sql/workbench/contrib/charts/browser/media/chartView.css
@@ -31,3 +31,7 @@
 	min-width: 250px;
 	padding-right: 10px;
 }
+
+.option-container {
+	margin-bottom: 5px;
+}


### PR DESCRIPTION
It bothers me to have a checkbox with no text next to it, finally fixing it.
also remove the default margin set on checkbox.

before
![image](https://user-images.githubusercontent.com/13777222/113792358-9e7e4d80-96fa-11eb-8cb5-23e48e593749.png)
![image](https://user-images.githubusercontent.com/13777222/113801079-fb82ff00-970c-11eb-8f34-651af8960c14.png)

after:
![image](https://user-images.githubusercontent.com/13777222/113801314-6e8c7580-970d-11eb-96db-2d98fe5e5156.png)
![image](https://user-images.githubusercontent.com/13777222/113801054-ec9c4c80-970c-11eb-97b4-61070b704ce7.png)
