### PR TITLE
a couple more table filter improvements

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -72,7 +72,7 @@ export class HeaderFilter<T extends Slick.SlickData> {
 			.subscribe(this.grid.onBeforeHeaderCellDestroy, (e: Event, args: Slick.OnBeforeHeaderCellDestroyEventArgs<T>) => this.handleBeforeHeaderCellDestroy(e, args))
 			.subscribe(this.grid.onClick, (e: DOMEvent) => this.handleBodyMouseDown(e as MouseEvent))
 			.subscribe(this.grid.onColumnsResized, () => this.columnsResized())
-			.subscribe(this.grid.onKeyDown, (e: DOMEvent) => this.handleGridKeyDown(e as KeyboardEvent));
+			.subscribe(this.grid.onKeyDown, async (e: DOMEvent) => { await this.handleGridKeyDown(e as KeyboardEvent); });
 		this.grid.setColumns(this.grid.getColumns());
 
 		this.disposableStore.add(addDisposableListener(document.body, 'mousedown', e => this.handleBodyMouseDown(e), true));
@@ -95,14 +95,14 @@ export class HeaderFilter<T extends Slick.SlickData> {
 		}
 	}
 
-	private handleGridKeyDown(e: KeyboardEvent): void {
+	private async handleGridKeyDown(e: KeyboardEvent): Promise<void> {
 		const event = new StandardKeyboardEvent(e);
 		if (event.keyCode === KeyCode.F3) {
 			const cell = this.grid.getActiveCell();
 			if (cell) {
 				const column = this.grid.getColumns()[cell.cell] as FilterableColumn<T>;
 				if (column.filterable !== false && this.enabled && this.columnButtonMapping[column.id]) {
-					this.showFilter(this.columnButtonMapping[column.id]);
+					await this.showFilter(this.columnButtonMapping[column.id]);
 					EventHelper.stop(e, true);
 				}
 			}

--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -160,7 +160,6 @@ export class HeaderFilter<T extends Slick.SlickData> {
 		button.label = title;
 		button.onDidClick(async () => {
 			await this.handleMenuItemClick(command, this.columnDef);
-			this.grid.setSortColumn(this.columnDef.id, command === 'sort-asc');
 		});
 		return button;
 	}

--- a/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/headerFilter.plugin.ts
@@ -97,6 +97,9 @@ export class HeaderFilter<T extends Slick.SlickData> {
 
 	private async handleGridKeyDown(e: KeyboardEvent): Promise<void> {
 		const event = new StandardKeyboardEvent(e);
+		// The shortcut key to open the filter menu is provided so that this feature is keyboard accessible.
+		// The buttons added to the column headers are set to not keyboard focusable so that they won't interfere with the slickgrid's internal focus management.
+		// F3 key is chosen because it is known for search related features
 		if (event.keyCode === KeyCode.F3) {
 			const cell = this.grid.getActiveCell();
 			if (cell) {

--- a/src/sql/workbench/contrib/query/browser/query.contribution.ts
+++ b/src/sql/workbench/contrib/query/browser/query.contribution.ts
@@ -393,7 +393,7 @@ const queryEditorConfiguration: IConfigurationNode = {
 		},
 		'queryEditor.results.inMemoryDataProcessingThreshold': {
 			'type': 'number',
-			'default': 2000,
+			'default': 5000,
 			'description': localize('queryEditor.inMemoryDataProcessingThreshold', "Controls the max number of rows allowed to do filtering and sorting in memory. If the number is exceeded, sorting and filtering will be disabled.")
 		},
 		'queryEditor.messages.showBatchTime': {


### PR DESCRIPTION
1. increase the max row count to 5000. when I first introduced this number, I didn't really think too much, later I found notebook also has a max results for query results, so I am using this number too.
2. slickgrid has its own focus management, now that we are adding a bunch of buttons to the header row, I've observed some weirdness while navigating using keyboard, sometimes I can't get to the buttons, sometimes the focus won't go into the grid itself, there is a race condition on who gets the focus, I am changing it so that the buttons are no longer keyboard focusable, add added a shortcut key to open the filter menu, I picked F3 as it is known for search related features. If the accessibility team think we to expose it through keyboard shortcut settings, I can further improve it.
3. on escape, restore the focus to previously focused element
