### PR TITLE
Fix for Rendered Notebook Diff from Timeline View

### DIFF
--- a/src/sql/workbench/contrib/editorReplacement/common/editorReplacerContribution.ts
+++ b/src/sql/workbench/contrib/editorReplacement/common/editorReplacerContribution.ts
@@ -60,7 +60,7 @@ export class EditorReplacementContribution implements IWorkbenchContribution {
 		if (!language) {
 			// Attempt to use extension or extension of modified input (if in diff editor)
 			// remove the .
-			language = editor instanceof DiffEditorInput ? path.extname(editor.modifiedInput.resource.toString()).slice(1) : path.extname(editor.resource.toString()).slice(1);
+			language = editor instanceof DiffEditorInput ? path.extname(editor.modifiedInput.resource.fsPath).slice(1) : path.extname(editor.resource.toString()).slice(1);
 		}
 
 		if (!language) {


### PR DESCRIPTION
Addresses #15067.

`resource.toString()` does not help us in the editorLanguageAssociation in cases where a URI is formed like the following:

```
git:/Users/blah/hello.ipynb?%7B%22path%22%3A%22%2FUsers%2Fblah%2Fhello.ipynb%22%2C%22ref%22%3A%22679a85607a5268942192715215a3158f089bae20%22%7D
```

This above scenario occurs when opening a file, going to the files viewlet, and choosing an item from the Timeline view.

Because in this scenario, `path.extName().split(1)` returns `ipynb%22%2C%22ref%22%3A%22679a85607a5268942192715215a3158f089bae20%22%7D`

The above string doesn't map to one of our known editor overrides (e.g. sql, ipynb, etc), which causes the notebook diff to appear as a text diff.

Instead of doing a `toString()` on the resource, getting the `extname` from the uri's `fspath` (which we do in many other places in the codebase) will reliably not return the query part of the uri and give us the expected result.