### PR TITLE
Fixing subscriptions and azure resource graph across ads.

### DIFF
--- a/extensions/azurecore/extension.webpack.config.js
+++ b/extensions/azurecore/extension.webpack.config.js
@@ -16,6 +16,8 @@ const externals = {
 	'bufferutil': 'commonjs bufferutil',
 	'utf-8-validate': 'commonjs utf-8-validate',
 	'keytar': 'commonjs keytar',
+	'@azure/arm-subscriptions': 'commonjs @azure/arm-subscriptions',
+	'@azure/arm-resourcegraph': 'commonjs @azure/arm-resourcegraph'
 };
 
 // conditionally add ws if we are going to be running in a node environment


### PR DESCRIPTION
This PR fixes #15391

This PR adds arm-subscriptions and arm-resourcegraph as external dependency to azure core extension. This will prevent the minimization of these libraries in web pack causing the above bug. 

Link for the build
https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=103560&view=results