### PR TITLE
Fixing an issue with backup restore launch (issue #15040)

### DIFF
--- a/src/sql/workbench/contrib/restore/browser/restoreActions.ts
+++ b/src/sql/workbench/contrib/restore/browser/restoreActions.ts
@@ -24,6 +24,10 @@ export function showRestore(accessor: ServicesAccessor, connection: IConnectionP
 }
 
 export const RestoreFeatureName = 'restore';
+export const restoreIsPreviewFeature = localize('restore.isPreviewFeature', "You must enable preview features in order to use restore");
+export const restoreNotSupportedOutOfContext = localize('restore.commandNotSupportedOutsideContext', "Restore command is not supported outside of a server context. Please select a server or database and try again.");
+export const restoreNotSupportedForAzure = localize('restore.commandNotSupported', "Restore command is not supported for Azure SQL databases.");
+
 
 export class RestoreAction extends Task {
 	public static readonly ID = RestoreFeatureName;
@@ -44,7 +48,7 @@ export class RestoreAction extends Task {
 		const configurationService = accessor.get<IConfigurationService>(IConfigurationService);
 		const previewFeaturesEnabled: boolean = configurationService.getValue<{ enablePreviewFeatures: boolean }>('workbench').enablePreviewFeatures;
 		if (!previewFeaturesEnabled) {
-			return accessor.get<INotificationService>(INotificationService).info(localize('restore.isPreviewFeature', "You must enable preview features in order to use restore"));
+			return accessor.get<INotificationService>(INotificationService).info(restoreIsPreviewFeature);
 		}
 
 		let connectionManagementService = accessor.get<IConnectionManagementService>(IConnectionManagementService);
@@ -56,13 +60,16 @@ export class RestoreAction extends Task {
 		if (profile) {
 			const serverInfo = connectionManagementService.getServerInfo(profile.id);
 			if (serverInfo && serverInfo.isCloud && profile.providerName === mssqlProviderName) {
-				return accessor.get<INotificationService>(INotificationService).info(localize('restore.commandNotSupported', "Restore command is not supported for Azure SQL databases."));
+				return accessor.get<INotificationService>(INotificationService).info(restoreNotSupportedForAzure);
 			}
 		}
 
 		const capabilitiesService = accessor.get(ICapabilitiesService);
 		const instantiationService = accessor.get(IInstantiationService);
 		profile = profile ? profile : new ConnectionProfile(capabilitiesService, profile);
+		if (!profile.serverName) {
+			return accessor.get<INotificationService>(INotificationService).info(restoreNotSupportedOutOfContext);
+		}
 		return instantiationService.invokeFunction(showRestore, profile);
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Ref approved issue #15040 (will close with port). 

Please note The desired behavior is **Backup to work in Database Context and Restore to work in Both Server and Database Context**. If the aprropriate context is not selected it should give the right error. **Note that backup and restore errors are similar but not same.**

Fix contains blocking to open when needed and minor error message corrections.

![backuprestorefix](https://user-images.githubusercontent.com/46980425/113946124-8e2ea700-97bc-11eb-91f7-a7ec84fc99b0.gif)

