### PR TITLE
Smoketests: remove close toast action from dialogs

### DIFF
--- a/test/automation/src/sql/configurePythonDialog.ts
+++ b/test/automation/src/sql/configurePythonDialog.ts
@@ -5,13 +5,12 @@
 
 import { Code } from '../code';
 import { Dialog } from './dialog';
-import { NotificationToast } from './notificationToast';
 
 const CONFIGURE_PYTHON_DIALOG_TITLE = 'Configure Python to run Python 3 kernel';
 
 export class ConfigurePythonDialog extends Dialog {
 
-	constructor(code: Code, private notificationToast: NotificationToast) {
+	constructor(code: Code) {
 		super(CONFIGURE_PYTHON_DIALOG_TITLE, code);
 	}
 
@@ -32,13 +31,9 @@ export class ConfigurePythonDialog extends Dialog {
 		const pythonInstallLocationDropdownValue = `${dialog} select[aria-label="Python Install Location"] option`;
 		await this.code.waitForElement(pythonInstallLocationDropdownValue);
 
-		await this.notificationToast.closeNotificationToasts();
-
 		const nextButton = '.modal-dialog .modal-content .modal-footer .right-footer .footer-button a[aria-label="Next"][aria-disabled="false"]';
 		await this.code.waitAndClick(dialog);
 		await this.code.waitAndClick(nextButton);
-
-		await this.notificationToast.closeNotificationToasts();
 
 		const installButton = '.modal-dialog .modal-content .modal-footer .right-footer .footer-button a[aria-label="Install"][aria-disabled="false"]';
 		await this.code.waitAndClick(dialog);

--- a/test/automation/src/sql/connectionDialog.ts
+++ b/test/automation/src/sql/connectionDialog.ts
@@ -5,13 +5,12 @@
 
 import { Code } from '../code';
 import { Dialog } from './dialog';
-import { NotificationToast } from './notificationToast';
 
 const CONNECTION_DIALOG_TITLE = 'Connection';
 
 export class ConnectionDialog extends Dialog {
 
-	constructor(code: Code, private notificationToast: NotificationToast) {
+	constructor(code: Code) {
 		super(CONNECTION_DIALOG_TITLE, code);
 	}
 
@@ -31,8 +30,6 @@ export class ConnectionDialog extends Dialog {
 
 	private static readonly CONNECT_BUTTON_SELECTOR = '.modal .modal-footer a[aria-label="Connect"]:not(.disabled)';
 	async connect(): Promise<void> {
-		await this.notificationToast.closeNotificationToasts();
-
 		await this.code.waitAndClick(ConnectionDialog.CONNECT_BUTTON_SELECTOR);
 
 		await this.waitForDialogGone();

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -82,12 +82,12 @@ export class Workbench {
 		this.terminal = new Terminal(code, this.quickaccess);
 		// {{SQL CARBON EDIT}}
 		this.notificationToast = new NotificationToast(code);
-		this.connectionDialog = new ConnectionDialog(code, this.notificationToast);
+		this.connectionDialog = new ConnectionDialog(code);
 		this.profiler = new Profiler(code, this.quickaccess);
 		this.queryEditors = new QueryEditors(code, this.editors);
 		this.queryEditor = new QueryEditor(code);
 		this.sqlNotebook = new SqlNotebook(code, this.quickaccess, this.quickinput, this.editors);
-		this.configurePythonDialog = new ConfigurePythonDialog(code, this.notificationToast);
+		this.configurePythonDialog = new ConfigurePythonDialog(code);
 		// {{END}}
 		this.notebook = new Notebook(this.quickaccess, code);
 	}


### PR DESCRIPTION
Added the setting here to not show the net core prompt: https://github.com/microsoft/azuredatastudio-smoke-test-repo/pull/2
Now theres no longer a need to check for toasts when clicking wizard buttons.

Ran an adhoc build to check: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=104612&view=results