### PR TITLE
fix tree view issue

### DIFF
--- a/src/sql/workbench/browser/modelComponents/treeViewDataProvider.ts
+++ b/src/sql/workbench/browser/modelComponents/treeViewDataProvider.ts
@@ -28,6 +28,13 @@ export class ResolvableTreeComponentItem extends ResolvableTreeItem implements I
 		this.onCheckedChanged = treeItem.onCheckedChanged;
 		this.children = deepClone(treeItem.children);
 	}
+
+	asTreeItem(): ITreeComponentItem {
+		const item = super.asTreeItem() as ITreeComponentItem;
+		item.checked = this.checked;
+		item.enabled = this.enabled;
+		return item;
+	}
 }
 
 export class TreeViewDataProvider extends vsTreeView.TreeViewDataProvider implements IModelViewTreeViewDataProvider {


### PR DESCRIPTION
This PR fixes #15526 

root cause:

in this commit: https://github.com/microsoft/vscode/commit/b9b92e3152617ff93e903a1af018ab503eca0d53#diff-e800dadf7ee98022eb1cff5a05d091ee52885bbb48ed0f116cfb404d1320e259R238, vscode added logic to use asTreeItem as the property comparison target, our implementation didn't implement this and caused the loss of our custom properties.

fix:

override the asTreeItem method in our implementation.

after:
![image](https://user-images.githubusercontent.com/13777222/118933443-0f21a800-b8fe-11eb-8019-9a3d564de190.png)
