### PR TITLE
fix welcome page tile spacing issue

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/welcomePage.css
+++ b/src/sql/workbench/contrib/welcome/page/browser/welcomePage.css
@@ -722,6 +722,8 @@
 .ads-homepage .header-bottom-nav-tiles {
 	display: flex;
 	flex-wrap: wrap;
+	column-gap: normal;
+	row-gap: normal;
 }
 
 .ads-homepage:not(.XS) .header-bottom-nav-tiles .col{


### PR DESCRIPTION
This PR fixes #15393

In the most recent VSCode merge, we brought in a new version of Chrome in which the column-gap and row-gap support is added: https://web.dev/flexbox-gap/. in welcome page, we are using grid-gap style for the overall layout, and it is a short hand for column-gap and row-gap, and the flex boxes inside it inherits these 2 styles, the fix is to reset the values on the flexbox.

I compared the other places of welcome page and didn't notice any other changes between current build and previous stable build.

the only other place using grid-gap which might be impacted by this is agent:
![image](https://user-images.githubusercontent.com/13777222/118317488-f738c700-b4ac-11eb-8233-c35f8a18d955.png)
src\sql\workbench\contrib\jobManagement\browser\media\jobHistory.css
@aasimkhan30  and @abist , could you please see whether this area is impacted and if so apply the same fix there.
