### PR TITLE
Fix URI encoding for connection provider calls

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.93",
+	"version": "3.0.0-release.94",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuredatastudio",
   "version": "1.29.0",
-  "distro": "4a6a8dea5e72ce892b5fc16c2cec0c43a3775f7b",
+  "distro": "2c6adba5d5c27f8119165dfa988b318cfe91a208",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -25,20 +25,17 @@ export function setup() {
 
 		it('can open ipynb file, run all, and save notebook with outputs', async function () {
 			const app = this.app as Application;
-			await app.workbench.sqlNotebook.openFile('hello.ipynb');
-			await app.workbench.sqlNotebook.waitForKernel('Python 3');
+			await openAndRunNotebook(app, 'hello.ipynb');
+		});
 
-			await app.workbench.sqlNotebook.clearResults();
-			await app.workbench.sqlNotebook.waitForAllResultsGone();
-			await app.workbench.sqlNotebook.runAllCells();
-			await app.workbench.sqlNotebook.waitForAllResults();
+		it('can open ipynb file from path with spaces, run all, and save notebook with outputs', async function () {
+			const app = this.app as Application;
+			await openAndRunNotebook(app, 'helloWithSpaces.ipynb');
+		});
 
-			await app.workbench.quickaccess.runCommand('workbench.action.files.save');
-			await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
-
-			await app.workbench.sqlNotebook.openFile('hello.ipynb');
-			await app.workbench.sqlNotebook.waitForKernel('Python 3');
-			await app.workbench.sqlNotebook.waitForAllResults();
+		it('can open ipynb file from path with escaped spaces, run all, and save notebook with outputs', async function () {
+			const app = this.app as Application;
+			await openAndRunNotebook(app, 'helloWithEscapedSpaces.ipynb');
 		});
 
 		it('can open untrusted notebook, trust, save, and reopen trusted notebook', async function () {
@@ -62,4 +59,21 @@ export function setup() {
 			await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
 		});
 	});
+}
+
+async function openAndRunNotebook(app: Application, filename: string): Promise<void> {
+	await app.workbench.sqlNotebook.openFile(filename);
+	await app.workbench.sqlNotebook.waitForKernel('Python 3');
+
+	await app.workbench.sqlNotebook.clearResults();
+	await app.workbench.sqlNotebook.waitForAllResultsGone();
+	await app.workbench.sqlNotebook.runAllCells();
+	await app.workbench.sqlNotebook.waitForAllResults();
+
+	await app.workbench.quickaccess.runCommand('workbench.action.files.save');
+	await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
+
+	await app.workbench.sqlNotebook.openFile(filename);
+	await app.workbench.sqlNotebook.waitForKernel('Python 3');
+	await app.workbench.sqlNotebook.waitForAllResults();
 }

--- a/test/smoke/src/sql/areas/queryEditor/queryEditor.test.ts
+++ b/test/smoke/src/sql/areas/queryEditor/queryEditor.test.ts
@@ -21,22 +21,39 @@ export function setup() {
 			await app.workbench.connectionDialog.connect();
 			await app.workbench.queryEditor.commandBar.run();
 			await app.workbench.queryEditor.waitForResults();
-			await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
 		});
 	});
 }
 
 export function setupWeb() {
-	it('can open, connect and execute file', async function () {
+	afterEach(async function (): Promise<void> {
 		const app = this.app as Application;
-		await app.workbench.quickaccess.openFile('test.sql');
-		await app.workbench.queryEditor.commandBar.connect();
-		await app.workbench.connectionDialog.waitForConnectionDialog();
-		await app.workbench.connectionDialog.setProvider('Sqlite');
-		await app.workbench.connectionDialog.setTarget('File', 'chinook.db');
-		await app.workbench.connectionDialog.connect();
-		await app.workbench.queryEditor.commandBar.run();
-		await app.workbench.queryEditor.waitForResults();
 		await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
 	});
+
+	it('can open, connect and execute file', async function () {
+		const app = this.app as Application;
+		await openAndExecuteFile(app, 'test.sql');
+	});
+
+	it('can open, connect and execute file with spaces', async function () {
+		const app = this.app as Application;
+		await openAndExecuteFile(app, 'testWithSpaces.sql');
+	});
+	it('can open, connect and execute file with escaped spaces', async function () {
+		const app = this.app as Application;
+		await openAndExecuteFile(app, 'testWithEscapedSpaces.sql');
+	});
+}
+
+async function openAndExecuteFile(app: Application, filename: string): Promise<void> {
+	await app.workbench.quickaccess.openFile(filename);
+	await app.workbench.queryEditor.commandBar.connect();
+	await app.workbench.connectionDialog.waitForConnectionDialog();
+	await app.workbench.connectionDialog.setProvider('Sqlite');
+	await app.workbench.connectionDialog.setTarget('File', 'chinook.db');
+	await app.workbench.connectionDialog.connect();
+
+	await app.workbench.queryEditor.commandBar.run();
+	await app.workbench.queryEditor.waitForResults();
 }

--- a/test/smoke/src/sql/main.ts
+++ b/test/smoke/src/sql/main.ts
@@ -31,7 +31,7 @@ const PLATFORM = '${PLATFORM}';
 const RUNTIME = '${RUNTIME}';
 const VERSION = '${VERSION}';
 
-const sqliteUrl = `https://github.com/Microsoft/azuredatastudio-sqlite/releases/download/1.1.0/azuredatastudio-sqlite-${PLATFORM}-${RUNTIME}-${VERSION}.zip`;
+const sqliteUrl = `https://github.com/Microsoft/azuredatastudio-sqlite/releases/download/1.1.2/azuredatastudio-sqlite-${PLATFORM}-${RUNTIME}-${VERSION}.zip`;
 
 export async function setup(app: ApplicationOptions): Promise<void> {
 	console.log('*** Downloading test extensions');


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/14044
Fixes https://github.com/microsoft/azuredatastudio/issues/10259

See previous PRs for some more explanation of the issues : 

https://github.com/microsoft/azuredatastudio/pull/13503
https://github.com/microsoft/azuredatastudio/pull/14299

Basically - we're putting the full file path URI in the "owner URI" fields to identify which file the query should be applied to. But previously we weren't encoding the paths here before parsing them as a URI - which meant that reserved characters such as %20 were getting turned into their mapped values (`%20` -> a space for example) before being sent to the providers. They then wouldn't be able to find the file because there wasn't a file opened with those decoded values.

So instead we have to encode the URIs before we parse them to preserver the characters as they came in. 

This did require a change in SQL Tools Service (https://github.com/microsoft/sqltoolsservice/pull/1189) to make sure all the parts were handling URIs in the same way. 

Note that doing this does mean that any other connection providers may be broken if they had custom logic to handle this case. But since PG is the only major user of this extensibility that I'm aware of and this is a pretty big edge case I figured it was better to make these changes now.

## Testing

I did lots of manual testing with various combinations of directory names and file names and didn't nothing anything too broken. I did start seeing a strange issue where the results for a query in the path with %20 in it wasn't showing up initially - if I switched to another tab and back it rendered properly though. I wasn't able to get a consistent repro on that so I figure I'll get this in and then continue looking into that since I want to get as much testing as possible in before our next release given the scope of this change. 

I added some smoke tests to cover the scenarios of opening and executing both SQL queries and Notebooks with various types of paths. This did require updating the sqlite repo since there was a bug there with handling the new escaped URIs https://github.com/microsoft/azuredatastudio-sqlite/commit/8a478af7e099e4c7f7f29fee7c2e562c14ae28db

