### PR TITLE
Fixing the update issue with backup default name

### DIFF
--- a/src/sql/base/browser/ui/selectBox/selectBox.ts
+++ b/src/sql/base/browser/ui/selectBox/selectBox.ts
@@ -216,6 +216,7 @@ export class SelectBox extends vsSelectBox {
 		let selectOptions: SelectOptionItemSQL[] = SelectBox.createOptions(options);
 		this.populateOptionsDictionary(selectOptions);
 		super.setOptions(selectOptions, selected);
+		this.select(selected);
 	}
 
 	public get value(): string {

--- a/src/sql/workbench/contrib/backup/browser/backup.component.ts
+++ b/src/sql/workbench/contrib/backup/browser/backup.component.ts
@@ -740,7 +740,8 @@ export class BackupComponent extends AngularDisposable {
 	}
 
 	private setDefaultBackupName(): void {
-		if (this.backupNameBox && (!this.backupNameBox.value || this.backupNameBox.value.trim().length === 0)) {
+		const suggestedNamePrefix = this.databaseName + '-' + this.getSelectedBackupType();
+		if (this.backupNameBox && (!this.backupNameBox.value || this.backupNameBox.value.trim().length === 0 || !this.backupNameBox.value.startsWith(suggestedNamePrefix))) {
 			let utc = new Date().toJSON().slice(0, 19);
 			this.backupNameBox.value = this.databaseName + '-' + this.getSelectedBackupType() + '-' + utc;
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #14649 

Incude 2 changes
1. Changing the type was not changing the name suffix - fixing that
2. After every open when the default type was getting selected it was not updating the previous _selectoption value because the select on super was called but not on current class.

**Before**
![backupnameissue](https://user-images.githubusercontent.com/46980425/114236405-695e3f00-9936-11eb-9dfa-fa9c6e29702d.gif)

**After** 
![backupnamefix](https://user-images.githubusercontent.com/46980425/114236432-72e7a700-9936-11eb-9d32-e1a630787efd.gif)





