### PR TITLE
select notebook in viewlet only expanding its parents

### DIFF
--- a/extensions/notebook/src/book/bookTreeView.ts
+++ b/extensions/notebook/src/book/bookTreeView.ts
@@ -451,8 +451,17 @@ export class BookTreeViewProvider implements vscode.TreeDataProvider<BookTreeIte
 			let parentBookPath: string = notebookFolders.slice(0, notebookFolders.length - depthOfNotebookInBook).join('/');
 			let bookItemToExpand = parentBook.bookItems.find(b => b.tooltip.indexOf(parentBookPath) > -1) ??
 				parentBook.bookItems.find(b => path.relative(notebookPath, b.tooltip)?.split(path.sep)?.length === depthOfNotebookInBook);
+
 			if (!bookItemToExpand) {
-				break;
+				// if the book isn't found, check if the book is in the same level as the parent
+				// since bookItems will not have them yet, check the sections->file property
+				bookItemToExpand = parentBook.bookItems.find(b => b.sections?.find(n => notebookFolders[notebookFolders.length - depthOfNotebookInBook - 1].indexOf(n.file.substring(n.file.lastIndexOf('/') + 1)) > -1));
+				// book isn't found even in the same level, break out and return.
+				if (!bookItemToExpand) {
+					break;
+				}
+				// increment to reset the depth since parent is in the same level
+				depthOfNotebookInBook++;
 			}
 			if (!bookItemToExpand.children) {
 				// We haven't loaded children of this node yet so do that now so we can


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses failed scenarios caused by expanding only parent node. (fixed by #15090 )

![selectNotebookInViewlet](https://user-images.githubusercontent.com/12754347/114814910-04f21400-9d6a-11eb-8e92-a39f67f36a44.gif)

