### PR TITLE
Fix error when connecting to a sqlite database

### DIFF
--- a/src/sql/workbench/services/connection/browser/connectionManagementService.ts
+++ b/src/sql/workbench/services/connection/browser/connectionManagementService.ts
@@ -1240,6 +1240,9 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 			if (!providerId) {
 				return Promise.resolve(false);
 			}
+			if (providerId === 'sqlite') {
+				return Promise.resolve(true);
+			}
 
 			return this._providers.get(providerId).onReady.then(provider => {
 				return provider.changeDatabase(connectionUri, databaseName).then(result => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes query editor smoke test. 

With the recent dropdown event changes (https://github.com/microsoft/azuredatastudio/pull/14952), the changeDatabase method gets called after a connection and database are set through the connection dialog. But the sqlite provider does not have a changeDatabase implementation.

