### PR TITLE
ISSUE10685 - Edits schemaCompareDialog to show connectionName if provided

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -549,7 +549,11 @@ export class SchemaCompareDialog {
 			count++;
 
 			let usr = c.options.user;
-			let srv = c.options.server;
+			let srv = c.connectionName;
+
+			if (!srv) {
+				srv = c.options.server;
+			}
 
 			if (!usr) {
 				usr = loc.defaultText;

--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -549,17 +549,19 @@ export class SchemaCompareDialog {
 			count++;
 
 			let usr = c.options.user;
-			let srv = c.connectionName;
-
-			if (!srv) {
-				srv = c.options.server;
-			}
 
 			if (!usr) {
 				usr = loc.defaultText;
 			}
 
+			let srv = c.options.server;
+
 			let finalName = `${srv} (${usr})`;
+
+			if (c.options.connectionName) {
+				finalName = c.options.connectionName;
+			}
+
 			// use previously selected server or current connection if there is one
 			if (endpointInfo && !isNullOrUndefined(endpointInfo.serverName) && !isNullOrUndefined(endpointInfo.serverDisplayName)
 				&& c.options.server.toLowerCase() === endpointInfo.serverName.toLowerCase()

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -98,8 +98,8 @@ export class SchemaCompareMainWindow {
 
 			this.sourceEndpointInfo = {
 				endpointType: mssql.SchemaCompareEndpointType.Database,
-				serverDisplayName: `${profile.serverName} (${usr})`,
-				serverName: profile.options.connectionName ? profile.options.connectionName : `${profile.serverName} (${usr})`,
+				serverDisplayName: profile.connectionName ? profile.connectionName : profile.serverName,
+				serverName: profile.serverName,
 				databaseName: profile.databaseName,
 				ownerUri: ownerUri,
 				packageFilePath: '',

--- a/extensions/schema-compare/src/schemaCompareMainWindow.ts
+++ b/extensions/schema-compare/src/schemaCompareMainWindow.ts
@@ -99,7 +99,7 @@ export class SchemaCompareMainWindow {
 			this.sourceEndpointInfo = {
 				endpointType: mssql.SchemaCompareEndpointType.Database,
 				serverDisplayName: `${profile.serverName} (${usr})`,
-				serverName: profile.serverName,
+				serverName: profile.options.connectionName ? profile.options.connectionName : `${profile.serverName} (${usr})`,
 				databaseName: profile.databaseName,
 				ownerUri: ownerUri,
 				packageFilePath: '',

--- a/extensions/schema-compare/src/test/schemaCompare.test.ts
+++ b/extensions/schema-compare/src/test/schemaCompare.test.ts
@@ -634,8 +634,8 @@ describe('SchemaCompareMainWindow: Button clicks', function (): void {
 		//Verify that switch actually happened
 		should.notEqual(result.sourceEndpointInfo, undefined);
 		should.equal(result.sourceEndpointInfo.endpointType, mssql.SchemaCompareEndpointType.Database);
-		should.equal(result.sourceEndpointInfo.serverName, 'My Server');
-		should.equal(result.sourceEndpointInfo.databaseName, 'My Database');
+		should.equal(result.sourceEndpointInfo.serverName, '');
+		should.equal(result.sourceEndpointInfo.databaseName, '');
 		should.notEqual(result.targetEndpointInfo, undefined);
 		should.equal(result.targetEndpointInfo.endpointType, mssql.SchemaCompareEndpointType.Dacpac);
 		should.equal(result.targetEndpointInfo.packageFilePath, 'source.dacpac');

--- a/extensions/schema-compare/src/test/schemaCompare.test.ts
+++ b/extensions/schema-compare/src/test/schemaCompare.test.ts
@@ -634,8 +634,8 @@ describe('SchemaCompareMainWindow: Button clicks', function (): void {
 		//Verify that switch actually happened
 		should.notEqual(result.sourceEndpointInfo, undefined);
 		should.equal(result.sourceEndpointInfo.endpointType, mssql.SchemaCompareEndpointType.Database);
-		should.equal(result.sourceEndpointInfo.serverName, '');
-		should.equal(result.sourceEndpointInfo.databaseName, '');
+		should.equal(result.sourceEndpointInfo.serverName, 'My Server');
+		should.equal(result.sourceEndpointInfo.databaseName, 'My Database');
 		should.notEqual(result.targetEndpointInfo, undefined);
 		should.equal(result.targetEndpointInfo.endpointType, mssql.SchemaCompareEndpointType.Dacpac);
 		should.equal(result.targetEndpointInfo.packageFilePath, 'source.dacpac');

--- a/extensions/schema-compare/src/test/testUtils.ts
+++ b/extensions/schema-compare/src/test/testUtils.ts
@@ -111,9 +111,9 @@ export function setDacpacEndpointInfo(path: string): mssql.SchemaCompareEndpoint
 
 export function setDatabaseEndpointInfo(): mssql.SchemaCompareEndpointInfo {
 	let endpointInfo: mssql.SchemaCompareEndpointInfo;
-	let serverName = 'My Server';
-	let dbName = 'My Database';
-	let serverDisplayName = 'My Connection';
+	const serverName = 'My Server';
+	const dbName = 'My Database';
+	const serverDisplayName = 'My Connection';
 
 	endpointInfo = { ...mockDatabaseEndpoint };
 	endpointInfo.databaseName = dbName;

--- a/extensions/schema-compare/src/test/testUtils.ts
+++ b/extensions/schema-compare/src/test/testUtils.ts
@@ -77,7 +77,7 @@ export const mockDacpacEndpoint: mssql.SchemaCompareEndpointInfo = {
 
 export const mockDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = {
 	endpointType: mssql.SchemaCompareEndpointType.Database,
-	serverDisplayName: '',
+	serverDisplayName: 'My Connection',
 	serverName: '',
 	databaseName: '',
 	ownerUri: '',
@@ -112,11 +112,11 @@ export function setDacpacEndpointInfo(path: string): mssql.SchemaCompareEndpoint
 export function setDatabaseEndpointInfo(): mssql.SchemaCompareEndpointInfo {
 	let endpointInfo: mssql.SchemaCompareEndpointInfo;
 	let dbName = 'My Database';
-	let serverName = 'My Server';
+	let serverDisplayName = 'My Connection';
 
 	endpointInfo = { ...mockDatabaseEndpoint };
 	endpointInfo.databaseName = dbName;
-	endpointInfo.serverName = serverName;
+	endpointInfo.serverDisplayName = serverDisplayName;
 
 	return endpointInfo;
 }

--- a/extensions/schema-compare/src/test/testUtils.ts
+++ b/extensions/schema-compare/src/test/testUtils.ts
@@ -56,6 +56,7 @@ export const mockConnectionResult: azdata.ConnectionResult = {
 
 export const mockConnectionInfo = {
 	options: {},
+	serverDisplayName: 'My Connection',
 	serverName: 'My Server',
 	databaseName: 'My Database',
 	userName: 'My User',
@@ -77,7 +78,7 @@ export const mockDacpacEndpoint: mssql.SchemaCompareEndpointInfo = {
 
 export const mockDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = {
 	endpointType: mssql.SchemaCompareEndpointType.Database,
-	serverDisplayName: 'My Connection',
+	serverDisplayName: '',
 	serverName: '',
 	databaseName: '',
 	ownerUri: '',

--- a/extensions/schema-compare/src/test/testUtils.ts
+++ b/extensions/schema-compare/src/test/testUtils.ts
@@ -56,7 +56,6 @@ export const mockConnectionResult: azdata.ConnectionResult = {
 
 export const mockConnectionInfo = {
 	options: {},
-	serverDisplayName: 'My Connection',
 	serverName: 'My Server',
 	databaseName: 'My Database',
 	userName: 'My User',
@@ -112,12 +111,14 @@ export function setDacpacEndpointInfo(path: string): mssql.SchemaCompareEndpoint
 
 export function setDatabaseEndpointInfo(): mssql.SchemaCompareEndpointInfo {
 	let endpointInfo: mssql.SchemaCompareEndpointInfo;
+	let serverName = 'My Server';
 	let dbName = 'My Database';
 	let serverDisplayName = 'My Connection';
 
 	endpointInfo = { ...mockDatabaseEndpoint };
 	endpointInfo.databaseName = dbName;
 	endpointInfo.serverDisplayName = serverDisplayName;
+	endpointInfo.serverName = serverName;
 
 	return endpointInfo;
 }

--- a/extensions/schema-compare/src/test/utils.test.ts
+++ b/extensions/schema-compare/src/test/utils.test.ts
@@ -33,11 +33,19 @@ describe('utils: Tests to verify getEndpointName @DacFx@', function (): void {
 		should(getEndpointName(mockDatabaseEndpoint)).equal(' ');
 	});
 
-	it('Should get endpoint information from ConnectionInfo', () => {
+	it('Should get only database information from ConnectionInfo if connection', () => {
 		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
+		testDatabaseEndpoint.serverDisplayName = 'My Connection';
 		testDatabaseEndpoint.connectionDetails = { ...mockConnectionInfo };
 
 		should(getEndpointName(testDatabaseEndpoint)).equal('My Connection.My Database');
+	});
+
+	it('Should get information from ConnectionInfo if no connection', () => {
+		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
+		testDatabaseEndpoint.connectionDetails = { ...mockConnectionInfo };
+
+		should(getEndpointName(testDatabaseEndpoint)).equal('My Server.My Database');
 	});
 
 	it('Should get correct endpoint information from SchemaCompareEndpointInfo', () => {
@@ -45,7 +53,7 @@ describe('utils: Tests to verify getEndpointName @DacFx@', function (): void {
 		let serverDisplayName = 'My Connection';
 		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
 		testDatabaseEndpoint.databaseName = dbName;
-		testDatabaseEndpoint.serverName = serverDisplayName;
+		testDatabaseEndpoint.serverDisplayName = serverDisplayName;
 
 		should(getEndpointName(testDatabaseEndpoint)).equal('My Connection.My Database');
 	});

--- a/extensions/schema-compare/src/test/utils.test.ts
+++ b/extensions/schema-compare/src/test/utils.test.ts
@@ -37,17 +37,17 @@ describe('utils: Tests to verify getEndpointName @DacFx@', function (): void {
 		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
 		testDatabaseEndpoint.connectionDetails = { ...mockConnectionInfo };
 
-		should(getEndpointName(testDatabaseEndpoint)).equal('My Server.My Database');
+		should(getEndpointName(testDatabaseEndpoint)).equal('My Connection.My Database');
 	});
 
 	it('Should get correct endpoint information from SchemaCompareEndpointInfo', () => {
 		let dbName = 'My Database';
-		let serverName = 'My Server';
+		let serverDisplayName = 'My Connection';
 		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
 		testDatabaseEndpoint.databaseName = dbName;
-		testDatabaseEndpoint.serverName = serverName;
+		testDatabaseEndpoint.serverName = serverDisplayName;
 
-		should(getEndpointName(testDatabaseEndpoint)).equal('My Server.My Database');
+		should(getEndpointName(testDatabaseEndpoint)).equal('My Connection.My Database');
 	});
 });
 

--- a/extensions/schema-compare/src/test/utils.test.ts
+++ b/extensions/schema-compare/src/test/utils.test.ts
@@ -34,7 +34,7 @@ describe('utils: Tests to verify getEndpointName @DacFx@', function (): void {
 	});
 
 	it('Should get only database information from ConnectionInfo if connection', () => {
-		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
+		const testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
 		testDatabaseEndpoint.serverDisplayName = 'My Connection';
 		testDatabaseEndpoint.connectionDetails = { ...mockConnectionInfo };
 
@@ -42,16 +42,16 @@ describe('utils: Tests to verify getEndpointName @DacFx@', function (): void {
 	});
 
 	it('Should get information from ConnectionInfo if no connection', () => {
-		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
+		const testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
 		testDatabaseEndpoint.connectionDetails = { ...mockConnectionInfo };
 
 		should(getEndpointName(testDatabaseEndpoint)).equal('My Server.My Database');
 	});
 
 	it('Should get correct endpoint information from SchemaCompareEndpointInfo', () => {
-		let dbName = 'My Database';
-		let serverDisplayName = 'My Connection';
-		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
+		const dbName = 'My Database';
+		const serverDisplayName = 'My Connection';
+		const testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
 		testDatabaseEndpoint.databaseName = dbName;
 		testDatabaseEndpoint.serverDisplayName = serverDisplayName;
 
@@ -73,7 +73,7 @@ describe('utils: Basic tests to verify verifyConnectionAndGetOwnerUri', function
 
 	it('Should return undefined for endpoint as database and no ConnectionInfo', async function (): Promise<void> {
 		let ownerUri = undefined;
-		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
+		const testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
 		testDatabaseEndpoint.connectionDetails = undefined;
 
 		ownerUri = await verifyConnectionAndGetOwnerUri(testDatabaseEndpoint, 'test');
@@ -92,9 +92,9 @@ describe('utils: In-depth tests to verify verifyConnectionAndGetOwnerUri', funct
 	});
 
 	it('Should throw an error asking to make a connection', async function (): Promise<void> {
-		let getConnectionsResults: azdata.connection.ConnectionProfile[] = [];
-		let connection = { ...mockConnectionResult };
-		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
+		const getConnectionsResults: azdata.connection.ConnectionProfile[] = [];
+		const connection = { ...mockConnectionResult };
+		const testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
 		testDatabaseEndpoint.connectionDetails = { ...mockConnectionInfo };
 		const getConnectionString = loc.getConnectionString('test');
 
@@ -109,9 +109,9 @@ describe('utils: In-depth tests to verify verifyConnectionAndGetOwnerUri', funct
 	});
 
 	it('Should throw an error for login failure', async function (): Promise<void> {
-		let getConnectionsResults: azdata.connection.ConnectionProfile[] = [{ ...mockConnectionProfile }];
-		let connection = { ...mockConnectionResult };
-		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
+		const getConnectionsResults: azdata.connection.ConnectionProfile[] = [{ ...mockConnectionProfile }];
+		const connection = { ...mockConnectionResult };
+		const testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
 		testDatabaseEndpoint.connectionDetails = { ...mockConnectionInfo };
 
 		sinon.stub(azdata.connection, 'connect').returns(<any>Promise.resolve(connection));
@@ -126,9 +126,9 @@ describe('utils: In-depth tests to verify verifyConnectionAndGetOwnerUri', funct
 	});
 
 	it('Should throw an error for login failure with openConnectionDialog but no ownerUri', async function (): Promise<void> {
-		let getConnectionsResults: azdata.connection.ConnectionProfile[] = [];
-		let connection = { ...mockConnectionResult };
-		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
+		const getConnectionsResults: azdata.connection.ConnectionProfile[] = [];
+		const connection = { ...mockConnectionResult };
+		const testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
 		testDatabaseEndpoint.connectionDetails = { ...mockConnectionInfo };
 
 		sinon.stub(azdata.connection, 'connect').returns(<any>Promise.resolve(connection));
@@ -147,9 +147,9 @@ describe('utils: In-depth tests to verify verifyConnectionAndGetOwnerUri', funct
 
 	it('Should not throw an error and set ownerUri appropriately', async function (): Promise<void> {
 		let ownerUri = undefined;
-		let connection = { ...mockConnectionResult };
-		let testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
-		let expectedOwnerUri: string = 'providerName:MSSQL|authenticationType:SqlLogin|database:My Database|server:My Server|user:My User|databaseDisplayName:My Database';
+		const connection = { ...mockConnectionResult };
+		const testDatabaseEndpoint: mssql.SchemaCompareEndpointInfo = { ...mockDatabaseEndpoint };
+		const expectedOwnerUri: string = 'providerName:MSSQL|authenticationType:SqlLogin|database:My Database|server:My Server|user:My User|databaseDisplayName:My Database';
 		testDatabaseEndpoint.connectionDetails = { ...mockConnectionInfo };
 
 		sinon.stub(azdata.connection, 'connect').returns(<any>Promise.resolve(connection));

--- a/extensions/schema-compare/src/utils.ts
+++ b/extensions/schema-compare/src/utils.ts
@@ -49,14 +49,14 @@ export function getEndpointName(endpoint: mssql.SchemaCompareEndpointInfo): stri
 	}
 
 	if (endpoint.endpointType === mssql.SchemaCompareEndpointType.Database) {
-		if (!endpoint.serverName && endpoint.connectionDetails) {
-			endpoint.serverName = endpoint.connectionDetails['serverName'];
+		if (!endpoint.serverDisplayName && endpoint.connectionDetails) {
+			endpoint.serverDisplayName = endpoint.connectionDetails['serverDisplayName'];
 		}
 		if (!endpoint.databaseName && endpoint.connectionDetails) {
 			endpoint.databaseName = endpoint.connectionDetails['databaseName'];
 		}
 		if (endpoint.serverName && endpoint.databaseName) {
-			return `${endpoint.serverName}.${endpoint.databaseName}`;
+			return `${endpoint.serverDisplayName}.${endpoint.databaseName}`;
 		} else {
 			return ' ';
 		}

--- a/extensions/schema-compare/src/utils.ts
+++ b/extensions/schema-compare/src/utils.ts
@@ -50,12 +50,12 @@ export function getEndpointName(endpoint: mssql.SchemaCompareEndpointInfo): stri
 
 	if (endpoint.endpointType === mssql.SchemaCompareEndpointType.Database) {
 		if (!endpoint.serverDisplayName && endpoint.connectionDetails) {
-			endpoint.serverDisplayName = endpoint.connectionDetails['serverDisplayName'];
+			endpoint.serverDisplayName = endpoint.connectionDetails['serverName'];
 		}
 		if (!endpoint.databaseName && endpoint.connectionDetails) {
 			endpoint.databaseName = endpoint.connectionDetails['databaseName'];
 		}
-		if (endpoint.serverName && endpoint.databaseName) {
+		if (endpoint.serverDisplayName && endpoint.databaseName) {
 			return `${endpoint.serverDisplayName}.${endpoint.databaseName}`;
 		} else {
 			return ' ';


### PR DESCRIPTION
fixes https://github.com/microsoft/azuredatastudio/issues/10685

Provides connectionName in place of server if provided by user.

Connection Name provided:
![editwconname](https://user-images.githubusercontent.com/17727716/114923366-96509d00-9de1-11eb-98d2-411607324320.JPG)
![compareconname](https://user-images.githubusercontent.com/17727716/114923397-a0729b80-9de1-11eb-8dc6-242f6bcb0ac9.JPG)


Connection Name not provided:
![editwservername](https://user-images.githubusercontent.com/17727716/114923463-b8e2b600-9de1-11eb-8b2b-557b3a6f9543.JPG)
![compareservername](https://user-images.githubusercontent.com/17727716/114923498-c26c1e00-9de1-11eb-84a2-a529dc747a31.jpg)


Unit tests do not seem to compare text but component states.  Will create issue to add unit tests to check text if necessary.


EDIT: Username does not appear if connectionName provided
![newconnection](https://user-images.githubusercontent.com/17727716/115099842-75756e00-9eed-11eb-919c-e8fdfb8c88f2.JPG)

