### PR TITLE
Fix welcome page enum descriptions

### DIFF
--- a/src/vs/workbench/contrib/welcome/page/browser/welcomePage.contribution.ts
+++ b/src/vs/workbench/contrib/welcome/page/browser/welcomePage.contribution.ts
@@ -24,7 +24,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				'scope': ConfigurationScope.APPLICATION, // Make sure repositories cannot trigger opening a README for tracking.
 				'type': 'string',
 				'enum': [
-					...['none', 'welcomePageWithTour', 'welcomePage', 'readme', 'newUntitledFile', 'welcomePageInEmptyWorkbench'],
+					...['none', 'welcomePageWithTour', 'welcomePage', 'readme', 'newUntitledFile', 'welcomePageInEmptyWorkbench'], // {{SQL CARBON EDIT}} Add our own welcomePageWithTour
 					// {{SQL CARBON EDIT}} We don't use the VS Code gettingStarted experience
 					// ...(product.quality !== 'stable'
 					// 	? ['gettingStarted']

--- a/src/vs/workbench/contrib/welcome/page/browser/welcomePage.contribution.ts
+++ b/src/vs/workbench/contrib/welcome/page/browser/welcomePage.contribution.ts
@@ -25,7 +25,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				'scope': ConfigurationScope.APPLICATION, // Make sure repositories cannot trigger opening a README for tracking.
 				'type': 'string',
 				'enum': [
-					...['none', 'welcomePage', 'welcomePageWithTour', 'readme', 'newUntitledFile', 'welcomePageInEmptyWorkbench'],
+					...['none', 'welcomePageWithTour', 'welcomePage', 'readme', 'newUntitledFile', 'welcomePageInEmptyWorkbench'],
 					...(product.quality !== 'stable'
 						? ['gettingStarted']
 						: [])

--- a/src/vs/workbench/contrib/welcome/page/browser/welcomePage.contribution.ts
+++ b/src/vs/workbench/contrib/welcome/page/browser/welcomePage.contribution.ts
@@ -15,7 +15,6 @@ import { IEditorInputFactoryRegistry, Extensions as EditorExtensions } from 'vs/
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuration';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import product from 'vs/platform/product/common/product';
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 	.registerConfiguration({
@@ -26,9 +25,10 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				'type': 'string',
 				'enum': [
 					...['none', 'welcomePageWithTour', 'welcomePage', 'readme', 'newUntitledFile', 'welcomePageInEmptyWorkbench'],
-					...(product.quality !== 'stable'
-						? ['gettingStarted']
-						: [])
+					// {{SQL CARBON EDIT}} We don't use the VS Code gettingStarted experience
+					// ...(product.quality !== 'stable'
+					// 	? ['gettingStarted']
+					// 	: [])
 				],
 				'enumDescriptions': [...[
 					localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.startupEditor.none' }, "Start without an editor."),
@@ -37,9 +37,10 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 					localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.startupEditor.readme' }, "Open the README when opening a folder that contains one, fallback to 'welcomePage' otherwise."),
 					localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.startupEditor.newUntitledFile' }, "Open a new untitled file (only applies when opening an empty workspace)."),
 					localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.startupEditor.welcomePageInEmptyWorkbench' }, "Open the Welcome page when opening an empty workbench."),],
-				...(product.quality !== 'stable'
-					? [localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.startupEditor.gettingStarted' }, "Open the Getting Started page (experimental).")]
-					: [])
+					// {{SQL CARBON EDIT}} We don't use the VS Code gettingStarted experience
+					// ...(product.quality !== 'stable'
+					// 	? [localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.startupEditor.gettingStarted' }, "Open the Getting Started page (experimental).")]
+					// 	: [])
 				],
 				'default': 'welcomePageWithTour',
 				'description': localize('workbench.startupEditor', "Controls which editor is shown at startup, if none are restored from the previous session.")


### PR DESCRIPTION
Order matters for the enum definitions.

Also removing the gettingStarted option - it doesn't appear to be working for us (it just opened the release notes for me) and we have our own welcomeTour experience anyways. 

Old : 

![image](https://user-images.githubusercontent.com/28519865/115783617-ef847780-a371-11eb-88e4-a91d5b7e761f.png)

Fixed :

![image](https://user-images.githubusercontent.com/28519865/115783957-5ace4980-a372-11eb-9938-278a89221ee7.png)
