### PR TITLE
Allow to ignore duplicate entires when adding files to SQL project.

### DIFF
--- a/extensions/sql-database-projects/src/common/utils.ts
+++ b/extensions/sql-database-projects/src/common/utils.ts
@@ -110,18 +110,24 @@ function getQuotedNonWindowsPath(filePath: string): string {
  * Get safe relative path for Windows and non-Windows Platform
  * This is needed to read sqlproj entried created on SSDT and opened in MAC
  * '/' in tree is recognized all platforms but "\\" only by windows
+ *
+ * @param filePath Path to the file or folder.
  */
 export function getPlatformSafeFileEntryPath(filePath: string): string {
-	const parts = filePath.split('\\');
-	return parts.join('/');
+	return filePath.includes('\\')
+		? filePath.split('\\').join('/')
+		: filePath;
 }
 
 /**
  * Standardizes slashes to be "\\" for consistency between platforms and compatibility with SSDT
+ *
+ * @param filePath Path to the file of folder.
  */
 export function convertSlashesForSqlProj(filePath: string): string {
-	const parts = filePath.split('/');
-	return parts.join('\\');
+	return filePath.includes('/')
+		? filePath.split('/').join('\\')
+		: filePath;
 }
 
 /**

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -307,18 +307,18 @@ export class Project implements ISqlProject {
 	/**
 	 * Adds a folder to the project, and saves the project file
 	 * @param relativeFolderPath Relative path of the folder
-	 * @param ignoreDuplicate
+	 * @param doNotThrowOnDuplicate
 	 *	Flag that indicates whether duplicate entries should be ignored or throw an error. If flag is set to `true` and
 	 *	item already exists in the project file, then existing entry will be returned.
 	 */
-	public async addFolderItem(relativeFolderPath: string, ignoreDuplicate?: boolean): Promise<FileProjectEntry> {
+	public async addFolderItem(relativeFolderPath: string, doNotThrowOnDuplicate?: boolean): Promise<FileProjectEntry> {
 		const absoluteFolderPath = path.join(this.projectFolderPath, relativeFolderPath);
 		const normalizedRelativeFolderPath = utils.convertSlashesForSqlProj(relativeFolderPath);
 
 		// check if folder already has been added to sqlproj
 		const existingEntry = this.files.find(f => f.relativePath.toUpperCase() === normalizedRelativeFolderPath.toUpperCase());
 		if (existingEntry) {
-			if (!ignoreDuplicate) {
+			if (!doNotThrowOnDuplicate) {
 				throw new Error(constants.folderAlreadyAddedToProject((relativeFolderPath)));
 			}
 
@@ -343,11 +343,11 @@ export class Project implements ISqlProject {
 	 * @param relativeFilePath Relative path of the file
 	 * @param contents Contents to be written to the new file
 	 * @param itemType Type of the project entry to add. This maps to the build action for the item.
-	 * @param ignoreDuplicate
+	 * @param doNotThrowOnDuplicate
 	 *	Flag that indicates whether duplicate entries should be ignored or throw an error. If flag is set to `true` and
 	 *	item already exists in the project file, then existing entry will be returned.
 	 */
-	public async addScriptItem(relativeFilePath: string, contents?: string, itemType?: string, ignoreDuplicate?: boolean): Promise<FileProjectEntry> {
+	public async addScriptItem(relativeFilePath: string, contents?: string, itemType?: string, doNotThrowOnDuplicate?: boolean): Promise<FileProjectEntry> {
 		const absoluteFilePath = path.join(this.projectFolderPath, relativeFilePath);
 
 		// check if file already exists if content was passed to write to a new file
@@ -360,7 +360,7 @@ export class Project implements ISqlProject {
 		// check if file already has been added to sqlproj
 		const existingEntry = this.files.find(f => f.relativePath.toUpperCase() === normalizedRelativeFilePath.toUpperCase());
 		if (existingEntry) {
-			if (!ignoreDuplicate) {
+			if (!doNotThrowOnDuplicate) {
 				throw new Error(constants.fileAlreadyAddedToProject((relativeFilePath)));
 			}
 
@@ -1005,9 +1005,9 @@ export class Project implements ISqlProject {
 	/**
 	 * Adds the list of sql files and directories to the project, and saves the project file
 	 * @param list list of files and folder Uris. Files and folders must already exist. No files or folders will be added if any do not exist.
-	 * @param ignoreDuplicates Flag that indicates whether duplicate entries should be ignored or throw an error.
+	 * @param doNotThrowOnDuplicate Flag that indicates whether duplicate entries should be ignored or throw an error.
 	 */
-	public async addToProject(list: Uri[], ignoreDuplicates?: boolean): Promise<void> {
+	public async addToProject(list: Uri[], doNotThrowOnDuplicate?: boolean): Promise<void> {
 		// verify all files/folders exist. If not all exist, none will be added
 		for (let file of list) {
 			const exists = await utils.exists(file.fsPath);
@@ -1024,9 +1024,9 @@ export class Project implements ISqlProject {
 				const fileStat = await fs.stat(file.fsPath);
 
 				if (fileStat.isFile() && file.fsPath.toLowerCase().endsWith(constants.sqlFileExtension)) {
-					await this.addScriptItem(relativePath, undefined, undefined, ignoreDuplicates);
+					await this.addScriptItem(relativePath, undefined, undefined, doNotThrowOnDuplicate);
 				} else if (fileStat.isDirectory()) {
-					await this.addFolderItem(relativePath, ignoreDuplicates);
+					await this.addFolderItem(relativePath, doNotThrowOnDuplicate);
 				}
 			}
 		}

--- a/extensions/sql-database-projects/src/models/project.ts
+++ b/extensions/sql-database-projects/src/models/project.ts
@@ -308,15 +308,15 @@ export class Project implements ISqlProject {
 	 * Adds a folder to the project, and saves the project file
 	 * @param relativeFolderPath Relative path of the folder
 	 * @param ignoreDuplicate
-	 *	Flag that indicates whether duplicate entries should be ignored. If flag is set to `true` and item already
-	 *	exists in the project file, then existing entry will be returned.
+	 *	Flag that indicates whether duplicate entries should be ignored or throw an error. If flag is set to `true` and
+	 *	item already exists in the project file, then existing entry will be returned.
 	 */
 	public async addFolderItem(relativeFolderPath: string, ignoreDuplicate?: boolean): Promise<FileProjectEntry> {
 		const absoluteFolderPath = path.join(this.projectFolderPath, relativeFolderPath);
 		const normalizedRelativeFolderPath = utils.convertSlashesForSqlProj(relativeFolderPath);
 
 		// check if folder already has been added to sqlproj
-		const existingEntry = this._files.find(f => f.relativePath.toUpperCase() === normalizedRelativeFolderPath.toUpperCase());
+		const existingEntry = this.files.find(f => f.relativePath.toUpperCase() === normalizedRelativeFolderPath.toUpperCase());
 		if (existingEntry) {
 			if (!ignoreDuplicate) {
 				throw new Error(constants.folderAlreadyAddedToProject((relativeFolderPath)));
@@ -344,8 +344,8 @@ export class Project implements ISqlProject {
 	 * @param contents Contents to be written to the new file
 	 * @param itemType Type of the project entry to add. This maps to the build action for the item.
 	 * @param ignoreDuplicate
-	 *	Flag that indicates whether duplicate entries should be ignored. If flag is set to `true` and item already
-	 *	exists in the project file, then existing entry will be returned.
+	 *	Flag that indicates whether duplicate entries should be ignored or throw an error. If flag is set to `true` and
+	 *	item already exists in the project file, then existing entry will be returned.
 	 */
 	public async addScriptItem(relativeFilePath: string, contents?: string, itemType?: string, ignoreDuplicate?: boolean): Promise<FileProjectEntry> {
 		const absoluteFilePath = path.join(this.projectFolderPath, relativeFilePath);
@@ -358,7 +358,7 @@ export class Project implements ISqlProject {
 		const normalizedRelativeFilePath = utils.convertSlashesForSqlProj(relativeFilePath);
 
 		// check if file already has been added to sqlproj
-		const existingEntry = this._files.find(f => f.relativePath.toUpperCase() === normalizedRelativeFilePath.toUpperCase());
+		const existingEntry = this.files.find(f => f.relativePath.toUpperCase() === normalizedRelativeFilePath.toUpperCase());
 		if (existingEntry) {
 			if (!ignoreDuplicate) {
 				throw new Error(constants.fileAlreadyAddedToProject((relativeFilePath)));
@@ -1005,7 +1005,7 @@ export class Project implements ISqlProject {
 	/**
 	 * Adds the list of sql files and directories to the project, and saves the project file
 	 * @param list list of files and folder Uris. Files and folders must already exist. No files or folders will be added if any do not exist.
-	 * @param ignoreDuplicates Flag that indicates whether duplicate entries should be ignored.
+	 * @param ignoreDuplicates Flag that indicates whether duplicate entries should be ignored or throw an error.
 	 */
 	public async addToProject(list: Uri[], ignoreDuplicates?: boolean): Promise<void> {
 		// verify all files/folders exist. If not all exist, none will be added

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -37,29 +37,29 @@ declare module 'sqldbproj' {
 		/**
 		 * Adds the list of sql files and directories to the project, and saves the project file
 		 * @param list list of files and folder Uris. Files and folders must already exist. No files or folders will be added if any do not exist.
-		 * @param ignoreDuplicates Flag that indicates whether duplicate entries should be ignored or throw an error.
+		 * @param doNotThrowOnDuplicate Flag that indicates whether duplicate entries should be ignored or throw an error.
 		 */
-		addToProject(list: vscode.Uri[], ignoreDuplicates?: boolean): Promise<void>;
+		addToProject(list: vscode.Uri[], doNotThrowOnDuplicate?: boolean): Promise<void>;
 
 		/**
 		 * Adds a folder to the project, and saves the project file
 		 * @param relativeFolderPath Relative path of the folder
-		 * @param ignoreDuplicate
+		 * @param doNotThrowOnDuplicate
 		 *	Flag that indicates whether duplicate entries should be ignored or throw an error. If flag is set to `true` and
 		 *	item already exists in the project file, then existing entry will be returned.
 		 */
-		addFolderItem(relativeFolderPath: string, ignoreDuplicate?: boolean): Promise<IFileProjectEntry>;
+		addFolderItem(relativeFolderPath: string, doNotThrowOnDuplicate?: boolean): Promise<IFileProjectEntry>;
 
 		/**
 		 * Writes a file to disk if contents are provided, adds that file to the project, and writes it to disk
 		 * @param relativeFilePath Relative path of the file
 		 * @param contents Contents to be written to the new file
 		 * @param itemType Type of the project entry to add. This maps to the build action for the item.
-		 * @param ignoreDuplicate
+		 * @param doNotThrowOnDuplicate
 		 *	Flag that indicates whether duplicate entries should be ignored or throw an error. If flag is set to `true` and
 		 *	item already exists in the project file, then existing entry will be returned.
 		 */
-		addScriptItem(relativeFilePath: string, contents?: string, itemType?: string, ignoreDuplicate?: boolean): Promise<IFileProjectEntry>;
+		addScriptItem(relativeFilePath: string, contents?: string, itemType?: string, doNotThrowOnDuplicate?: boolean): Promise<IFileProjectEntry>;
 
 		/**
 		 * Adds a SQLCMD variable to the project

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -37,7 +37,7 @@ declare module 'sqldbproj' {
 		/**
 		 * Adds the list of sql files and directories to the project, and saves the project file
 		 * @param list list of files and folder Uris. Files and folders must already exist. No files or folders will be added if any do not exist.
-		 * @param ignoreDuplicates Flag that indicates whether duplicate entries should be ignored.
+		 * @param ignoreDuplicates Flag that indicates whether duplicate entries should be ignored or throw an error.
 		 */
 		addToProject(list: vscode.Uri[], ignoreDuplicates?: boolean): Promise<void>;
 
@@ -45,8 +45,8 @@ declare module 'sqldbproj' {
 		 * Adds a folder to the project, and saves the project file
 		 * @param relativeFolderPath Relative path of the folder
 		 * @param ignoreDuplicate
-		 *	Flag that indicates whether duplicate entries should be ignored. If flag is set to `true` and item already
-	 	 *	exists in the project file, then existing entry will be returned.
+		 *	Flag that indicates whether duplicate entries should be ignored or throw an error. If flag is set to `true` and
+		 *	item already exists in the project file, then existing entry will be returned.
 		 */
 		addFolderItem(relativeFolderPath: string, ignoreDuplicate?: boolean): Promise<IFileProjectEntry>;
 
@@ -56,8 +56,8 @@ declare module 'sqldbproj' {
 		 * @param contents Contents to be written to the new file
 		 * @param itemType Type of the project entry to add. This maps to the build action for the item.
 		 * @param ignoreDuplicate
-		 *	Flag that indicates whether duplicate entries should be ignored. If flag is set to `true` and item already
-		 *	exists in the project file, then existing entry will be returned.
+		 *	Flag that indicates whether duplicate entries should be ignored or throw an error. If flag is set to `true` and
+		 *	item already exists in the project file, then existing entry will be returned.
 		 */
 		addScriptItem(relativeFilePath: string, contents?: string, itemType?: string, ignoreDuplicate?: boolean): Promise<IFileProjectEntry>;
 

--- a/extensions/sql-database-projects/src/sqldbproj.d.ts
+++ b/extensions/sql-database-projects/src/sqldbproj.d.ts
@@ -37,21 +37,29 @@ declare module 'sqldbproj' {
 		/**
 		 * Adds the list of sql files and directories to the project, and saves the project file
 		 * @param list list of files and folder Uris. Files and folders must already exist. No files or folders will be added if any do not exist.
+		 * @param ignoreDuplicates Flag that indicates whether duplicate entries should be ignored.
 		 */
-		addToProject(list: vscode.Uri[]): Promise<void>;
+		addToProject(list: vscode.Uri[], ignoreDuplicates?: boolean): Promise<void>;
 
 		/**
 		 * Adds a folder to the project, and saves the project file
 		 * @param relativeFolderPath Relative path of the folder
+		 * @param ignoreDuplicate
+		 *	Flag that indicates whether duplicate entries should be ignored. If flag is set to `true` and item already
+	 	 *	exists in the project file, then existing entry will be returned.
 		 */
-		addFolderItem(relativeFolderPath: string): Promise<IFileProjectEntry>;
+		addFolderItem(relativeFolderPath: string, ignoreDuplicate?: boolean): Promise<IFileProjectEntry>;
 
 		/**
 		 * Writes a file to disk if contents are provided, adds that file to the project, and writes it to disk
 		 * @param relativeFilePath Relative path of the file
 		 * @param contents Contents to be written to the new file
+		 * @param itemType Type of the project entry to add. This maps to the build action for the item.
+		 * @param ignoreDuplicate
+		 *	Flag that indicates whether duplicate entries should be ignored. If flag is set to `true` and item already
+		 *	exists in the project file, then existing entry will be returned.
 		 */
-		addScriptItem(relativeFilePath: string, contents?: string, itemType?: string): Promise<IFileProjectEntry>;
+		addScriptItem(relativeFilePath: string, contents?: string, itemType?: string, ignoreDuplicate?: boolean): Promise<IFileProjectEntry>;
 
 		/**
 		 * Adds a SQLCMD variable to the project


### PR DESCRIPTION
This change introduces new boolean flag for `addToProject`, `addScriptItem` and `addFolderItem` APIs that allows to skip files/folders if they are already included in the project file. Original behavior was to throw an error if duplicate entry is encountered, so I kept that as a default (new flag is not set). This new flag allows to reuse the de-dupe code that we otherwise have to add to each consumer of the API.

I started by fixing the original behavior, as it was not always working as expected. In our extension that relies on `addToProject` API we've hit an issue where duplicate items were added and no errors were thrown. There was a test for this scenario, but unfortunately the test had few bugs in it as well, so I addressed that first. First issue with the test code was missing `await` on the `testUtils.shouldThrowSpecificError` calls, so test was not actually testing anything. After adding missing keywords, I hit an issue where exception was not thrown, but this turned out to be different issue, compared to what we were hitting. In the test code, it was using the very first folder from the generate list of test entries. This folder was actually the root of the project (where sqlproj file is located), and `addToProject` API had a special case to ignore the root. This means neither first call nor second call was actually adding anything to the project and no errors were produced. I fixed this problem by using next available folder in the generated files list.

After addressing the test code I could not reproduce the issue that we were seeing with duplicate entries being added, everything was working as expected and errors were thrown. I started adding more tests that better resemble our production scenario - add files in subfolders, add files to existing project, rather than a new one. Finally I was able to reproduce the problem in tests when adding a file in a subfolder to an existing project. After investigation this turned out to be an issue with mismatch in how `relativePath` is maintained within the `FileProjectEntry`. When loading an existing project, `relativePath` is populated based on the value of the `Include` attribute of the `Build` item. This attribute is normalized to Windows-style path, using `\`, so for nested file you will have `folder\file.sql`. When adding new item to the project, one could pass either Windows or Unix-style path (`folder/file.sql`), so the path comparison between loaded Windows-style path and newly added Unix-style path was failing, resulting in them being treated as different items. In fact, `addToProject` API that we were using was relying on `Uri` helpers to extract relative path, thus the path was forced to be Unix-style and path was never the same as the loaded one. After this discovery I added a dedicated test to validate the round-trip of the `relativePath` for serialized and desirialized project file.

In order to address this problem, I updated the factory method `createFileProjectEntry` to always run `utils.convertSlashesForSqlProj` on the relative path to ensure we have Windows-style path stored in there. I also optimized the helper code slightly to not do split/join, if there are no split points in the input string, which should eliminate unnecessary array instantiation. It is worth mentioning that I had to normalize the input relative paths in the `addScriptItem` and `addFolderItem` APIs, because there is no guarantee that they will be Windows-style when we try to compare them to `relativePath` of the existing project items.

Finally I was able to add a simply flag and update the condition to return existing record, if duplicates were allowed. I also updated typings file for the extension and added tests to cover this scenario.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->