### PR TITLE
Fix extension publishing during CI build

### DIFF
--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -223,18 +223,18 @@ steps:
     displayName: 'Signing Extensions and Langpacks'
     condition: and(succeeded(), eq(variables['signed'], true))
 
-  - script: |
-      set -e
-      cd ./extensions/mssql/node_modules/@microsoft/ads-kerberos
-      # npx node-gyp rebuild
-      yarn install
-    displayName: Recompile native node modules
+  # - script: |
+  #     set -e
+  #     cd ./extensions/mssql/node_modules/@microsoft/ads-kerberos
+  #     # npx node-gyp rebuild
+  #     yarn install
+  #   displayName: Recompile native node modules
 
-  - script: |
-      set -e
-      VSCODE_MIXIN_PASSWORD="$(github-distro-mixin-password)" \
-          yarn gulp vscode-reh-web-linux-x64-min
-    displayName: Build web server
+  # - script: |
+  #     set -e
+  #     VSCODE_MIXIN_PASSWORD="$(github-distro-mixin-password)" \
+  #         yarn gulp vscode-reh-web-linux-x64-min
+  #   displayName: Build web server
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/sql-product-build-linux.yml
+++ b/build/azure-pipelines/linux/sql-product-build-linux.yml
@@ -95,6 +95,7 @@ steps:
       set -e
       yarn gulp vscode-linux-x64-min-ci
       yarn gulp vscode-web-min-ci
+      yarn gulp vscode-reh-web-linux-x64-min
     displayName: Build
     env:
       VSCODE_MIXIN_PASSWORD: $(github-distro-mixin-password)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azuredatastudio",
   "version": "1.30.0",
-  "distro": "99c64148d3393e4f67e531240b870f4cee111e06",
+  "distro": "ab16639070613df1c9772fe028786f44ff9096f3",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
This is a working PR to enable extension publishing during CI builds.  The previous webmode commit broke this.  Other aspects to this change are in the distro repo.