### PR TITLE
Remove duplicate artifact upload

### DIFF
--- a/build/azure-pipelines/darwin/sql-product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/sql-product-build-darwin.yml
@@ -8,12 +8,11 @@ steps:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: Compilation
-      path: $(Build.ArtifactStagingDirectory)
     displayName: Download compilation output
 
   - script: |
       set -e
-      tar -xzf $(Build.ArtifactStagingDirectory)/compilation.tar.gz
+      tar -xzf $(Pipeline.Workspace)/compilation.tar.gz
     displayName: Extract compilation output
 
   - task: NodeTool@0

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -20,12 +20,11 @@ steps:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: Compilation
-      path: $(Build.ArtifactStagingDirectory)
     displayName: Download compilation output
 
   - script: |
       set -e
-      tar -xzf $(Build.ArtifactStagingDirectory)/compilation.tar.gz
+      tar -xzf $(Pipeline.Workspace)/compilation.tar.gz
     displayName: Extract compilation output
 
   - script: |

--- a/build/azure-pipelines/web/sql-product-build-web.yml
+++ b/build/azure-pipelines/web/sql-product-build-web.yml
@@ -18,12 +18,11 @@ steps:
 - task: DownloadPipelineArtifact@2
   inputs:
     artifact: Compilation
-    path: $(Build.ArtifactStagingDirectory)
   displayName: Download compilation output
 
 - script: |
     set -e
-    tar -xzf $(Build.ArtifactStagingDirectory)/compilation.tar.gz
+    tar -xzf $(Pipeline.Workspace)/compilation.tar.gz
   displayName: Extract compilation output
 
 - script: |

--- a/build/azure-pipelines/win32/sql-product-build-win32.yml
+++ b/build/azure-pipelines/win32/sql-product-build-win32.yml
@@ -22,13 +22,12 @@ steps:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: Compilation
-      path: $(Build.ArtifactStagingDirectory)
     displayName: Download compilation output
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { tar --force-local -xzf $(Build.ArtifactStagingDirectory)/compilation.tar.gz }
+      exec { tar --force-local -xzf $(Pipeline.Workspace)/compilation.tar.gz }
     displayName: Extract compilation output
 
   - powershell: |


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15112

The staging directory should only be used for stuff we want to publish as a build artifact. When downloading the compilation tarball we just let it put it in the default location instead (Pipeline.Workspace) so it doesn't get re-uploaded by each of the platform compilation jobs. 

Test build : 
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=100379&view=artifacts&pathAsName=false&type=publishedArtifacts