### PR TITLE
add sorting option for saved connections

### DIFF
--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -16,7 +16,12 @@ import { deepClone } from 'vs/base/common/objects';
 
 export const GROUPS_CONFIG_KEY = 'datasource.connectionGroups';
 export const CONNECTIONS_CONFIG_KEY = 'datasource.connections';
-export const CONNECTION_SORT_BY_CONFIG_KEY = 'datasource.connections.sortBy';
+export const CONNECTIONS_SORT_BY_CONFIG_KEY = 'datasource.connections.sortBy';
+
+export const enum ConnectionsSortBy {
+	dateAdded = 'dateAdded',
+	displayName = 'displayName'
+}
 
 export interface ISaveGroupResult {
 	groups: IConnectionProfileGroup[];
@@ -51,10 +56,10 @@ export class ConnectionConfig {
 			allGroups = allGroups.concat(userValue);
 		}
 
-		const sortBy = this.configurationService.getValue<string>(CONNECTION_SORT_BY_CONFIG_KEY);
+		const sortBy = this.configurationService.getValue<string>(CONNECTIONS_SORT_BY_CONFIG_KEY);
 		let sortFunc: (a: IConnectionProfileGroup, b: IConnectionProfileGroup) => number;
 
-		if (sortBy === 'DisplayName') {
+		if (sortBy === ConnectionsSortBy.displayName) {
 			sortFunc = ((a, b) => {
 				if (a.name < b.name) {
 					return -1;
@@ -235,10 +240,10 @@ export class ConnectionConfig {
 			return ConnectionProfile.createFromStoredProfile(p, this._capabilitiesService);
 		});
 
-		const sortBy = this.configurationService.getValue<string>(CONNECTION_SORT_BY_CONFIG_KEY);
+		const sortBy = this.configurationService.getValue<string>(CONNECTIONS_SORT_BY_CONFIG_KEY);
 		let sortFunc: (a: ConnectionProfile, b: ConnectionProfile) => number;
 
-		if (sortBy === 'DisplayName') {
+		if (sortBy === ConnectionsSortBy.displayName) {
 			sortFunc = ((a, b) => {
 				if (a.title < b.title) {
 					return -1;

--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -50,6 +50,26 @@ export class ConnectionConfig {
 			}
 			allGroups = allGroups.concat(userValue);
 		}
+
+		const sortBy = this.configurationService.getValue<string>(CONNECTION_SORT_CONFIG_KEY);
+		let sortFunc: (a: IConnectionProfileGroup, b: IConnectionProfileGroup) => number;
+
+		if (sortBy === 'byTitleAlphabetically') {
+			sortFunc = ((a, b) => {
+				if (a.name < b.name) {
+					return -1;
+				} else if (a.name > b.name) {
+					return 1;
+				} else {
+					return 0;
+				}
+			});
+		}
+
+		if (sortFunc) {
+			allGroups.sort(sortFunc);
+		}
+
 		return deepClone(allGroups).map(g => {
 			if (g.parentId === '' || !g.parentId) {
 				g.parentId = undefined;

--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -216,20 +216,24 @@ export class ConnectionConfig {
 		});
 
 		const sortBy = this.configurationService.getValue<string>(CONNECTION_SORT_CONFIG_KEY);
-		if (sortBy === 'by name') {
-			connectionProfiles.sort((a, b) => {
-				let aSortString = a.title;
-				let bSortString = b.title;
-				if (aSortString < bSortString) {
+		let sortFunc: (a: ConnectionProfile, b: ConnectionProfile) => number;
+
+		if (sortBy === 'by title alphabetically') {
+			sortFunc = ((a, b) => {
+				if (a.title < b.title) {
 					return -1;
-				}
-				else if (aSortString > bSortString) {
+				} else if (a.title > b.title) {
 					return 1;
 				} else {
 					return 0;
 				}
 			});
 		}
+
+		if (sortFunc) {
+			connectionProfiles.sort(sortFunc);
+		}
+
 		return connectionProfiles;
 	}
 

--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -14,9 +14,9 @@ import * as nls from 'vs/nls';
 import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { deepClone } from 'vs/base/common/objects';
 
-const GROUPS_CONFIG_KEY = 'datasource.connectionGroups';
-const CONNECTIONS_CONFIG_KEY = 'datasource.connections';
-const CONNECTION_SORT_CONFIG_KEY = 'datasource.connectionSort';
+export const GROUPS_CONFIG_KEY = 'datasource.connectionGroups';
+export const CONNECTIONS_CONFIG_KEY = 'datasource.connections';
+export const CONNECTION_SORT_BY_CONFIG_KEY = 'datasource.connections.sortBy';
 
 export interface ISaveGroupResult {
 	groups: IConnectionProfileGroup[];
@@ -51,10 +51,10 @@ export class ConnectionConfig {
 			allGroups = allGroups.concat(userValue);
 		}
 
-		const sortBy = this.configurationService.getValue<string>(CONNECTION_SORT_CONFIG_KEY);
+		const sortBy = this.configurationService.getValue<string>(CONNECTION_SORT_BY_CONFIG_KEY);
 		let sortFunc: (a: IConnectionProfileGroup, b: IConnectionProfileGroup) => number;
 
-		if (sortBy === 'byTitleAlphabetically') {
+		if (sortBy === 'DisplayName') {
 			sortFunc = ((a, b) => {
 				if (a.name < b.name) {
 					return -1;
@@ -235,10 +235,10 @@ export class ConnectionConfig {
 			return ConnectionProfile.createFromStoredProfile(p, this._capabilitiesService);
 		});
 
-		const sortBy = this.configurationService.getValue<string>(CONNECTION_SORT_CONFIG_KEY);
+		const sortBy = this.configurationService.getValue<string>(CONNECTION_SORT_BY_CONFIG_KEY);
 		let sortFunc: (a: ConnectionProfile, b: ConnectionProfile) => number;
 
-		if (sortBy === 'byTitleAlphabetically') {
+		if (sortBy === 'DisplayName') {
 			sortFunc = ((a, b) => {
 				if (a.title < b.title) {
 					return -1;

--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -218,7 +218,7 @@ export class ConnectionConfig {
 		const sortBy = this.configurationService.getValue<string>(CONNECTION_SORT_CONFIG_KEY);
 		let sortFunc: (a: ConnectionProfile, b: ConnectionProfile) => number;
 
-		if (sortBy === 'by title alphabetically') {
+		if (sortBy === 'byTitleAlphabetically') {
 			sortFunc = ((a, b) => {
 				if (a.title < b.title) {
 					return -1;

--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -16,6 +16,7 @@ import { deepClone } from 'vs/base/common/objects';
 
 const GROUPS_CONFIG_KEY = 'datasource.connectionGroups';
 const CONNECTIONS_CONFIG_KEY = 'datasource.connections';
+const CONNECTION_SORT_CONFIG_KEY = 'datasource.connectionSort';
 
 export interface ISaveGroupResult {
 	groups: IConnectionProfileGroup[];
@@ -214,6 +215,21 @@ export class ConnectionConfig {
 			return ConnectionProfile.createFromStoredProfile(p, this._capabilitiesService);
 		});
 
+		const sortBy = this.configurationService.getValue<string>(CONNECTION_SORT_CONFIG_KEY);
+		if (sortBy === 'by name') {
+			connectionProfiles.sort((a, b) => {
+				let aSortString = a.title;
+				let bSortString = b.title;
+				if (aSortString < bSortString) {
+					return -1;
+				}
+				else if (aSortString > bSortString) {
+					return 1;
+				} else {
+					return 0;
+				}
+			});
+		}
 		return connectionProfiles;
 	}
 

--- a/src/sql/platform/connection/test/common/connectionConfig.test.ts
+++ b/src/sql/platform/connection/test/common/connectionConfig.test.ts
@@ -384,6 +384,18 @@ suite('ConnectionConfig', () => {
 		});
 	});
 
+	test('getConnections should return connections sorted alphabetically by title given datasource.connectionSort is set to \'by title alphabetically\'', () => {
+		let configurationService = new TestConfigurationService();
+		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(0, 2).reverse(), ConfigurationTarget.USER);
+		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(2, testConnections.length).reverse(), ConfigurationTarget.WORKSPACE);
+		configurationService.updateValue('datasource.connectionSort', 'by title alphabetically', ConfigurationTarget.USER);
+
+		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
+		let allConnections = config.getConnections(true);
+		assert.equal(allConnections.length, testConnections.length);
+		assert.ok(allConnections.slice(1).every((item, i) => allConnections[i].title <= item.title));
+	});
+
 	test('saveGroup should save the new groups to tree and return the id of the last group name', () => {
 		let config = new ConnectionConfig(undefined!, undefined!);
 		let groups: IConnectionProfileGroup[] = deepClone(testGroups);

--- a/src/sql/platform/connection/test/common/connectionConfig.test.ts
+++ b/src/sql/platform/connection/test/common/connectionConfig.test.ts
@@ -239,6 +239,20 @@ suite('ConnectionConfig', () => {
 		assert.ok(groupsAreEqual(allGroups, testGroups), 'the groups returned did not match expectation');
 	});
 
+	test('getAllGroups should return groups sorted alphabetically by name given datasource.connectionSort is set to \'byTitleAlphabetically\'', () => {
+		let configurationService = new TestConfigurationService();
+		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(0, 3), ConfigurationTarget.USER);
+		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(2, testGroups.length), ConfigurationTarget.WORKSPACE);
+		configurationService.updateValue('datasource.connectionSort', 'byTitleAlphabetically', ConfigurationTarget.USER);
+
+		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
+		let allGroups = config.getAllGroups();
+
+		assert.equal(allGroups.length, testGroups.length, 'did not meet the expected length');
+		assert.ok(groupsAreEqual(allGroups, testGroups), 'the groups returned did not match expectation');
+		assert.ok(allGroups.slice(1).every((item, i) => allGroups[i].name <= item.name), 'the groups are not sorted correctly');
+	});
+
 	test('addConnection should add the new profile to user settings', async () => {
 		let newProfile: IConnectionProfile = {
 			serverName: 'new server',

--- a/src/sql/platform/connection/test/common/connectionConfig.test.ts
+++ b/src/sql/platform/connection/test/common/connectionConfig.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as azdata from 'azdata';
 import { ProviderFeatures } from 'sql/platform/capabilities/common/capabilitiesService';
-import { ConnectionConfig, ISaveGroupResult } from 'sql/platform/connection/common/connectionConfig';
+import { ConnectionConfig, ISaveGroupResult, CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy } from 'sql/platform/connection/common/connectionConfig';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { ConnectionProfileGroup, IConnectionProfileGroup } from 'sql/platform/connection/common/connectionProfileGroup';
 import { IConnectionProfile, IConnectionProfileStore, ConnectionOptionSpecialType, ServiceOptionType } from 'sql/platform/connection/common/interfaces';
@@ -239,11 +239,11 @@ suite('ConnectionConfig', () => {
 		assert.ok(groupsAreEqual(allGroups, testGroups), 'the groups returned did not match expectation');
 	});
 
-	test('getAllGroups should return groups sorted alphabetically by display name given datasource.connections.sortBy is set to \'DisplayName\'', () => {
+	test('getAllGroups should return groups sorted alphabetically by display name given datasource.connections.sortBy is set to \'' + ConnectionsSortBy.displayName + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(0, 3), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(2, testGroups.length), ConfigurationTarget.WORKSPACE);
-		configurationService.updateValue('datasource.connections.sortBy', 'DisplayName', ConfigurationTarget.USER);
+		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy.displayName, ConfigurationTarget.USER);
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allGroups = config.getAllGroups();
@@ -253,11 +253,11 @@ suite('ConnectionConfig', () => {
 		assert.ok(allGroups.slice(1).every((item, i) => allGroups[i].name <= item.name), 'the groups are not sorted correctly');
 	});
 
-	test('getAllGroups should return groups sorted by date added given datasource.connections.sortBy is set to \'DateAdded\'', () => {
+	test('getAllGroups should return groups sorted by date added given datasource.connections.sortBy is set to \'' + ConnectionsSortBy.dateAdded + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(0, 3).reverse(), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(2, testGroups.length).reverse(), ConfigurationTarget.WORKSPACE);
-		configurationService.updateValue('datasource.connections.sortBy', 'DateAdded', ConfigurationTarget.USER);
+		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy.dateAdded, ConfigurationTarget.USER);
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allGroups = config.getAllGroups();
@@ -411,11 +411,11 @@ suite('ConnectionConfig', () => {
 		});
 	});
 
-	test('getConnections should return connections sorted alphabetically by title given datasource.connections.sortBy is set to \'DisplayName\'', () => {
+	test('getConnections should return connections sorted alphabetically by title given datasource.connections.sortBy is set to \'' + ConnectionsSortBy.displayName + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(0, 2).reverse(), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(2, testConnections.length).reverse(), ConfigurationTarget.WORKSPACE);
-		configurationService.updateValue('datasource.connections.sortBy', 'DisplayName', ConfigurationTarget.USER);
+		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy.displayName, ConfigurationTarget.USER);
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(true);
@@ -423,10 +423,10 @@ suite('ConnectionConfig', () => {
 		assert.ok(allConnections.slice(1).every((item, i) => allConnections[i].title <= item.title), 'The connections are not sorted correctly');
 	});
 
-	test('getConnections should return connections sorted by date added given datasource.connections.sortBy is set to \'DateAdded\'', () => {
+	test('getConnections should return connections sorted by date added given datasource.connections.sortBy is set to \'' + ConnectionsSortBy.dateAdded + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).reverse(), ConfigurationTarget.USER);
-		configurationService.updateValue('datasource.connections.sortBy', 'DateAdded', ConfigurationTarget.USER);
+		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy.dateAdded, ConfigurationTarget.USER);
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(false);

--- a/src/sql/platform/connection/test/common/connectionConfig.test.ts
+++ b/src/sql/platform/connection/test/common/connectionConfig.test.ts
@@ -239,11 +239,11 @@ suite('ConnectionConfig', () => {
 		assert.ok(groupsAreEqual(allGroups, testGroups), 'the groups returned did not match expectation');
 	});
 
-	test('getAllGroups should return groups sorted alphabetically by name given datasource.connectionSort is set to \'byTitleAlphabetically\'', () => {
+	test('getAllGroups should return groups sorted alphabetically by display name given datasource.connections.sortBy is set to \'DisplayName\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(0, 3), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(2, testGroups.length), ConfigurationTarget.WORKSPACE);
-		configurationService.updateValue('datasource.connectionSort', 'byTitleAlphabetically', ConfigurationTarget.USER);
+		configurationService.updateValue('datasource.connections.sortBy', 'DisplayName', ConfigurationTarget.USER);
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allGroups = config.getAllGroups();
@@ -251,6 +251,19 @@ suite('ConnectionConfig', () => {
 		assert.equal(allGroups.length, testGroups.length, 'did not meet the expected length');
 		assert.ok(groupsAreEqual(allGroups, testGroups), 'the groups returned did not match expectation');
 		assert.ok(allGroups.slice(1).every((item, i) => allGroups[i].name <= item.name), 'the groups are not sorted correctly');
+	});
+
+	test('getAllGroups should return groups sorted by date added given datasource.connections.sortBy is set to \'DateAdded\'', () => {
+		let configurationService = new TestConfigurationService();
+		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(0, 3).reverse(), ConfigurationTarget.USER);
+		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(2, testGroups.length).reverse(), ConfigurationTarget.WORKSPACE);
+		configurationService.updateValue('datasource.connections.sortBy', 'DateAdded', ConfigurationTarget.USER);
+
+		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
+		let allGroups = config.getAllGroups();
+		let expectedGroups = deepClone(testGroups).slice(0, 3).reverse().concat(deepClone(testGroups).slice(3, testGroups.length).reverse());
+		assert.equal(allGroups.length, expectedGroups.length, 'The result groups length is invalid');
+		assert.ok(allGroups.every((item, i) => item.id === allGroups[i].id));
 	});
 
 	test('addConnection should add the new profile to user settings', async () => {
@@ -398,16 +411,28 @@ suite('ConnectionConfig', () => {
 		});
 	});
 
-	test('getConnections should return connections sorted alphabetically by title given datasource.connectionSort is set to \'byTitleAlphabetically\'', () => {
+	test('getConnections should return connections sorted alphabetically by title given datasource.connections.sortBy is set to \'DisplayName\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(0, 2).reverse(), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(2, testConnections.length).reverse(), ConfigurationTarget.WORKSPACE);
-		configurationService.updateValue('datasource.connectionSort', 'byTitleAlphabetically', ConfigurationTarget.USER);
+		configurationService.updateValue('datasource.connections.sortBy', 'DisplayName', ConfigurationTarget.USER);
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(true);
-		assert.equal(allConnections.length, testConnections.length, 'The result groups length is invalid');
+		assert.equal(allConnections.length, testConnections.length, 'The result connections length is invalid');
 		assert.ok(allConnections.slice(1).every((item, i) => allConnections[i].title <= item.title), 'The connections are not sorted correctly');
+	});
+
+	test('getConnections should return connections sorted by date added given datasource.connections.sortBy is set to \'DateAdded\'', () => {
+		let configurationService = new TestConfigurationService();
+		configurationService.updateValue('datasource.connections', deepClone(testConnections).reverse(), ConfigurationTarget.USER);
+		configurationService.updateValue('datasource.connections.sortBy', 'DateAdded', ConfigurationTarget.USER);
+
+		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
+		let allConnections = config.getConnections(false);
+		let expectedConnections = deepClone(testConnections).reverse();
+		assert.equal(allConnections.length, expectedConnections.length, 'The result connections length is invalid');
+		assert.ok(allConnections.every((item, i) => item.id === expectedConnections[i].id));
 	});
 
 	test('saveGroup should save the new groups to tree and return the id of the last group name', () => {

--- a/src/sql/platform/connection/test/common/connectionConfig.test.ts
+++ b/src/sql/platform/connection/test/common/connectionConfig.test.ts
@@ -384,16 +384,16 @@ suite('ConnectionConfig', () => {
 		});
 	});
 
-	test('getConnections should return connections sorted alphabetically by title given datasource.connectionSort is set to \'by title alphabetically\'', () => {
+	test('getConnections should return connections sorted alphabetically by title given datasource.connectionSort is set to \'byTitleAlphabetically\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(0, 2).reverse(), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(2, testConnections.length).reverse(), ConfigurationTarget.WORKSPACE);
-		configurationService.updateValue('datasource.connectionSort', 'by title alphabetically', ConfigurationTarget.USER);
+		configurationService.updateValue('datasource.connectionSort', 'byTitleAlphabetically', ConfigurationTarget.USER);
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(true);
-		assert.equal(allConnections.length, testConnections.length);
-		assert.ok(allConnections.slice(1).every((item, i) => allConnections[i].title <= item.title));
+		assert.equal(allConnections.length, testConnections.length, 'The result groups length is invalid');
+		assert.ok(allConnections.slice(1).every((item, i) => allConnections[i].title <= item.title), 'The connections are not sorted correctly');
 	});
 
 	test('saveGroup should save the new groups to tree and return the id of the last group name', () => {

--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
@@ -11,7 +11,7 @@ import { Extensions, IConfigurationRegistry } from 'vs/platform/configuration/co
 import { DataExplorerContainerExtensionHandler } from 'sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 import { DataExplorerViewletViewsContribution } from 'sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet';
-import { GROUPS_CONFIG_KEY, CONNECTIONS_CONFIG_KEY, CONNECTION_SORT_BY_CONFIG_KEY } from 'sql/platform/connection/common/connectionConfig';
+import { GROUPS_CONFIG_KEY, CONNECTIONS_CONFIG_KEY, CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy } from 'sql/platform/connection/common/connectionConfig';
 
 const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 workbenchRegistry.registerWorkbenchContribution(DataExplorerViewletViewsContribution, LifecyclePhase.Starting);
@@ -31,15 +31,15 @@ configurationRegistry.registerConfiguration({
 			'description': localize(GROUPS_CONFIG_KEY, "data source groups"),
 			'type': 'array'
 		},
-		[CONNECTION_SORT_BY_CONFIG_KEY]: {
+		[CONNECTIONS_SORT_BY_CONFIG_KEY]: {
 			'type': 'string',
-			'enum': ['DateAdded', 'DisplayName'],
+			'enum': [ConnectionsSortBy.dateAdded, ConnectionsSortBy.displayName],
 			'enumDescriptions': [
-				localize('sortBy.DateAdded', 'Saved connections are sorted by the date they were added.'),
-				localize('sortBy.DisplayName', 'Saved connections are sorted by their display name alphabetically.')
+				localize('connections.sortBy.dateAdded', 'Saved connections are sorted by the dates they were added.'),
+				localize('connections.sortBy.displayName', 'Saved connections are sorted by their display names alphabetically.')
 			],
-			'default': 'byTimeAdded',
-			'description': localize(CONNECTION_SORT_BY_CONFIG_KEY, "Order used for sorting saved connections and connection groups")
+			'default': ConnectionsSortBy.dateAdded,
+			'description': localize(CONNECTIONS_SORT_BY_CONFIG_KEY, "Order used for sorting saved connections and connection groups")
 		}
 	}
 });

--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
@@ -32,9 +32,13 @@ configurationRegistry.registerConfiguration({
 		},
 		'datasource.connectionSort': {
 			'type': 'string',
-			'enum': ['by time added', 'by title alphabetically'],
-			'default': 'by time added',
-			'description': localize('datasource.connectionSort', "Order used for sorting saved connections")
+			'enum': ['byTimeAdded', 'byTitleAlphabetically'],
+			'enumDescriptions': [
+				localize('connectionSort.byTimeAdded', 'Saved connections are sorted by the time they were added.'),
+				localize('connectionSort.byTitleAlphabetically', 'Saved connections are sorted by their titles alphabetically.')
+			],
+			'default': 'byTimeAdded',
+			'description': localize('datasource.connectionSort', "Order used for sorting saved connections and connection groups")
 		}
 	}
 });

--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
@@ -24,11 +24,11 @@ configurationRegistry.registerConfiguration({
 	'type': 'object',
 	'properties': {
 		[CONNECTIONS_CONFIG_KEY]: {
-			'description': localize(CONNECTIONS_CONFIG_KEY, "data source connections"),
+			'description': localize('datasource.connections', "data source connections"),
 			'type': 'array'
 		},
 		[GROUPS_CONFIG_KEY]: {
-			'description': localize(GROUPS_CONFIG_KEY, "data source groups"),
+			'description': localize('datasource.connectionGroups', "data source groups"),
 			'type': 'array'
 		},
 		[CONNECTIONS_SORT_BY_CONFIG_KEY]: {
@@ -39,7 +39,7 @@ configurationRegistry.registerConfiguration({
 				localize('connections.sortBy.displayName', 'Saved connections are sorted by their display names alphabetically.')
 			],
 			'default': ConnectionsSortBy.dateAdded,
-			'description': localize(CONNECTIONS_SORT_BY_CONFIG_KEY, "Order used for sorting saved connections and connection groups")
+			'description': localize('datasource.connections.sortBy', "Order used for sorting saved connections and connection groups")
 		}
 	}
 });

--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
@@ -29,6 +29,12 @@ configurationRegistry.registerConfiguration({
 		'datasource.connectionGroups': {
 			'description': localize('datasource.connectionGroups', "data source groups"),
 			'type': 'array'
+		},
+		'datasource.connectionSort': {
+			'type': 'string',
+			'enum': ['by added time', 'by name'],
+			'default': 'by added time',
+			'description': localize('datasource.connectionSort', "Order used for sorting saved connections")
 		}
 	}
 });

--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
@@ -11,6 +11,7 @@ import { Extensions, IConfigurationRegistry } from 'vs/platform/configuration/co
 import { DataExplorerContainerExtensionHandler } from 'sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 import { DataExplorerViewletViewsContribution } from 'sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet';
+import { GROUPS_CONFIG_KEY, CONNECTIONS_CONFIG_KEY, CONNECTION_SORT_BY_CONFIG_KEY } from 'sql/platform/connection/common/connectionConfig';
 
 const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 workbenchRegistry.registerWorkbenchContribution(DataExplorerViewletViewsContribution, LifecyclePhase.Starting);
@@ -22,23 +23,23 @@ configurationRegistry.registerConfiguration({
 	'title': localize('databaseConnections', "Database Connections"),
 	'type': 'object',
 	'properties': {
-		'datasource.connections': {
-			'description': localize('datasource.connections', "data source connections"),
+		[CONNECTIONS_CONFIG_KEY]: {
+			'description': localize(CONNECTIONS_CONFIG_KEY, "data source connections"),
 			'type': 'array'
 		},
-		'datasource.connectionGroups': {
-			'description': localize('datasource.connectionGroups', "data source groups"),
+		[GROUPS_CONFIG_KEY]: {
+			'description': localize(GROUPS_CONFIG_KEY, "data source groups"),
 			'type': 'array'
 		},
-		'datasource.connectionSort': {
+		[CONNECTION_SORT_BY_CONFIG_KEY]: {
 			'type': 'string',
-			'enum': ['byTimeAdded', 'byTitleAlphabetically'],
+			'enum': ['DateAdded', 'DisplayName'],
 			'enumDescriptions': [
-				localize('connectionSort.byTimeAdded', 'Saved connections are sorted by the time they were added.'),
-				localize('connectionSort.byTitleAlphabetically', 'Saved connections are sorted by their titles alphabetically.')
+				localize('sortBy.DateAdded', 'Saved connections are sorted by the date they were added.'),
+				localize('sortBy.DisplayName', 'Saved connections are sorted by their display name alphabetically.')
 			],
 			'default': 'byTimeAdded',
-			'description': localize('datasource.connectionSort', "Order used for sorting saved connections and connection groups")
+			'description': localize(CONNECTION_SORT_BY_CONFIG_KEY, "Order used for sorting saved connections and connection groups")
 		}
 	}
 });

--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
@@ -32,8 +32,8 @@ configurationRegistry.registerConfiguration({
 		},
 		'datasource.connectionSort': {
 			'type': 'string',
-			'enum': ['by added time', 'by name'],
-			'default': 'by added time',
+			'enum': ['by time added', 'by title alphabetically'],
+			'default': 'by time added',
 			'description': localize('datasource.connectionSort', "Order used for sorting saved connections")
 		}
 	}

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -41,6 +41,7 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { AsyncServerTree, ServerTreeElement } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
 import { coalesce } from 'vs/base/common/arrays';
+import { CONNECTION_SORT_BY_CONFIG_KEY } from 'sql/platform/connection/common/connectionConfig';
 
 /**
  * ServerTreeview implements the dynamic tree view.
@@ -197,7 +198,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 			}
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('datasource.connectionSort')) {
+			if (e.affectsConfiguration(CONNECTION_SORT_BY_CONFIG_KEY)) {
 				this.refreshTree().catch(err => errors.onUnexpectedError);
 			}
 		}));

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -196,6 +196,11 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 				this.deleteObjectExplorerNodeAndRefreshTree(connectionParams.connectionProfile).catch(errors.onUnexpectedError);
 			}
 		}));
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('datasource.connectionSort')) {
+				this.refreshTree().catch(err => errors.onUnexpectedError);
+			}
+		}));
 
 		if (this._objectExplorerService && this._objectExplorerService.onUpdateObjectExplorerNodes) {
 			this._register(this._objectExplorerService.onUpdateObjectExplorerNodes(args => {

--- a/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
+++ b/src/sql/workbench/contrib/objectExplorer/browser/serverTreeView.ts
@@ -41,7 +41,7 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { AsyncServerTree, ServerTreeElement } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
 import { coalesce } from 'vs/base/common/arrays';
-import { CONNECTION_SORT_BY_CONFIG_KEY } from 'sql/platform/connection/common/connectionConfig';
+import { CONNECTIONS_SORT_BY_CONFIG_KEY } from 'sql/platform/connection/common/connectionConfig';
 
 /**
  * ServerTreeview implements the dynamic tree view.
@@ -198,7 +198,7 @@ export class ServerTreeView extends Disposable implements IServerTreeView {
 			}
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(CONNECTION_SORT_BY_CONFIG_KEY)) {
+			if (e.affectsConfiguration(CONNECTIONS_SORT_BY_CONFIG_KEY)) {
 				this.refreshTree().catch(err => errors.onUnexpectedError);
 			}
 		}));

--- a/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
+++ b/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
@@ -12,7 +12,7 @@ import { ConnectionProfile } from 'sql/platform/connection/common/connectionProf
 import { ConnectionProfileGroup } from 'sql/platform/connection/common/connectionProfileGroup';
 import { attachInputBoxStyler } from 'sql/platform/theme/common/styler';
 import { ITreeItem } from 'sql/workbench/common/views';
-import { CONNECTION_SORT_BY_CONFIG_KEY } from 'sql/platform/connection/common/connectionConfig';
+import { CONNECTIONS_SORT_BY_CONFIG_KEY } from 'sql/platform/connection/common/connectionConfig';
 import { IConnectionTreeDescriptor, IConnectionTreeService } from 'sql/workbench/services/connection/common/connectionTreeService';
 import { AsyncRecentConnectionTreeDataSource } from 'sql/workbench/services/objectExplorer/browser/asyncRecentConnectionTreeDataSource';
 import { ServerTreeElement } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
@@ -228,7 +228,7 @@ export class ConnectionBrowserView extends Disposable implements IPanelView {
 		}));
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(CONNECTION_SORT_BY_CONFIG_KEY)) {
+			if (e.affectsConfiguration(CONNECTIONS_SORT_BY_CONFIG_KEY)) {
 				this.updateSavedConnectionsNode();
 			}
 		}));

--- a/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
+++ b/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
@@ -91,7 +91,8 @@ export class ConnectionBrowserView extends Disposable implements IPanelView {
 		@ICommandService private readonly commandService: ICommandService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IConnectionManagementService private readonly connectionManagementService: IConnectionManagementService,
-		@ICapabilitiesService private readonly capabilitiesService: ICapabilitiesService
+		@ICapabilitiesService private readonly capabilitiesService: ICapabilitiesService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super();
 		this.connectionTreeService.setView(this);
@@ -224,6 +225,13 @@ export class ConnectionBrowserView extends Disposable implements IPanelView {
 		this._register(this.themeService.onDidColorThemeChange(async () => {
 			await this.refresh();
 		}));
+
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('datasource.connectionSort')) {
+				this.updateSavedConnectionsNode();
+			}
+		}));
+
 	}
 
 	private handleTreeElementSelection(selectedNode: TreeElement, connect: boolean): void {

--- a/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
+++ b/src/sql/workbench/services/connection/browser/connectionBrowseTab.ts
@@ -12,6 +12,7 @@ import { ConnectionProfile } from 'sql/platform/connection/common/connectionProf
 import { ConnectionProfileGroup } from 'sql/platform/connection/common/connectionProfileGroup';
 import { attachInputBoxStyler } from 'sql/platform/theme/common/styler';
 import { ITreeItem } from 'sql/workbench/common/views';
+import { CONNECTION_SORT_BY_CONFIG_KEY } from 'sql/platform/connection/common/connectionConfig';
 import { IConnectionTreeDescriptor, IConnectionTreeService } from 'sql/workbench/services/connection/common/connectionTreeService';
 import { AsyncRecentConnectionTreeDataSource } from 'sql/workbench/services/objectExplorer/browser/asyncRecentConnectionTreeDataSource';
 import { ServerTreeElement } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
@@ -227,7 +228,7 @@ export class ConnectionBrowserView extends Disposable implements IPanelView {
 		}));
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('datasource.connectionSort')) {
+			if (e.affectsConfiguration(CONNECTION_SORT_BY_CONFIG_KEY)) {
 				this.updateSavedConnectionsNode();
 			}
 		}));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #2799 by adding a user setting (enum) `datasource.connections.sortBy` for connection sorting.

This setting is default to `dateAdded` which aligns with the current implementation so the default order for connections in Saved Connections tab remains unchanged.

Users will be able to select `displayName` which sort saved connections and groups by their display names.

Before:
![demo_15229_before_compressed](https://user-images.githubusercontent.com/21186993/116169796-609d9500-a6ba-11eb-8415-997c97cee47a.gif)

After:
![demo_15229_after_compressed](https://user-images.githubusercontent.com/21186993/116169972-b96d2d80-a6ba-11eb-8632-01819a572e6a.gif)

