### PR TITLE
fix schema compare display name having username

### DIFF
--- a/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
+++ b/extensions/schema-compare/src/dialogs/schemaCompareDialog.ts
@@ -100,12 +100,13 @@ export class SchemaCompareDialog {
 				connectionDetails: undefined
 			};
 		} else {
-			let ownerUri = await azdata.connection.getUriForConnection((this.sourceServerDropdown.value as ConnectionDropdownValue).connection.connectionId);
+			const ownerUri = await azdata.connection.getUriForConnection((this.sourceServerDropdown.value as ConnectionDropdownValue).connection.connectionId);
+			const sourceServerDropdownValue = this.sourceServerDropdown.value as ConnectionDropdownValue;
 
 			this.schemaCompareMainWindow.sourceEndpointInfo = {
 				endpointType: mssql.SchemaCompareEndpointType.Database,
-				serverDisplayName: (this.sourceServerDropdown.value as ConnectionDropdownValue).displayName,
-				serverName: (this.sourceServerDropdown.value as ConnectionDropdownValue).name,
+				serverDisplayName: sourceServerDropdownValue.connection.options.connectionName !== '' ? sourceServerDropdownValue.connection.options.connectionName : sourceServerDropdownValue.name,
+				serverName: sourceServerDropdownValue.name,
 				databaseName: this.sourceDatabaseDropdown.value.toString(),
 				ownerUri: ownerUri,
 				packageFilePath: '',
@@ -124,12 +125,13 @@ export class SchemaCompareDialog {
 				connectionDetails: undefined
 			};
 		} else {
-			let ownerUri = await azdata.connection.getUriForConnection((this.targetServerDropdown.value as ConnectionDropdownValue).connection.connectionId);
+			const ownerUri = await azdata.connection.getUriForConnection((this.targetServerDropdown.value as ConnectionDropdownValue).connection.connectionId);
+			const targetServerDropdownValue = this.targetServerDropdown.value as ConnectionDropdownValue;
 
 			this.schemaCompareMainWindow.targetEndpointInfo = {
 				endpointType: mssql.SchemaCompareEndpointType.Database,
-				serverDisplayName: (this.targetServerDropdown.value as ConnectionDropdownValue).displayName,
-				serverName: (this.targetServerDropdown.value as ConnectionDropdownValue).name,
+				serverDisplayName: targetServerDropdownValue.connection.options.connectionName !== '' ? targetServerDropdownValue.connection.options.connectionName : targetServerDropdownValue.name,
+				serverName: targetServerDropdownValue.name,
 				databaseName: this.targetDatabaseDropdown.value.toString(),
 				ownerUri: ownerUri,
 				packageFilePath: '',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15349. The username started showing up after this PR change to show connection name if there is one https://github.com/microsoft/azuredatastudio/pull/15152.

example where source local host uses username to login and target test2019 is a named connection
![image](https://user-images.githubusercontent.com/31145923/117361867-6ab85400-ae6f-11eb-9080-5d8a23216ace.png)

Before:
![image](https://user-images.githubusercontent.com/31145923/117361796-56745700-ae6f-11eb-8ca7-d8fb1e486dac.png)

After:
![image](https://user-images.githubusercontent.com/31145923/117361317-bcacaa00-ae6e-11eb-8943-b8b21b29b72c.png)

