### PR TITLE
Adjust icon badge size

### DIFF
--- a/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
@@ -168,13 +168,13 @@
 
 /* Connected badge */
 .monaco-list .connection-tile .connection-status-badge.connected {
-	border: 0.12rem solid rgba(59, 180, 74, 100%);
+	border: 0.15rem solid rgba(59, 180, 74, 100%);
 	background: rgba(59, 180, 74, 100%);
 }
 
 /* Disconnected badge */
 .monaco-list .connection-tile .connection-status-badge.disconnected {
-	border: 0.12rem solid rgba(208, 46, 0, 100%);
+	border: 0.15rem solid rgba(208, 46, 0, 100%);
 	background: rgba(255, 255, 255, 80%);
 }
 

--- a/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
+++ b/src/sql/workbench/contrib/dataExplorer/browser/media/connectionViewletPanel.css
@@ -168,13 +168,13 @@
 
 /* Connected badge */
 .monaco-list .connection-tile .connection-status-badge.connected {
-	border: 0.15rem solid rgba(59, 180, 74, 100%);
+	border: 2.4px solid rgba(59, 180, 74, 100%);
 	background: rgba(59, 180, 74, 100%);
 }
 
 /* Disconnected badge */
 .monaco-list .connection-tile .connection-status-badge.disconnected {
-	border: 0.15rem solid rgba(208, 46, 0, 100%);
+	border: 2.4px solid rgba(208, 46, 0, 100%);
 	background: rgba(255, 255, 255, 80%);
 }
 

--- a/src/sql/workbench/services/objectExplorer/browser/iconRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/iconRenderer.ts
@@ -71,7 +71,7 @@ class BadgeRenderer {
 			width: 0.25rem;
 			top: 14px;
 			left: 19px;
-			border: 0.12rem solid ${circleColor};
+			border: 0.15rem solid ${circleColor};
 			border-radius: 100%;
 			background: ${bgColor};
 			content:"";

--- a/src/sql/workbench/services/objectExplorer/browser/iconRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/iconRenderer.ts
@@ -71,7 +71,7 @@ class BadgeRenderer {
 			width: 0.25rem;
 			top: 14px;
 			left: 19px;
-			border: 0.15rem solid ${circleColor};
+			border: 2.4px solid ${circleColor};
 			border-radius: 100%;
 			background: ${bgColor};
 			content:"";


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/15254

Fixed for both the default and asyncTree

Earlier -

![Screen Shot 2021-04-29 at 4 35 17 PM](https://user-images.githubusercontent.com/6411451/116631134-591ffb00-a909-11eb-86a7-d5feae822062.png)

After change -

![Screen Shot 2021-04-29 at 4 35 01 PM](https://user-images.githubusercontent.com/6411451/116631140-5d4c1880-a909-11eb-8710-f5c88a11f9b9.png)

The connected scenario (green badge) looks the same.