### PR TITLE
Bump STS Version to 103

### DIFF
--- a/extensions/mssql/config.json
+++ b/extensions/mssql/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "3.0.0-release.102",
+	"version": "3.0.0-release.103",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp3.1.zip",
 		"Windows_64": "win-x64-netcoreapp3.1.zip",


### PR DESCRIPTION
This contains a new migration assessment nuget which fixes an issue with being unable to migrate a database with a memory optimized file group