### PR TITLE
Fix event property name

### DIFF
--- a/src/sql/platform/telemetry/common/adsTelemetryService.ts
+++ b/src/sql/platform/telemetry/common/adsTelemetryService.ts
@@ -48,7 +48,7 @@ class TelemetryEventImpl implements ITelemetryEvent {
 		assign(this._properties,
 			{
 				authenticationType: connectionInfo?.authenticationType,
-				providerName: connectionInfo?.providerName
+				provider: connectionInfo?.providerName
 			});
 		return this;
 	}


### PR DESCRIPTION
This function was recently added to be used by certain events such as DatabaseConnected - which previously were adding similar properties directly themselves. This was mostly fine - but the provider property was named `provider` previously where as this named it `providerName`. This meant any new events weren't being processed properly since providers.provider was blank.

Given that the only users of this function are the ones that were recently modified or completely new events I decided just to have this match the original name of the property so that the processing scripts don't have to do anything extra. 