### PR TITLE
fix the menu not hide issue

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -60,7 +60,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
 			.subscribe(this.grid.onKeyDown, (e: DOMEvent) => this.handleKeyDown(e as KeyboardEvent));
 		this.grid.setColumns(this.grid.getColumns());
 
-		this.disposableStore.add(addDisposableListener(document.body, 'mousedown', e => this.handleBodyMouseDown(e)));
+		this.disposableStore.add(addDisposableListener(document.body, 'mousedown', e => this.handleBodyMouseDown(e), true));
 		this.disposableStore.add(addDisposableListener(document.body, 'keydown', e => this.handleKeyDown(e)));
 	}
 
@@ -80,8 +80,6 @@ export class HeaderFilter<T extends Slick.SlickData> {
 	private handleBodyMouseDown(e: MouseEvent): void {
 		if (this.$menu && this.$menu[0] !== e.target && !jQuery.contains(this.$menu[0], e.target as Element)) {
 			this.hideMenu();
-			e.preventDefault();
-			e.stopPropagation();
 		}
 	}
 

--- a/src/sql/workbench/contrib/query/browser/gridPanel.ts
+++ b/src/sql/workbench/contrib/query/browser/gridPanel.ts
@@ -528,7 +528,7 @@ export abstract class GridTableBase<T> extends Disposable implements IView {
 		}));
 		if (this.enableFilteringFeature) {
 			this.filterPlugin = new HeaderFilter(this.contextViewService);
-			attachTableFilterStyler(this.filterPlugin, this.themeService);
+			this._register(attachTableFilterStyler(this.filterPlugin, this.themeService));
 			this.table.registerPlugin(this.filterPlugin);
 		}
 		if (this.styles) {


### PR DESCRIPTION
I noticed that the menu is not going away if I click on some places, I am changing the event phase to use capture phase so that we can reliably get the click event and close the menu properly.

also slide in a change to add the table filter styler to disposable store in query results.

more information about event phase and useCapture parameter:
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
https://www.w3.org/TR/2003/NOTE-DOM-Level-3-Events-20031107/events.html#Events-phases

before:
![before](https://user-images.githubusercontent.com/13777222/114785950-3f3fbf00-9d32-11eb-9d18-39759c90d88a.gif)

after:
![after](https://user-images.githubusercontent.com/13777222/114785970-42d34600-9d32-11eb-932f-24bd1b839715.gif)
