### PR TITLE
Links handling in commands

### DIFF
--- a/src/sql/workbench/contrib/modelView/browser/webview.component.ts
+++ b/src/sql/workbench/contrib/modelView/browser/webview.component.ts
@@ -128,8 +128,10 @@ export default class WebViewComponent extends ComponentBase<WebViewProperties> i
 		if (!link) {
 			return;
 		}
-		if (WebViewComponent.standardSupportedLinkSchemes.indexOf(link.scheme) >= 0 || this.enableCommandUris && link.scheme === 'command') {
+		if (WebViewComponent.standardSupportedLinkSchemes.indexOf(link.scheme) >= 0) {
 			this._openerService.open(link);
+		} else if (this.enableCommandUris && link.scheme === 'command') {
+			this._openerService.open(link, { allowCommands: true });
 		}
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts
@@ -80,7 +80,7 @@ export class LinkHandlerDirective {
 					this.openerService.open(uri, { openExternal: true }).catch(onUnexpectedError);
 				}
 				else {
-					this.openerService.open(uri).catch(onUnexpectedError);
+					this.openerService.open(uri, { allowCommands: true }).catch(onUnexpectedError);
 				}
 			}
 		}

--- a/src/vs/editor/browser/core/markdownRenderer.ts
+++ b/src/vs/editor/browser/core/markdownRenderer.ts
@@ -58,7 +58,7 @@ export class MarkdownRenderer {
 		if (!markdown) {
 			element = document.createElement('span');
 		} else {
-			element = renderMarkdown(markdown, { ...this._getRenderOptions(disposeables), ...options }, markedOptions);
+			element = renderMarkdown(markdown, { ...this._getRenderOptions(markdown, disposeables), ...options }, markedOptions);
 		}
 
 		return {
@@ -67,7 +67,7 @@ export class MarkdownRenderer {
 		};
 	}
 
-	protected _getRenderOptions(disposeables: DisposableStore): MarkdownRenderOptions {
+	protected _getRenderOptions(markdown: IMarkdownString, disposeables: DisposableStore): MarkdownRenderOptions {
 		return {
 			baseUrl: this._options.baseUrl,
 			codeBlockRenderer: async (languageAlias, value) => {
@@ -105,7 +105,7 @@ export class MarkdownRenderer {
 			},
 			asyncRenderCallback: () => this._onDidRenderAsync.fire(),
 			actionHandler: {
-				callback: (content) => this._openerService.open(content, { fromUserGesture: true }).catch(onUnexpectedError),
+				callback: (content) => this._openerService.open(content, { fromUserGesture: true, allowContributedOpeners: true, allowCommands: markdown.isTrusted }).catch(onUnexpectedError),
 				disposeables
 			}
 		};

--- a/src/vs/editor/browser/services/openerService.ts
+++ b/src/vs/editor/browser/services/openerService.ts
@@ -21,9 +21,14 @@ class CommandOpener implements IOpener {
 
 	constructor(@ICommandService private readonly _commandService: ICommandService) { }
 
-	async open(target: URI | string) {
+	async open(target: URI | string, options?: OpenOptions): Promise<boolean> {
 		if (!matchesScheme(target, Schemas.command)) {
 			return false;
+		}
+		if (!options?.allowCommands) {
+			// silently ignore commands when command-links are disabled, also
+			// surpress other openers by returning TRUE
+			return true;
 		}
 		// run command or bail out if command isn't known
 		if (typeof target === 'string') {

--- a/src/vs/editor/contrib/gotoError/gotoErrorWidget.ts
+++ b/src/vs/editor/contrib/gotoError/gotoErrorWidget.ts
@@ -143,7 +143,7 @@ class MessageWidget {
 					this._codeLink.setAttribute('href', `${code.target.toString()}`);
 
 					this._codeLink.onclick = (e) => {
-						this._openerService.open(code.target);
+						this._openerService.open(code.target, { allowCommands: true });
 						e.preventDefault();
 						e.stopPropagation();
 					};

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -536,7 +536,7 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 				this._codeLink.setAttribute('href', code.target.toString());
 
 				this._codeLink.onclick = (e) => {
-					this._openerService.open(code.target);
+					this._openerService.open(code.target, { allowCommands: true });
 					e.preventDefault();
 					e.stopPropagation();
 				};

--- a/src/vs/editor/contrib/links/links.ts
+++ b/src/vs/editor/contrib/links/links.ts
@@ -327,7 +327,7 @@ export class LinkDetector implements IEditorContribution {
 				}
 			}
 
-			return this.openerService.open(uri, { openToSide, fromUserGesture });
+			return this.openerService.open(uri, { openToSide, fromUserGesture, allowContributedOpeners: true, allowCommands: true });
 
 		}, err => {
 			const messageOrError =

--- a/src/vs/platform/opener/browser/link.ts
+++ b/src/vs/platform/opener/browser/link.ts
@@ -50,7 +50,7 @@ export class Link extends Disposable {
 
 		this._register(onOpen(e => {
 			EventHelper.stop(e, true);
-			openerService.open(link.href);
+			openerService.open(link.href, { allowCommands: true });
 		}));
 
 		this.applyStyles();

--- a/src/vs/platform/opener/common/opener.ts
+++ b/src/vs/platform/opener/common/opener.ts
@@ -29,6 +29,11 @@ type OpenInternalOptions = {
 	 * action, such as keyboard or mouse usage.
 	 */
 	readonly fromUserGesture?: boolean;
+
+	/**
+	 * Allow command links to be handled.
+	 */
+	readonly allowCommands?: boolean;
 };
 
 type OpenExternalOptions = { readonly openExternal?: boolean; readonly allowTunneling?: boolean };

--- a/src/vs/platform/opener/common/opener.ts
+++ b/src/vs/platform/opener/common/opener.ts
@@ -36,7 +36,11 @@ type OpenInternalOptions = {
 	readonly allowCommands?: boolean;
 };
 
-type OpenExternalOptions = { readonly openExternal?: boolean; readonly allowTunneling?: boolean };
+export type OpenExternalOptions = {
+	readonly openExternal?: boolean;
+	readonly allowTunneling?: boolean;
+	readonly allowContributedOpeners?: boolean | string;
+};
 
 export type OpenOptions = OpenInternalOptions & OpenExternalOptions;
 

--- a/src/vs/workbench/api/browser/mainThreadWebviews.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebviews.ts
@@ -78,7 +78,7 @@ export class MainThreadWebviews extends Disposable implements extHostProtocol.Ma
 	private onDidClickLink(handle: extHostProtocol.WebviewHandle, link: string): void {
 		const webview = this.getWebview(handle);
 		if (this.isSupportedLink(webview, URI.parse(link))) {
-			this._openerService.open(link, { fromUserGesture: true });
+			this._openerService.open(link, { fromUserGesture: true, allowContributedOpeners: true, allowCommands: true });
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
@@ -371,7 +371,7 @@ export class NotificationTemplateRenderer extends Disposable {
 	private renderMessage(notification: INotificationViewItem): boolean {
 		clearNode(this.template.message);
 		this.template.message.appendChild(NotificationMessageRenderer.render(notification.message, {
-			callback: link => this.openerService.open(URI.parse(link)),
+			callback: link => this.openerService.open(URI.parse(link), { allowCommands: true }),
 			toDispose: this.inputDisposables
 		}));
 

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -581,7 +581,7 @@ export abstract class ViewPane extends Pane implements IView {
 					button.label = node.label;
 					button.onDidClick(_ => {
 						this.telemetryService.publicLog2<{ viewId: string, uri: string }, WelcomeActionClassification>('views.welcomeAction', { viewId: this.id, uri: node.href });
-						this.openerService.open(node.href);
+						this.openerService.open(node.href, { allowCommands: true });
 					}, null, disposables);
 					disposables.add(button);
 					disposables.add(attachButtonStyler(button, this.themeService));

--- a/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsTreeViewer.ts
@@ -127,7 +127,7 @@ export class CommentNodeRenderer implements IListRenderer<ITreeNode<CommentNode>
 			inline: true,
 			actionHandler: {
 				callback: (content) => {
-					this.openerService.open(content).catch(onUnexpectedError);
+					this.openerService.open(content, { allowCommands: node.element.comment.body.isTrusted }).catch(onUnexpectedError);
 				},
 				disposeables: disposables
 			}

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -625,10 +625,11 @@ export class ExtensionEditor extends EditorPane {
 					return;
 				}
 				// Only allow links with specific schemes
-				if (matchesScheme(link, Schemas.http) || matchesScheme(link, Schemas.https) || matchesScheme(link, Schemas.mailto)
-					|| (matchesScheme(link, Schemas.command) && URI.parse(link).path === ShowCurrentReleaseNotesActionId)
-				) {
+				if (matchesScheme(link, Schemas.http) || matchesScheme(link, Schemas.https) || matchesScheme(link, Schemas.mailto)) {
 					this.openerService.open(link);
+				}
+				if (matchesScheme(link, Schemas.command) && URI.parse(link).path === ShowCurrentReleaseNotesActionId) {
+					this.openerService.open(link, { allowCommands: true }); // TODO@sandy081 use commands service
 				}
 			}, null, this.contentDisposables));
 

--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -430,7 +430,7 @@ class MarkerWidget extends Disposable {
 
 					this._register(onOpen(e => {
 						dom.EventHelper.stop(e, true);
-						this._openerService.open(codeUri);
+						this._openerService.open(codeUri, { allowCommands: true });
 					}));
 
 					const code = new HighlightedLabel(dom.append(this._codeLink, dom.$('.marker-code')), false);

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -424,7 +424,7 @@ var requirejs = (function() {
 
 			if (matchesScheme(link, Schemas.http) || matchesScheme(link, Schemas.https) || matchesScheme(link, Schemas.mailto)
 				|| matchesScheme(link, Schemas.command)) {
-				this.openerService.open(link, { fromUserGesture: true });
+				this.openerService.open(link, { fromUserGesture: true, allowContributedOpeners: true, allowCommands: true });
 			}
 		}));
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -755,7 +755,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 						};
 						this._onDidClickSettingLink.fire(e);
 					} else {
-						this._openerService.open(content).catch(onUnexpectedError);
+						this._openerService.open(content, { allowCommands: true }).catch(onUnexpectedError);
 					}
 				},
 				disposeables

--- a/src/vs/workbench/contrib/remote/browser/remote.ts
+++ b/src/vs/workbench/contrib/remote/browser/remote.ts
@@ -365,7 +365,7 @@ class HelpItem extends HelpItemBase {
 	}
 
 	protected async takeAction(extensionDescription: IExtensionDescription, url: string): Promise<void> {
-		await this.openerService.open(URI.parse(url));
+		await this.openerService.open(URI.parse(url), { allowCommands: true });
 	}
 }
 

--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart.ts
@@ -189,7 +189,7 @@ export class WalkThroughPart extends EditorPane {
 			this.notificationService.info(localize('walkThrough.gitNotFound', "It looks like Git is not installed on your system."));
 			return;
 		}
-		this.openerService.open(this.addFrom(uri));
+		this.openerService.open(this.addFrom(uri), { allowCommands: true });
 	}
 
 	private addFrom(uri: URI) {


### PR DESCRIPTION
This PR addresses https://github.com/microsoft/vscode/issues/121211 in ADS

Fix taken from - https://github.com/microsoft/vscode/commit/23e346ab55a317c322a184eab4d10597927cd491

Again the files were different, so I couldn't cherry pick and fixed the issues in different files like vscode did. 

**NOTE: If we are using commands to open links anywhere, we will also need to add the `allowCommands` flag to every `openerService.open` call. This will also need some more testing from the team**

The following files in `sql/*` use the `openerService.open()` call which is now updated. I'm adding the files and the people who worked on it (or area owners) to make sure we don't have breaking changes:

EDIT - only these need attention

- [x] `src/sql/workbench/contrib/modelView/browser/webview.component.ts`: @adbist
- [x] `src/sql/workbench/contrib/notebook/browser/cellViews/linkHandler.directive.ts`: @Charles-Gagnon @chlafreniere 
- [x] `src/sql/workbench/contrib/resourceViewer/browser/resourceViewerTable.ts`: @Charles-Gagnon 

