### PR TITLE
Disable npm recompile step

### DIFF
--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -223,18 +223,18 @@ steps:
     displayName: 'Signing Extensions and Langpacks'
     condition: and(succeeded(), eq(variables['signed'], true))
 
-  - script: |
-      set -e
-      cd ./extensions/mssql/node_modules/@microsoft/ads-kerberos
-      # npx node-gyp rebuild
-      yarn install
-    displayName: Recompile native node modules
+  # - script: |
+  #     set -e
+  #     cd ./extensions/mssql/node_modules/@microsoft/ads-kerberos
+  #     # npx node-gyp rebuild
+  #     yarn install
+  #   displayName: Recompile native node modules
 
-  - script: |
-      set -e
-      VSCODE_MIXIN_PASSWORD="$(github-distro-mixin-password)" \
-          yarn gulp vscode-reh-web-linux-x64-min
-    displayName: Build web server
+  # - script: |
+  #     set -e
+  #     VSCODE_MIXIN_PASSWORD="$(github-distro-mixin-password)" \
+  #         yarn gulp vscode-reh-web-linux-x64-min
+  #   displayName: Build web server
 
   - script: |
       set -e


### PR DESCRIPTION
Disable steps that attempt to recompile native npm module with node ABI instead of electron ABI.  I'm disabling instead of removing since the steps are necessary but are currently causing side-effects.  There will be a follow-up PR to re-enable without side-effects (and to actually accomplish the npm recompile 😄).