### PR TITLE
declarative table improvement

### DIFF
--- a/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
@@ -775,11 +775,14 @@ export class SqlDatabaseTree {
 			this._model._assessmentResults.databaseAssessments.sort((db1, db2) => {
 				return db2.issues.length - db1.issues.length;
 			});
+			// Reset the dbName list so that it is in sync with the table
+			this._dbNames = this._model._assessmentResults.databaseAssessments.map(da => da.name);
 			this._model._assessmentResults.databaseAssessments.forEach((db) => {
 				databaseTableValues.push(
 					[
 						{
 							value: selectedDbs.includes(db.name),
+							enabled: db.issues.length === 0,
 							style: styleLeft
 						},
 						{

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -256,7 +256,6 @@ declare module 'azdata' {
 		rowCssStyles?: CssStyles;
 		ariaLabel?: string;
 		showCheckAll?: boolean;
-		isChecked?: boolean;
 	}
 
 
@@ -384,9 +383,23 @@ declare module 'azdata' {
 	}
 
 	export interface DeclarativeTableCellValue {
+		/**
+		 * The cell value
+		 */
 		value: string | number | boolean | Component;
+		/**
+		 * The aria-label of the cell
+		 */
 		ariaLabel?: string;
-		style?: CssStyles
+		/**
+		 * The CSS style of the cell
+		 */
+		style?: CssStyles;
+		/**
+		 * A boolean value indicates whether the cell is enabled. Default value is true.
+		 * Note: this is currently only implemented for boolean type (checkbox).
+		 */
+		enabled?: boolean;
 	}
 
 	/**

--- a/src/sql/base/browser/ui/checkbox/checkbox.ts
+++ b/src/sql/base/browser/ui/checkbox/checkbox.ts
@@ -52,8 +52,8 @@ export class Checkbox extends Widget {
 		this._label.setAttribute('for', id);
 
 		this.label = opts.label;
-		this.enabled = opts.enabled || true;
-		this.checked = opts.checked || false;
+		this.enabled = opts.enabled ?? true;
+		this.checked = opts.checked ?? false;
 
 		if (opts.onChange) {
 			this.onChange(opts.onChange);

--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.html
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.html
@@ -6,7 +6,7 @@
 					[ngStyle]="column.headerCssStyles"
 					[attr.aria-label]="getHeaderAriaLabel(c)">
 					{{column.displayName}}
-					<checkbox *ngIf="isCheckBox(c)" [checked]="isHeaderChecked(c)"
+					<checkbox *ngIf="headerCheckboxVisible(c)" [checked]="isHeaderChecked(c)"
 					[aria-label]="getCheckAllColumnAriaLabel(c)" (onChange)="onHeaderCheckBoxChanged($event,c)"
 						label=""></checkbox>
 				</th>
@@ -23,7 +23,7 @@
 							[ngStyle]="mergeCss(columns[c].rowCssStyles, cellData.style)"
 							role="gridcell">
 							<checkbox *ngIf="isCheckBox(c)" label="" (onChange)="onCheckBoxChanged($event,r,c)"
-								[enabled]="isControlEnabled(c)" [checked]="isChecked(r,c)"
+								[enabled]="isControlEnabled(r, c)" [checked]="isChecked(r,c)"
 								[ngStyle]="mergeCss(columns[c].rowCssStyles, cellData.style)">
 							</checkbox>
 							<select-box *ngIf="isSelectBox(c)" [options]="getOptions(c)"


### PR DESCRIPTION
this PR fixes: #15013
1. allow the extension to specify whether a checkbox cell is enabled or not
2. remove the isChecked on the column definition, it was used to store the value of whether the header checkbox is checked, It is not necessary and could cause inconsistent state. Now it is based on the checked state of the cell data in that column.
3. migration wizard doesn't get the list of selected databases correct because it is based on the wrong dbNames list, Modified to make sure it is in sync with the table data.
