### PR TITLE
Run with Parameters learn more link to use correct format and kernels

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -312,7 +312,7 @@ export class RunParametersAction extends TooltipFromLabelAction {
 		const editor = this._notebookService.findNotebookEditor(context);
 		// Only run action for kernels that are supported (Python, PySpark, PowerShell)
 		let supportedKernels: string[] = [KernelsLanguage.Python, KernelsLanguage.PowerShell];
-		if (!supportedKernels.includes(editor.model.language)) {
+		if (!supportedKernels.includes(editor.model.languageInfo.name)) {
 			// If there is no parameters in the cell indicate to user to add them
 			this.notificationService.notify({
 				severity: Severity.Info,

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -32,7 +32,7 @@ import { URI } from 'vs/base/common/uri';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { IAdsTelemetryService } from 'sql/platform/telemetry/common/telemetry';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
-import { KernelsLanguage } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { KernelsLanguage } from 'sql/workbench/services/notebook/common/notebookConstants';
 
 const msgLoading = localize('loading', "Loading kernels...");
 export const msgChanging = localize('changing', "Changing kernel...");

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -313,7 +313,7 @@ export class RunParametersAction extends TooltipFromLabelAction {
 		// Only run action for kernels that are supported (Python, PySpark, PowerShell)
 		let supportedKernels: string[] = [KernelsLanguage.Python, KernelsLanguage.PowerShell];
 		if (!supportedKernels.includes(editor.model.languageInfo.name)) {
-			// If there is no parameters in the cell indicate to user to add them
+			// If the kernel is not supported indicate to user to use supported kernels
 			this.notificationService.notify({
 				severity: Severity.Info,
 				message: kernelNotSupported,

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookActions.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookActions.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as azdata from 'azdata';
 import * as sinon from 'sinon';
 import { TestConfigurationService } from 'sql/platform/connection/test/common/testConfigurationService';
-import { AddCellAction, ClearAllOutputsAction, CollapseCellsAction, KernelsDropdown, msgChanging, NewNotebookAction, noKernelName, noParameterCell, noParametersInCell, RunAllCellsAction, RunParametersAction, TrustedAction } from 'sql/workbench/contrib/notebook/browser/notebookActions';
+import { AddCellAction, ClearAllOutputsAction, CollapseCellsAction, kernelNotSupported, KernelsDropdown, msgChanging, NewNotebookAction, noKernelName, noParameterCell, noParametersInCell, RunAllCellsAction, RunParametersAction, TrustedAction } from 'sql/workbench/contrib/notebook/browser/notebookActions';
 import { ClientSessionStub, ContextViewProviderStub, NotebookComponentStub, NotebookModelStub, NotebookServiceStub } from 'sql/workbench/contrib/notebook/test/stubs';
 import { NotebookEditorStub } from 'sql/workbench/contrib/notebook/test/testCommon';
 import { ICellModel, INotebookModel } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
@@ -259,7 +259,7 @@ suite('Notebook Actions', function (): void {
 		assert.strictEqual(actualCmdId, NewNotebookAction.INTERNAL_NEW_NOTEBOOK_CMD_ID);
 	});
 
-	test('Run with Parameters Action', async function (): Promise<void> {
+	test('Should Run with Parameters Action', async function (): Promise<void> {
 		const testContents: azdata.nb.INotebookContents = {
 			cells: [{
 				cell_type: CellTypes.Code,
@@ -281,8 +281,10 @@ suite('Notebook Actions', function (): void {
 		let mockNotification = TypeMoq.Mock.ofType<INotificationService>(TestNotificationService);
 		mockNotification.setup(n => n.notify(TypeMoq.It.isAny()));
 		let quickInputService = new MockQuickInputService;
-		let mockNotebookModel = new NotebookModelStub(undefined, undefined, testContents);
-
+		let testLanguageInfo: azdata.nb.ILanguageInfo = {
+			name: 'python',
+		};
+		let mockNotebookModel = new NotebookModelStub(testLanguageInfo, undefined, testContents);
 		let action = new RunParametersAction('TestId', true, testUri, quickInputService, mockNotebookService.object, mockNotification.object);
 
 		const testCells = [<ICellModel>{
@@ -301,7 +303,7 @@ suite('Notebook Actions', function (): void {
 		assert.call(mockNotebookService.object.openNotebook(testUri, testShowOptions), 'Should Open Parameterized Notebook');
 	});
 
-	test('Run with Parameters Action with no parameter cell in notebook', async function (): Promise<void> {
+	test('Should inform user to add a parameter cell if Run with Parameters Action has no parameter cell', async function (): Promise<void> {
 		const testContents: azdata.nb.INotebookContents = {
 			cells: [{
 				cell_type: CellTypes.Code,
@@ -328,8 +330,10 @@ suite('Notebook Actions', function (): void {
 			return undefined;
 		});
 		let quickInputService = new MockQuickInputService;
-		let mockNotebookModel = new NotebookModelStub(undefined, undefined, testContents);
-
+		let testLanguageInfo: azdata.nb.ILanguageInfo = {
+			name: 'python',
+		};
+		let mockNotebookModel = new NotebookModelStub(testLanguageInfo, undefined, testContents);
 		let action = new RunParametersAction('TestId', true, testUri, quickInputService, mockNotebookService.object, mockNotification.object);
 
 		mockNotebookEditor.setup(x => x.model).returns(() => mockNotebookModel);
@@ -340,7 +344,7 @@ suite('Notebook Actions', function (): void {
 		assert.strictEqual(actualMsg, expectedMsg);
 	});
 
-	test('Run with Parameters Action with empty string parameter cell in notebook', async function (): Promise<void> {
+	test('Should inform user to add parameters if Run with Parameters Action contains empty string parameter cell', async function (): Promise<void> {
 		const testContents: azdata.nb.INotebookContents = {
 			cells: [{
 				cell_type: CellTypes.Code,
@@ -367,8 +371,10 @@ suite('Notebook Actions', function (): void {
 			return undefined;
 		});
 		let quickInputService = new MockQuickInputService;
-		let mockNotebookModel = new NotebookModelStub(undefined, undefined, testContents);
-
+		let testLanguageInfo: azdata.nb.ILanguageInfo = {
+			name: 'python',
+		};
+		let mockNotebookModel = new NotebookModelStub(testLanguageInfo, undefined, testContents);
 		let action = new RunParametersAction('TestId', true, testUri, quickInputService, mockNotebookService.object, mockNotification.object);
 		const testCells = [<ICellModel>{
 			isParameter: true,
@@ -383,7 +389,7 @@ suite('Notebook Actions', function (): void {
 		assert.strictEqual(actualMsg, expectedMsg);
 	});
 
-	test('Run with Parameters Action with empty array string parameter cell in notebook', async function (): Promise<void> {
+	test('Should inform user to add parameters if Run with Parameters Action contains empty array string parameter cell', async function (): Promise<void> {
 		const testContents: azdata.nb.INotebookContents = {
 			cells: [{
 				cell_type: CellTypes.Code,
@@ -410,8 +416,10 @@ suite('Notebook Actions', function (): void {
 			return undefined;
 		});
 		let quickInputService = new MockQuickInputService;
-		let mockNotebookModel = new NotebookModelStub(undefined, undefined, testContents);
-
+		let testLanguageInfo: azdata.nb.ILanguageInfo = {
+			name: 'python',
+		};
+		let mockNotebookModel = new NotebookModelStub(testLanguageInfo, undefined, testContents);
 		let action = new RunParametersAction('TestId', true, testUri, quickInputService, mockNotebookService.object, mockNotification.object);
 
 		const testCells = [<ICellModel>{
@@ -427,7 +435,7 @@ suite('Notebook Actions', function (): void {
 		assert.strictEqual(actualMsg, expectedMsg);
 	});
 
-	test('Run with Parameters Action with empty parameter cell in notebook', async function (): Promise<void> {
+	test('Should inform user to add parameters if Run with Parameters Action contains empty parameter cell', async function (): Promise<void> {
 		const testContents: azdata.nb.INotebookContents = {
 			cells: [{
 				cell_type: CellTypes.Code,
@@ -454,7 +462,10 @@ suite('Notebook Actions', function (): void {
 			return undefined;
 		});
 		let quickInputService = new MockQuickInputService;
-		let mockNotebookModel = new NotebookModelStub(undefined, undefined, testContents);
+		let testLanguageInfo: azdata.nb.ILanguageInfo = {
+			name: 'python',
+		};
+		let mockNotebookModel = new NotebookModelStub(testLanguageInfo, undefined, testContents);
 
 		let action = new RunParametersAction('TestId', true, testUri, quickInputService, mockNotebookService.object, mockNotification.object);
 
@@ -464,6 +475,51 @@ suite('Notebook Actions', function (): void {
 		}];
 		mockNotebookEditor.setup(x => x.model).returns(() => mockNotebookModel);
 		mockNotebookEditor.setup(x => x.cells).returns(() => testCells);
+
+		// Run Parameters Action
+		await action.run(testUri);
+
+		assert.strictEqual(actualMsg, expectedMsg);
+	});
+
+	test('Should inform user kernel is not supported if Run with Parameters Action is run with unsupported kernels', async function (): Promise<void> {
+		// Kernels that are supported (Python, PySpark, PowerShell)
+
+		const testContents: azdata.nb.INotebookContents = {
+			cells: [{
+				cell_type: CellTypes.Code,
+				source: [],
+				metadata: { language: 'sql' },
+				execution_count: 1
+			}],
+			metadata: {
+				kernelspec: {
+					name: 'sql',
+					language: 'sql',
+					display_name: 'SQL'
+				}
+			},
+			nbformat: 4,
+			nbformat_minor: 5
+		};
+		let expectedMsg: string = kernelNotSupported;
+
+		let actualMsg: string;
+		let mockNotification = TypeMoq.Mock.ofType<INotificationService>(TestNotificationService);
+		mockNotification.setup(n => n.notify(TypeMoq.It.isAny())).returns(notification => {
+			actualMsg = notification.message;
+			return undefined;
+		});
+
+		let quickInputService = new MockQuickInputService;
+		let testLanguageInfo: azdata.nb.ILanguageInfo = {
+			name: 'sql',
+		};
+		let mockNotebookModel = new NotebookModelStub(testLanguageInfo, undefined, testContents);
+
+		let action = new RunParametersAction('TestId', true, testUri, quickInputService, mockNotebookService.object, mockNotification.object);
+
+		mockNotebookEditor.setup(x => x.model).returns(() => mockNotebookModel);
 
 		// Run Parameters Action
 		await action.run(testUri);

--- a/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
+++ b/src/sql/workbench/services/notebook/browser/models/notebookModel.ts
@@ -11,7 +11,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 
 import { IClientSession, INotebookModel, INotebookModelOptions, ICellModel, NotebookContentChange, MoveDirection, ViewMode } from 'sql/workbench/services/notebook/browser/models/modelInterfaces';
 import { NotebookChangeType, CellType, CellTypes } from 'sql/workbench/services/notebook/common/contracts';
-import { nbversion } from 'sql/workbench/services/notebook/common/notebookConstants';
+import { KernelsLanguage, nbversion } from 'sql/workbench/services/notebook/common/notebookConstants';
 import * as notebookUtils from 'sql/workbench/services/notebook/browser/models/notebookUtils';
 import * as TelemetryKeys from 'sql/platform/telemetry/common/telemetryKeys';
 import { INotebookManager, SQL_NOTEBOOK_PROVIDER, DEFAULT_NOTEBOOK_PROVIDER } from 'sql/workbench/services/notebook/browser/notebookService';
@@ -882,12 +882,12 @@ export class NotebookModel extends Disposable implements INotebookModel {
 				language = language.replace(mimeTypePrefix, '');
 			} else if (language.toLowerCase() === 'ipython') {
 				// Special case ipython because in many cases this is defined as the code mirror mode for python notebooks
-				language = 'python';
+				language = KernelsLanguage.Python;
 			} else if (language.toLowerCase() === 'c#') {
-				language = 'cs';
+				language = KernelsLanguage.CSharp;
 			}
 		} else {
-			language = 'python';
+			language = KernelsLanguage.Python;
 		}
 
 		this._language = language.toLowerCase();

--- a/src/sql/workbench/services/notebook/common/notebookConstants.ts
+++ b/src/sql/workbench/services/notebook/common/notebookConstants.ts
@@ -14,3 +14,13 @@ export namespace nbversion {
 	 */
 	export const MINOR_VERSION: number = 2;
 }
+
+export enum KernelsLanguage {
+	SQL = 'sql',
+	Python = 'python',
+	PySpark = 'python',
+	SparkScala = 'scala',
+	SparkR = 'sparkr',
+	PowerShell = 'powershell',
+	CSharp = 'cs'
+}

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -36,6 +36,15 @@ export enum CellOutputKind {
 	Rich = 3
 }
 
+export enum KernelsLanguage {
+	SQL = 'sql',
+	Python = 'python',
+	PySpark = 'python',
+	SparkScala = 'scala',
+	SparkR = 'sparkr',
+	PowerShell = 'powershell'
+}
+
 export const NOTEBOOK_DISPLAY_ORDER = [
 	'application/json',
 	'application/javascript',

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -36,14 +36,6 @@ export enum CellOutputKind {
 	Rich = 3
 }
 
-export enum KernelsLanguage {
-	SQL = 'sql',
-	Python = 'python',
-	PySpark = 'python',
-	SparkScala = 'scala',
-	SparkR = 'sparkr',
-	PowerShell = 'powershell'
-}
 
 export const NOTEBOOK_DISPLAY_ORDER = [
 	'application/json',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15170. 

We should indicate the proper formatting and kernels that we support via the documentation. This will be an ongoing effort to indicate which parameterization method the user can utilize and which ones would work best for their use case. Run with parameters focuses on the parameter cell containing syntax as such:
variable = value
variable2 = value2
...
Only parameters that have an assignment using '=' will be parsed properly and as such, any multi-line parameters will not be. If we were to support multi-line parameters then we would have to create a parser to go validate each parameter and its type. 
