### PR TITLE
Fix for PG parameters table disappearing when trying to reset a value

### DIFF
--- a/extensions/arc/src/common/utils.ts
+++ b/extensions/arc/src/common/utils.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ResourceType } from 'arc';
+import * as azdata from 'azdata';
 import * as azurecore from 'azurecore';
 import * as vscode from 'vscode';
 import { ConnectionMode, IconPath, IconPathHelper } from '../constants';
@@ -298,6 +299,13 @@ export function convertToGibibyteString(value: string): string {
 	}
 
 	return String(floatValue);
+}
+
+/**
+ * Used to confirm if object is an azdata CheckBoxComponent
+ */
+export function instanceOfCheckBox(object: any): object is azdata.CheckBoxComponent {
+	return 'checked' in object;
 }
 
 /*

--- a/extensions/arc/src/test/models/postgresModel.test.ts
+++ b/extensions/arc/src/test/models/postgresModel.test.ts
@@ -462,29 +462,6 @@ describe('PostgresModel', function (): void {
 			should(postgresModel.engineSettingsLastUpdated).be.Date();
 		});
 
-		it('Calls onEngineSettingsUpdated event after populating engine settings', async function (): Promise<void> {
-			const connectionResultMock = TypeMoq.Mock.ofType<azdata.ConnectionResult>();
-			connectionResultMock.setup(x => x.connected).returns(() => true);
-			connectionResultMock.setup((x: any) => x.then).returns(() => undefined);
-			sinon.stub(azdata.connection, 'connect').returns(Promise.resolve(connectionResultMock.object));
-
-			const array: azdata.DbCellValue[][] = [];
-
-			const executeMock = TypeMoq.Mock.ofType<azdata.SimpleExecuteResult>();
-			executeMock.setup(x => x.rows).returns(() => array);
-			executeMock.setup((x: any) => x.then).returns(() => undefined);
-
-			const providerMock = TypeMoq.Mock.ofType<azdata.QueryProvider>();
-			providerMock.setup(x => x.runQueryAndReturn(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(async () => executeMock.object);
-			providerMock.setup((x: any) => x.then).returns(() => undefined);
-			sinon.stub(azdata.dataprotocol, 'getProvider').returns(providerMock.object);
-
-			const onEngineSettingsUpdated = sinon.spy(vscode.EventEmitter.prototype, 'fire');
-
-			await postgresModel.getEngineSettings();
-			sinon.assert.calledOnceWithExactly(onEngineSettingsUpdated, postgresModel.workerNodesEngineSettings);
-		});
-
 		it('Populating engine settings skips certain parameters', async function (): Promise<void> {
 			const connectionResultMock = TypeMoq.Mock.ofType<azdata.ConnectionResult>();
 			connectionResultMock.setup(x => x.connected).returns(() => true);

--- a/extensions/arc/src/ui/dashboards/postgres/postgresParameters.ts
+++ b/extensions/arc/src/ui/dashboards/postgres/postgresParameters.ts
@@ -608,9 +608,11 @@ export abstract class PostgresParametersPage extends DashboardPage {
 		});
 	}
 
+	/**
+	 * Checks if exisiting parameter values needs to be updated.
+	 * Only updates exisiting parameters, will not add/remove parameters from the table.
+	 */
 	private refreshParametersTableValues(): void {
-		//Checks if exisiting parameter values needs to be updated.
-		//Only updates exisiting parameters, will not add/remove parameters from the table.
 		this.engineSettings.map(parameter => {
 			let param = this._parameters.find(p => p.parameterName === parameter.parameterName);
 			if (param) {


### PR DESCRIPTION
This PR is meant to address the issue of the parameters table disappearing after trying to reset a value. 

1.  Instead of repopulating the table every refresh, only values that have been changed get updated within the components
2. Took out calling refresh postgres model after every azdata call since the parameter updates does not depend on the show command
3. Add promise to make sure calling engine settings only happens once at a time. 

This PR fixes #15250 
