### PR TITLE
Schema Compare failing test condition set to uncomment state.

### DIFF
--- a/extensions/integration-tests/src/test/schemaCompare.test.ts
+++ b/extensions/integration-tests/src/test/schemaCompare.test.ts
@@ -493,8 +493,7 @@ function assertIncludeExcludeResult(result: mssql.SchemaCompareIncludeExcludeRes
 function assertSchemaCompareResult(schemaCompareResult: mssql.SchemaCompareResult, operationId: string, expectedDifferenceCount: number, expectedIfEqual: boolean = false): void {
 	assert(schemaCompareResult.areEqual === expectedIfEqual, `Expected: the schemas equivalency to be ${expectedIfEqual} Actual: ${schemaCompareResult.areEqual}`);
 	assert(schemaCompareResult.success === true, `Expected: success in schema compare. Actual: Failure`);
-	// TODO: uncomment this after fix to only return errors, not warnings, gets checking into sqltoolsservice
-	// assert(schemaCompareResult.errorMessage === null, `Expected: there should be no error for comparison. Actual Error message: "${schemaCompareResult.errorMessage}"`);
+	assert(schemaCompareResult.errorMessage === null, `Expected: there should be no error for comparison. Actual Error message: "${schemaCompareResult.errorMessage}"`);
 	assert(schemaCompareResult.differences.length === expectedDifferenceCount, `Expected: ${expectedDifferenceCount} differences. Actual differences: "${schemaCompareResult.differences.length}"`);
 	assert(schemaCompareResult.operationId === operationId, `Operation Id Expected to be same as passed. Expected : ${operationId}, Actual ${schemaCompareResult.operationId}`);
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes the schema compare test after uncommenting the commented line because of STS change. With the code change in Schema compare in STS, we are now filtering out the fatal error messages form warning messages and allowing only error related messages to ADS.
