### PR TITLE
Update server tree action contributions

### DIFF
--- a/src/sql/base/common/codicons.ts
+++ b/src/sql/base/common/codicons.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Set of IDs used to identify SQL contributed icons, which override the default
+ * codicon behavior vs/base/common/codicons.ts
+ */
+export const enum SqlIconId {
+	book = 'book',
+	dataExplorer = 'dataExplorer',
+	addServerGroupAction = 'add-server-group-action',
+	addServerAction = 'add-server-action',
+	activeConnectionsAction = 'active-connections-action',
+	serverPage = 'server-page'
+}

--- a/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
+++ b/src/sql/workbench/contrib/connection/browser/connection.contribution.ts
@@ -5,11 +5,10 @@
 
 import { IConfigurationRegistry, Extensions as ConfigExtensions } from 'vs/platform/configuration/common/configurationRegistry';
 import { Registry } from 'vs/platform/registry/common/platform';
-import { AddServerGroupAction, AddServerAction } from 'sql/workbench/services/objectExplorer/browser/connectionTreeAction';
 import { ClearRecentConnectionsAction, GetCurrentConnectionStringAction } from 'sql/workbench/services/connection/browser/connectionActions';
 import * as azdata from 'azdata';
 import { IWorkbenchActionRegistry, Extensions } from 'vs/workbench/common/actions';
-import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
+import { MenuId, MenuRegistry, SyncActionDescriptor } from 'vs/platform/actions/common/actions';
 import { localize } from 'vs/nls';
 import { ConnectionStatusbarItem } from 'sql/workbench/contrib/connection/browser/connectionStatus';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
@@ -20,12 +19,18 @@ import { integrated, azureMFA } from 'sql/platform/connection/common/constants';
 import { AuthenticationType } from 'sql/workbench/services/connection/browser/connectionWidget';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
+import { ConnectionViewletPanel } from 'sql/workbench/contrib/dataExplorer/browser/connectionViewletPanel';
+import { ContextKeyEqualsExpr } from 'vs/platform/contextkey/common/contextkey';
+import { ActiveConnectionsFilterAction, AddServerAction, AddServerGroupAction } from 'sql/workbench/services/objectExplorer/browser/connectionTreeAction';
+import { CONTEXT_SERVER_TREE_VIEW, CONTEXT_SERVER_TREE_HAS_CONNECTIONS } from 'sql/workbench/contrib/objectExplorer/browser/serverTreeView';
+import { SqlIconId } from 'sql/base/common/codicons';
 
 const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 
 workbenchRegistry.registerWorkbenchContribution(ConnectionStatusbarItem, LifecyclePhase.Restored);
 
 import 'sql/workbench/contrib/connection/common/connectionTreeProviderExentionPoint';
+import { ServerTreeViewView } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
 
 // Connection Dashboard registration
 
@@ -52,12 +57,60 @@ actionRegistry.registerWorkbenchAction(
 
 actionRegistry.registerWorkbenchAction(
 	SyncActionDescriptor.create(
+		ActiveConnectionsFilterAction,
+		ActiveConnectionsFilterAction.ID,
+		ActiveConnectionsFilterAction.SHOW_ACTIVE_CONNECTIONS_LABEL
+	),
+	ActiveConnectionsFilterAction.SHOW_ACTIVE_CONNECTIONS_LABEL
+);
+
+actionRegistry.registerWorkbenchAction(
+	SyncActionDescriptor.create(
 		AddServerAction,
 		AddServerAction.ID,
 		AddServerAction.LABEL
 	),
 	AddServerAction.LABEL
 );
+
+MenuRegistry.appendMenuItem(MenuId.ViewTitle, {
+	group: 'navigation',
+	order: 10,
+	command: {
+		id: AddServerAction.ID,
+		title: AddServerAction.LABEL,
+		icon: { id: SqlIconId.addServerAction }
+	},
+	when: ContextKeyEqualsExpr.create('view', ConnectionViewletPanel.ID),
+});
+
+MenuRegistry.appendMenuItem(MenuId.ViewTitle, {
+	group: 'navigation',
+	order: 20,
+	command: {
+		id: AddServerGroupAction.ID,
+		title: AddServerGroupAction.LABEL,
+		icon: { id: SqlIconId.addServerGroupAction }
+	},
+	when: ContextKeyEqualsExpr.create('view', ConnectionViewletPanel.ID),
+});
+
+MenuRegistry.appendMenuItem(MenuId.ViewTitle, {
+	group: 'navigation',
+	order: 30,
+	command: {
+		id: ActiveConnectionsFilterAction.ID,
+		title: ActiveConnectionsFilterAction.SHOW_ACTIVE_CONNECTIONS_LABEL,
+		icon: { id: SqlIconId.activeConnectionsAction },
+		precondition: CONTEXT_SERVER_TREE_HAS_CONNECTIONS,
+		toggled: {
+			condition: CONTEXT_SERVER_TREE_VIEW.isEqualTo(ServerTreeViewView.active),
+			icon: { id: SqlIconId.serverPage },
+			tooltip: ActiveConnectionsFilterAction.SHOW_ALL_CONNECTIONS_LABEL
+		}
+	},
+	when: ContextKeyEqualsExpr.create('view', ConnectionViewletPanel.ID),
+});
 
 CommandsRegistry.registerCommand('azdata.connect',
 	function (accessor, args: {

--- a/src/sql/workbench/contrib/dataExplorer/browser/connectionViewletPanel.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/connectionViewletPanel.ts
@@ -10,12 +10,7 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IViewletViewOptions } from 'vs/workbench/browser/parts/views/viewsViewlet';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IAction } from 'vs/base/common/actions';
 import { ServerTreeView } from 'sql/workbench/contrib/objectExplorer/browser/serverTreeView';
-import {
-	ActiveConnectionsFilterAction,
-	AddServerAction, AddServerGroupAction
-} from 'sql/workbench/services/objectExplorer/browser/connectionTreeAction';
 import { IObjectExplorerService } from 'sql/workbench/services/objectExplorer/browser/objectExplorerService';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
@@ -33,9 +28,6 @@ export class ConnectionViewletPanel extends ViewPane {
 
 	private _root?: HTMLElement;
 	private _serverTreeView: ServerTreeView;
-	private _addServerAction: IAction;
-	private _addServerGroupAction: IAction;
-	private _activeConnectionsFilterAction: ActiveConnectionsFilterAction;
 
 	constructor(
 		private options: IViewletViewOptions,
@@ -52,18 +44,11 @@ export class ConnectionViewletPanel extends ViewPane {
 		@ITelemetryService telemetryService: ITelemetryService,
 	) {
 		super({ ...(options as IViewPaneOptions) }, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, opener, themeService, telemetryService);
-		this._addServerAction = this.instantiationService.createInstance(AddServerAction,
-			AddServerAction.ID,
-			AddServerAction.LABEL);
-		this._addServerGroupAction = this.instantiationService.createInstance(AddServerGroupAction,
-			AddServerGroupAction.ID,
-			AddServerGroupAction.LABEL);
-		this._serverTreeView = <any>this.objectExplorerService.getServerTreeView() as ServerTreeView;
+		this._serverTreeView = this.objectExplorerService.getServerTreeView() as ServerTreeView;
 		if (!this._serverTreeView) {
 			this._serverTreeView = this.instantiationService.createInstance(ServerTreeView);
 			this.objectExplorerService.registerServerTreeView(this._serverTreeView);
 		}
-		this._activeConnectionsFilterAction = this._serverTreeView.activeConnectionsFilterAction;
 	}
 
 	protected renderHeader(container: HTMLElement): void {
@@ -112,14 +97,6 @@ export class ConnectionViewletPanel extends ViewPane {
 
 	count(): number {
 		return 0;
-	}
-
-	public getActions(): IAction[] {
-		return [
-			this._addServerAction,
-			this._addServerGroupAction,
-			this._activeConnectionsFilterAction
-		];
 	}
 
 	public clearSearch() {

--- a/src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet.ts
+++ b/src/sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet.ts
@@ -27,6 +27,7 @@ import { ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneCont
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { Viewlet } from 'vs/workbench/browser/viewlet';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { SqlIconId } from 'sql/base/common/codicons';
 
 export const VIEWLET_ID = 'workbench.view.connections';
 
@@ -132,8 +133,6 @@ export class DataExplorerViewPaneContainer extends ViewPaneContainer {
 	}
 }
 
-export const dataExplorerIconId = 'dataExplorer';
-
 export const VIEW_CONTAINER = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer({
 	id: VIEWLET_ID,
 	title: localize('dataexplorer.name', "Connections"),
@@ -144,7 +143,7 @@ export const VIEW_CONTAINER = Registry.as<IViewContainersRegistry>(ViewContainer
 		keybindings: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_D },
 		order: 0
 	},
-	icon: { id: 'dataExplorer' },
+	icon: { id: SqlIconId.dataExplorer },
 	order: 0,
 	storageId: `${VIEWLET_ID}.state`
 }, ViewContainerLocation.Sidebar, { isDefault: true });

--- a/src/sql/workbench/contrib/objectExplorer/browser/media/serverTreeActions.css
+++ b/src/sql/workbench/contrib/objectExplorer/browser/media/serverTreeActions.css
@@ -4,29 +4,38 @@
  *--------------------------------------------------------------------------------------------*/
 
 /* Icons for various registered servers actions */
-.monaco-workbench .add-server-action {
-	background-image: url('add_server.svg');
+.monaco-workbench .dataExplorer-viewlet .actions-container .action-label.add-server-action {
+	background-image: url('add_server.svg') !important;
 }
 
-.monaco-workbench.vs-dark .add-server-action,
-.monaco-workbench.hc-black .add-server-action {
-	background-image: url('add_server_inverse.svg');
+.monaco-workbench.vs-dark .dataExplorer-viewlet .actions-container .action-label.add-server-action,
+.monaco-workbench.hc-black .dataExplorer-viewlet .actions-container .action-label.add-server-action {
+	background-image: url('add_server_inverse.svg') !important;
 }
 
-.monaco-workbench .add-server-group-action {
-	background-image: url('new_servergroup.svg');
+.monaco-workbench .dataExplorer-viewlet .actions-container .action-label.add-server-group-action {
+	background-image: url('new_servergroup.svg') !important;
 }
 
-.monaco-workbench.vs-dark .add-server-group-action,
-.monaco-workbench.hc-black .add-server-group-action {
-	background-image: url('new_servergroup_inverse.svg');
+.monaco-workbench.vs-dark .dataExplorer-viewlet .actions-container .action-label.add-server-group-action,
+.monaco-workbench.hc-black .dataExplorer-viewlet .actions-container .action-label.add-server-group-action {
+	background-image: url('new_servergroup_inverse.svg') !important;
 }
 
-.monaco-workbench .active-connections-action {
-	background-image: url('connected_active_server.svg');
+.monaco-workbench .dataExplorer-viewlet .actions-container .action-label.active-connections-action {
+	background-image: url('connected_active_server.svg') !important;
 }
 
-.monaco-workbench.vs-dark .active-connections-action,
-.monaco-workbench.hc-black .active-connections-action{
-	background-image: url('connected_active_server_inverse.svg');
+.monaco-workbench.vs-dark .dataExplorer-viewlet .actions-container .action-label.active-connections-action,
+.monaco-workbench.hc-black .dataExplorer-viewlet .actions-container .action-label.active-connections-action {
+	background-image: url('connected_active_server_inverse.svg') !important;
+}
+
+.monaco-workbench .dataExplorer-viewlet .actions-container .action-label.server-page {
+	background-image: url('server_page.svg') !important;
+}
+
+.monaco-workbench.vs-dark .dataExplorer-viewlet .actions-container .action-label.server-page,
+.monaco-workbench.hc-black .dataExplorer-viewlet .actions-container .action-label.server-page {
+	background-image: url('server_page_inverse.svg') !important;
 }

--- a/src/sql/workbench/contrib/objectExplorer/browser/media/server_page.svg
+++ b/src/sql/workbench/contrib/objectExplorer/browser/media/server_page.svg
@@ -1,0 +1,1 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:#212121;}.cls-2{fill:#231f20;}</style></defs><title>server_16x16</title><path class="cls-1" d="M0,0V16H10.53V0ZM1,1H9.53v9H1ZM9.53,15H1V11H9.53Z"/><path class="cls-2" d="M4.39,4.23H1.94V1.77H4.39Zm-2-.5H3.89V2.27H2.44Z"/></svg>

--- a/src/sql/workbench/contrib/objectExplorer/browser/media/server_page_inverse.svg
+++ b/src/sql/workbench/contrib/objectExplorer/browser/media/server_page_inverse.svg
@@ -1,0 +1,1 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:#fff;}</style></defs><title>server_inverse_16x16</title><path class="cls-1" d="M2.73,0V16H13.26V0Zm1,1h8.53v9H3.73ZM12.26,15H3.73V11h8.53Z"/><path class="cls-1" d="M7.21,4.23H4.75V1.77H7.21Zm-2-.5H6.71V2.27H5.25Z"/></svg>

--- a/src/sql/workbench/contrib/objectExplorer/test/browser/serverTreeView.test.ts
+++ b/src/sql/workbench/contrib/objectExplorer/test/browser/serverTreeView.test.ts
@@ -16,6 +16,7 @@ import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServic
 import { TreeItemCollapsibleState } from 'sql/workbench/services/objectExplorer/common/treeNode';
 import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 import * as assert from 'assert';
+import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
 
 suite('ServerTreeView onAddConnectionProfile handler tests', () => {
 
@@ -37,7 +38,7 @@ suite('ServerTreeView onAddConnectionProfile handler tests', () => {
 		);
 		mockConnectionManagementService.setup(x => x.getConnectionGroups()).returns(x => []);
 		mockConnectionManagementService.setup(x => x.hasRegisteredServers()).returns(() => true);
-		serverTreeView = new ServerTreeView(mockConnectionManagementService.object, instantiationService, undefined, new TestThemeService(), undefined, undefined, capabilitiesService, undefined, undefined);
+		serverTreeView = new ServerTreeView(mockConnectionManagementService.object, instantiationService, undefined, new TestThemeService(), undefined, undefined, capabilitiesService, undefined, undefined, new MockContextKeyService());
 		mockTree = TypeMoq.Mock.ofType(TestTree);
 		(serverTreeView as any)._tree = mockTree.object;
 		mockRefreshTreeMethod = TypeMoq.Mock.ofType(Function);

--- a/src/sql/workbench/contrib/scripting/test/browser/scriptingActions.test.ts
+++ b/src/sql/workbench/contrib/scripting/test/browser/scriptingActions.test.ts
@@ -22,6 +22,7 @@ import { createObjectExplorerServiceMock } from 'sql/workbench/services/objectEx
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { TestTree } from 'sql/workbench/test/treeMock';
 import { TestConnectionManagementService } from 'sql/platform/connection/test/common/testConnectionManagementService';
+import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
 
 const connection: azdata.IConnectionProfile = {
 	options: [],
@@ -64,7 +65,7 @@ suite('Scripting Actions', () => {
 		instantiationService = new InstantiationService(collection);
 		const capabilitiesService = new TestCapabilitiesService();
 		const connectionManagementServiceMock = TypeMoq.Mock.ofType(TestConnectionManagementService, TypeMoq.MockBehavior.Loose);
-		const serverTreeViewMock = TypeMoq.Mock.ofType(ServerTreeView, TypeMoq.MockBehavior.Loose, connectionManagementServiceMock.object, instantiationService, undefined, undefined, undefined, undefined, capabilitiesService);
+		const serverTreeViewMock = TypeMoq.Mock.ofType(ServerTreeView, TypeMoq.MockBehavior.Loose, connectionManagementServiceMock.object, instantiationService, undefined, undefined, undefined, undefined, capabilitiesService, undefined, undefined, new MockContextKeyService());
 		treeMock = TypeMoq.Mock.ofType(TestTree);
 		serverTreeViewMock.setup(x => x.tree).returns(() => treeMock.object);
 		collection.set(IObjectExplorerService, createObjectExplorerServiceMock({ serverTreeView: serverTreeViewMock.object, treeNode: treeNode }));

--- a/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/az_data_welcome_page.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AddServerAction } from 'sql/workbench/services/objectExplorer/browser/connectionTreeAction';
 import { escape } from 'vs/base/common/strings';
 import { localize } from 'vs/nls';
 
@@ -37,7 +38,7 @@ export default () => `
 						</div>
 						<div class="row header-bottom-nav-tiles ads-grid">
 							<div class="col">
-								<a role="button" class="header-bottom-nav-tile-link ads-welcome-page-link" href="command:registeredServers.addConnection">
+								<a role="button" class="header-bottom-nav-tile-link ads-welcome-page-link" href="command:${AddServerAction.ID}">
 									<div class="header-bottom-nav-tile tile tile-connection">
 										<h3>${escape(localize('welcomePage.createConnection', "Create a connection"))}</h3>
 										<p>${escape(localize('welcomePage.createConnectionBody', "Connect to a database instance through the connection dialog."))}</p>

--- a/src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/gettingStartedTour.ts
@@ -22,8 +22,8 @@ import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { Button } from 'sql/base/browser/ui/button/button';
 import { extensionsViewIcon } from 'vs/workbench/contrib/extensions/browser/extensionsIcons';
 import { settingsViewBarIcon } from 'vs/workbench/browser/parts/activitybar/activitybarPart';
-import { dataExplorerIconId } from 'sql/workbench/contrib/dataExplorer/browser/dataExplorerViewlet';
 import { notebookIconId } from 'sql/workbench/contrib/notebook/browser/notebookExplorer/notebookExplorerViewlet';
+import { SqlIconId } from 'sql/base/common/codicons';
 
 const $ = dom.$;
 interface TourData {
@@ -44,7 +44,7 @@ interface TourData {
 	popupImage: string;
 }
 
-const dataExplorerIconCssSelector = `.action-label.${dataExplorerIconId}`;
+const dataExplorerIconCssSelector = `.action-label.${SqlIconId.dataExplorer}`;
 const notebookIconCssSelector = `.action-label.${notebookIconId}`;
 const extensionsIconCssSelector = ThemeIcon.asCSSSelector(extensionsViewIcon);
 const settingsGearIconCssSelector = ThemeIcon.asCSSSelector(settingsViewBarIcon);

--- a/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -54,6 +54,7 @@ import { ICommandAction, MenuItemAction } from 'vs/platform/actions/common/actio
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IExtensionRecommendationsService } from 'vs/workbench/services/extensionRecommendations/common/extensionRecommendations';
 import { attachButtonStyler } from 'vs/platform/theme/common/styler';
+import { AddServerAction } from 'sql/workbench/services/objectExplorer/browser/connectionTreeAction';
 const configurationKey = 'workbench.startupEditor';
 const oldConfigurationKey = 'workbench.welcome.enabled';
 const telemetryFrom = 'welcomePage';
@@ -211,7 +212,7 @@ const extensionPackStrings = {
 const NewActionItems: ICommandAction[] = [
 	{
 		title: localize('welcomePage.newConnection', "New connection"),
-		id: 'registeredServers.addConnection'
+		id: AddServerAction.ID
 	}, {
 		title: localize('welcomePage.newQuery', "New query"),
 		id: 'workbench.action.files.newUntitledFile'

--- a/src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page.ts
+++ b/src/sql/workbench/contrib/welcome2/page/browser/az_data_welcome_page.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AddServerAction } from 'sql/workbench/services/objectExplorer/browser/connectionTreeAction';
 import { escape } from 'vs/base/common/strings';
 import { localize } from 'vs/nls';
 
@@ -18,7 +19,7 @@ export default () => `
 				<div class="section start">
 					<h2 class="caption">${escape(localize('welcomePage.start', "Start"))}</h2>
 					<ul>
-						<li><a href="command:registeredServers.addConnection">${escape(localize('welcomePage.newConnection', "New connection"))}</a></li>
+						<li><a href="command:${AddServerAction.ID}">${escape(localize('welcomePage.newConnection', "New connection"))}</a></li>
 						<li><a href="command:workbench.action.files.newUntitledFile">${escape(localize('welcomePage.newQuery', "New query"))}</a></li>
 						<li><a href="command:notebook.command.new">${escape(localize('welcomePage.newNotebook', "New notebook"))}</a></li>
 						<li class="mac-only"><a href="command:workbench.action.files.openLocalFileFolder">${escape(localize('welcomePage.openFileMac', "Open file"))}</a></li>

--- a/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/objectExplorerService.ts
@@ -20,7 +20,6 @@ import { entries } from 'sql/base/common/collections';
 import { values } from 'vs/base/common/collections';
 import { startsWith } from 'vs/base/common/strings';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
-import { IAction } from 'vs/base/common/actions';
 import { ServerTreeActionProvider } from 'sql/workbench/services/objectExplorer/browser/serverTreeActionProvider';
 import { ITree } from 'vs/base/parts/tree/browser/tree';
 import { AsyncServerTree, ServerTreeElement } from 'sql/workbench/services/objectExplorer/browser/asyncServerTree';
@@ -31,6 +30,11 @@ export const IObjectExplorerService = createDecorator<IObjectExplorerService>(SE
 
 export interface NodeExpandInfoWithProviderId extends azdata.ObjectExplorerExpandInfo {
 	providerId: string;
+}
+
+export const enum ServerTreeViewView {
+	all = 'all',
+	active = 'active'
 }
 
 export interface IServerTreeView {
@@ -47,9 +51,10 @@ export interface IServerTreeView {
 	setExpandedState(node: ServerTreeElement, state?: TreeItemCollapsibleState): Promise<void>;
 	setSelected(node: ServerTreeElement, selected?: boolean, clearOtherSelections?: boolean): Promise<void>;
 	refreshTree(): Promise<void>;
-	readonly activeConnectionsFilterAction: IAction;
 	renderBody(container: HTMLElement): Promise<void>;
 	layout(size: number): void;
+	showFilteredTree(view: ServerTreeViewView): void;
+	view: ServerTreeViewView;
 }
 
 export interface IObjectExplorerService {

--- a/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/serverTreeActionProvider.ts
@@ -9,8 +9,8 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 import {
-	DisconnectConnectionAction, AddServerAction, EditConnectionAction,
-	DeleteConnectionAction, RefreshAction, EditServerGroupAction
+	DisconnectConnectionAction, EditConnectionAction,
+	DeleteConnectionAction, RefreshAction, EditServerGroupAction, AddServerAction
 } from 'sql/workbench/services/objectExplorer/browser/connectionTreeAction';
 import { TreeNode } from 'sql/workbench/services/objectExplorer/common/treeNode';
 import { NodeType } from 'sql/workbench/services/objectExplorer/common/nodeType';
@@ -157,6 +157,7 @@ export class ServerTreeActionProvider {
 	 * Return actions for connection group elements
 	 */
 	private getConnectionProfileGroupActions(element: ConnectionProfileGroup): IAction[] {
+		// TODO: Should look into using the MenuRegistry for this
 		return [
 			this._instantiationService.createInstance(AddServerAction, AddServerAction.ID, AddServerAction.LABEL),
 			this._instantiationService.createInstance(EditServerGroupAction, EditServerGroupAction.ID, EditServerGroupAction.LABEL, element),

--- a/src/vs/base/common/codicons.ts
+++ b/src/vs/base/common/codicons.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { SqlIconId } from 'sql/base/common/codicons';
 import { codiconStartMarker } from 'vs/base/common/codicon';
 import { Emitter, Event } from 'vs/base/common/event';
 import { localize } from 'vs/nls';
@@ -91,9 +92,9 @@ export namespace CSSIcon {
 		let [, id, modifier] = match;
 
 		// {{SQL CARBON EDIT}} Modifying method to not add 'codicon' in front of sql carbon icons.
-		let sqlCarbonIcons = ['book', 'dataExplorer'];
+		let sqlCarbonIcons: string[] = [SqlIconId.book, SqlIconId.dataExplorer, SqlIconId.activeConnectionsAction, SqlIconId.addServerAction, SqlIconId.addServerGroupAction, SqlIconId.serverPage];
 		if (sqlCarbonIcons.includes(id)) {
-			return [id];
+			return ['codicon', id];
 			// {{SQL CARBON EDIT}} End of edit
 		} else {
 			const classNames = ['codicon', 'codicon-' + id];


### PR DESCRIPTION
In an [incoming VS Code merge](https://github.com/microsoft/vscode/commit/585c5cc04b99ea2a9e03d25035f73c1354188fc0#diff-3e738fc4417c6ddcfa32cbda3356cb2b2b30943137d429757e3d7585764f22b9) they removed the get*Actions functions from View Panes, which means that the servers view that utilized this no longer had any of the titlebar actions displayed.

Instead of pushing it along with thousands of other changes being made for that I figured I'd fix it here now since it shouldn't result in any behavior change and allows for actual reviewing of the changes.

The general idea of the fix for this is simple - we should be using the Menu registry to register actions instead (this is how all of the view panes that I looked at for VS Code does it).

Unfortunately it wasn't so simple in our case as just adding the menu registries - our logic was embedded pretty deeply with the server tree view such that the actions depended on being created once and then updated as they were interacted with. But with menu registrations that isn't the case anymore - a new instance is created each time and it's expected that something else handles the state. 

For the add server/add server group actions this wasn't a huge problem - just minor refactoring and moving stuff around. But for the filtering action this ended up being a pretty hefty reworking of how that action functions. I can go into more details as needed, but a quick summary is that now it just uses the current state ("view") of the tree to determine which action to take, and then uses context keys to determine what state to display itself as. 

Along the way I did some other cleanup such as :

1. Consolidating the icon IDs used to override codicon IDs (since the menu registration system doesn't allow customizing classes directly)
2. Removing an unused action - RecentConnectionsFilterAction
3. Scoped down the CSS rules for the action icons

Note that I had to add `!important` to the rules because of how action labels work in VS Code now - they set their own background-image property which was overwriting the values we were setting (this was an issue I've already fixed before for the dashboard toolbar icons). 

Also at the end of all of this there's still going to be work we'll likely need to do eventually. Typically menu actions are registered using the [registerAction2](https://github.com/Microsoft/vscode/blob/main/src/vs/platform/actions/common/actions.ts#L535) function, but in our case we're using these Actions in other places (such as context menus for the server tree) which require an Action - not an Action2. And so in the interest of keeping the change slightly simpler I opted to just do this for now and we can follow up as needed once we hit any issues there. 