### PR TITLE
Ability to see and edit links in split view/markdown mode

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -317,7 +317,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 			if (selection && !selection.isEmpty()) {
 				const textModel = editorControl?.getModel() as TextModel;
 				const value = textModel?.getValueInRange(selection);
-				let linkMatches = value.match(linksRegex);
+				let linkMatches = value?.match(linksRegex);
 				return linkMatches?.groups.text || value || '';
 			}
 			return '';
@@ -337,7 +337,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 			if (selection && !selection.isEmpty()) {
 				const textModel = editorControl?.getModel() as TextModel;
 				const value = textModel?.getValueInRange(selection);
-				let linkMatches = value.match(linksRegex);
+				let linkMatches = value?.match(linksRegex);
 				return linkMatches?.groups.url || '';
 			}
 			return '';

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -316,7 +316,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 			if (selection && !selection.isEmpty()) {
 				const textModel = editorControl?.getModel() as TextModel;
 				const value = textModel?.getValueInRange(selection);
-				let linkLabel = value.substring(value.indexOf('[') + 1, value.indexOf(']'));
+				let linkLabel = value.substring(value.indexOf('[') + 1, value.lastIndexOf(']'));
 				return linkLabel || '';
 			}
 			return '';
@@ -336,8 +336,8 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 			if (selection && !selection.isEmpty()) {
 				const textModel = editorControl?.getModel() as TextModel;
 				const value = textModel?.getValueInRange(selection);
-				let linkLabel = value.substring(value.indexOf('(') + 1, value.indexOf(')'));
-				return linkLabel || '';
+				let linkURI = value.substring(value.lastIndexOf('(') + 1, value.lastIndexOf(')'));
+				return linkURI || '';
 			}
 			return '';
 		}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -309,24 +309,37 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 
 	private getCurrentSelectionText(): string {
 		if (this.cellModel.currentMode === CellEditModes.WYSIWYG) {
-			return document.getSelection()?.toString() || '';
+			return document.getSelection()?.anchorNode.nodeValue || '';
 		} else {
 			const editorControl = this.getCellEditorControl();
 			const selection = editorControl?.getSelection();
 			if (selection && !selection.isEmpty()) {
 				const textModel = editorControl?.getModel() as TextModel;
 				const value = textModel?.getValueInRange(selection);
-				return value || '';
+				let linkLabel = value.substring(value.indexOf('[') + 1, value.indexOf(']'));
+				return linkLabel || '';
 			}
 			return '';
 		}
 	}
 
 	private getCurrentLinkUrl(): string {
-		if (document.getSelection().anchorNode.parentNode['protocol'] === 'file:') {
-			return document.getSelection().anchorNode.parentNode['pathname'] || '';
+		if (this.cellModel.currentMode === CellEditModes.WYSIWYG) {
+			if (document.getSelection().anchorNode.parentNode['protocol'] === 'file:') {
+				return document.getSelection().anchorNode.parentNode['pathname'] || '';
+			} else {
+				return document.getSelection().anchorNode.parentNode['href'] || '';
+			}
 		} else {
-			return document.getSelection().anchorNode.parentNode['href'] || '';
+			const editorControl = this.getCellEditorControl();
+			const selection = editorControl?.getSelection();
+			if (selection && !selection.isEmpty()) {
+				const textModel = editorControl?.getModel() as TextModel;
+				const value = textModel?.getValueInRange(selection);
+				let linkLabel = value.substring(value.indexOf('(') + 1, value.indexOf(')'));
+				return linkLabel || '';
+			}
+			return '';
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15079.

User will have to select the entire link: [](), and we will show the title in the 'Text to Display' and link in the 'Address' input box. Once user changes the link or title it will also update the selected text.

![image](https://user-images.githubusercontent.com/23587151/114909979-2f77b780-9dd2-11eb-912f-d8516dabf84e.png)

