### PR TITLE
Add notebook query event listeners before connect

### DIFF
--- a/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
+++ b/src/sql/workbench/services/notebook/browser/sql/sqlSessionManager.ts
@@ -331,8 +331,8 @@ class SqlKernel extends Disposable implements nb.IKernel {
 			this._queryRunner.runQuery(code).catch(err => onUnexpectedError(err));
 		} else if (this._currentConnection && this._currentConnectionProfile) {
 			this._queryRunner = this._instantiationService.createInstance(QueryRunner, this._connectionPath);
+			this.addQueryEventListeners(this._queryRunner);
 			this._connectionManagementService.connect(this._currentConnectionProfile, this._connectionPath).then((result) => {
-				this.addQueryEventListeners(this._queryRunner);
 				this._queryRunner.runQuery(code).catch(err => onUnexpectedError(err));
 			}).catch(err => onUnexpectedError(err));
 		} else {


### PR DESCRIPTION
Noticed this while fixing something else, because we were hooking up the event listeners only after a successful connection that meant if an error occurred while connecting then any future attempts to run that query wouldn't display any messages. 

Scenario : 

1. New notebook
2. Try to execute code cell with a connection that will error out trying to connect
3. Re-run the cell

Expected : Error will be displayed

Actual : No error displayed, cell just immediately returns

![image](https://user-images.githubusercontent.com/28519865/114757482-c5e3a480-9d10-11eb-935f-73a6aa3dd48f.png)

I'd say that displaying this kind of error in the cell output isn't ideal though - really this kind of thing I think should be shown as a toast notification. But this at least is a step in the right direction so people aren't left wondering what's going wrong. 
