### PR TITLE
Add setting to hide netcore installation prompt

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -18,8 +18,8 @@ export const OpenWorkspace = localize('dataworkspace.openWorkspace', "Open Works
 export const CreateWorkspaceConfirmation = localize('dataworkspace.createWorkspaceConfirmation', "A workspace will be created and opened in order to open project. Azure Data Studio will restart and if there is a folder currently open, it will be closed.");
 export const EnterWorkspaceConfirmation = localize('dataworkspace.enterWorkspaceConfirmation', "To open this workspace, Azure Data Studio will restart. If there is a workspace or folder currently open, it will be closed.");
 export const WorkspaceContainsNotAddedProjects = localize('dataworkspace.workspaceContainsNotAddedProjects', "The current workspace contains one or more projects that have not been added to the workspace. Use the 'Open existing' dialog to add projects to the projects pane.");
-export const LaunchOpenExisitingDialog = localize('dataworkspace.launchOpenExistingDialog', "Launch Open existing dialog");
-export const DoNotShowAgain = localize('dataworkspace.doNotShowAgain', "Do not show again");
+export const LaunchOpenExisitingDialog = localize('dataworkspace.launchOpenExistingDialog', "Launch 'Open Existing' Dialog");
+export const DoNotAskAgain = localize('dataworkspace.doNotAskAgain', "Don't Ask Again");
 export const ProjectsFailedToLoad = localize('dataworkspace.projectsFailedToLoad', "Some projects failed to load. To view more details, [open the developer console](command:workbench.action.toggleDevTools)");
 export const fileDoesNotExist = (name: string): string => { return localize('fileDoesNotExist', "File '{0}' doesn't exist", name); };
 export const projectNameNull = localize('projectNameNull', "Project name is null");

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -206,11 +206,11 @@ export class WorkspaceService implements IWorkspaceService {
 			}
 
 			if (containsNotAddedProject) {
-				const result = await vscode.window.showInformationMessage(constants.WorkspaceContainsNotAddedProjects, constants.LaunchOpenExisitingDialog, constants.DoNotShowAgain);
+				const result = await vscode.window.showInformationMessage(constants.WorkspaceContainsNotAddedProjects, constants.LaunchOpenExisitingDialog, constants.DoNotAskAgain);
 				if (result === constants.LaunchOpenExisitingDialog) {
 					// open settings
 					await vscode.commands.executeCommand('projects.openExisting');
-				} else if (result === constants.DoNotShowAgain) {
+				} else if (result === constants.DoNotAskAgain) {
 					await config.update(constants.showNotAddedProjectsMessageKey, false, true);
 				}
 

--- a/extensions/data-workspace/src/test/workspaceService.test.ts
+++ b/extensions/data-workspace/src/test/workspaceService.test.ts
@@ -427,7 +427,7 @@ suite('WorkspaceService Tests', function (): void {
 			description: '',
 			icon: ''
 		}]);
-		const infoMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves(<any>constants.DoNotShowAgain);
+		const infoMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves(<any>constants.DoNotAskAgain);
 		const getProjectsInwWorkspaceFolderStub = sinon.stub(service, 'getAllProjectsInFolder').resolves([vscode.Uri.file('abc.sqlproj').fsPath, vscode.Uri.file('folder1/abc1.sqlproj').fsPath]);
 
 		await service.checkForProjectsNotAddedToWorkspace();

--- a/extensions/sql-database-projects/package.json
+++ b/extensions/sql-database-projects/package.json
@@ -39,6 +39,10 @@
           "sqlDatabaseProjects.netCoreSDKLocation": {
             "type": "string",
             "description": "%sqlDatabaseProjects.netCoreInstallLocation%"
+          },
+          "sqlDatabaseProjects.netCoreDoNotAsk": {
+            "type": "boolean",
+            "description": "%sqlDatabaseProjects.netCoreDoNotAsk%"
           }
         }
       }

--- a/extensions/sql-database-projects/package.nls.json
+++ b/extensions/sql-database-projects/package.nls.json
@@ -32,6 +32,7 @@
 	"sqlDatabaseProjects.changeTargetPlatform": "Change Target Platform",
 
 	"sqlDatabaseProjects.Settings": "Database Projects",
-	"sqlDatabaseProjects.netCoreInstallLocation": "Full path to .Net Core SDK on the machine.",
+	"sqlDatabaseProjects.netCoreInstallLocation": "Full path to .NET Core SDK on the machine.",
+	"sqlDatabaseProjects.netCoreDoNotAsk": "Whether to prompt the user to install .NET Core when not detected.",
 	"sqlDatabaseProjects.welcome": "No database projects currently open.\n[New Project](command:sqlDatabaseProjects.new)\n[Open Project](command:sqlDatabaseProjects.open)\n[Create Project From Database](command:sqlDatabaseProjects.importDatabase)"
 }

--- a/extensions/sql-database-projects/src/test/netCoreTool.test.ts
+++ b/extensions/sql-database-projects/src/test/netCoreTool.test.ts
@@ -42,7 +42,7 @@ describe('NetCoreTool: Net core tests', function (): void {
 		if (os.platform() === 'win32') {
 			// check that path should start with c:\program files
 			let result = isNullOrUndefined(netcoreTool.netcoreInstallLocation) || netcoreTool.netcoreInstallLocation.toLowerCase().startsWith('c:\\program files');
-			should(result).true('dotnet is either not present or in pogramfiles by default');
+			should(result).true('dotnet is either not present or in programfiles by default');
 		}
 
 		if (os.platform() === 'linux' || os.platform() === 'darwin') {

--- a/extensions/sql-database-projects/src/tools/netcoreTool.ts
+++ b/extensions/sql-database-projects/src/tools/netcoreTool.ts
@@ -18,8 +18,8 @@ export const NetCoreInstallLocationKey: string = 'netCoreSDKLocation';
 export const NetCoreDoNotAskAgainKey: string = 'netCoreDoNotAsk';
 export const NextCoreNonWindowsDefaultPath = '/usr/local/share';
 export const NetCoreInstallationConfirmation: string = localize('sqlDatabaseProjects.NetCoreInstallationConfirmation', "The .NET Core SDK cannot be located. Project build will not work. Please install .NET Core SDK version 3.1 or update the .Net Core SDK location in settings if already installed.");
-export const UpdateNetCoreLocation: string = localize('sqlDatabaseProjects.UpdateNetCoreLocation', "Update .Net Core location");
-export const InstallNetCore: string = localize('sqlDatabaseProjects.InstallNetCore', "Install .Net Core SDK");
+export const UpdateNetCoreLocation: string = localize('sqlDatabaseProjects.UpdateNetCoreLocation', "Update Location");
+export const InstallNetCore: string = localize('sqlDatabaseProjects.InstallNetCore', "Install");
 export const DoNotAskAgain: string = localize('sqlDatabaseProjects.doNotAskAgain', "Don't Ask Again");
 
 const projectsOutputChannel = localize('sqlDatabaseProjects.outputChannel', "Database Projects");


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15247 by adding a "Don't ask again" option to not prompt the user to install .NET core if it's not found.

However, adding a third button caused everything to get truncated:
![image](https://user-images.githubusercontent.com/1609827/118204248-a1174580-b412-11eb-9bf1-ccf962418b61.png)

so I had to update the strings a bit:
![image](https://user-images.githubusercontent.com/1609827/118299568-c305dc00-b495-11eb-912e-ec4d58d64700.png)
