### PR TITLE
Enable run unit tests current file and cleanup launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -140,7 +140,6 @@
 			"type": "pwa-chrome",
 			"request": "launch",
 			"outFiles": [],
-			"outFiles": [],
 			"perScriptSourcemaps": "yes",
 			"name": "VS Code (Web, Chrome)",
 			"url": "http://localhost:8080",
@@ -214,7 +213,7 @@
 				"${workspaceFolder}/out/**/*.js"
 			],
 			"cascadeTerminateToConfigurations": [
-				"Attach to VS Code"
+				"Attach to azuredatastudio"
 			],
 			"env": {
 				"MOCHA_COLORS": "true"
@@ -228,15 +227,15 @@
 			"request": "launch",
 			"name": "Run Unit Tests For Current File",
 			"program": "${workspaceFolder}/test/unit/electron/index.js",
-			"runtimeExecutable": "${workspaceFolder}/.build/electron/Code - OSS.app/Contents/MacOS/Electron",
+			"runtimeExecutable": "${workspaceFolder}/.build/electron/Azure Data Studio.app/Contents/MacOS/Electron",
 			"windows": {
-				"runtimeExecutable": "${workspaceFolder}/.build/electron/Code - OSS.exe"
+				"runtimeExecutable": "${workspaceFolder}/.build/electron/azuredatastudio.exe"
 			},
 			"linux": {
-				"runtimeExecutable": "${workspaceFolder}/.build/electron/code-oss"
+				"runtimeExecutable": "${workspaceFolder}/.build/electron/azuredatastudio"
 			},
 			"cascadeTerminateToConfigurations": [
-				"Attach to VS Code"
+				"Attach to azuredatastudio"
 			],
 			"outputCapture": "std",
 			"args": [
@@ -250,9 +249,6 @@
 			],
 			"env": {
 				"MOCHA_COLORS": "true"
-			},
-			"presentation": {
-				"hidden": true
 			}
 		},
 		{
@@ -355,7 +351,7 @@
 		{
 			"name": "Debug Unit Tests (Current File)",
 			"configurations": [
-				"Attach to VS Code",
+				"Attach to azuredatastudio",
 				"Run Unit Tests For Current File"
 			],
 			"presentation": {


### PR DESCRIPTION
Was looking through launch.json a while back and saw that VS Code had a gulp task for running unit tests in the current file (core only, not extensions). I've wanted similar functionality before, so figured why not fix that to enable it for us too 😄.

Also did some minor cleanup in the launch.json file.