### PR TITLE
Notebook smoke test fixes

### DIFF
--- a/test/automation/src/sql/configurePythonDialog.ts
+++ b/test/automation/src/sql/configurePythonDialog.ts
@@ -25,9 +25,20 @@ export class ConfigurePythonDialog extends Dialog {
 		const newPythonInstallation = '.modal .modal-body input[aria-label="New Python installation"]';
 		await this.code.waitAndClick(newPythonInstallation);
 
+		// Wait a small bit for the dialog to load since otherwise pressing the button may not do anything
+		// (not ideal - should look into finding better thing to wait on)
+		await new Promise<void>(resolve => {
+			setTimeout(() => resolve(), 1000);
+		});
 		const nextButton = '.modal-dialog .modal-content .modal-footer .right-footer .footer-button a[aria-label="Next"][aria-disabled="false"]';
 		await this.code.waitForElement(nextButton);
 		await this.code.dispatchKeybinding('enter');
+
+		// Wait a bit for the dialog to load since otherwise pressing the button may not do anything
+		// (not ideal - should look into finding better thing to wait on)
+		await new Promise<void>(resolve => {
+			setTimeout(() => resolve(), 5000);
+		});
 
 		const installButton = '.modal-dialog .modal-content .modal-footer .right-footer .footer-button a[aria-label="Install"][aria-disabled="false"]';
 		await this.code.waitForElement(installButton);

--- a/test/automation/src/sql/configurePythonDialog.ts
+++ b/test/automation/src/sql/configurePythonDialog.ts
@@ -25,20 +25,9 @@ export class ConfigurePythonDialog extends Dialog {
 		const newPythonInstallation = '.modal .modal-body input[aria-label="New Python installation"]';
 		await this.code.waitAndClick(newPythonInstallation);
 
-		// Wait a small bit for the dialog to load since otherwise pressing the button may not do anything
-		// (not ideal - should look into finding better thing to wait on)
-		await new Promise<void>(resolve => {
-			setTimeout(() => resolve(), 1000);
-		});
 		const nextButton = '.modal-dialog .modal-content .modal-footer .right-footer .footer-button a[aria-label="Next"][aria-disabled="false"]';
 		await this.code.waitForElement(nextButton);
 		await this.code.dispatchKeybinding('enter');
-
-		// Wait a bit for the dialog to load since otherwise pressing the button may not do anything
-		// (not ideal - should look into finding better thing to wait on)
-		await new Promise<void>(resolve => {
-			setTimeout(() => resolve(), 5000);
-		});
 
 		const installButton = '.modal-dialog .modal-content .modal-footer .right-footer .footer-button a[aria-label="Install"][aria-disabled="false"]';
 		await this.code.waitForElement(installButton);

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -37,9 +37,9 @@ export class Notebook {
 
 	async addCell(cellType: 'markdown' | 'code'): Promise<void> {
 		if (cellType === 'markdown') {
-			await this.code.dispatchKeybinding(winOrCtrl + '+shift+t');
+			await this.code.dispatchKeybinding('ctrl+shift+t');
 		} else {
-			await this.code.dispatchKeybinding(winOrCtrl + '+shift+c');
+			await this.code.dispatchKeybinding('ctrl+shift+c');
 		}
 
 		await this.code.waitForElement('.notebook-cell.active');
@@ -58,7 +58,7 @@ export class Notebook {
 	}
 
 	async runAllCells(): Promise<void> {
-		await this.code.dispatchKeybinding(winOrCtrl + '+shift+F5');
+		await this.code.dispatchKeybinding('ctrl+shift+F5');
 	}
 
 	async clearResults(): Promise<void> {

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -13,6 +13,7 @@ export function setup() {
 			await app.workbench.sqlNotebook.newUntitledNotebook();
 			await app.workbench.sqlNotebook.addCell('code');
 			await app.workbench.sqlNotebook.waitForTypeInEditor('print("Hello world!")');
+			await app.workbench.sqlNotebook.waitForKernel('SQL');
 
 			await app.workbench.sqlNotebook.changeKernel('Python 3');
 			await app.workbench.configurePythonDialog.waitForConfigurePythonDialog();


### PR DESCRIPTION
1. Always use ctrl for run all/make cell shortcuts. These have never been set up to use the windows key so I assume this was just done accidently as a copy/paste (and never noticed since the smoke tests run on a Mac currently)
2. Wait for SQL kernel to be loaded before starting the tests - I was running into an issue where the kernels wouldn't have finished loading yet and so the test would fail if we didn't add the wait there. 