### PR TITLE
Fix deploy data to be presented on dashboard

### DIFF
--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -2,7 +2,7 @@
   "name": "sql-database-projects",
   "displayName": "SQL Database Projects",
   "description": "The SQL Database Projects extension for Azure Data Studio allows users to develop and publish database schemas.",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "publisher": "Microsoft",
   "preview": true,
   "engines": {

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -319,7 +319,11 @@ export class ProjectsController {
 		telemetryProps.totalDuration = (actionEndTime - buildStartTime).toString();
 
 		const currentDeployIndex = this.deployInfo.findIndex(d => d.startDate === currentDeployTimeInfo);
-		this.deployInfo[currentDeployIndex].status = Status.success;
+		if (result.success === true) {
+			this.deployInfo[currentDeployIndex].status = Status.success;
+		} else {
+			this.deployInfo[currentDeployIndex].status = Status.failed;
+		}
 		this.deployInfo[currentDeployIndex].timeToCompleteAction = utils.timeConversion(timeToDeploy);
 
 		TelemetryReporter.createActionEvent(TelemetryViews.ProjectController, TelemetryActions.publishProject)

--- a/extensions/sql-database-projects/src/controllers/projectController.ts
+++ b/extensions/sql-database-projects/src/controllers/projectController.ts
@@ -319,11 +319,7 @@ export class ProjectsController {
 		telemetryProps.totalDuration = (actionEndTime - buildStartTime).toString();
 
 		const currentDeployIndex = this.deployInfo.findIndex(d => d.startDate === currentDeployTimeInfo);
-		if (result.success === true) {
-			this.deployInfo[currentDeployIndex].status = Status.success;
-		} else {
-			this.deployInfo[currentDeployIndex].status = Status.failed;
-		}
+		this.deployInfo[currentDeployIndex].status = result.success ? Status.success : Status.failed;
 		this.deployInfo[currentDeployIndex].timeToCompleteAction = utils.timeConversion(timeToDeploy);
 
 		TelemetryReporter.createActionEvent(TelemetryViews.ProjectController, TelemetryActions.publishProject)


### PR DESCRIPTION
This PR addresses the problem in #15070.

Originally, the code wasn't looking for the outcome of deploy functionality, hence presented passed for a successful DacFx operation, but failed scenario. Now the code checks for the outcome of the deploy task and presents information based on that.

![image](https://user-images.githubusercontent.com/57200045/114213190-8a636780-9917-11eb-8710-ea382143136d.png)
