### PR TITLE
[Port] Only reveal parent node when finding notebook item (#15091)

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -461,7 +461,7 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			}
 			try {
 				// TO DO: Check why the reveal fails during initial load with 'TreeError [bookTreeView] Tree element not found'
-				await this._bookViewer.reveal(bookItemToExpand, { select: false, focus: true, expand: 3 });
+				await this._bookViewer.reveal(bookItemToExpand, { select: false, focus: true, expand: true });
 			}
 			catch (e) {
 				console.error(e);


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15090

(cherry picked from commit 42cd650147185270204c52635581dd1de0376644)

