### PR TITLE
Disable workspace tags event

### DIFF
--- a/src/vs/workbench/contrib/tags/electron-browser/workspaceTags.ts
+++ b/src/vs/workbench/contrib/tags/electron-browser/workspaceTags.ts
@@ -94,7 +94,7 @@ export class WorkspaceTags implements IWorkbenchContribution {
 				]
 			}
 		*/
-		this.telemetryService.publicLog('workspce.tags', tags);
+		// this.telemetryService.publicLog('workspce.tags', tags); {{SQL CARBON EDIT}} We don't need this event
 	}
 
 	private reportRemoteDomains(workspaceUris: URI[]): void {


### PR DESCRIPTION
This event gets sent with a lot of different properties which makes tagging it annoying - we have no need for this at this point in time so just disabling it for now. 