### PR TITLE
Fix actionbar trigger key handling

### DIFF
--- a/src/sql/base/browser/ui/taskbar/actionbar.ts
+++ b/src/sql/base/browser/ui/taskbar/actionbar.ts
@@ -37,6 +37,9 @@ export class ActionBar extends ActionRunner implements IActionRunner {
 	protected _focusedItem?: number;
 	protected _focusTracker: DOM.IFocusTracker;
 
+	// Trigger Key Tracking
+	private _triggerKeyDown: boolean = false;
+
 	// Elements
 	protected _domNode: HTMLElement;
 	protected _actionsList: HTMLElement;
@@ -81,7 +84,7 @@ export class ActionBar extends ActionRunner implements IActionRunner {
 			} else if (event.equals(KeyCode.Escape)) {
 				this.cancel();
 			} else if (event.equals(KeyCode.Enter) || event.equals(KeyCode.Space)) {
-				// Nothing, just staying out of the else branch
+				this._triggerKeyDown = true;
 			} else {
 				eventHandled = false;
 			}
@@ -103,7 +106,10 @@ export class ActionBar extends ActionRunner implements IActionRunner {
 
 			// Run action on Enter/Space
 			if (event.equals(KeyCode.Enter) || event.equals(KeyCode.Space)) {
-				this.doTrigger(event);
+				if (this._triggerKeyDown) {
+					this.doTrigger(event);
+					this._triggerKeyDown = false;
+				}
 				event.preventDefault();
 				event.stopPropagation();
 			}

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
@@ -22,7 +22,6 @@ import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
 import { attachCalloutDialogStyler } from 'sql/workbench/common/styler';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { escapeLabel, escapeUrl } from 'sql/workbench/contrib/notebook/browser/calloutDialog/common/utils';
-import { KeyCode } from 'vs/base/common/keyCodes';
 
 export interface ILinkCalloutDialogOptions {
 	insertTitle?: string,

--- a/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
+++ b/src/sql/workbench/contrib/notebook/browser/calloutDialog/linkCalloutDialog.ts
@@ -101,13 +101,6 @@ export class LinkCalloutDialog extends Modal {
 	}
 
 	protected renderBody(container: HTMLElement) {
-		this._register(DOM.addDisposableListener(document, DOM.EventType.KEY_UP, (e: KeyboardEvent) => {
-			let event = new StandardKeyboardEvent(e);
-			if (event.equals(KeyCode.Enter)) {
-				DOM.EventHelper.stop(e, true);
-				this.hide('ok');
-			}
-		}));
 		let linkContentColumn = DOM.$('.column.insert-link');
 		DOM.append(container, linkContentColumn);
 
@@ -155,8 +148,7 @@ export class LinkCalloutDialog extends Modal {
 	protected onAccept(e?: StandardKeyboardEvent) {
 		// EventHelper.stop() will call preventDefault. Without it, text cell will insert an extra newline when pressing enter on dialog
 		DOM.EventHelper.stop(e, true);
-		const keyboardEventExists = !!e;
-		this.insert(keyboardEventExists);
+		this.insert();
 	}
 
 	protected onClose(e?: StandardKeyboardEvent) {
@@ -164,10 +156,8 @@ export class LinkCalloutDialog extends Modal {
 		this.cancel();
 	}
 
-	public insert(willHideByKeyboardEvent = false): void {
-		if (!willHideByKeyboardEvent) {
-			this.hide('ok');
-		}
+	public insert(): void {
+		this.hide('ok');
 		let escapedLabel = escapeLabel(this._linkTextInputBox.value);
 		let escapedUrl = escapeUrl(this._linkUrlInputBox.value);
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15484

Took this from VS Code actionbar, it basically makes it so that we only trigger on KEY_UP if the actionbar also received the KEY_DOWN as well. This fixes the Notebook scenario since the KEY_DOWN was sent to the callout dialog and so even though the actionbar gets the KEY_UP it won't fire the event. 

Something to remember for the future as well - they've also added functionality to support triggering on KEY_DOWN as well through an option passed in to the constructor. https://github.com/microsoft/azuredatastudio/blob/main/src/vs/base/browser/ui/actionbar/actionbar.ts#L90