### PR TITLE
add margin for checkbox in modelview tree

### DIFF
--- a/samples/sqlservices/.gitignore
+++ b/samples/sqlservices/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.vsix
 typings/*
+out

--- a/src/sql/workbench/browser/modelComponents/media/treeComponent.css
+++ b/src/sql/workbench/browser/modelComponents/media/treeComponent.css
@@ -17,3 +17,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
+
+.tree-component-node-tile .checkboxWrapper .checkbox {
+	margin: 3px;
+}


### PR DESCRIPTION
This PR fixes #15521

a while back I updated the checkbox to remove the default margin, it seems this scenario we do need the margins for the model view tree.

with the changes:
![image](https://user-images.githubusercontent.com/13777222/118890870-4a978480-b8b4-11eb-98c7-c92626ca0125.png)
