### PR TITLE
fix smoke test failure

### DIFF
--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -299,6 +299,7 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	if (opts.log) {
 		beforeEach(async function () {
 			console.log('Entering test setup...');
+			console.log(this);
 			console.log(this.app);
 			const app = this.app as Application;
 			const title = this.currentTest!.fullTitle();
@@ -312,33 +313,30 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	// 		setupDataMigrationTests(opts['stable-build'], testDataPath);
 	// 	});
 	// }
-
-	describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
-		before(async function () {
-			console.log('Entering test suite setup');
-			const app = new Application(this.defaultOptions);
-			await app!.start(opts.web ? false : undefined);
-			this.app = app;
-			console.log('Test suite setup done');
-			console.log(this.app);
-		});
-
-		after(async function () {
-			await this.app.stop();
-		});
-
-		sqlMain(opts.web);
-
-		/* if (!opts.web) { setupDataLossTests(); }
-		if (!opts.web) { setupDataPreferencesTests(); }
-		setupDataSearchTests();
-		setupDataNotebookTests();
-		setupDataLanguagesTests();
-		setupDataEditorTests();
-		setupDataStatusbarTests(!!opts.web);
-		setupDataExtensionTests();
-		if (!opts.web) { setupDataMultirootTests(); }
-		if (!opts.web) { setupDataLocalizationTests(); }
-		if (!opts.web) { setupLaunchTests(); }*/
+	before(async function () {
+		console.log('Entering test suite setup');
+		const app = new Application(this.defaultOptions);
+		await app!.start(opts.web ? false : undefined);
+		this.app = app;
+		console.log('Test suite setup done');
+		console.log(this.app);
 	});
+
+	after(async function () {
+		await this.app.stop();
+	});
+
+	sqlMain(opts.web);
+
+	/* if (!opts.web) { setupDataLossTests(); }
+	if (!opts.web) { setupDataPreferencesTests(); }
+	setupDataSearchTests();
+	setupDataNotebookTests();
+	setupDataLanguagesTests();
+	setupDataEditorTests();
+	setupDataStatusbarTests(!!opts.web);
+	setupDataExtensionTests();
+	if (!opts.web) { setupDataMultirootTests(); }
+	if (!opts.web) { setupDataLocalizationTests(); }
+	if (!opts.web) { setupLaunchTests(); }*/
 });

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -298,9 +298,6 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 
 	if (opts.log) {
 		beforeEach(async function () {
-			console.log('Entering test setup...');
-			console.log(this);
-			console.log(this.app);
 			const app = this.app as Application;
 			const title = this.currentTest!.fullTitle();
 
@@ -314,12 +311,9 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	// 	});
 	// }
 	before(async function () {
-		console.log('Entering test suite setup');
 		const app = new Application(this.defaultOptions);
 		await app!.start(opts.web ? false : undefined);
 		this.app = app;
-		console.log('Test suite setup done');
-		console.log(this.app);
 	});
 
 	after(async function () {

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -310,6 +310,10 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	// 		setupDataMigrationTests(opts['stable-build'], testDataPath);
 	// 	});
 	// }
+
+	// {{SQL CARBON EDIT}} - Remove the nested test suite to make sure the suite setup is also applied to beforeEach and afterEach
+	// describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
+
 	before(async function () {
 		const app = new Application(this.defaultOptions);
 		await app!.start(opts.web ? false : undefined);
@@ -333,4 +337,5 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	if (!opts.web) { setupDataMultirootTests(); }
 	if (!opts.web) { setupDataLocalizationTests(); }
 	if (!opts.web) { setupLaunchTests(); }*/
+	// });
 });

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -298,6 +298,8 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 
 	if (opts.log) {
 		beforeEach(async function () {
+			console.log('Entering test setup...');
+			console.log(this.app);
 			const app = this.app as Application;
 			const title = this.currentTest!.fullTitle();
 
@@ -313,9 +315,12 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 
 	describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 		before(async function () {
+			console.log('Entering test suite setup');
 			const app = new Application(this.defaultOptions);
 			await app!.start(opts.web ? false : undefined);
 			this.app = app;
+			console.log('Test suite setup done');
+			console.log(this.app);
 		});
 
 		after(async function () {


### PR DESCRIPTION
This PR fixes #15268 

Not sure how does vscode run their smoke test, that seems to be a bad merge on their side that they have nested test suite with same name, the issue is beforeEach and before have different context (this) because they are created in different suite, the parent suite's beforeEach doesn't have `app` property in its context. 

fix:

remove the unnecessary nested test suite so that all the setup are done within the same context (this object).
