### PR TITLE
fix result selection summary issues

### DIFF
--- a/src/sql/workbench/services/query/common/query.ts
+++ b/src/sql/workbench/services/query/common/query.ts
@@ -73,4 +73,5 @@ export interface ResultSetSubset {
 export interface ICellValue {
 	displayValue: string;
 	isNull?: boolean;
+	invariantCultureDisplayValue?: string;
 }

--- a/src/sql/workbench/services/query/common/queryModel.ts
+++ b/src/sql/workbench/services/query/common/queryModel.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
-import { IQueryMessage, ResultSetSubset } from 'sql/workbench/services/query/common/query';
+import { ICellValue, IQueryMessage, ResultSetSubset } from 'sql/workbench/services/query/common/query';
 import { DataService } from 'sql/workbench/services/query/common/dataService';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Event } from 'vs/base/common/event';
@@ -48,8 +48,8 @@ export interface IQueryEvent {
 export interface IQueryModelService {
 	_serviceBrand: undefined;
 
-	onCellSelectionChanged: Event<string[]>;
-	notifyCellSelectionChanged(selectedValues: string[]): void;
+	onCellSelectionChanged: Event<ICellValue[]>;
+	notifyCellSelectionChanged(selectedValues: ICellValue[]): void;
 
 	getQueryRunner(uri: string): QueryRunner | undefined;
 

--- a/src/sql/workbench/services/query/common/queryModelService.ts
+++ b/src/sql/workbench/services/query/common/queryModelService.ts
@@ -5,7 +5,7 @@
 
 import * as GridContentEvents from 'sql/workbench/services/query/common/gridContentEvents';
 import QueryRunner from 'sql/workbench/services/query/common/queryRunner';
-import { ResultSetSubset } from 'sql/workbench/services/query/common/query';
+import { ICellValue, ResultSetSubset } from 'sql/workbench/services/query/common/query';
 import { DataService } from 'sql/workbench/services/query/common/dataService';
 import { IQueryModelService, IQueryEvent } from 'sql/workbench/services/query/common/queryModel';
 
@@ -62,7 +62,7 @@ export class QueryModelService implements IQueryModelService {
 	private _onRunQueryComplete: Emitter<string>;
 	private _onQueryEvent: Emitter<IQueryEvent>;
 	private _onEditSessionReady: Emitter<azdata.EditSessionReadyParams>;
-	private _onCellSelectionChangedEmitter = new Emitter<string[]>();
+	private _onCellSelectionChangedEmitter = new Emitter<ICellValue[]>();
 
 	// EVENTS /////////////////////////////////////////////////////////////
 	public get onRunQueryStart(): Event<string> { return this._onRunQueryStart.event; }
@@ -70,7 +70,7 @@ export class QueryModelService implements IQueryModelService {
 	public get onRunQueryComplete(): Event<string> { return this._onRunQueryComplete.event; }
 	public get onQueryEvent(): Event<IQueryEvent> { return this._onQueryEvent.event; }
 	public get onEditSessionReady(): Event<azdata.EditSessionReadyParams> { return this._onEditSessionReady.event; }
-	public get onCellSelectionChanged(): Event<string[]> { return this._onCellSelectionChangedEmitter.event; }
+	public get onCellSelectionChanged(): Event<ICellValue[]> { return this._onCellSelectionChangedEmitter.event; }
 
 	// CONSTRUCTOR /////////////////////////////////////////////////////////
 	constructor(
@@ -100,10 +100,10 @@ export class QueryModelService implements IQueryModelService {
 
 	/**
 	 * Notify the event subscribers about the new selected cell values
-	 * @param selectedValues current selected cell values
+	 * @param selectedCells current selected cells
 	 */
-	public notifyCellSelectionChanged(selectedValues: string[]): void {
-		this._onCellSelectionChangedEmitter.fire(selectedValues);
+	public notifyCellSelectionChanged(selectedCells: ICellValue[]): void {
+		this._onCellSelectionChangedEmitter.fire(selectedCells);
 	}
 
 	/**

--- a/src/sql/workbench/services/query/test/common/testQueryModelService.ts
+++ b/src/sql/workbench/services/query/test/common/testQueryModelService.ts
@@ -10,12 +10,12 @@ import { Event } from 'vs/base/common/event';
 import { QueryInfo } from 'sql/workbench/services/query/common/queryModelService';
 import { DataService } from 'sql/workbench/services/query/common/dataService';
 import { IRange } from 'vs/editor/common/core/range';
-
+import { ICellValue } from 'sql/workbench/services/query/common/query';
 export class TestQueryModelService implements IQueryModelService {
 	_serviceBrand: any;
 	onRunQueryUpdate: Event<string>;
-	onCellSelectionChanged: Event<string[]>;
-	notifyCellSelectionChanged(selectedValues: string[]): void {
+	onCellSelectionChanged: Event<ICellValue[]>;
+	notifyCellSelectionChanged(selectedCells: ICellValue[]): void {
 		throw new Error('Method not implemented.');
 	}
 	getQueryRunner(uri: string): QueryRunner {


### PR DESCRIPTION
This PR fixes #14868 

1. The query result selection failed to parse the numbers that are formatted based on current locale. the formatting is done inside the SQL tools service (.NET core), and the original values(culture invariant) are also passed to ADS. instead of using the cell's display value, I am changing it to prefer the cultureInvariantDisplayValue when doing the selection summary calculation.
2. also fixes the issue that when filtered the selection summary still shows the numbers for the values of the original data set.

![image](https://user-images.githubusercontent.com/13777222/116167847-06023a00-a6b6-11eb-8108-77975b37d157.png)


NOTE: 
1. we are still not handling the values that are not number/decimal typed when returned by SQL Server, for example, if you have a string typed cell display value: '1,2', it will not be recognized as a valid number. extra work of bringing in globalization packages is needed, we will consider doing it when there are a lot of user requests.
2. the numbers in the status bar will be displayed in a culture invariant way.