### PR TITLE
fix action label vertical alignment issue

### DIFF
--- a/src/sql/workbench/services/connection/browser/media/connectionBrowseTab.css
+++ b/src/sql/workbench/services/connection/browser/media/connectionBrowseTab.css
@@ -72,3 +72,7 @@
 .connection-dialog .monaco-list .monaco-list-row:hover .actions {
 	display: block;
 }
+
+.connection-dialog .monaco-list .monaco-list-row .actions .action-label {
+	display: flex;
+}


### PR DESCRIPTION
caused by recent vscode merge, I didn't really spend time digging into what might have happened.
before
![image](https://user-images.githubusercontent.com/13777222/116632881-f9c3ea00-a90c-11eb-89ed-2b31949ec52f.png)
after
![image](https://user-images.githubusercontent.com/13777222/116632902-047e7f00-a90d-11eb-8264-490e73e8a0d4.png)

