### PR TITLE
Select active notebook in viewlet when opened from command pallet

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -445,7 +445,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			if (bookItem) {
 				return bookItem;
 			}
-			// Walk up to the parent folders one level at each iteration
+			// Walk down from the top level parent folder one level at each iteration
 			// and keep expanding until we reach the target notebook leaf
 			let parentBookPath: string = notebookFolders.slice(0, notebookFolders.length - depthOfNotebookInBook).join('/');
 			let bookItemToExpand = parentBook.bookItems.find(b => b.tooltip.indexOf(parentBookPath) > -1) ??

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -397,10 +397,10 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		if (!uri) {
 			let openDocument = azdata.nb.activeNotebookEditor;
 			if (openDocument) {
-				notebookPath = openDocument.document.uri.fsPath.replace(/\\/g, '/');
+				notebookPath = openDocument.document.uri.fsPath;
 			}
 		} else if (uri.fsPath) {
-			notebookPath = uri.fsPath.replace(/\\/g, '/');
+			notebookPath = uri.fsPath;
 		}
 
 		if (shouldReveal || this._bookViewer?.visible) {
@@ -415,6 +415,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 	}
 
 	async findAndExpandParentNode(notebookPath: string): Promise<BookTreeItem | undefined> {
+		notebookPath = notebookPath.replace(/\\/g, '/');
 		const parentBook = this.books.find(b => notebookPath.indexOf(b.bookPath) > -1);
 		if (!parentBook) {
 			// No parent book, likely because the Notebook is at the top level and not under a Notebook.
@@ -432,7 +433,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		// get the children of root node and expand the nodes to the notebook level.
 		await this.getChildren(parentBook.rootNode);
 		// The path to the Notebook we're looking for (these are the nodes we're looking to expand)
-		const notebookFolders = notebookPath.split(path.posix.sep);
+		const notebookFolders = notebookPath.split('/');
 		// Find number of directories between the Notebook path and the root of the book it's contained in
 		// so we know how many parent nodes to expand
 		let depthOfNotebookInBook: number = path.relative(notebookPath, parentBook.bookPath).split(path.sep).length;
@@ -444,10 +445,9 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			if (bookItem) {
 				return bookItem;
 			}
-			// Search for the parent item
-			// notebook can be inside the same folder as parent and can be in a different folder as well
-			// so check for both scenarios.
-			let parentBookPath: string = notebookFolders.slice(0, notebookFolders.length - depthOfNotebookInBook).join(path.posix.sep);
+			// Walk up to the parent folders one level at each iteration
+			// and keep expanding until we reach the target notebook leaf
+			let parentBookPath: string = notebookFolders.slice(0, notebookFolders.length - depthOfNotebookInBook).join('/');
 			let bookItemToExpand = parentBook.bookItems.find(b => b.tooltip.indexOf(parentBookPath) > -1) ??
 				parentBook.bookItems.find(b => path.relative(notebookPath, b.tooltip)?.split(path.sep)?.length === depthOfNotebookInBook);
 			if (!bookItemToExpand) {
@@ -459,6 +459,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				await this.getChildren(bookItemToExpand);
 			}
 			try {
+				// TO DO: Check why the reveal fails during initial load with 'TreeError [bookTreeView] Tree element not found'
 				await this._bookViewer.reveal(bookItemToExpand, { select: false, focus: true, expand: 3 });
 			}
 			catch (e) {

--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -432,7 +432,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 		// get the children of root node and expand the nodes to the notebook level.
 		await this.getChildren(parentBook.rootNode);
 		// The path to the Notebook we're looking for (these are the nodes we're looking to expand)
-		const notebookFolders = notebookPath.split(path.sep);
+		const notebookFolders = notebookPath.split(path.posix.sep);
 		// Find number of directories between the Notebook path and the root of the book it's contained in
 		// so we know how many parent nodes to expand
 		let depthOfNotebookInBook: number = path.relative(notebookPath, parentBook.bookPath).split(path.sep).length;
@@ -447,7 +447,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			// Search for the parent item
 			// notebook can be inside the same folder as parent and can be in a different folder as well
 			// so check for both scenarios.
-			let parentBookPath: string = notebookFolders.slice(0, notebookFolders.length - depthOfNotebookInBook).join(path.sep);
+			let parentBookPath: string = notebookFolders.slice(0, notebookFolders.length - depthOfNotebookInBook).join(path.posix.sep);
 			let bookItemToExpand = parentBook.bookItems.find(b => b.tooltip.indexOf(parentBookPath) > -1) ??
 				parentBook.bookItems.find(b => path.relative(notebookPath, b.tooltip)?.split(path.sep)?.length === depthOfNotebookInBook);
 			if (!bookItemToExpand) {
@@ -458,7 +458,12 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 				// continue expanding and search its children
 				await this.getChildren(bookItemToExpand);
 			}
-			await this._bookViewer.reveal(bookItemToExpand, { select: false, focus: true, expand: 3 });
+			try {
+				await this._bookViewer.reveal(bookItemToExpand, { select: false, focus: true, expand: 3 });
+			}
+			catch (e) {
+				console.error(e);
+			}
 			depthOfNotebookInBook--;
 		}
 		return bookItem;

--- a/extensions/notebook/src/book/bookTrustManager.ts
+++ b/extensions/notebook/src/book/bookTrustManager.ts
@@ -29,7 +29,7 @@ export class BookTrustManager implements IBookTrustManager {
 		let hasTrustedBookPath: boolean = treeBookItems
 			.filter(bookItem => trustableBookPaths.some(trustableBookPath => trustableBookPath === path.join(bookItem.book.root, path.sep)))
 			.some(bookItem => normalizedNotebookUri.startsWith(bookItem.book.version === BookVersion.v1 ? path.join(bookItem.book.root, 'content', path.sep) : path.join(bookItem.book.root, path.sep)));
-		let isNotebookTrusted = hasTrustedBookPath && this.books.some(bookModel => bookModel.getNotebook(normalizedNotebookUri));
+		let isNotebookTrusted = hasTrustedBookPath && this.books.some(bookModel => bookModel.getNotebook(vscode.Uri.file(normalizedNotebookUri).fsPath));
 		return isNotebookTrusted;
 	}
 

--- a/extensions/notebook/src/test/book/book.test.ts
+++ b/extensions/notebook/src/test/book/book.test.ts
@@ -34,13 +34,13 @@ export interface IExpectedBookItem {
 }
 
 export function equalBookItems(book: BookTreeItem, expectedBook: IExpectedBookItem, errorMsg?: string): void {
-	should(book.title).equal(expectedBook.title, `Book titles do not match, expected ${expectedBook?.title} and got ${book?.title}`);
-	if (expectedBook.file) {
+	should(book?.title).equal(expectedBook?.title, `Book titles do not match, expected ${expectedBook?.title} and got ${book?.title}`);
+	if (expectedBook?.file) {
 		should(path.posix.parse(book.uri)).deepEqual(path.posix.parse(expectedBook.file));
 	} else {
 		should(path.posix.parse(book.uri)).deepEqual(path.posix.parse(expectedBook.url));
 	}
-	if (expectedBook.previousUri || expectedBook.nextUri) {
+	if (expectedBook?.previousUri || expectedBook?.nextUri) {
 		let prevUri = book.previousUri ? book.previousUri.toLocaleLowerCase() : undefined;
 		let expectedPrevUri = expectedBook.previousUri ? expectedBook.previousUri.replace(/\\/g, '/') : undefined;
 		should(prevUri).equal(expectedPrevUri, errorMsg ?? `PreviousUri\'s do not match, expected ${expectedPrevUri} and got ${prevUri}`);
@@ -233,7 +233,7 @@ describe('BooksTreeViewTests', function () {
 
 			});
 
-			it.skip('getParent should return when element is a valid child notebook', async () => {
+			it('getParent should return when element is a valid child notebook', async () => {
 				let parent = await bookTreeViewProvider.getParent();
 				should(parent).be.undefined();
 
@@ -243,7 +243,7 @@ describe('BooksTreeViewTests', function () {
 			});
 
 			it('revealActiveDocumentInViewlet should return correct bookItem for highlight', async () => {
-				let notebook1Path = vscode.Uri.file(path.join(rootFolderPath, 'Book', 'content', 'notebook1.ipynb')).fsPath;
+				let notebook1Path = path.join(rootFolderPath, 'Book', 'content', 'notebook1.ipynb').replace(/\\/g, '/');
 				let currentSelection = await bookTreeViewProvider.findAndExpandParentNode(notebook1Path);
 				equalBookItems(currentSelection, expectedNotebook1);
 			});
@@ -327,7 +327,7 @@ describe('BooksTreeViewTests', function () {
 			});
 
 			it('revealActiveDocumentInViewlet should return correct bookItem for highlight', async () => {
-				let notebook1Path = path.join(rootFolderPath, 'Book', 'content', 'notebook1.ipynb');
+				let notebook1Path = path.join(rootFolderPath, 'Book', 'content', 'notebook1.ipynb').replace(/\\/g, '/');
 				let currentSelection = await providedbookTreeViewProvider.findAndExpandParentNode(notebook1Path);
 				equalBookItems(currentSelection, expectedNotebook1);
 			});

--- a/extensions/notebook/src/test/book/book.test.ts
+++ b/extensions/notebook/src/test/book/book.test.ts
@@ -33,12 +33,12 @@ export interface IExpectedBookItem {
 	nextUri?: string | undefined;
 }
 
-export function equalBookItems(book: BookTreeItem, expectedBook: IExpectedBookItem, errorMsg?: string): void {
+export function equalBookItems(book: BookTreeItem | undefined, expectedBook: IExpectedBookItem, errorMsg?: string): void {
 	should(book?.title).equal(expectedBook?.title, `Book titles do not match, expected ${expectedBook?.title} and got ${book?.title}`);
 	if (expectedBook?.file) {
-		should(path.posix.parse(book.uri)).deepEqual(path.posix.parse(expectedBook.file));
+		should(path.posix.parse(book?.uri)).deepEqual(path.posix.parse(expectedBook.file));
 	} else {
-		should(path.posix.parse(book.uri)).deepEqual(path.posix.parse(expectedBook.url));
+		should(path.posix.parse(book?.uri)).deepEqual(path.posix.parse(expectedBook.url));
 	}
 	if (expectedBook?.previousUri || expectedBook?.nextUri) {
 		let prevUri = book.previousUri ? book.previousUri.toLocaleLowerCase() : undefined;

--- a/extensions/notebook/src/test/book/book.test.ts
+++ b/extensions/notebook/src/test/book/book.test.ts
@@ -33,14 +33,14 @@ export interface IExpectedBookItem {
 	nextUri?: string | undefined;
 }
 
-export function equalBookItems(book: BookTreeItem | undefined, expectedBook: IExpectedBookItem, errorMsg?: string): void {
-	should(book?.title).equal(expectedBook?.title, `Book titles do not match, expected ${expectedBook?.title} and got ${book?.title}`);
-	if (expectedBook?.file) {
-		should(path.posix.parse(book?.uri)).deepEqual(path.posix.parse(expectedBook.file));
+export function equalBookItems(book: BookTreeItem, expectedBook: IExpectedBookItem, errorMsg?: string): void {
+	should(book.title).equal(expectedBook.title, `Book titles do not match, expected ${expectedBook?.title} and got ${book?.title}`);
+	if (expectedBook.file) {
+		should(path.posix.parse(book.uri)).deepEqual(path.posix.parse(expectedBook.file));
 	} else {
-		should(path.posix.parse(book?.uri)).deepEqual(path.posix.parse(expectedBook.url));
+		should(path.posix.parse(book.uri)).deepEqual(path.posix.parse(expectedBook.url));
 	}
-	if (expectedBook?.previousUri || expectedBook?.nextUri) {
+	if (expectedBook.previousUri || expectedBook.nextUri) {
 		let prevUri = book.previousUri ? book.previousUri.toLocaleLowerCase() : undefined;
 		let expectedPrevUri = expectedBook.previousUri ? expectedBook.previousUri.replace(/\\/g, '/') : undefined;
 		should(prevUri).equal(expectedPrevUri, errorMsg ?? `PreviousUri\'s do not match, expected ${expectedPrevUri} and got ${prevUri}`);
@@ -245,6 +245,7 @@ describe('BooksTreeViewTests', function () {
 			it('revealActiveDocumentInViewlet should return correct bookItem for highlight', async () => {
 				let notebook1Path = path.join(rootFolderPath, 'Book', 'content', 'notebook1.ipynb').replace(/\\/g, '/');
 				let currentSelection = await bookTreeViewProvider.findAndExpandParentNode(notebook1Path);
+				should(currentSelection).not.be.undefined();
 				equalBookItems(currentSelection, expectedNotebook1);
 			});
 
@@ -329,6 +330,7 @@ describe('BooksTreeViewTests', function () {
 			it('revealActiveDocumentInViewlet should return correct bookItem for highlight', async () => {
 				let notebook1Path = path.join(rootFolderPath, 'Book', 'content', 'notebook1.ipynb').replace(/\\/g, '/');
 				let currentSelection = await providedbookTreeViewProvider.findAndExpandParentNode(notebook1Path);
+				should(currentSelection).not.be.undefined();
 				equalBookItems(currentSelection, expectedNotebook1);
 			});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15023 

On windows, reveal node sometimes throws 'TreeError [bookTreeView] Tree element not found: [object Object]' even when the node is valid, added a try catch block to just add that error to console and continue the reveal flow.
![selectFileInViewlet](https://user-images.githubusercontent.com/12754347/113934709-f07eac00-97aa-11eb-9e2b-bfa8672d117f.gif)