### PR TITLE
Save Kusto Notebook with proper language notebook info

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -963,14 +963,9 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	private async updateKernelInfoOnKernelChange(kernel: nb.IKernel, kernelAlias?: string) {
 		await this.updateKernelInfo(kernel);
-		let aliasLanguageInfo: nb.ILanguageInfo;
-		this.kernelAliases.forEach(kernel => {
-			if (this._defaultLanguageInfo?.name === kernel.toLowerCase()) {
-				kernelAlias = kernel;
-			}
-		});
+		kernelAlias = this.kernelAliases.find(kernel => this._defaultLanguageInfo?.name === kernel.toLowerCase()) ?? kernelAlias;
 		if (kernelAlias) {
-			aliasLanguageInfo = {
+			let aliasLanguageInfo: nb.ILanguageInfo = {
 				name: kernelAlias.toLowerCase(),
 				version: ''
 			};

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -963,12 +963,20 @@ export class NotebookModel extends Disposable implements INotebookModel {
 
 	private async updateKernelInfoOnKernelChange(kernel: nb.IKernel, kernelAlias?: string) {
 		await this.updateKernelInfo(kernel);
+		let aliasLanguageInfo: nb.ILanguageInfo;
 		this.kernelAliases.forEach(kernel => {
 			if (this._defaultLanguageInfo?.name === kernel.toLowerCase()) {
 				kernelAlias = kernel;
 			}
 		});
-		if (kernel.info) {
+		if (kernelAlias) {
+			aliasLanguageInfo = {
+				name: kernelAlias.toLowerCase(),
+				version: ''
+			};
+			this.updateLanguageInfo(aliasLanguageInfo);
+		}
+		else if (kernel.info) {
 			this.updateLanguageInfo(kernel.info.language_info);
 		}
 		this.adstelemetryService.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.KernelChanged)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #14545. Which now saves the language_info upon changing the kernel to Kusto and then saving the notebook.

Aliases such as Kusto in this example still use SQL as the kernel in the backed but we can set the language info to be set to kusto here before the user saves the new kusto notebook therefore the metadata will contain the proper kusto name and be opened with the Kusto kernel.
