### PR TITLE
use local azdata.d.ts for sqlservices

### DIFF
--- a/samples/sqlservices/package.json
+++ b/samples/sqlservices/package.json
@@ -96,7 +96,6 @@
   },
   "devDependencies": {
     "@types/node": "^7.0.43",
-    "@types/azdata": "^1.0.0",
     "@types/vscode": "^1.0.0",
     "braces": "^2.3.2",
     "child-process-promise": "^2.2.1",

--- a/samples/sqlservices/src/typings/refs.d.ts
+++ b/samples/sqlservices/src/typings/refs.d.ts
@@ -2,6 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-
+/// <reference path='../../../../src/sql/azdata.d.ts'/>
 /// <reference path='../../../../src/sql/azdata.proposed.d.ts'/>
 /// <reference path='../../../../src/vs/vscode.proposed.d.ts'/>

--- a/samples/sqlservices/tasks/buildtasks.js
+++ b/samples/sqlservices/tasks/buildtasks.js
@@ -115,8 +115,3 @@ gulp.task('test', (done) => {
 		done();
 	});
 });
-
-gulp.task('copytypings', function () {
-	return gulp.src(config.paths.project.root + '/../../src/sql/azdata.proposed.d.ts')
-		.pipe(gulp.dest('typings/'));
-});

--- a/samples/sqlservices/yarn.lock
+++ b/samples/sqlservices/yarn.lock
@@ -21,13 +21,6 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@types/azdata@^1.0.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@types/azdata/-/azdata-1.25.0.tgz#ae353317408358669f6c27987422d5b56da12429"
-  integrity sha512-Q13MATghre9+C34/YnitHfAa01tbfZm6z/KJZwrMXJ+RjNAlpEb8ym6gazMS40WQCEr8YBfl3KRoi12dMCjdcg==
-  dependencies:
-    "@types/vscode" "*"
-
 "@types/node@*":
   version "13.11.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.0.tgz#390ea202539c61c8fa6ba4428b57e05bc36dc47b"
@@ -38,7 +31,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.10.9.tgz#4343e3b009f8cf5e1ed685e36097b74b4101e880"
   integrity sha512-usSpgoUsRtO5xNV5YEPU8PPnHisFx8u0rokj1BPVn/hDF7zwUDzVLiuKZM38B7z8V2111Fj6kd4rGtQFUZpNOw==
 
-"@types/vscode@*", "@types/vscode@^1.0.0":
+"@types/vscode@^1.0.0":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.52.0.tgz#61917968dd403932127fc4004a21fd8d69e4f61c"
   integrity sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==


### PR DESCRIPTION
sqlservices needs to use the azdata.proposed.d.ts, if we use the definitely typed azdata package, it is very likely to hit issues due to the mismatch between these 2 typing files. update to use local typing file to avoid the issue.