### PR TITLE
Update build timeouts

### DIFF
--- a/build/azure-pipelines/sql-product-build.yml
+++ b/build/azure-pipelines/sql-product-build.yml
@@ -15,6 +15,7 @@ jobs:
       echo "##vso[build.addbuildtag]$(VSCODE_QUALITY)"
     displayName: Add Quality Build Tag
   - template: sql-product-compile.yml
+  timeoutInMinutes: 90
 
 - job: macOS
   condition: and(succeeded(), eq(variables['VSCODE_BUILD_MACOS'], 'true'), ne(variables['VSCODE_QUALITY'], 'saw'))
@@ -24,7 +25,7 @@ jobs:
   - Compile
   steps:
   - template: darwin/sql-product-build-darwin.yml
-  timeoutInMinutes: 180
+  timeoutInMinutes: 90
 
 - job: macOS_Signing
   condition: and(succeeded(), eq(variables['VSCODE_BUILD_MACOS'], 'true'), eq(variables['signed'], true), ne(variables['VSCODE_QUALITY'], 'saw'))
@@ -47,7 +48,7 @@ jobs:
   - template: linux/sql-product-build-linux.yml
     parameters:
       extensionsToUnitTest: ["admin-tool-ext-win", "agent", "azdata", "azurecore", "cms", "dacpac", "import", "schema-compare", "notebook", "resource-deployment", "machine-learning", "sql-database-projects", "data-workspace"]
-  timeoutInMinutes: 300
+  timeoutInMinutes: 90
 
 - job: LinuxWeb
   condition: and(succeeded(), eq(variables['VSCODE_BUILD_WEB'], 'true'), ne(variables['VSCODE_QUALITY'], 'saw'))
@@ -60,6 +61,7 @@ jobs:
   - Compile
   steps:
   - template: web/sql-product-build-web.yml
+  timeoutInMinutes: 90
 
 - job: Docker
   condition: and(succeeded(), eq(variables['VSCODE_BUILD_DOCKER'], 'true'))
@@ -70,6 +72,7 @@ jobs:
   - Linux
   steps:
   - template: docker/sql-product-build-docker.yml
+  timeoutInMinutes: 90
 
 - job: Windows
   condition: and(succeeded(), eq(variables['VSCODE_BUILD_WIN32'], 'true'))
@@ -79,7 +82,7 @@ jobs:
   - Compile
   steps:
   - template: win32/sql-product-build-win32.yml
-  timeoutInMinutes: 300
+  timeoutInMinutes: 90
 
 - job: Windows_Test
   condition: and(succeeded(), eq(variables['VSCODE_BUILD_WIN32'], 'true'))
@@ -90,6 +93,7 @@ jobs:
   - Windows
   steps:
   - template: win32/sql-product-test-win32.yml
+  timeoutInMinutes: 90
 
 - job: Release
   condition: and(succeeded(), or(eq(variables['VSCODE_RELEASE'], 'true'), and(eq(variables['VSCODE_QUALITY'], 'insider'), eq(variables['Build.Reason'], 'Schedule'))))


### PR DESCRIPTION
Added timeouts to a few steps - we've seen a couple instances recently where the builds get stuck and hit the max timeout of 5 hours. There's no reason that our builds should take this long so in order to fail faster setting the timeouts (and updating existing ones) to a more reasonable 90 minutes for each step