### PR TITLE
Add back open view keybindings

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet.ts
@@ -40,6 +40,7 @@ import { URI } from 'vs/base/common/uri';
 import { TreeViewPane } from 'vs/workbench/browser/parts/views/treeView';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 
 export const VIEWLET_ID = 'workbench.view.notebooks';
 
@@ -435,6 +436,11 @@ export const NOTEBOOK_VIEW_CONTAINER = Registry.as<IViewContainersRegistry>(View
 	id: VIEWLET_ID,
 	title: localize('notebookExplorer.name', "Notebooks"),
 	ctorDescriptor: new SyncDescriptor(NotebookExplorerViewPaneContainer),
+	openCommandActionDescriptor: {
+		id: VIEWLET_ID,
+		keybindings: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_B },
+		order: 0
+	},
 	icon: { id: notebookIconId },
 	order: 6,
 	storageId: `${VIEWLET_ID}.state`

--- a/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
@@ -149,13 +149,6 @@ export class ExplorerViewletViewsContribution extends Disposable implements IWor
 			ctorDescriptor: new SyncDescriptor(ExplorerView),
 			order: 1,
 			canToggleVisibility: false,
-			openCommandActionDescriptor: {
-				id: VIEW_CONTAINER.id,
-				title: localize('explore', "Explorer"),
-				mnemonicTitle: localize({ key: 'miViewExplorer', comment: ['&& denotes a mnemonic'] }, "&&Explorer"),
-				keybindings: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_E },
-				order: 0
-			},
 			focusCommand: {
 				id: 'workbench.explorer.fileView.focus'
 			}
@@ -282,7 +275,14 @@ export const VIEW_CONTAINER: ViewContainer = viewContainerRegistry.registerViewC
 	storageId: 'workbench.explorer.views.state',
 	icon: explorerViewIcon,
 	alwaysUseContainerInfo: true,
-	order: 10 // {{SQL CARBON EDIT}} change order
+	order: 10, // {{SQL CARBON EDIT}} change order
+	openCommandActionDescriptor: {
+		id: VIEWLET_ID,
+		title: localize('explore', "Explorer"),
+		mnemonicTitle: localize({ key: 'miViewExplorer', comment: ['&& denotes a mnemonic'] }, "&&Explorer"),
+		keybindings: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_E },
+		order: 0
+	},
 }, ViewContainerLocation.Sidebar); // {{SQL CARBON EDIT}} not default
 
 const viewsRegistry = Registry.as<IViewsRegistry>(Extensions.ViewsRegistry);


### PR DESCRIPTION
https://github.com/microsoft/azuredatastudio/issues/15251

(The only ones missing keybindings were Notebooks and Explorer)

The explorer fix was taken from https://github.com/microsoft/vscode/commit/c11bf9d7dfd561c618b3793e5cd11e4557767c0d (which was done after our merge point). I'm not exactly sure why this change was necessary - it's possible that this was a bug in VS Code too at the merge point we picked up. Didn't see the need to dig into it though since this fixes the issue and is something we'll pick up in the future anyways. 

![image](https://user-images.githubusercontent.com/28519865/116451719-b59fef00-a811-11eb-8b24-d780228440f9.png)

![image](https://user-images.githubusercontent.com/28519865/116452499-a4a3ad80-a812-11eb-94d4-f8555afe1f2f.png)

![image](https://user-images.githubusercontent.com/28519865/116452556-b38a6000-a812-11eb-9872-5d372e5e9053.png)