### PR TITLE
Fix for New Notebook task when localizing dashboard for server and database.

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -23,6 +23,7 @@ import { WIDGETS_CONTAINER } from 'sql/workbench/contrib/dashboard/browser/conta
 import { GRID_CONTAINER } from 'sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution';
 import { AngularDisposable } from 'sql/base/browser/lifecycle';
 import * as Constants from 'sql/platform/connection/common/constants';
+import { language } from 'vs/base/common/platform';
 
 import { Registry } from 'vs/platform/registry/common/platform';
 import * as types from 'vs/base/common/types';
@@ -261,7 +262,7 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		let toolbarActions = [];
 		_tasks.forEach(a => {
 			let iconClassName = TaskRegistry.getOrCreateTaskIconClassName(a);
-			toolbarActions.push(new ToolbarAction(a.id, this.extensionTasks[a.id] ? this.extensionTasks[a.id] : a.title.toString(), iconClassName, this.runAction, this, this.logService));
+			toolbarActions.push(new ToolbarAction(a.id, (this.extensionTasks[a.id] && (language !== 'en')) ? this.extensionTasks[a.id] : a.title.toString(), iconClassName, this.runAction, this, this.logService));
 		});
 
 		let content: ITaskbarContent[] = [];

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -23,7 +23,7 @@ import { WIDGETS_CONTAINER } from 'sql/workbench/contrib/dashboard/browser/conta
 import { GRID_CONTAINER } from 'sql/workbench/contrib/dashboard/browser/containers/dashboardGridContainer.contribution';
 import { AngularDisposable } from 'sql/base/browser/lifecycle';
 import * as Constants from 'sql/platform/connection/common/constants';
-import { language } from 'vs/base/common/platform';
+import { Language } from 'vs/base/common/platform';
 
 import { Registry } from 'vs/platform/registry/common/platform';
 import * as types from 'vs/base/common/types';
@@ -262,7 +262,7 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		let toolbarActions = [];
 		_tasks.forEach(a => {
 			let iconClassName = TaskRegistry.getOrCreateTaskIconClassName(a);
-			toolbarActions.push(new ToolbarAction(a.id, (this.extensionTasks[a.id] && (language !== 'en')) ? this.extensionTasks[a.id] : a.title.toString(), iconClassName, this.runAction, this, this.logService));
+			toolbarActions.push(new ToolbarAction(a.id, (this.extensionTasks[a.id] && Language.isDefault()) ? this.extensionTasks[a.id] : a.title.toString(), iconClassName, this.runAction, this, this.logService));
 		});
 
 		let content: ITaskbarContent[] = [];

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -81,6 +81,12 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 	// tslint:disable:no-unused-variable
 	private readonly homeTabTitle: string = nls.localize('home', "Home");
 	private readonly homeTabId: string = 'homeTab';
+
+	//list of tasks that are from extensions that will need to have their labels replaced due to localization issues.
+	private readonly extensionTasks = {
+		'mssqlCluster.task.newNotebook': nls.localize('notebook.command.new', "New Notebook")
+	};
+
 	private tabToolbarActionsConfig = new Map<string, any[]>();
 	private tabContents = new Map<string, string>();
 
@@ -255,7 +261,7 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		let toolbarActions = [];
 		_tasks.forEach(a => {
 			let iconClassName = TaskRegistry.getOrCreateTaskIconClassName(a);
-			toolbarActions.push(new ToolbarAction(a.id, a.title.toString(), iconClassName, this.runAction, this, this.logService));
+			toolbarActions.push(new ToolbarAction(a.id, this.extensionTasks[a.id] ? this.extensionTasks[a.id] : a.title.toString(), iconClassName, this.runAction, this, this.logService));
 		});
 
 		let content: ITaskbarContent[] = [];

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -262,7 +262,7 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 		let toolbarActions = [];
 		_tasks.forEach(a => {
 			let iconClassName = TaskRegistry.getOrCreateTaskIconClassName(a);
-			toolbarActions.push(new ToolbarAction(a.id, (this.extensionTasks[a.id] && Language.isDefault()) ? this.extensionTasks[a.id] : a.title.toString(), iconClassName, this.runAction, this, this.logService));
+			toolbarActions.push(new ToolbarAction(a.id, (this.extensionTasks[a.id] && Language.isDefaultVariant()) ? this.extensionTasks[a.id] : a.title.toString(), iconClassName, this.runAction, this, this.logService));
 		});
 
 		let content: ITaskbarContent[] = [];


### PR DESCRIPTION
When a language pack is installed on ADS, and the server or database dashboard is clicked, there is a noticeable issue with the "mssqlCLuster.task.newNotebook" task as it reads "object object" rather than "New Notebook" as intended. I'm not sure why this is the case but its a task from an extension (which is localized by itself rather than all at once as with the core files from my understanding) and attempting to retrieve the label string when calling "a.title.toString()" results in an invalid object appearing instead of the title. To fix this edge case, a key value pair of extension task ids and their titles have been added so that they can be localized in the core part of ADS as well rather than just inside the extensions. If an extension task is detected, a replacement translated string is provided instead of the problematic original string.