### PR TITLE
fix the find highlight issues

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -381,16 +381,18 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 						markAllOccurances.mark(searchString, {
 							className: findHighlightClass
 						});
-						elementContainingText.scrollIntoView({ behavior: 'smooth' });
 					}
 				}
 				markCurrent.markRanges([{
 					start: range.startColumn - 1, //subtracting 1 since markdown html is 0 indexed.
 					length: range.endColumn - range.startColumn
 				}], {
-					className: findRangeSpecificClass
+					className: findRangeSpecificClass,
+					each: function (node, range) {
+						// node is the marked DOM element
+						node.scrollIntoView({ behavior: 'smooth' });
+					}
 				});
-				elementContainingText.scrollIntoView({ behavior: 'smooth' });
 			}
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -390,7 +390,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 					className: findRangeSpecificClass,
 					each: function (node, range) {
 						// node is the marked DOM element
-						node.scrollIntoView({ behavior: 'smooth' });
+						node.scrollIntoView({ behavior: 'smooth', block: 'center' });
 					}
 				});
 			}

--- a/src/sql/workbench/contrib/notebook/browser/find/notebookFindModel.ts
+++ b/src/sql/workbench/contrib/notebook/browser/find/notebookFindModel.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from 'vs/base/common/lifecycle';
-import { ICellModel, INotebookModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
+import { CellEditModes, ICellModel, INotebookModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { INotebookFindModel } from 'sql/workbench/contrib/notebook/browser/models/notebookFindModel';
 import { Event, Emitter } from 'vs/base/common/event';
 import * as types from 'vs/base/common/types';
@@ -535,7 +535,7 @@ export class NotebookFindModel extends Disposable implements INotebookFindModel 
 
 	private searchFn(cell: ICellModel, exp: string, matchCase: boolean = false, wholeWord: boolean = false, maxMatches?: number): NotebookRange[] {
 		let findResults: NotebookRange[] = [];
-		if (cell.cellType === 'markdown' && cell.isEditMode && typeof cell.source !== 'string') {
+		if (cell.cellType === 'markdown' && (cell.showMarkdown || cell.currentMode === CellEditModes.SPLIT) && typeof cell.source !== 'string') {
 			let cellSource = cell.source;
 			for (let j = 0; j < cellSource.length; j++) {
 				let findStartResults = this.search(cellSource[j], exp, matchCase, wholeWord, maxMatches - findResults.length);
@@ -546,7 +546,8 @@ export class NotebookFindModel extends Disposable implements INotebookFindModel 
 				});
 			}
 		}
-		let cellVal = cell.cellType === 'markdown' ? cell.renderedOutputTextContent : cell.source;
+		// if it's markdown cell in Markdown only mode, don't search on renderedOutput.
+		let cellVal = cell.cellType === 'markdown' ? (cell.currentMode === CellEditModes.SPLIT || !cell.showMarkdown ? cell.renderedOutputTextContent : undefined) : cell.source;
 		if (cellVal) {
 			if (typeof cellVal === 'string') {
 				let findStartResults = this.search(cellVal, exp, matchCase, wholeWord, maxMatches);
@@ -557,7 +558,7 @@ export class NotebookFindModel extends Disposable implements INotebookFindModel 
 
 			} else {
 				for (let j = 0; j < cellVal.length; j++) {
-					let cellValFormatted = cell.cellType === 'markdown' ? this.cleanMarkdownLinks(cellVal[j]) : cellVal[j];
+					let cellValFormatted = cellVal[j];
 					let findStartResults = this.search(cellValFormatted, exp, matchCase, wholeWord, maxMatches - findResults.length);
 					findStartResults.forEach(start => {
 						// lineNumber: j+1 since notebook editors aren't zero indexed.
@@ -604,12 +605,6 @@ export class NotebookFindModel extends Disposable implements INotebookFindModel 
 			searchText = input.substr(index - 1);
 		}
 		return findResults;
-	}
-
-	// In markdown links are defined as [Link Text](https://url/of/the/text). when searching for text we shouldn't
-	// look for the values inside the (), below regex replaces that with just the Link Text.
-	cleanMarkdownLinks(cellSrc: string): string {
-		return cellSrc.replace(/(?:__|[*#])|\[(.*?)\]\(.*?\)/gm, '$1');
 	}
 
 	clearFind(): void {

--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -296,7 +296,7 @@ export class NotebookEditor extends EditorPane implements IFindNotebookControlle
 			}
 		}
 
-		if (e.searchString || e.matchCase || e.wholeWord) {
+		if (e.searchString || e.matchCase || e.wholeWord || this.notebookFindModel.findExpression !== this._findState.searchString) {
 			this._findDecorations.clearDecorations();
 			// if the search scope changes remove the prev
 			if (this._notebookModel && this._findState.searchString) {
@@ -371,10 +371,14 @@ export class NotebookEditor extends EditorPane implements IFindNotebookControlle
 		};
 		this._notebookModel.cells?.forEach(cell => {
 			this._register(cell.onCellModeChanged((state) => {
-				this._onFindStateChange(changeEvent).catch(onUnexpectedError);
+				if (state) {
+					this._onFindStateChange(changeEvent).catch(onUnexpectedError);
+				}
 			}));
 			this._register(cell.onCellMarkdownModeChanged(e => {
-				this._onFindStateChange(changeEvent).catch(onUnexpectedError);
+				if (e) {
+					this._onFindStateChange(changeEvent).catch(onUnexpectedError);
+				}
 			}));
 		});
 		this._register(this._notebookModel.contentChanged(e => {
@@ -452,9 +456,10 @@ export class NotebookEditor extends EditorPane implements IFindNotebookControlle
 
 	private _setCurrentFindMatch(match: NotebookRange): void {
 		if (match) {
-			this._notebookModel.updateActiveCell(match.cell);
+			if (this._notebookModel.activeCell !== match.cell) {
+				this._notebookModel.updateActiveCell(match.cell);
+			}
 			this._findDecorations.setCurrentFindMatch(match);
-			this.setSelection(match);
 		}
 	}
 

--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -296,7 +296,7 @@ export class NotebookEditor extends EditorPane implements IFindNotebookControlle
 			}
 		}
 
-		if (e.searchString || e.matchCase || e.wholeWord || this.notebookFindModel.findExpression !== this._findState.searchString) {
+		if (e.searchString || e.matchCase || e.wholeWord) {
 			this._findDecorations.clearDecorations();
 			// if the search scope changes remove the prev
 			if (this._notebookModel && this._findState.searchString) {

--- a/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -373,6 +373,9 @@ export class NotebookEditor extends EditorPane implements IFindNotebookControlle
 			this._register(cell.onCellModeChanged((state) => {
 				this._onFindStateChange(changeEvent).catch(onUnexpectedError);
 			}));
+			this._register(cell.onCellMarkdownModeChanged(e => {
+				this._onFindStateChange(changeEvent).catch(onUnexpectedError);
+			}));
 		});
 		this._register(this._notebookModel.contentChanged(e => {
 			this._onFindStateChange(changeEvent).catch(onUnexpectedError);

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookEditor.test.ts
@@ -81,6 +81,10 @@ class NotebookModelStub extends stubs.NotebookModelStub {
 		// When relevant a mock is used to intercept this call to do any verifications or run
 		// any code relevant for testing in the context of the test.
 	}
+
+	get activeCell(): ICellModel {
+		return <ICellModel>{};
+	}
 }
 
 suite('Test class NotebookEditor:', () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15094 and #14455 

We had cleanMarkdownLinks to clean up markdown links back when we didn't use the renderedOutput of the markdown cell, to remove the link syntax with just the link. But we have come a long way with wysiwyg and the old logic doesn't make sense anymore. So removed it.
Added the mode change events to trigger findStateChange -> Previously on edit mode we have a code cell with markdown code and the rendered html text cell but now even in edit mode we can still be on rich text mode only and have only rendered output so updated the logic to check if the markdown is actually visible (which can happen in split view and markdown only mode) and search accordingly.
Also fixed the scroll issue to scroll to the current highlighted node.

