### PR TITLE
error handling for browse azure resources

### DIFF
--- a/extensions/azurecore/src/azureResource/tree/flatAccountTreeNode.ts
+++ b/extensions/azurecore/src/azureResource/tree/flatAccountTreeNode.ts
@@ -16,7 +16,6 @@ import { TreeNode } from '../treeNode';
 import { AzureResourceCredentialError } from '../errors';
 import { AzureResourceContainerTreeNodeBase } from './baseTreeNodes';
 import { AzureResourceItemType, AzureResourceServiceNames } from '../constants';
-import { AzureResourceMessageTreeNode } from '../messageTreeNode';
 import { IAzureResourceTreeChangeHandler } from './treeChangeHandler';
 import { IAzureResourceSubscriptionService, IAzureResourceSubscriptionFilterService } from '../../azureResource/interfaces';
 import { AzureAccount } from 'azurecore';

--- a/extensions/azurecore/src/azureResource/tree/flatAccountTreeNode.ts
+++ b/extensions/azurecore/src/azureResource/tree/flatAccountTreeNode.ts
@@ -223,7 +223,10 @@ class FlatAccountTreeNodeLoader {
 			if (error instanceof AzureResourceCredentialError) {
 				vscode.commands.executeCommand('azure.resource.signin');
 			}
-			this._nodes = [AzureResourceMessageTreeNode.create(AzureResourceErrorMessageUtil.getErrorMessage(error), this._accountNode)];
+			// http status code 429 means "too many requests"
+			// use a custom error message for azure resource graph api throttling error to make it more actionable for users.
+			const errorMessage = error?.statusCode === 429 ? localize('azure.resource.throttleerror', "Requests from this account have been throttled. To retry, please select a smaller number of subscriptions.") : AzureResourceErrorMessageUtil.getErrorMessage(error);
+			vscode.window.showErrorMessage(localize('azure.resource.tree.loadresourceerror', "An error occured while loading Azure resources: {0}", errorMessage));
 		}
 
 		this._isLoading = false;


### PR DESCRIPTION
this is based on a discussion with Karl/Jared/Alan Yu yesterday.

1. leave the resources that have already been loaded when error occurs and show a toast notification for the error.
2. have a custom error message for throttling exception to make it more actionable for users

before
![image](https://user-images.githubusercontent.com/13777222/116354695-a2f3ce80-a7ad-11eb-984b-3ef8b82fe265.png)

after
![image](https://user-images.githubusercontent.com/13777222/116622393-7c42ae80-a8f9-11eb-83f5-7747a4fa3b1b.png)

