### PR TITLE
Kusto to 0.5.4

### DIFF
--- a/extensions/kusto/config.json
+++ b/extensions/kusto/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.92",
+	"version": "3.0.0-release.99",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",

--- a/extensions/kusto/package.json
+++ b/extensions/kusto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kusto",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "publisher": "Microsoft",
   "aiKey": "AIF-444c3af9-8e69-4462-ab49-4191e6ad1916",
   "activationEvents": [


### PR DESCRIPTION
Bumped sqltoolservice version to 99 for Kusto. Bumped Kusto version to 0.5.4

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR bumps the Kusto version to fix an issue with databases with special characters in the name.