### PR TITLE
Fix VM Page displaying MI assessment results

### DIFF
--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -347,6 +347,7 @@ export const INSTANCE = localize('sql.migration.instance', "Instance");
 export const WARNINGS = localize('sql.migration.warnings', "Warnings");
 export const IMPACTED_OBJECTS = localize('sql.migration.impacted.objects', "Impacted Objects");
 export const OBJECT_DETAILS = localize('sql.migration.object.details', "Object details");
+export const ASSESSMENT_RESULTS = localize('sql.migration.assessmen.results', "Assessment Results");
 export const TYPES_LABEL = localize('sql.migration.type.label', "Type:");
 export const NAMES_LABEL = localize('sql.migration.name.label', "Names:");
 export const DESCRIPTION = localize('sql.migration.description', "Description");

--- a/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
@@ -353,7 +353,7 @@ export class SqlDatabaseTree {
 				value: constants.NO_ISSUES_FOUND_VM,
 				CSSStyles: {
 					'font-size': '14px',
-					'width': '400px',
+					'width': '100%',
 					'margin': '10px 0px 0px 0px',
 					'text-align': 'left'
 				}
@@ -363,7 +363,7 @@ export class SqlDatabaseTree {
 				value: constants.NO_ISSUES_FOUND_MI,
 				CSSStyles: {
 					'font-size': '14px',
-					'width': '400px',
+					'width': '100%',
 					'margin': '10px 0px 0px 0px',
 					'text-align': 'left'
 				}
@@ -748,8 +748,32 @@ export class SqlDatabaseTree {
 
 	public refreshResults(): void {
 		const assessmentResults: azdata.DeclarativeTableCellValue[][] = [];
-		if (this._activeIssues.length === 0) {
-			/// show no issues here
+		if (this._model._targetType === MigrationTargetType.SQLMI) {
+			if (this._activeIssues.length === 0) {
+				/// show no issues here
+				this._assessmentsTable.updateCssStyles({
+					'display': 'none',
+					'border-right': 'none'
+				});
+				this._assessmentContainer.updateCssStyles({
+					'display': 'none'
+				});
+				this._noIssuesContainer.updateCssStyles({
+					'display': 'flex'
+				});
+			} else {
+				this._assessmentContainer.updateCssStyles({
+					'display': 'flex'
+				});
+				this._assessmentsTable.updateCssStyles({
+					'display': 'flex',
+					'border-right': 'solid 1px'
+				});
+				this._noIssuesContainer.updateCssStyles({
+					'display': 'none'
+				});
+			}
+		} else {
 			this._assessmentsTable.updateCssStyles({
 				'display': 'none',
 				'border-right': 'none'
@@ -760,17 +784,8 @@ export class SqlDatabaseTree {
 			this._noIssuesContainer.updateCssStyles({
 				'display': 'flex'
 			});
-		} else {
-			this._assessmentContainer.updateCssStyles({
-				'display': 'flex'
-			});
-			this._assessmentsTable.updateCssStyles({
-				'display': 'flex',
-				'border-right': 'solid 1px'
-			});
-			this._noIssuesContainer.updateCssStyles({
-				'display': 'none'
-			});
+			this._recommendationTitle.value = constants.ASSESSMENT_RESULTS;
+			this._recommendation.value = '';
 		}
 		this._activeIssues.forEach((v) => {
 			assessmentResults.push(

--- a/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
@@ -179,8 +179,12 @@ export class SqlDatabaseTree {
 		this._databaseTable.onRowSelected(({ row }) => {
 
 			this._databaseTable.focus();
-			this._activeIssues = this._model._assessmentResults?.databaseAssessments[row].issues;
-			this._selectedIssue = this._model._assessmentResults?.databaseAssessments[row].issues[0];
+			if (this._targetType === MigrationTargetType.SQLMI) {
+				this._activeIssues = this._model._assessmentResults?.databaseAssessments[row].issues;
+				this._selectedIssue = this._model._assessmentResults?.databaseAssessments[row].issues[0];
+			} else {
+				this._activeIssues = [];
+			}
 			this._dbName.value = this._dbNames[row];
 			this._recommendationTitle.value = constants.ISSUES_COUNT(this._activeIssues.length);
 			this._recommendation.value = constants.ISSUES_DETAILS;


### PR DESCRIPTION
There was a bug where the VM assessment page would display MI assessment results, when VM Migrations should not have any assessment issues.  I have fixed this bug and here is the new view:
![vm-page](https://user-images.githubusercontent.com/18150417/115598070-dd7dd880-a28e-11eb-9711-f6faa18d1391.PNG)


