### PR TITLE
Fix for gulp remote in extensions.ts

### DIFF
--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -201,6 +201,7 @@ const baseHeaders = {
 };
 
 export function fromMarketplace(extensionName: string, version: string, metadata: any): Stream {
+	const remote = require('gulp-remote-retry-src');
 	const json = require('gulp-json-editor') as typeof import('gulp-json-editor');
 
 	const [, name] = extensionName.split('.');


### PR DESCRIPTION
Recently with the vscode merge, the build/lib folder no longer properly builds. In addition there's a missing import that is removed in the extensions.ts file, but appears in its corresponding json file. This PR adds it back in, as its found in the main vscode branch as well.
