### PR TITLE
Update drop-down selected value in accessibility mode

### DIFF
--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -96,9 +96,13 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 			this._register(this._selectBox);
 			this._register(attachSelectBoxStyler(this._selectBox, this.themeService));
 			this._register(this._selectBox.onDidSelect(async e => {
-				if (!this.editable) {
+				// also update the selected value here while in accessibility mode since the read-only selectbox
+				// is used even if the editable flag is true
+				if (!this.editable || (this._isInAccessibilityMode && !this.loading)) {
 					this.setSelectedValue(e.selected);
 					await this.validate();
+				}
+				if (!this.editable) {
 					// This is currently sending the ISelectData as the args, but to change this now would be a breaking
 					// change for extensions using it. So while not ideal this should be left as is for the time being.
 					this.fireEvent({


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/13499.

There is special-case logic in the dropdown control to ignore the `editable` flag in accessibility mode.  The event handlers for the read-only dropdown list checks the control is not editable prior to updating the selected value.  This results in the dropdown having the default, potentially incorrect, value resulting in behavior such as what is observed in #13499.

*Target Selection dialog*
![image](https://user-images.githubusercontent.com/599935/115525773-42f8a780-a244-11eb-95ff-1461143f101e.png)

*Target Selection toolbar* 
![image](https://user-images.githubusercontent.com/599935/115525885-5c99ef00-a244-11eb-8f82-74b92ce56d46.png)
