### PR TITLE
fix secrets api issue

### DIFF
--- a/src/sql/platform/credentials/common/credentialsService.ts
+++ b/src/sql/platform/credentials/common/credentialsService.ts
@@ -8,7 +8,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 import * as azdata from 'azdata';
 import { Deferred } from 'sql/base/common/promise';
 
-export const SERVICE_ID = 'credentialsService';
+export const SERVICE_ID = 'sqlCredentialsService';
 
 export interface CredentialManagementEvents {
 	onSaveCredential(credentialId: string, password: string): Thenable<boolean>;

--- a/src/vs/workbench/api/browser/mainThreadSecretState.ts
+++ b/src/vs/workbench/api/browser/mainThreadSecretState.ts
@@ -8,11 +8,11 @@ import { IProductService } from 'vs/platform/product/common/productService';
 import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { ICredentialsService } from 'vs/workbench/services/credentials/common/credentials';
 import { IEncryptionService } from 'vs/workbench/services/encryption/common/encryptionService';
-import { IExtHostContext, MainContext, MainThreadSecretStateShape } from '../common/extHost.protocol';
+import { ExtHostContext, ExtHostSecretStateShape, IExtHostContext, MainContext, MainThreadSecretStateShape } from '../common/extHost.protocol';
 
 @extHostNamedCustomer(MainContext.MainThreadSecretState)
 export class MainThreadSecretState extends Disposable implements MainThreadSecretStateShape {
-	// private readonly _proxy: ExtHostSecretStateShape;
+	private readonly _proxy: ExtHostSecretStateShape;
 
 	constructor(
 		extHostContext: IExtHostContext,
@@ -21,13 +21,12 @@ export class MainThreadSecretState extends Disposable implements MainThreadSecre
 		@IProductService private readonly productService: IProductService
 	) {
 		super();
-		// this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostSecretState);
+		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostSecretState);
 
-		// {{SQL CARBON EDIT}} - throws null
-		/* this._register(this.credentialsService.onDidChangePassword(e => {
+		this._register(this.credentialsService.onDidChangePassword(e => {
 			const extensionId = e.service.substring(this.productService.urlProtocol.length);
 			this._proxy.$onDidChangePassword({ extensionId, key: e.account });
-		})); */
+		}));
 	}
 
 	private getFullKey(extensionId: string): string {


### PR DESCRIPTION
This PR fixes #15299 

root cause:
the ICredentialsService is newly introduced in VSCode, and ADS also has a ICredentialsService, they happen to use the same ID when registering service singleton. so at run time we are getting the ADS version of the service, that is why we are getting the exception and also the reason Karl has commented out some code during code merge.

the fix is to use a different id, I think eventually we will remove our implementation, but I will leave it to @abist to decide.

tested all the api features with the following code:
![image](https://user-images.githubusercontent.com/13777222/116732596-e4e46680-a99f-11eb-99d6-e13d402acdf2.png)

output
![image](https://user-images.githubusercontent.com/13777222/116732565-d9913b00-a99f-11eb-9ce0-a3eb77a47e49.png)


also tested the connection password retrieval. 