### PR TITLE
Fix parameterized notebook output

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -363,11 +363,14 @@ export class RunParametersAction extends TooltipFromLabelAction {
 	**/
 	public async openParameterizedNotebook(uri: URI): Promise<void> {
 		const editor = this._notebookService.findNotebookEditor(uri);
-		let modelContents = JSON.stringify(editor.model.toJSON());
+		let modelContents = editor.model.toJSON();
+		modelContents.cells.forEach(cell => {
+			cell.outputs = [];
+		});
 		let untitledUriPath = this._notebookService.getUntitledUriPath(path.basename(uri.fsPath));
 		let untitledUri = uri.with({ authority: '', scheme: 'untitled', path: untitledUriPath });
 		this._notebookService.openNotebook(untitledUri, {
-			initialContent: modelContents,
+			initialContent: JSON.stringify(modelContents),
 			preserveFocus: true
 		});
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15232.

When the original notebook contains output we also retrieve that and pass that on to the parameterized notebook through the initialContent. As such, we should clear out the outputs of the model contents without affecting the original notebook.
