### PR TITLE
Fix error when disconnecting database

### DIFF
--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -44,7 +44,7 @@ import { ConnectionProfile } from 'sql/platform/connection/common/connectionProf
 import { IQueryManagementService } from 'sql/workbench/services/query/common/queryManagement';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IRange } from 'vs/editor/common/core/range';
-import { onUnexpectedError } from 'vs/base/common/errors';
+import { getErrorMessage, onUnexpectedError } from 'vs/base/common/errors';
 
 /**
  * Action class that query-based Actions will extend. This base class automatically handles activating and
@@ -719,7 +719,7 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 					this.resetDatabaseName();
 					this.notificationService.notify({
 						severity: Severity.Error,
-						message: nls.localize('changeDatabase.failedWithError', "Failed to change database {0}", error)
+						message: nls.localize('changeDatabase.failedWithError', "Failed to change database: {0}", getErrorMessage(error))
 					});
 				});
 	}

--- a/src/sql/workbench/contrib/query/browser/queryActions.ts
+++ b/src/sql/workbench/contrib/query/browser/queryActions.ts
@@ -684,6 +684,11 @@ export class ListDatabasesActionItem extends Disposable implements IActionViewIt
 
 	// PRIVATE HELPERS /////////////////////////////////////////////////////
 	private databaseSelected(dbName: string): void {
+		// If dbName is blank (this can happen for example when setting the box value to empty when disconnecting)
+		// then just no-op, there's nothing we can do.
+		if (!dbName) {
+			return;
+		}
 		if (!this._editor.input) {
 			this.logService.error('editor input was null');
 			return;


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15145

@aasimkhan30 - This was caused by your recent changes since we now fire this event in places that we didn't before.

Could you please take some time to go through all the places where we use this event and do a quick check to make sure they won't have the same kind of issue?

I also fixed an issue where the error wasn't being displayed properly (noticed this during a smoke test run) - the localize function can't handle error objects directly so we have to get the error string out of it first. 

Before :

![image](https://user-images.githubusercontent.com/28519865/114892837-f9cad280-9dc1-11eb-9ede-37bf9d61eb96.png)

After :
![image](https://user-images.githubusercontent.com/28519865/114892738-e4ee3f00-9dc1-11eb-9eef-de008b30dcb1.png)
