### PR TITLE
keep title up to date when connection changes

### DIFF
--- a/src/sql/platform/connection/test/common/testConnectionManagementService.ts
+++ b/src/sql/platform/connection/test/common/testConnectionManagementService.ts
@@ -24,7 +24,6 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 	_serviceBrand: undefined;
 	onAddConnectionProfile = undefined!;
 	onDeleteConnectionProfile = undefined!;
-	onConnectionChanged = undefined!;
 	onLanguageFlavorChanged = undefined!;
 
 	public get onConnect(): Event<any> {
@@ -32,6 +31,10 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 	}
 
 	public get onDisconnect(): Event<any> {
+		return Event.None;
+	}
+
+	public get onConnectionChanged(): Event<any> {
 		return Event.None;
 	}
 

--- a/src/sql/workbench/common/editor/query/queryEditorInput.ts
+++ b/src/sql/workbench/common/editor/query/queryEditorInput.ts
@@ -156,6 +156,10 @@ export abstract class QueryEditorInput extends EditorInput implements IConnectab
 			}
 		}));
 
+		this._register(this.connectionManagementService.onConnectionChanged(e => {
+			this._onDidChangeLabel.fire();
+		}));
+
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectedKeys.indexOf('queryEditor') > -1) {
 				this._onDidChangeLabel.fire();

--- a/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
+++ b/src/sql/workbench/contrib/commandLine/test/electron-browser/commandLine.test.ts
@@ -386,6 +386,7 @@ suite('commandLineService tests', () => {
 			}).verifiable(TypeMoq.Times.once());
 		connectionManagementService.setup(c => c.getConnectionProfileById(TypeMoq.It.isAnyString())).returns(() => originalProfile);
 		connectionManagementService.setup(c => c.onDisconnect).returns(() => Event.None);
+		connectionManagementService.setup(c => c.onConnectionChanged).returns(() => Event.None);
 		connectionManagementService.setup(c => c.ensureDefaultLanguageFlavor(TypeMoq.It.isAny()));
 		const configurationService = getConfigurationServiceMock(true);
 		const querymodelService = TypeMoq.Mock.ofType<IQueryModelService>(TestQueryModelService, TypeMoq.MockBehavior.Strict);

--- a/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
+++ b/src/sql/workbench/contrib/query/test/browser/queryActions.test.ts
@@ -68,6 +68,7 @@ suite('SQL QueryAction Tests', () => {
 		queryModelService.setup(q => q.onRunQueryComplete).returns(() => Event.None);
 		connectionManagementService = TypeMoq.Mock.ofType<TestConnectionManagementService>(TestConnectionManagementService);
 		connectionManagementService.setup(q => q.onDisconnect).returns(() => Event.None);
+		connectionManagementService.setup(q => q.onConnectionChanged).returns(() => Event.None);
 		connectionManagementService.setup(q => q.listDatabases(TypeMoq.It.isAny())).returns(() => Promise.resolve({ databaseNames: ['master', 'msdb', 'model'] }));
 		const workbenchinstantiationService = workbenchInstantiationService();
 		const accessor = workbenchinstantiationService.createInstance(ServiceAccessor);


### PR DESCRIPTION
This PR fixes #15231

fix: subscribe to the connection change event and update the title when connection changes.
