### PR TITLE
Fix changing kernels from kusto to other kernels

### DIFF
--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -964,14 +964,18 @@ export class NotebookModel extends Disposable implements INotebookModel {
 	private async updateKernelInfoOnKernelChange(kernel: nb.IKernel, kernelAlias?: string) {
 		await this.updateKernelInfo(kernel);
 		kernelAlias = this.kernelAliases.find(kernel => this._defaultLanguageInfo?.name === kernel.toLowerCase()) ?? kernelAlias;
+		// In order to change from kernel alias to other kernel, set kernelAlias to undefined in order to update to new kernel language info
+		if (this._selectedKernelDisplayName !== kernelAlias && this._selectedKernelDisplayName) {
+			kernelAlias = undefined;
+		}
+		// Sets the kernel alias language info properly in order to open the notebook with the kernel alias
 		if (kernelAlias) {
 			let aliasLanguageInfo: nb.ILanguageInfo = {
 				name: kernelAlias.toLowerCase(),
 				version: ''
 			};
 			this.updateLanguageInfo(aliasLanguageInfo);
-		}
-		else if (kernel.info) {
+		} else if (kernel.info) {
 			this.updateLanguageInfo(kernel.info.language_info);
 		}
 		this.adstelemetryService.createActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.KernelChanged)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR addresses #15544.

Ensures that Kusto Notebook with language_info containing kusto still opens up with Kusto kernel properly. 
Fixes when a user changes from Kusto (kernel alias) to another kernel by ensuring we update the language_info to use the selectedKernel language_info, and not the current kernelAlias. 
