### PR TITLE
add ADS checks back to install extension workflow

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -18,7 +18,7 @@ import { IGalleryExtension, IExtensionGalleryService, INSTALL_ERROR_MALICIOUS, I
 import { IWorkbenchExtensionEnablementService, EnablementState, IExtensionManagementServerService, IExtensionManagementServer, IWorkbenchExtensioManagementService, IWebExtensionsScannerService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
 import { ExtensionRecommendationReason, IExtensionIgnoredRecommendationsService, IExtensionRecommendationsService } from 'vs/workbench/services/extensionRecommendations/common/extensionRecommendations';
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
-import { ExtensionType, ExtensionIdentifier, IExtensionDescription, IExtensionManifest, isLanguagePackExtension, ExtensionsPolicy, ExtensionsPolicyKey } from 'vs/platform/extensions/common/extensions'; // {{SQL CARBON EDIT}}
+import { ExtensionType, ExtensionIdentifier, IExtensionDescription, IExtensionManifest, isLanguagePackExtension } from 'vs/platform/extensions/common/extensions'; // {{SQL CARBON EDIT}}
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { IFileService, IFileContent } from 'vs/platform/files/common/files';
@@ -48,7 +48,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { prefersExecuteOnUI, prefersExecuteOnWorkspace, canExecuteOnUI, canExecuteOnWorkspace, prefersExecuteOnWeb } from 'vs/workbench/services/extensions/common/extensionsUtil';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { IProductService } from 'vs/platform/product/common/productService';
-import { IDialogService, IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
 import { IActionViewItemOptions, ActionViewItem } from 'vs/base/browser/ui/actionbar/actionViewItems';
 import { EXTENSIONS_CONFIG, IExtensionsConfigContent } from 'vs/workbench/services/extensionRecommendations/common/workspaceExtensionsConfig';
@@ -59,9 +59,6 @@ import { IContextMenuProvider } from 'vs/base/browser/contextmenu';
 import { ILogService } from 'vs/platform/log/common/log';
 import * as Constants from 'vs/workbench/contrib/logs/common/logConstants';
 import { infoIcon, manageExtensionIcon, syncEnabledIcon, syncIgnoredIcon, warningIcon } from 'vs/workbench/contrib/extensions/browser/extensionsIcons';
-import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage'; // {{SQL CARBON EDIT}}
-import product from 'vs/platform/product/common/product';
-import { mnemonicButtonLabel } from 'vs/base/common/labels';
 
 function getRelativeDateLabel(date: Date): string {
 	const delta = new Date().getTime() - date.getTime();
@@ -2370,110 +2367,6 @@ export class EnableAllWorkspaceAction extends Action {
 
 	run(): Promise<any> {
 		return this.extensionsWorkbenchService.setEnablement(this.getExtensionsToEnable(), EnablementState.EnabledWorkspace);
-	}
-}
-
-export class InstallVSIXAction extends Action {
-
-	static readonly ID = 'workbench.extensions.action.installVSIX';
-	static readonly LABEL = localize('installVSIX', "Install from VSIX...");
-	static readonly AVAILABLE = !(product.disabledFeatures && product.disabledFeatures.indexOf(InstallVSIXAction.ID) >= 0);  // {{SQL CARBON EDIT}} add available logic
-
-	constructor(
-		id = InstallVSIXAction.ID,
-		label = InstallVSIXAction.LABEL,
-		@IExtensionsWorkbenchService private readonly extensionsWorkbenchService: IExtensionsWorkbenchService,
-		@INotificationService private readonly notificationService: INotificationService,
-		@IHostService private readonly hostService: IHostService,
-		@IFileDialogService private readonly fileDialogService: IFileDialogService,
-		@IExtensionService private readonly extensionService: IExtensionService,
-		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IConfigurationService private readonly configurationService: IConfigurationService, // {{SQL CARBON EDIT}}
-		@IStorageService private storageService: IStorageService
-	) {
-		super(id, label, 'extension-action install-vsix', true);
-	}
-
-	async run(vsixPaths?: URI[]): Promise<void> {
-		// {{SQL CARBON EDIT}} - Replace run body
-		let extensionPolicy = this.configurationService.getValue<string>(ExtensionsPolicyKey);
-		if (extensionPolicy === ExtensionsPolicy.allowAll) {
-			if (!vsixPaths) {
-				vsixPaths = await this.fileDialogService.showOpenDialog({
-					title: localize('installFromVSIX', "Install from VSIX"),
-					filters: [{ name: 'VSIX Extensions', extensions: ['vsix'] }],
-					canSelectFiles: true,
-					canSelectMany: true,
-					openLabel: mnemonicButtonLabel(localize({ key: 'installButton', comment: ['&& denotes a mnemonic'] }, "&&Install"))
-				});
-
-				if (!vsixPaths) {
-					return;
-				}
-			}
-
-			await Promise.all(vsixPaths.map(async vsix => {
-				if (!this.storageService.getBoolean(vsix.fsPath, StorageScope.GLOBAL)) {
-					const accept = await new Promise<boolean>(resolve => {
-						this.notificationService.prompt(
-							Severity.Warning,
-							localize('thirdPartyExtension.vsix', 'This is a third party extension and might involve security risks. Are you sure you want to install this extension?'),
-							[
-								{
-									label: localize('thirdPartExt.yes', 'Yes'),
-									run: () => resolve(true)
-								},
-								{
-									label: localize('thirdPartyExt.no', 'No'),
-									run: () => resolve(false)
-								},
-								{
-									label: localize('thirdPartyExt.dontShowAgain', 'Don\'t Show Again'),
-									isSecondary: true,
-									run: () => {
-										this.storageService.store(vsix.fsPath, true, StorageScope.GLOBAL, StorageTarget.MACHINE);
-										resolve(true);
-									}
-								}
-							],
-							{ sticky: true }
-						);
-					});
-
-					if (!accept) {
-						return undefined;
-					}
-				}
-
-				return this.extensionsWorkbenchService.install(vsix);
-			})).then(async (extensions) => {
-				for (const extension of extensions) {
-					if (!extension) {
-						return;
-					}
-					const requireReload = !(extension.local && this.extensionService.canAddExtension(toExtensionDescription(extension.local)));
-					const message = requireReload ? localize('InstallVSIXAction.successReload', "Please reload Azure Data Studio to complete installing the extension {0}.", extension.displayName || extension.name) // {{SQL CARBON EDIT}}
-						: localize('InstallVSIXAction.success', "Completed installing the extension {0}.", extension.displayName || extension.name);
-					const actions = requireReload ? [{
-						label: localize('InstallVSIXAction.reloadNow', "Reload Now"),
-						run: () => this.hostService.reload()
-					}] : [];
-					this.notificationService.prompt(
-						Severity.Info,
-						message,
-						actions,
-						{ sticky: true }
-					);
-				}
-				await this.instantiationService.createInstance(ShowInstalledExtensionsAction, ShowInstalledExtensionsAction.ID, ShowInstalledExtensionsAction.LABEL).run();
-			});
-		} else {
-			this.notificationService.error(localize('InstallVSIXAction.allowNone', 'Your extension policy does not allow downloading extensions. Please change your extension policy and try again.'));
-		}
-	}
-
-	get enabled(): boolean { // {{SQL CARBON EDIT}} add enabled logic
-		return InstallVSIXAction.AVAILABLE;
 	}
 }
 

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -24,7 +24,7 @@ import { IJSONContributionRegistry, Extensions as JSONExtensions } from 'vs/plat
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 
 // eslint-disable-next-line code-import-patterns
-import { InstallVSIXAction } from 'vs/workbench/contrib/extensions/browser/extensionsActions'; // {{SQL CARBON EDIT}} add import
+import { SELECT_INSTALL_VSIX_EXTENSION_COMMAND_ID } from 'vs/workbench/contrib/extensions/common/extensions';
 
 // Actions
 (function registerActions(): void {
@@ -99,15 +99,15 @@ import { InstallVSIXAction } from 'vs/workbench/contrib/extensions/browser/exten
 
 // Menu
 (function registerMenu(): void {
-	if (InstallVSIXAction.AVAILABLE) {
-		MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, { // {{SQL CARBON EDIT}} - Add install VSIX menu item
-			group: '5.1_installExtension',
-			command: {
-				id: InstallVSIXAction.ID,
-				title: localize({ key: 'miinstallVsix', comment: ['&& denotes a mnemonic'] }, "Install Extension from VSIX Package")
-			}
-		});
-	}
+
+	MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, { // {{SQL CARBON EDIT}} - Add install VSIX menu item
+		group: '5.1_installExtension',
+		command: {
+			id: SELECT_INSTALL_VSIX_EXTENSION_COMMAND_ID,
+			title: localize({ key: 'miinstallVsix', comment: ['&& denotes a mnemonic'] }, "Install Extension from VSIX Package")
+		}
+	});
+
 
 	MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
 		group: '6_close',


### PR DESCRIPTION
This PR fixes #15274
vscode has moved the action from extensionsActions.ts to a extensions.contributions.ts in this commit: https://github.com/microsoft/vscode/commit/a416c1534bb9159c7ad9d88f19d70019ded16a6a#diff-4a5d50360f90c6ae6aefc53feeb1824c570429a00bb07de93e77c97117fa8828

fix:
add the checks to the new location and meanwhile, vscode introduced another entry point for install VSIX: in file explorer when a vsix file is selected, I am also making it go through ADS checks.
