### PR TITLE
Fix dipose "method not implemented" errors in MainThread API classes

### DIFF
--- a/src/sql/workbench/api/browser/mainThreadDashboardWebview.ts
+++ b/src/sql/workbench/api/browser/mainThreadDashboardWebview.ts
@@ -7,9 +7,10 @@ import { MainThreadDashboardWebviewShape, SqlMainContext, ExtHostDashboardWebvie
 import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { IExtHostContext } from 'vs/workbench/api/common/extHost.protocol';
 import { IDashboardViewService, IDashboardWebview } from 'sql/platform/dashboard/browser/dashboardViewService';
+import { Disposable } from 'vs/base/common/lifecycle';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadDashboardWebview)
-export class MainThreadDashboardWebview implements MainThreadDashboardWebviewShape {
+export class MainThreadDashboardWebview extends Disposable implements MainThreadDashboardWebviewShape {
 
 	private static _handlePool = 0;
 	private readonly _proxy: ExtHostDashboardWebviewsShape;
@@ -21,8 +22,9 @@ export class MainThreadDashboardWebview implements MainThreadDashboardWebviewSha
 		context: IExtHostContext,
 		@IDashboardViewService viewService: IDashboardViewService
 	) {
+		super();
 		this._proxy = context.getProxy(SqlExtHostContext.ExtHostDashboardWebviews);
-		viewService.onRegisteredWebview(e => {
+		this._register(viewService.onRegisteredWebview(e => {
 			if (this.knownWidgets.find(x => x === e.id)) {
 				let handle = MainThreadDashboardWebview._handlePool++;
 				this._dialogs.set(handle, e);
@@ -31,11 +33,7 @@ export class MainThreadDashboardWebview implements MainThreadDashboardWebviewSha
 					this._proxy.$onMessage(handle, e);
 				});
 			}
-		});
-	}
-
-	public dispose(): void {
-		throw new Error('Method not implemented.');
+		}));
 	}
 
 	$sendMessage(handle: number, message: string) {

--- a/src/sql/workbench/api/browser/mainThreadModalDialog.ts
+++ b/src/sql/workbench/api/browser/mainThreadModalDialog.ts
@@ -11,9 +11,10 @@ import { MainThreadModalDialogShape, SqlMainContext, SqlExtHostContext, ExtHostM
 import { IExtHostContext } from 'vs/workbench/api/common/extHost.protocol';
 import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { Disposable } from 'vs/base/common/lifecycle';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadModalDialog)
-export class MainThreadModalDialog implements MainThreadModalDialogShape {
+export class MainThreadModalDialog extends Disposable implements MainThreadModalDialogShape {
 	private readonly _proxy: ExtHostModalDialogsShape;
 	private readonly _dialogs = new Map<number, WebViewDialog>();
 
@@ -21,11 +22,8 @@ export class MainThreadModalDialog implements MainThreadModalDialogShape {
 		context: IExtHostContext,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService
 	) {
+		super();
 		this._proxy = context.getProxy(SqlExtHostContext.ExtHostModalDialogs);
-	}
-
-	dispose(): void {
-		throw new Error('Method not implemented.');
 	}
 
 	$createDialog(handle: number): void {

--- a/src/sql/workbench/api/browser/mainThreadModelViewDialog.ts
+++ b/src/sql/workbench/api/browser/mainThreadModelViewDialog.ts
@@ -20,9 +20,10 @@ import { assign } from 'vs/base/common/objects';
 import { TelemetryView, TelemetryAction } from 'sql/platform/telemetry/common/telemetryKeys';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { IEditorInput, IEditorPane } from 'vs/workbench/common/editor';
+import { Disposable } from 'vs/base/common/lifecycle';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadModelViewDialog)
-export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape {
+export class MainThreadModelViewDialog extends Disposable implements MainThreadModelViewDialogShape {
 	private readonly _proxy: ExtHostModelViewDialogShape;
 	private readonly _dialogs = new Map<number, Dialog>();
 	private readonly _tabs = new Map<number, DialogTab>();
@@ -40,12 +41,9 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 		@IEditorService private _editorService: IEditorService,
 		@IAdsTelemetryService private _telemetryService: IAdsTelemetryService
 	) {
+		super();
 		this._proxy = context.getProxy(SqlExtHostContext.ExtHostModelViewDialog);
 		this._dialogService = new CustomDialogService(_instatiationService);
-	}
-
-	public dispose(): void {
-		throw new Error('Method not implemented.');
 	}
 
 	public $openEditor(handle: number, modelViewId: string, title: string, name?: string, options?: azdata.ModelViewEditorOptions, position?: vscode.ViewColumn): Thenable<void> {

--- a/src/sql/workbench/api/browser/mainThreadTasks.ts
+++ b/src/sql/workbench/api/browser/mainThreadTasks.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
-import { IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 import { IExtHostContext } from 'vs/workbench/api/common/extHost.protocol';
 
 import {
@@ -20,23 +20,21 @@ import { ConnectionProfile } from 'sql/platform/connection/common/connectionProf
 import { TaskRegistry } from 'sql/workbench/services/tasks/browser/tasksRegistry';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadTasks)
-export class MainThreadTasks implements MainThreadTasksShape {
+export class MainThreadTasks extends Disposable implements MainThreadTasksShape {
 
 	private readonly _disposables = new Map<string, IDisposable>();
-	private readonly _generateCommandsDocumentationRegistration: IDisposable;
 	private readonly _proxy: ExtHostTasksShape;
 
 	constructor(
 		extHostContext: IExtHostContext
 	) {
+		super();
 		this._proxy = extHostContext.getProxy(SqlExtHostContext.ExtHostTasks);
 	}
 
 	dispose() {
 		this._disposables.forEach(value => value.dispose());
 		this._disposables.clear();
-
-		this._generateCommandsDocumentationRegistration.dispose();
 	}
 
 	$registerTask(id: string): Promise<any> {


### PR DESCRIPTION
With the latest VS Code merge the extension host is now shut down at the end of a test run, which is then causing a bunch of errors similar to this to appear 

```
Method not implemented.: Error: Method not implemented.
    at MainThreadModelViewDialog.dispose (file:///C:/src/AzureDataStudio/out/sql/workbench/api/browser/mainThreadModelViewDialog.js:35:19) [<root>]
    at ExtensionHostManager.dispose (file:///C:/src/AzureDataStudio/out/vs/workbench/services/extensions/common/extensionHostManager.js:61:30) [<root>]
    at ExtensionService._stopExtensionHosts (file:///C:/src/AzureDataStudio/out/vs/workbench/services/extensions/common/abstractExtensionService.js:324:25) [<root>]
    at ExtensionService._onExtensionHostExit (file:///C:/src/AzureDataStudio/out/vs/workbench/services/extensions/electron-browser/extensionService.js:291:18) [<root>]
    at MainThreadExtensionService.$onExtensionHostExit (file:///C:/src/AzureDataStudio/out/vs/workbench/api/browser/mainThreadExtensionService.js:110:36) [<root>]
```
    
They don't seem to cause any actual issues (the tests still pass) but there's no reason these functions should throw.

Ideally they should actually be cleaning up all the resources that they're in charge of - but that gets tricky with things like editors. So I opted to just make most of them a no-op with a few exceptions that were easy to fix, and then if we run into issues later we can fix them at that point. 