### PR TITLE
Only reveal parent node when finding notebook item

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -461,7 +461,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			}
 			try {
 				// TO DO: Check why the reveal fails during initial load with 'TreeError [bookTreeView] Tree element not found'
-				await this._bookViewer.reveal(bookItemToExpand, { select: false, focus: true, expand: 3 });
+				await this._bookViewer.reveal(bookItemToExpand, { select: false, focus: true, expand: true });
 			}
 			catch (e) {
 				console.error(e);


### PR DESCRIPTION
For https://github.com/microsoft/azuredatastudio/issues/15090

By passing 3 in to reveal we tell the tree to expand not only that node but also up to 3 of its children. And because we reveal a node at each level of the path we can potentially expand many unrelated nodes.

Then in addition - some of those nodes had expand_sections set to true in the TOC, which meant that when it was revealed it was displayed as expanded automatically.

Changing this to true will mean we only expand the node we're currently looking at as we go down the path. 

This isn't a perfect solution though - since books can be ordered such that the actual paths on disk don't actually correspond to which TOC they're contained in we can't just use the path of the Notebook as the path we walk to try and find the node. Previously by expanding these 3 children nodes it increased the chance that we'd accidently stumble across the Notebook item in the process of expanding all the other nodes, but this was never guaranteed (if the actual parent wasn't one of the 3 chosen). 

But that's going to be a more complex fix since that would probably require parsing the whole book structure at the beginning and then creating the logical layout such that we know which BookTreeItems to expand on the way to our target Notebook. 