### PR TITLE
Fix notebook file URI test by adding a required forward slash to Windows file paths.

### DIFF
--- a/extensions/notebook/src/test/protocol/notebookUriHandler.test.ts
+++ b/extensions/notebook/src/test/protocol/notebookUriHandler.test.ts
@@ -19,6 +19,7 @@ import * as constants from '../../common/constants';
 
 import { NotebookUriHandler } from '../../protocol/notebookUriHandler';
 import { CellTypes } from '../../contracts/content';
+import { winPlatform } from '../../common/constants';
 
 describe('Notebook URI Handler', function (): void {
 	let notebookUriHandler: NotebookUriHandler;
@@ -127,7 +128,14 @@ describe('Notebook URI Handler', function (): void {
 		let notebookPath: string = path.join(notebookDir, 'hello.ipynb');
 
 		await fs.mkdir(notebookDir);
-		let fileURI = 'azuredatastudio://microsoft.notebook/open?url=file://' + notebookPath;
+		let baseUrl = 'azuredatastudio://microsoft.notebook/open?url=file://';
+		if (process.platform === winPlatform) {
+			// URI paths are formatted as "hostname/path", but since we're using a local path
+			// we omit the host part and just add the slash. Unix paths already start with a
+			// forward slash, but we have to prepend it manually when using Windows paths.
+			baseUrl = baseUrl + '/';
+		}
+		let fileURI = baseUrl + notebookPath;
 		let fileNotebookUri = vscode.Uri.parse(fileURI);
 		let notebookContent: azdata.nb.INotebookContents = {
 			cells: [{


### PR DESCRIPTION
Noticed this URI test was failing on Windows. Local URI paths have to start with a forward slash, since the URL path format is "hostname/path" and we omit the host name for local paths. Unix paths already start with a forward slash, so there's no problem there, but we needed to manually prepend the forward slash to Windows paths.

For example, if we're using the path C:\Users\\[user]\notebook.ipynb on Windows, then the file URI should be file:///C:\Users\\[user]\notebook.ipynb
