### PR TITLE
Fix crash when opening SQL diff input

### DIFF
--- a/src/sql/workbench/contrib/editorReplacement/common/editorReplacerContribution.ts
+++ b/src/sql/workbench/contrib/editorReplacement/common/editorReplacerContribution.ts
@@ -19,6 +19,7 @@ import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/u
 import { isThenable } from 'vs/base/common/async';
 import { withNullAsUndefined } from 'vs/base/common/types';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
+import { mixin } from 'vs/base/common/objects';
 
 const languageAssociationRegistry = Registry.as<ILanguageAssociationRegistry>(LanguageAssociationExtensions.LanguageAssociations);
 

--- a/src/sql/workbench/contrib/editorReplacement/common/editorReplacerContribution.ts
+++ b/src/sql/workbench/contrib/editorReplacement/common/editorReplacerContribution.ts
@@ -77,7 +77,7 @@ export class EditorReplacementContribution implements IWorkbenchContribution {
 						// is replicating the behavior for the non-Thenable returns where we just let the openEditor
 						// continue on
 						override: isThenable(newInput) ?
-							newInput.then(input => this.editorService.openEditor(input ?? editor, mixin(options, { override: input ? options.override : false }), group)) :
+							newInput.then(input => this.editorService.openEditor(input ?? editor, mixin(options, { override: input ? options?.override : false }), group)) :
 							this.editorService.openEditor(newInput, options, group)
 					};
 				}
@@ -94,7 +94,7 @@ export class EditorReplacementContribution implements IWorkbenchContribution {
 						// is replicating the behavior for the non-Thenable returns where we just let the openEditor
 						// continue on
 						override: isThenable(newInput) ?
-							newInput.then(input => this.editorService.openEditor(input ?? editor, mixin(options, { override: input ? options.override : false }), group))
+							newInput.then(input => this.editorService.openEditor(input ?? editor, mixin(options, { override: input ? options?.override : false }), group))
 							: this.editorService.openEditor(newInput, options, group)
 					};
 				}

--- a/src/sql/workbench/contrib/editorReplacement/common/editorReplacerContribution.ts
+++ b/src/sql/workbench/contrib/editorReplacement/common/editorReplacerContribution.ts
@@ -69,7 +69,16 @@ export class EditorReplacementContribution implements IWorkbenchContribution {
 				editor.setMode(defaultInputCreator[0]);
 				const newInput = defaultInputCreator[1].convertInput(editor);
 				if (newInput) {
-					return { override: isThenable(newInput) ? newInput.then(input => this.editorService.openEditor(input ?? editor, options, group)) : this.editorService.openEditor(newInput, options, group) };
+					return {
+						// If the new input is a thenable which resolves to undefined (no input to convert)
+						// then don't allow further overriding since otherwise we could get in an infinite loop
+						// (openEditor calls onEditorOpening handler and we keep repeating this process). This
+						// is replicating the behavior for the non-Thenable returns where we just let the openEditor
+						// continue on
+						override: isThenable(newInput) ?
+							newInput.then(input => this.editorService.openEditor(input ?? editor, mixin(options, { override: input ? options.override : false }), group)) :
+							this.editorService.openEditor(newInput, options, group)
+					};
 				}
 			}
 		} else {
@@ -77,7 +86,16 @@ export class EditorReplacementContribution implements IWorkbenchContribution {
 			if (inputCreator) {
 				const newInput = inputCreator.convertInput(editor);
 				if (newInput) {
-					return { override: isThenable(newInput) ? newInput.then(input => this.editorService.openEditor(input ?? editor, options, group)) : this.editorService.openEditor(newInput, options, group) };
+					return {
+						// If the new input is a thenable which resolves to undefined (no input to convert)
+						// then don't allow further overriding since otherwise we could get in an infinite loop
+						// (openEditor calls onEditorOpening handler and we keep repeating this process). This
+						// is replicating the behavior for the non-Thenable returns where we just let the openEditor
+						// continue on
+						override: isThenable(newInput) ?
+							newInput.then(input => this.editorService.openEditor(input ?? editor, mixin(options, { override: input ? options.override : false }), group))
+							: this.editorService.openEditor(newInput, options, group)
+					};
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15180

What was happening here is that we were calling convertInput which was then returning a Promise that resolved to undefined (since the SQL diff doesn't use a specialized input for that - just the normal DiffEditorInput). But we still were returning an override to this call, which would then call openEditor and repeat the process - getting in an infinite loop.

(note this wouldn't happen for a non-Promise undefined return value, since we don't override in that case)

This was exposed by https://github.com/microsoft/azuredatastudio/commit/0d3112ef35163387cdd0653247f46b9a1c274019 but has been an issue ever since this was originally made - we just never had a case where we were returning a Promise resolving to undefined from a convertInput before. 

I considered refactoring the query input factory to return a non-Promised undefined if it didn't support converting the input, but it seemed better to me to make this logic be able to handle those cases since otherwise every implementation would have to make sure they're doing this correctly. 