### PR TITLE
Update project toolbar actions comments and name for clarity

### DIFF
--- a/extensions/data-workspace/src/dataworkspace.d.ts
+++ b/extensions/data-workspace/src/dataworkspace.d.ts
@@ -80,7 +80,7 @@ declare module 'dataworkspace' {
 		/**
 		 * Gets the project actions to be placed on the dashboard toolbar
 		 */
-		readonly projectActions: (IProjectAction | IProjectActionGroup)[];
+		readonly projectToolbarActions: (IProjectAction | IProjectActionGroup)[];
 
 		/**
 		 * Gets the project image to be used as background in dashboard container

--- a/extensions/data-workspace/src/dialogs/projectDashboard.ts
+++ b/extensions/data-workspace/src/dialogs/projectDashboard.ts
@@ -62,7 +62,7 @@ export class ProjectDashboard {
 	}
 
 	private createToolbarContainer(projectFilePath: string): azdata.ToolbarContainer {
-		const projectActions: (IProjectAction | IProjectActionGroup)[] = this.projectProvider!.projectActions;
+		const projectActions: (IProjectAction | IProjectActionGroup)[] = this.projectProvider!.projectToolbarActions;
 
 		// Add actions as buttons
 		const buttons: azdata.ToolbarComponent[] = [];

--- a/extensions/data-workspace/src/test/projectProviderRegistry.test.ts
+++ b/extensions/data-workspace/src/test/projectProviderRegistry.test.ts
@@ -32,7 +32,7 @@ export function createProjectProvider(projectTypes: IProjectType[], projectActio
 		createProject: (name: string, location: vscode.Uri, projectTypeId: string): Promise<vscode.Uri> => {
 			return Promise.resolve(location);
 		},
-		projectActions: projectActions,
+		projectToolbarActions: projectActions,
 		getDashboardComponents: (projectFile: string): IDashboardTable[] => {
 			return dashboardComponents;
 		}

--- a/extensions/data-workspace/src/test/workspaceTreeDataProvider.test.ts
+++ b/extensions/data-workspace/src/test/workspaceTreeDataProvider.test.ts
@@ -91,7 +91,7 @@ suite('workspaceTreeDataProvider Tests', function (): void {
 			createProject: (name: string, location: vscode.Uri): Promise<vscode.Uri> => {
 				return Promise.resolve(location);
 			},
-			projectActions: [{
+			projectToolbarActions: [{
 				id: 'Add',
 				run: async (): Promise<any> => { return Promise.resolve(); }
 			},

--- a/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
+++ b/extensions/sql-database-projects/src/projectProvider/projectProvider.ts
@@ -85,9 +85,9 @@ export class SqlDatabaseProjectProvider implements dataworkspace.IProjectProvide
 	}
 
 	/**
-	 * Gets the supported project types
+	 * Gets the project actions to be placed on the dashboard toolbar
 	 */
-	get projectActions(): (dataworkspace.IProjectAction | dataworkspace.IProjectActionGroup)[] {
+	get projectToolbarActions(): (dataworkspace.IProjectAction | dataworkspace.IProjectActionGroup)[] {
 		const addItemAction: dataworkspace.IProjectAction = {
 			id: constants.addItemAction,
 			icon: IconPathHelper.add,


### PR DESCRIPTION
Updating this for clarity. We were showing the projectProvider to the orcas team today and I noticed it wasn't clear that the projectActions was specifically for the toolbar, not just all the project actions.