### PR TITLE
bump sts version

### DIFF
--- a/extensions/kusto/config.json
+++ b/extensions/kusto/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.92",
+	"version": "3.0.0-release.93",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",


### PR DESCRIPTION
https://github.com/microsoft/sqltoolsservice/releases/tag/v3.0.0-release.93

Contains this PR: https://github.com/microsoft/sqltoolsservice/pull/1190 which I need to filter some of the DB migration warnings
