### PR TITLE
undo carbon edit changes for markdown relative links issue

### DIFF
--- a/extensions/markdown-language-features/src/commands/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/commands/openDocumentLink.ts
@@ -10,7 +10,6 @@ import { Command } from '../commandManager';
 import { MarkdownEngine } from '../markdownEngine';
 import { TableOfContentsProvider } from '../tableOfContentsProvider';
 import { isMarkdownFile } from '../util/file';
-import { isString } from 'util'; // {{SQL CARBON EDIT}}
 
 
 type UriComponents = {
@@ -154,7 +153,7 @@ export class OpenDocumentLinkCommand implements Command {
 }
 
 function reviveUri(parts: any) {
-	if (parts.scheme === 'file' && isString(parts.path)) {  // {{SQL CARBON EDIT}} Fix markdown relative links https://github.com/microsoft/azuredatastudio/issues/11657
+	if (parts.scheme === 'file') {
 		return vscode.Uri.file(parts.path);
 	}
 	return vscode.Uri.parse('').with(parts);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR reverts carbon edit changes added in https://github.com/microsoft/azuredatastudio/pull/11708 to address the below vscode introduced issue which is now fixed:
https://github.com/microsoft/vscode/issues/104267

