### PR TITLE
Use a different config name for connection sorting

### DIFF
--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -16,9 +16,9 @@ import { deepClone } from 'vs/base/common/objects';
 
 export const GROUPS_CONFIG_KEY = 'datasource.connectionGroups';
 export const CONNECTIONS_CONFIG_KEY = 'datasource.connections';
-export const CONNECTIONS_SORT_BY_CONFIG_KEY = 'datasource.connectionsSortBy';
+export const CONNECTIONS_SORT_BY_CONFIG_KEY = 'datasource.connectionsSortOrder';
 
-export const enum ConnectionsSortBy {
+export const enum ConnectionsSortOrder {
 	dateAdded = 'dateAdded',
 	displayName = 'displayName'
 }
@@ -59,7 +59,7 @@ export class ConnectionConfig {
 		const sortBy = this.configurationService.getValue<string>(CONNECTIONS_SORT_BY_CONFIG_KEY);
 		let sortFunc: (a: IConnectionProfileGroup, b: IConnectionProfileGroup) => number;
 
-		if (sortBy === ConnectionsSortBy.displayName) {
+		if (sortBy === ConnectionsSortOrder.displayName) {
 			sortFunc = ((a, b) => {
 				if (a.name < b.name) {
 					return -1;
@@ -243,7 +243,7 @@ export class ConnectionConfig {
 		const sortBy = this.configurationService.getValue<string>(CONNECTIONS_SORT_BY_CONFIG_KEY);
 		let sortFunc: (a: ConnectionProfile, b: ConnectionProfile) => number;
 
-		if (sortBy === ConnectionsSortBy.displayName) {
+		if (sortBy === ConnectionsSortOrder.displayName) {
 			sortFunc = ((a, b) => {
 				if (a.title < b.title) {
 					return -1;

--- a/src/sql/platform/connection/common/connectionConfig.ts
+++ b/src/sql/platform/connection/common/connectionConfig.ts
@@ -16,7 +16,7 @@ import { deepClone } from 'vs/base/common/objects';
 
 export const GROUPS_CONFIG_KEY = 'datasource.connectionGroups';
 export const CONNECTIONS_CONFIG_KEY = 'datasource.connections';
-export const CONNECTIONS_SORT_BY_CONFIG_KEY = 'datasource.connections.sortBy';
+export const CONNECTIONS_SORT_BY_CONFIG_KEY = 'datasource.connectionsSortBy';
 
 export const enum ConnectionsSortBy {
 	dateAdded = 'dateAdded',

--- a/src/sql/platform/connection/test/common/connectionConfig.test.ts
+++ b/src/sql/platform/connection/test/common/connectionConfig.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as azdata from 'azdata';
 import { ProviderFeatures } from 'sql/platform/capabilities/common/capabilitiesService';
-import { ConnectionConfig, ISaveGroupResult, CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy } from 'sql/platform/connection/common/connectionConfig';
+import { ConnectionConfig, ISaveGroupResult, CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortOrder } from 'sql/platform/connection/common/connectionConfig';
 import { ConnectionProfile } from 'sql/platform/connection/common/connectionProfile';
 import { ConnectionProfileGroup, IConnectionProfileGroup } from 'sql/platform/connection/common/connectionProfileGroup';
 import { IConnectionProfile, IConnectionProfileStore, ConnectionOptionSpecialType, ServiceOptionType } from 'sql/platform/connection/common/interfaces';
@@ -239,11 +239,11 @@ suite('ConnectionConfig', () => {
 		assert.ok(groupsAreEqual(allGroups, testGroups), 'the groups returned did not match expectation');
 	});
 
-	test('getAllGroups should return groups sorted alphabetically by display name given datasource.connectionsSortBy is set to \'' + ConnectionsSortBy.displayName + '\'', () => {
+	test('getAllGroups should return groups sorted alphabetically by display name given datasource.connectionsSortOrder is set to \'' + ConnectionsSortOrder.displayName + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(0, 3), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(2, testGroups.length), ConfigurationTarget.WORKSPACE);
-		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy.displayName, ConfigurationTarget.USER);
+		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortOrder.displayName, ConfigurationTarget.USER);
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allGroups = config.getAllGroups();
@@ -253,11 +253,11 @@ suite('ConnectionConfig', () => {
 		assert.ok(allGroups.slice(1).every((item, i) => allGroups[i].name <= item.name), 'the groups are not sorted correctly');
 	});
 
-	test('getAllGroups should return groups sorted by date added given datasource.connectionsSortBy is set to \'' + ConnectionsSortBy.dateAdded + '\'', () => {
+	test('getAllGroups should return groups sorted by date added given datasource.connectionsSortOrder is set to \'' + ConnectionsSortOrder.dateAdded + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(0, 3).reverse(), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(2, testGroups.length).reverse(), ConfigurationTarget.WORKSPACE);
-		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy.dateAdded, ConfigurationTarget.USER);
+		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortOrder.dateAdded, ConfigurationTarget.USER);
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allGroups = config.getAllGroups();
@@ -411,11 +411,11 @@ suite('ConnectionConfig', () => {
 		});
 	});
 
-	test('getConnections should return connections sorted alphabetically by title given datasource.connectionsSortBy is set to \'' + ConnectionsSortBy.displayName + '\'', () => {
+	test('getConnections should return connections sorted alphabetically by title given datasource.connectionsSortOrder is set to \'' + ConnectionsSortOrder.displayName + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(0, 2).reverse(), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(2, testConnections.length).reverse(), ConfigurationTarget.WORKSPACE);
-		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy.displayName, ConfigurationTarget.USER);
+		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortOrder.displayName, ConfigurationTarget.USER);
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(true);
@@ -423,10 +423,10 @@ suite('ConnectionConfig', () => {
 		assert.ok(allConnections.slice(1).every((item, i) => allConnections[i].title <= item.title), 'The connections are not sorted correctly');
 	});
 
-	test('getConnections should return connections sorted by date added given datasource.connectionsSortBy is set to \'' + ConnectionsSortBy.dateAdded + '\'', () => {
+	test('getConnections should return connections sorted by date added given datasource.connectionsSortOrder is set to \'' + ConnectionsSortOrder.dateAdded + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).reverse(), ConfigurationTarget.USER);
-		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy.dateAdded, ConfigurationTarget.USER);
+		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortOrder.dateAdded, ConfigurationTarget.USER);
 
 		let config = new ConnectionConfig(configurationService, capabilitiesService.object);
 		let allConnections = config.getConnections(false);

--- a/src/sql/platform/connection/test/common/connectionConfig.test.ts
+++ b/src/sql/platform/connection/test/common/connectionConfig.test.ts
@@ -239,7 +239,7 @@ suite('ConnectionConfig', () => {
 		assert.ok(groupsAreEqual(allGroups, testGroups), 'the groups returned did not match expectation');
 	});
 
-	test('getAllGroups should return groups sorted alphabetically by display name given datasource.connections.sortBy is set to \'' + ConnectionsSortBy.displayName + '\'', () => {
+	test('getAllGroups should return groups sorted alphabetically by display name given datasource.connectionsSortBy is set to \'' + ConnectionsSortBy.displayName + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(0, 3), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(2, testGroups.length), ConfigurationTarget.WORKSPACE);
@@ -253,7 +253,7 @@ suite('ConnectionConfig', () => {
 		assert.ok(allGroups.slice(1).every((item, i) => allGroups[i].name <= item.name), 'the groups are not sorted correctly');
 	});
 
-	test('getAllGroups should return groups sorted by date added given datasource.connections.sortBy is set to \'' + ConnectionsSortBy.dateAdded + '\'', () => {
+	test('getAllGroups should return groups sorted by date added given datasource.connectionsSortBy is set to \'' + ConnectionsSortBy.dateAdded + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(0, 3).reverse(), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connectionGroups', deepClone(testGroups).slice(2, testGroups.length).reverse(), ConfigurationTarget.WORKSPACE);
@@ -411,7 +411,7 @@ suite('ConnectionConfig', () => {
 		});
 	});
 
-	test('getConnections should return connections sorted alphabetically by title given datasource.connections.sortBy is set to \'' + ConnectionsSortBy.displayName + '\'', () => {
+	test('getConnections should return connections sorted alphabetically by title given datasource.connectionsSortBy is set to \'' + ConnectionsSortBy.displayName + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(0, 2).reverse(), ConfigurationTarget.USER);
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).slice(2, testConnections.length).reverse(), ConfigurationTarget.WORKSPACE);
@@ -423,7 +423,7 @@ suite('ConnectionConfig', () => {
 		assert.ok(allConnections.slice(1).every((item, i) => allConnections[i].title <= item.title), 'The connections are not sorted correctly');
 	});
 
-	test('getConnections should return connections sorted by date added given datasource.connections.sortBy is set to \'' + ConnectionsSortBy.dateAdded + '\'', () => {
+	test('getConnections should return connections sorted by date added given datasource.connectionsSortBy is set to \'' + ConnectionsSortBy.dateAdded + '\'', () => {
 		let configurationService = new TestConfigurationService();
 		configurationService.updateValue('datasource.connections', deepClone(testConnections).reverse(), ConfigurationTarget.USER);
 		configurationService.updateValue(CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy.dateAdded, ConfigurationTarget.USER);

--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
@@ -35,8 +35,8 @@ configurationRegistry.registerConfiguration({
 			'type': 'string',
 			'enum': [ConnectionsSortBy.dateAdded, ConnectionsSortBy.displayName],
 			'enumDescriptions': [
-				localize('connections.sortBy.dateAdded', 'Saved connections are sorted by the dates they were added.'),
-				localize('connections.sortBy.displayName', 'Saved connections are sorted by their display names alphabetically.')
+				localize('connectionsSortBy.dateAdded', 'Saved connections are sorted by the dates they were added.'),
+				localize('connectionsSortBy.displayName', 'Saved connections are sorted by their display names alphabetically.')
 			],
 			'default': ConnectionsSortBy.dateAdded,
 			'description': localize('datasource.connections.sortBy', "Order used for sorting saved connections and connection groups")

--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
@@ -39,7 +39,7 @@ configurationRegistry.registerConfiguration({
 				localize('connectionsSortBy.displayName', 'Saved connections are sorted by their display names alphabetically.')
 			],
 			'default': ConnectionsSortBy.dateAdded,
-			'description': localize('datasource.connections.sortBy', "Order used for sorting saved connections and connection groups")
+			'description': localize('datasource.connectionsSortBy', "Order used for sorting saved connections and connection groups")
 		}
 	}
 });

--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorer.contribution.ts
@@ -11,7 +11,7 @@ import { Extensions, IConfigurationRegistry } from 'vs/platform/configuration/co
 import { DataExplorerContainerExtensionHandler } from 'sql/workbench/contrib/dataExplorer/browser/dataExplorerExtensionPoint';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 import { DataExplorerViewletViewsContribution } from 'sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet';
-import { GROUPS_CONFIG_KEY, CONNECTIONS_CONFIG_KEY, CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortBy } from 'sql/platform/connection/common/connectionConfig';
+import { GROUPS_CONFIG_KEY, CONNECTIONS_CONFIG_KEY, CONNECTIONS_SORT_BY_CONFIG_KEY, ConnectionsSortOrder } from 'sql/platform/connection/common/connectionConfig';
 
 const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 workbenchRegistry.registerWorkbenchContribution(DataExplorerViewletViewsContribution, LifecyclePhase.Starting);
@@ -33,13 +33,13 @@ configurationRegistry.registerConfiguration({
 		},
 		[CONNECTIONS_SORT_BY_CONFIG_KEY]: {
 			'type': 'string',
-			'enum': [ConnectionsSortBy.dateAdded, ConnectionsSortBy.displayName],
+			'enum': [ConnectionsSortOrder.dateAdded, ConnectionsSortOrder.displayName],
 			'enumDescriptions': [
-				localize('connectionsSortBy.dateAdded', 'Saved connections are sorted by the dates they were added.'),
-				localize('connectionsSortBy.displayName', 'Saved connections are sorted by their display names alphabetically.')
+				localize('connectionsSortOrder.dateAdded', 'Saved connections are sorted by the dates they were added.'),
+				localize('connectionsSortOrder.displayName', 'Saved connections are sorted by their display names alphabetically.')
 			],
-			'default': ConnectionsSortBy.dateAdded,
-			'description': localize('datasource.connectionsSortBy', "Order used for sorting saved connections and connection groups")
+			'default': ConnectionsSortOrder.dateAdded,
+			'description': localize('datasource.connectionsSortOrder', "Controls sorting order of saved connections and connection groups.")
 		}
 	}
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15272 by using a different config name for connection sorting. The original implementation was in #15229 .