### PR TITLE
Fixes notebook integration tests + running parameterized notebook

### DIFF
--- a/extensions/integration-tests/src/test/notebook.test.ts
+++ b/extensions/integration-tests/src/test/notebook.test.ts
@@ -55,7 +55,7 @@ suite('Notebook integration test suite', function () {
 		assert(actualOutput2[0] === '1', `Expected result: 1, Actual: '${actualOutput2[0]}'`);
 	});
 
-	test.skip('Sql NB multiple cells test', async function () {
+	test('Sql NB multiple cells test', async function () {
 		let notebook = await openNotebook(sqlNotebookMultipleCellsContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		await runCells(notebook);
 		const expectedOutput0 = '(1 row affected)';
@@ -84,7 +84,7 @@ suite('Notebook integration test suite', function () {
 		}
 	});
 
-	test.skip('Sql NB run cells above and below test', async function () {
+	test('Sql NB run cells above and below test', async function () {
 		let notebook = await openNotebook(sqlNotebookMultipleCellsContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		// When running all cells above a cell, ensure that only cells preceding current cell have output
 		await runCells(notebook, true, undefined, notebook.document.cells[1]);
@@ -101,13 +101,13 @@ suite('Notebook integration test suite', function () {
 		assert(notebook.document.cells[2].contents.outputs.length === 3, `Expected length: '3', Actual: '${notebook.document.cells[2].contents.outputs.length}'`);
 	});
 
-	test.skip('Clear cell output - SQL notebook', async function () {
+	test('Clear cell output - SQL notebook', async function () {
 		let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		await runCell(notebook);
 		await verifyClearOutputs(notebook);
 	});
 
-	test.skip('Clear all outputs - SQL notebook', async function () {
+	test('Clear all outputs - SQL notebook', async function () {
 		let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata, this.test.title + this.invocationCount++);
 		await runCell(notebook);
 		await verifyClearAllOutputs(notebook);
@@ -128,7 +128,7 @@ suite('Notebook integration test suite', function () {
 		});
 	});
 
-	test.skip('should not be dirty after saving notebook test', async function () {
+	test('should not be dirty after saving notebook test', async function () {
 		// Given a notebook that's been edited (in this case, open notebook runs the 1st cell and adds an output)
 		let notebook = await openNotebook(sqlNotebookContent, sqlKernelMetadata, this.test.title);
 		await runCell(notebook);

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -351,8 +351,7 @@ export class RunParametersAction extends TooltipFromLabelAction {
 				}
 			}
 			let stringParams = unescape(uriParams.toString());
-			context = context.with({ query: stringParams });
-			return this.openParameterizedNotebook(context);
+			return this.openParameterizedNotebook(context, stringParams);
 		}
 	}
 
@@ -361,11 +360,11 @@ export class RunParametersAction extends TooltipFromLabelAction {
 	 * TODO - Call Extensibility API for ShowNotebook
 	 * (showNotebookDocument to be utilized in Notebook Service)
 	**/
-	public async openParameterizedNotebook(uri: URI): Promise<void> {
+	public async openParameterizedNotebook(uri: URI, uriParams: string): Promise<void> {
 		const editor = this._notebookService.findNotebookEditor(uri);
 		let modelContents = JSON.stringify(editor.model.toJSON());
 		let basename = path.basename(uri.fsPath);
-		let untitledUri = uri.with({ authority: '', scheme: 'untitled', path: basename });
+		let untitledUri = uri.with({ query: uriParams, authority: '', scheme: 'untitled', path: basename });
 		this._notebookService.openNotebook(untitledUri, {
 			initialContent: modelContents,
 			preserveFocus: true

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -351,7 +351,8 @@ export class RunParametersAction extends TooltipFromLabelAction {
 				}
 			}
 			let stringParams = unescape(uriParams.toString());
-			return this.openParameterizedNotebook(context, stringParams);
+			context = context.with({ query: stringParams });
+			return this.openParameterizedNotebook(context);
 		}
 	}
 
@@ -360,11 +361,11 @@ export class RunParametersAction extends TooltipFromLabelAction {
 	 * TODO - Call Extensibility API for ShowNotebook
 	 * (showNotebookDocument to be utilized in Notebook Service)
 	**/
-	public async openParameterizedNotebook(uri: URI, uriParams: string): Promise<void> {
+	public async openParameterizedNotebook(uri: URI): Promise<void> {
 		const editor = this._notebookService.findNotebookEditor(uri);
 		let modelContents = JSON.stringify(editor.model.toJSON());
 		let basename = path.basename(uri.fsPath);
-		let untitledUri = uri.with({ query: uriParams, authority: '', scheme: 'untitled', path: basename });
+		let untitledUri = uri.with({ authority: '', scheme: 'untitled', path: basename });
 		this._notebookService.openNotebook(untitledUri, {
 			initialContent: modelContents,
 			preserveFocus: true

--- a/src/sql/workbench/services/notebook/browser/interface.ts
+++ b/src/sql/workbench/services/notebook/browser/interface.ts
@@ -25,7 +25,6 @@ export function isINotebookInput(value: any): value is INotebookInput {
 	if (
 		(typeof value.defaultKernel === 'object' || value.defaultKernel === undefined) &&
 		(typeof value.connectionProfile === 'object' || value.connectionProfile === undefined) &&
-		value.isDirty() === true &&
 		typeof value.notebookUri === 'object' &&
 		typeof value.layoutChanged === 'function' &&
 		typeof value.editorOpenedTimestamp === 'number' &&

--- a/src/sql/workbench/services/notebook/browser/interface.ts
+++ b/src/sql/workbench/services/notebook/browser/interface.ts
@@ -9,8 +9,8 @@ import { IContentManager } from 'sql/workbench/services/notebook/browser/models/
 import { IStandardKernelWithProvider } from 'sql/workbench/services/notebook/browser/models/notebookUtils';
 
 export interface INotebookInput {
-	defaultKernel: azdata.nb.IKernelSpec,
-	connectionProfile: azdata.IConnectionProfile,
+	defaultKernel?: azdata.nb.IKernelSpec,
+	connectionProfile?: azdata.IConnectionProfile,
 	isDirty(): boolean;
 	setDirty(boolean);
 	readonly notebookUri: URI;
@@ -22,12 +22,13 @@ export interface INotebookInput {
 }
 
 export function isINotebookInput(value: any): value is INotebookInput {
-	if (typeof value.defaultKernel === 'object' &&
-		typeof value.connectionProfile === 'object' &&
-		typeof value.isDirty === 'boolean' &&
-		value.notebookUri instanceof URI &&
+	if (
+		(typeof value.defaultKernel === 'object' || value.defaultKernel === undefined) &&
+		(typeof value.connectionProfile === 'object' || value.connectionProfile === undefined) &&
+		value.isDirty() === true &&
+		// URI.isUri(value.notebookUri)  &&
+		typeof value.layoutChanged === 'function' &&
 		typeof value.editorOpenedTimestamp === 'number' &&
-		typeof value.layoutChanged === 'object' &&
 		typeof value.contentManager === 'object' &&
 		typeof value.standardKernels === 'object') {
 		return true;

--- a/src/sql/workbench/services/notebook/browser/interface.ts
+++ b/src/sql/workbench/services/notebook/browser/interface.ts
@@ -26,6 +26,7 @@ export function isINotebookInput(value: any): value is INotebookInput {
 		(typeof value.defaultKernel === 'object' || value.defaultKernel === undefined) &&
 		(typeof value.connectionProfile === 'object' || value.connectionProfile === undefined) &&
 		typeof value.notebookUri === 'object' &&
+		typeof value.isDirty === 'function' &&
 		typeof value.layoutChanged === 'function' &&
 		typeof value.editorOpenedTimestamp === 'number' &&
 		typeof value.contentManager === 'object' &&

--- a/src/sql/workbench/services/notebook/browser/interface.ts
+++ b/src/sql/workbench/services/notebook/browser/interface.ts
@@ -26,7 +26,7 @@ export function isINotebookInput(value: any): value is INotebookInput {
 		(typeof value.defaultKernel === 'object' || value.defaultKernel === undefined) &&
 		(typeof value.connectionProfile === 'object' || value.connectionProfile === undefined) &&
 		value.isDirty() === true &&
-		// URI.isUri(value.notebookUri)  &&
+		typeof value.notebookUri === 'object' &&
 		typeof value.layoutChanged === 'function' &&
 		typeof value.editorOpenedTimestamp === 'number' &&
 		typeof value.contentManager === 'object' &&

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -407,8 +407,7 @@ export class NotebookService extends Disposable implements INotebookService {
 		if (!notebookUri) {
 			return undefined;
 		}
-		// The NotebookEditor will not be found if there is query or fragments attached to the URI
-		let uriString = notebookUri.with({ query: '', fragment: '' }).toString();
+		let uriString = notebookUri.toString();
 		let editor = this.listNotebookEditors().find(n => n.id === uriString);
 		return editor;
 	}

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -708,18 +708,14 @@ export class NotebookService extends Disposable implements INotebookService {
 }
 
 /**
+ * Untitled notebookUri's need to have the query in order to get the NotebookEditor to run other actions (Run All Cells for example) on parameterized notebooks
+ * otherwise we strip the query and fragment from the notebookUri for all other file schemes
  * @param notebookUri of the notebook
  * @returns uriString that contains the formatted notebookUri
- * If the notebookUri is untitled then we keep the query to ensure parameterized notebooks open properly
- * otherwise we strip the query and fragment from the notebookUri for all other file schemes
  */
 export function getNotebookUri(notebookUri: URI): string {
-	// if its untitled keep query
-	let uriString: string = '';
 	if (notebookUri.scheme === 'untitled') {
-		uriString = notebookUri.toString();
-	} else {
-		uriString = notebookUri.with({ query: '', fragment: '' }).toString();
+		return notebookUri.toString();
 	}
-	return uriString;
+	return notebookUri.with({ query: '', fragment: '' }).toString();
 }

--- a/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
+++ b/src/sql/workbench/services/notebook/browser/notebookServiceImpl.ts
@@ -407,7 +407,7 @@ export class NotebookService extends Disposable implements INotebookService {
 		if (!notebookUri) {
 			return undefined;
 		}
-		let uriString = notebookUri.toString();
+		let uriString = getNotebookUri(notebookUri);
 		let editor = this.listNotebookEditors().find(n => n.id === uriString);
 		return editor;
 	}
@@ -705,4 +705,21 @@ export class NotebookService extends Disposable implements INotebookService {
 	notifyCellExecutionStarted(): void {
 		this._onCodeCellExecutionStart.fire();
 	}
+}
+
+/**
+ * @param notebookUri of the notebook
+ * @returns uriString that contains the formatted notebookUri
+ * If the notebookUri is untitled then we keep the query to ensure parameterized notebooks open properly
+ * otherwise we strip the query and fragment from the notebookUri for all other file schemes
+ */
+export function getNotebookUri(notebookUri: URI): string {
+	// if its untitled keep query
+	let uriString: string = '';
+	if (notebookUri.scheme === 'untitled') {
+		uriString = notebookUri.toString();
+	} else {
+		uriString = notebookUri.with({ query: '', fragment: '' }).toString();
+	}
+	return uriString;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes the failing integration tests, as the isNotebookInput function was returning false due to defaultKernel and connectionProfile being undefined. Moreover, notebookUri and layoutChanged were also returning false previously so now we check there type specifically. 

After the parameterized notebook was opened, I saw that when I clicked run all cells, it said "unable to runAllCells of undefined". As such, I debugged and found runAllCells function call findNotebook, which then alters the URI as done previously by removing the query and fragment, but then it is compared to the id retrieved by the call here - 
`let editor = this.listNotebookEditors().find(n => n.id === uriString);`. 
The id contains the URI and query, as such it would return an undefined editor. 

I changed the logic to pass in the uriParams later to the parameterized notebook URI so that the findNotebook works properly for other actions. 