### PR TITLE
fix extension commands loc display issue

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.component.ts
@@ -254,8 +254,9 @@ export abstract class DashboardPage extends AngularDisposable implements IConfig
 
 		let toolbarActions = [];
 		_tasks.forEach(a => {
-			let iconClassName = TaskRegistry.getOrCreateTaskIconClassName(a);
-			toolbarActions.push(new ToolbarAction(a.id, a.title.toString(), iconClassName, this.runAction, this, this.logService));
+			const iconClassName = TaskRegistry.getOrCreateTaskIconClassName(a);
+			const title = typeof a.title === 'string' ? a.title : a.title.value;
+			toolbarActions.push(new ToolbarAction(a.id, title, iconClassName, this.runAction, this, this.logService));
 		});
 
 		let content: ITaskbarContent[] = [];


### PR DESCRIPTION

fix the issue that the extension contributed commands in dashboard is not displayed properly.

![image](https://user-images.githubusercontent.com/13777222/118739015-3b093480-b7fd-11eb-8f15-a03510be3556.png)

I will produce a build to check the results.

