### PR TITLE
Fix MIAA connection strings page showing user as undefined

### DIFF
--- a/extensions/arc/src/ui/dashboards/miaa/miaaConnectionStringsPage.ts
+++ b/extensions/arc/src/ui/dashboards/miaa/miaaConnectionStringsPage.ts
@@ -20,6 +20,8 @@ export class MiaaConnectionStringsPage extends DashboardPage {
 		super(modelView, dashboard);
 		this.disposables.push(this._miaaModel.onConfigUpdated(_ =>
 			this.eventuallyRunOnInitialized(() => this.updateConnectionStrings())));
+		this.disposables.push(this._miaaModel.onDatabasesUpdated(_ =>
+			this.eventuallyRunOnInitialized(() => this.updateConnectionStrings())));
 	}
 
 	protected get title(): string {
@@ -77,7 +79,7 @@ export class MiaaConnectionStringsPage extends DashboardPage {
 		}
 
 		const externalEndpoint = parseIpAndPort(config.status.externalEndpoint);
-		const username = this._miaaModel.username;
+		const username = this._miaaModel.username ?? '{your_username_here}';
 
 		return [
 			new InputKeyValue(this.modelView.modelBuilder, 'ADO.NET', `Server=tcp:${externalEndpoint.ip},${externalEndpoint.port};Persist Security Info=False;User ID=${username};Password={your_password_here};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;`),


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/12853

Default to placeholder value until we get a valid username from the user (same logic we use on the overview page)

![ConnectionStrings](https://user-images.githubusercontent.com/28519865/114477198-b1889600-9bb0-11eb-8e71-5e0322a5d088.gif)