### PR TITLE
Add webpack config for localization

### DIFF
--- a/extensions/admin-tool-ext-win/.vscodeignore
+++ b/extensions/admin-tool-ext-win/.vscodeignore
@@ -1,8 +1,9 @@
-coverage
-out/test
-src
 .gitignore
-coverConfig.json
+src/**
+out/**
+extension.webpack.config.js
 tsconfig.json
-cgmanifest.json
-.vscode
+yarn.lock
+coverConfig.json
+*.vsix
+coverage

--- a/extensions/admin-tool-ext-win/extension.webpack.config.js
+++ b/extensions/admin-tool-ext-win/extension.webpack.config.js
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../shared.webpack.config');
+
+const externals = {
+	'applicationinsights-native-metrics': 'commonjs applicationinsights-native-metrics',
+	'@opentelemetry/tracing': 'commonjs @opentelemetry/tracing'
+};
+
+module.exports = withDefaults({
+	context: __dirname,
+	entry: {
+		main: './src/main.ts'
+	},
+	externals: externals
+});

--- a/extensions/agent/.vscodeignore
+++ b/extensions/agent/.vscodeignore
@@ -1,5 +1,9 @@
-src
-out/test
+.gitignore
+src/**
+out/**
+extension.webpack.config.js
 tsconfig.json
-coverage
+yarn.lock
 coverConfig.json
+*.vsix
+coverage

--- a/extensions/agent/extension.webpack.config.js
+++ b/extensions/agent/extension.webpack.config.js
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../shared.webpack.config');
+
+module.exports = withDefaults({
+	context: __dirname,
+	entry: {
+		main: './src/main.ts'
+	}
+});

--- a/extensions/cms/.vscodeignore
+++ b/extensions/cms/.vscodeignore
@@ -1,5 +1,9 @@
-out/test
-src
+.gitignore
+src/**
+out/**
+extension.webpack.config.js
 tsconfig.json
-coverage
+yarn.lock
 coverConfig.json
+*.vsix
+coverage

--- a/extensions/cms/extension.webpack.config.js
+++ b/extensions/cms/extension.webpack.config.js
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../shared.webpack.config');
+
+module.exports = withDefaults({
+	context: __dirname,
+	entry: {
+		extension: './src/extension.ts'
+	}
+});

--- a/extensions/dacpac/.vscodeignore
+++ b/extensions/dacpac/.vscodeignore
@@ -1,5 +1,9 @@
-coverage
-coverageConfig.json
-src
-out/test
+.gitignore
+src/**
+out/**
+extension.webpack.config.js
 tsconfig.json
+yarn.lock
+coverConfig.json
+*.vsix
+coverage

--- a/extensions/dacpac/extension.webpack.config.js
+++ b/extensions/dacpac/extension.webpack.config.js
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../shared.webpack.config');
+
+const externals = {
+	'applicationinsights-native-metrics': 'commonjs applicationinsights-native-metrics',
+	'@opentelemetry/tracing': 'commonjs @opentelemetry/tracing'
+};
+
+module.exports = withDefaults({
+	context: __dirname,
+	entry: {
+		extension: './src/extension.ts'
+	},
+	externals: externals
+});

--- a/extensions/import/.vscodeignore
+++ b/extensions/import/.vscodeignore
@@ -1,3 +1,9 @@
-src/**
-tsconfig.json
 .gitignore
+src/**
+out/**
+extension.webpack.config.js
+tsconfig.json
+yarn.lock
+coverConfig.json
+*.vsix
+coverage

--- a/extensions/import/extension.webpack.config.js
+++ b/extensions/import/extension.webpack.config.js
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../shared.webpack.config');
+
+const externals = {
+	'applicationinsights-native-metrics': 'commonjs applicationinsights-native-metrics',
+	'@opentelemetry/tracing': 'commonjs @opentelemetry/tracing'
+};
+
+module.exports = withDefaults({
+	context: __dirname,
+	entry: {
+		main: './src/main.ts'
+	},
+	externals: externals
+});

--- a/extensions/profiler/.vscodeignore
+++ b/extensions/profiler/.vscodeignore
@@ -1,2 +1,8 @@
+.gitignore
 client/src/**
+client/out/**
+extension.webpack.config.js
 client/tsconfig.json
+yarn.lock
+*.vsix
+coverage

--- a/extensions/profiler/extension.webpack.config.js
+++ b/extensions/profiler/extension.webpack.config.js
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../shared.webpack.config');
+
+module.exports = withDefaults({
+	context: __dirname,
+	entry: {
+		main: './client/src/main.ts'
+	}
+});

--- a/extensions/schema-compare/.vscodeignore
+++ b/extensions/schema-compare/.vscodeignore
@@ -1,5 +1,9 @@
-src
-out/test
+.gitignore
+src/**
+out/**
+extension.webpack.config.js
 tsconfig.json
-coverage
+yarn.lock
 coverConfig.json
+*.vsix
+coverage

--- a/extensions/schema-compare/extension.webpack.config.js
+++ b/extensions/schema-compare/extension.webpack.config.js
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../shared.webpack.config');
+
+const externals = {
+	'applicationinsights-native-metrics': 'commonjs applicationinsights-native-metrics',
+	'@opentelemetry/tracing': 'commonjs @opentelemetry/tracing'
+};
+
+module.exports = withDefaults({
+	context: __dirname,
+	entry: {
+		extension: './src/extension.ts'
+	},
+	externals: externals
+});


### PR DESCRIPTION
As part of localization, the code checks to see if an extension includes a webpack.config file, if it does it is marked as a bundled extension then creates a dist folder from the source folder and it also allows for localization of any source file located in the dist folder. If this file is absent, the files in the source folders are not processed at all. 

More recent extensions include this file and their contents are processed properly. 

This PR adds the required webpack.config files as well as updating the vscode ignore files to better reflect the current contents of the extension folder.