### PR TITLE
Update action run return type

### DIFF
--- a/src/sql/base/browser/ui/panel/tabActions.ts
+++ b/src/sql/base/browser/ui/panel/tabActions.ts
@@ -18,12 +18,7 @@ export class CloseTabAction extends Action {
 		super(CloseTabAction.ID, CloseTabAction.LABEL, CloseTabAction.ICON);
 	}
 
-	run(): Promise<boolean> {
-		try {
-			this.closeFn.apply(this.context);
-			return Promise.resolve(true);
-		} catch (e) {
-			return Promise.resolve(false);
-		}
+	async run(): Promise<void> {
+		this.closeFn.apply(this.context);
 	}
 }

--- a/src/sql/workbench/browser/actions.ts
+++ b/src/sql/workbench/browser/actions.ts
@@ -45,13 +45,11 @@ export class ManageAction extends Action {
 		super(id, label);
 	}
 
-	async run(actionContext: ManageActionContext): Promise<boolean> {
+	async run(actionContext: ManageActionContext): Promise<void> {
 		if (actionContext.profile) {
 			await this._connectionManagementService.connect(actionContext.profile, actionContext.uri, { showDashboard: true, saveTheConnection: false, params: undefined, showConnectionDialogOnError: false, showFirewallRuleOnError: true });
 			this._angularEventingService.sendAngularEvent(actionContext.uri, AngularEventType.NAV_DATABASE);
-			return true;
 		}
-		return false;
 	}
 }
 

--- a/src/sql/workbench/browser/scriptingActions.ts
+++ b/src/sql/workbench/browser/scriptingActions.ts
@@ -26,8 +26,8 @@ export class ScriptSelectAction extends Action {
 		super(id, label);
 	}
 
-	public async run(actionContext: BaseActionContext): Promise<boolean> {
-		return scriptSelect(
+	public async run(actionContext: BaseActionContext): Promise<void> {
+		await scriptSelect(
 			actionContext.profile!,
 			actionContext.object!,
 			this._connectionManagementService,
@@ -51,8 +51,8 @@ export class ScriptExecuteAction extends Action {
 		super(id, label);
 	}
 
-	public async run(actionContext: BaseActionContext): Promise<boolean> {
-		return script(
+	public async run(actionContext: BaseActionContext): Promise<void> {
+		await script(
 			actionContext.profile!,
 			actionContext.object!,
 			this._connectionManagementService,
@@ -78,8 +78,8 @@ export class ScriptAlterAction extends Action {
 		super(id, label);
 	}
 
-	public async run(actionContext: BaseActionContext): Promise<boolean> {
-		return script(
+	public async run(actionContext: BaseActionContext): Promise<void> {
+		await script(
 			actionContext.profile!,
 			actionContext.object!,
 			this._connectionManagementService,
@@ -104,8 +104,8 @@ export class EditDataAction extends Action {
 		super(id, label);
 	}
 
-	public async run(actionContext: BaseActionContext): Promise<boolean> {
-		return scriptEditSelect(
+	public async run(actionContext: BaseActionContext): Promise<void> {
+		await scriptEditSelect(
 			actionContext.profile!,
 			actionContext.object!,
 			this._connectionManagementService,
@@ -129,8 +129,8 @@ export class ScriptCreateAction extends Action {
 		super(id, label);
 	}
 
-	public async run(actionContext: BaseActionContext): Promise<boolean> {
-		return script(
+	public async run(actionContext: BaseActionContext): Promise<void> {
+		await script(
 			actionContext.profile!,
 			actionContext.object!,
 			this._connectionManagementService,
@@ -156,8 +156,8 @@ export class ScriptDeleteAction extends Action {
 		super(id, label);
 	}
 
-	public async run(actionContext: BaseActionContext): Promise<boolean> {
-		return script(
+	public async run(actionContext: BaseActionContext): Promise<void> {
+		await script(
 			actionContext.profile!,
 			actionContext.object!,
 			this._connectionManagementService,

--- a/src/sql/workbench/contrib/assessment/browser/asmtActions.ts
+++ b/src/sql/workbench/contrib/assessment/browser/asmtActions.ts
@@ -60,7 +60,7 @@ abstract class AsmtServerAction extends Action {
 		super(id, label, TARGET_ICON_CLASS[AssessmentTargetType.Server]);
 	}
 
-	public async run(context: IAsmtActionInfo): Promise<boolean> {
+	public async run(context: IAsmtActionInfo): Promise<void> {
 		this._telemetryService.sendActionEvent(TelemetryView.SqlAssessment, this.id);
 		if (context && context.component && !context.component.isBusy) {
 			context.component.showProgress(this.asmtType);
@@ -87,11 +87,7 @@ abstract class AsmtServerAction extends Action {
 			}
 
 			context.component.stopProgress(this.asmtType);
-
-			return true;
 		}
-
-		return false;
 	}
 
 	abstract getServerItems(ownerUri: string): Thenable<SqlAssessmentResult>;
@@ -137,16 +133,14 @@ export class AsmtDatabaseSelectItemsAction extends Action {
 			TARGET_ICON_CLASS[AssessmentTargetType.Database]);
 	}
 
-	public async run(context: IAsmtActionInfo): Promise<boolean> {
+	public async run(context: IAsmtActionInfo): Promise<void> {
 		this._telemetryService.sendActionEvent(TelemetryView.SqlAssessment, this.id);
 		if (context && context.component && !context.component.isBusy) {
 			context.component.showProgress(AssessmentType.AvailableRules);
 			let dbAsmtResults = await this._assessmentService.getAssessmentItems(context.ownerUri, AssessmentTargetType.Database);
 			context.component.showInitialResults(dbAsmtResults, AssessmentType.AvailableRules);
 			context.component.stopProgress(AssessmentType.AvailableRules);
-			return true;
 		}
-		return false;
 	}
 }
 
@@ -185,16 +179,14 @@ export class AsmtDatabaseInvokeItemsAction extends Action {
 			TARGET_ICON_CLASS[AssessmentTargetType.Database]);
 	}
 
-	public async run(context: IAsmtActionInfo): Promise<boolean> {
+	public async run(context: IAsmtActionInfo): Promise<void> {
 		this._telemetryService.sendActionEvent(TelemetryView.SqlAssessment, this.id);
 		if (context && context.component && !context.component.isBusy) {
 			context.component.showProgress(AssessmentType.InvokeAssessment);
 			let dbAsmtResults = await this._assessmentService.assessmentInvoke(context.ownerUri, AssessmentTargetType.Database);
 			context.component.showInitialResults(dbAsmtResults, AssessmentType.InvokeAssessment);
 			context.component.stopProgress(AssessmentType.InvokeAssessment);
-			return true;
 		}
-		return false;
 	}
 }
 
@@ -209,14 +201,12 @@ export class AsmtExportAsScriptAction extends Action {
 		super(AsmtExportAsScriptAction.ID, AsmtExportAsScriptAction.LABEL, 'exportAsScriptIcon');
 	}
 
-	public async run(context: IAsmtActionInfo): Promise<boolean> {
+	public async run(context: IAsmtActionInfo): Promise<void> {
 		this._telemetryService.sendActionEvent(TelemetryView.SqlAssessment, AsmtExportAsScriptAction.ID);
 		const items = context?.component?.recentResult?.result.items;
 		if (items) {
 			await this._assessmentService.generateAssessmentScript(context.ownerUri, items);
-			return true;
 		}
-		return false;
 	}
 }
 
@@ -234,9 +224,9 @@ export class AsmtSamplesLinkAction extends Action {
 		super(AsmtSamplesLinkAction.ID, AsmtSamplesLinkAction.LABEL, AsmtSamplesLinkAction.ICON);
 	}
 
-	public async run(): Promise<boolean> {
+	public async run(): Promise<void> {
 		this._telemetryService.sendActionEvent(TelemetryView.SqlAssessment, AsmtSamplesLinkAction.ID);
-		return this._openerService.open(URI.parse(AsmtSamplesLinkAction.configHelpUri));
+		await this._openerService.open(URI.parse(AsmtSamplesLinkAction.configHelpUri));
 	}
 }
 
@@ -262,12 +252,12 @@ export class AsmtGenerateHTMLReportAction extends Action {
 		return URI.file(filePath);
 	}
 
-	public async run(context: IAsmtActionInfo): Promise<boolean> {
+	public async run(context: IAsmtActionInfo): Promise<void> {
 		context.component.showProgress(AssessmentType.ReportGeneration);
 		const choosenPath = await this._fileDialogService.pickFileToSave(this.suggestReportFile(context.component.recentResult.dateUpdated));
 		context.component.stopProgress(AssessmentType.ReportGeneration);
 		if (!choosenPath) {
-			return false;
+			return;
 		}
 
 		this._telemetryService.sendActionEvent(TelemetryView.SqlAssessment, AsmtGenerateHTMLReportAction.ID);
@@ -291,7 +281,6 @@ export class AsmtGenerateHTMLReportAction extends Action {
 					run: () => { }
 				}]);
 		}
-		return true;
 	}
 }
 

--- a/src/sql/workbench/contrib/assessment/test/browser/asmtActions.test.ts
+++ b/src/sql/workbench/contrib/assessment/test/browser/asmtActions.test.ts
@@ -137,8 +137,7 @@ suite('Assessment Actions', () => {
 		assert.equal(action.id, AsmtServerSelectItemsAction.ID, 'Get Server Rules id action mismatch');
 		assert.equal(action.label, AsmtServerSelectItemsAction.LABEL, 'Get Server Rules label action mismatch');
 
-		let result = await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
-		assert.ok(result, 'Get Server Rules action should succeed');
+		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		mockAsmtViewComponent.verify(s => s.showProgress(AssessmentType.AvailableRules), TypeMoq.Times.once());
 		mockAssessmentService.verify(s => s.getAssessmentItems(TypeMoq.It.isAny(), AssessmentTargetType.Server), TypeMoq.Times.once());
 		mockAsmtViewComponent.verify(s => s.showInitialResults(TypeMoq.It.isAny(), AssessmentType.AvailableRules), TypeMoq.Times.once());
@@ -161,8 +160,7 @@ suite('Assessment Actions', () => {
 		assert.equal(action.id, AsmtServerInvokeItemsAction.ID, 'Invoke Server Assessment id action mismatch');
 		assert.equal(action.label, AsmtServerInvokeItemsAction.LABEL, 'Invoke Server Assessment label action mismatch');
 
-		let result = await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
-		assert.ok(result, 'Invoke Server Assessment action should succeed');
+		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		mockAsmtViewComponent.verify(s => s.showProgress(AssessmentType.InvokeAssessment), TypeMoq.Times.once());
 		mockAssessmentService.verify(s => s.assessmentInvoke(TypeMoq.It.isAny(), AssessmentTargetType.Server), TypeMoq.Times.once());
 		mockAsmtViewComponent.verify(s => s.showInitialResults(TypeMoq.It.isAny(), AssessmentType.InvokeAssessment), TypeMoq.Times.once());
@@ -177,8 +175,7 @@ suite('Assessment Actions', () => {
 		const action = new AsmtDatabaseSelectItemsAction('databaseName', mockAssessmentService.object, new NullAdsTelemetryService());
 		assert.equal(action.id, AsmtDatabaseSelectItemsAction.ID, 'Get Database Rules id action mismatch');
 
-		let result = await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
-		assert.ok(result, 'Get Assessment Database action should succeed');
+		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		mockAsmtViewComponent.verify(s => s.showProgress(AssessmentType.AvailableRules), TypeMoq.Times.once());
 		mockAsmtViewComponent.verify(s => s.showInitialResults(TypeMoq.It.isAny(), AssessmentType.AvailableRules), TypeMoq.Times.once());
 		mockAsmtViewComponent.verify(s => s.stopProgress(AssessmentType.AvailableRules), TypeMoq.Times.once());
@@ -190,8 +187,7 @@ suite('Assessment Actions', () => {
 		const action = new AsmtDatabaseInvokeItemsAction('databaseName', mockAssessmentService.object, new NullAdsTelemetryService());
 		assert.equal(action.id, AsmtDatabaseInvokeItemsAction.ID, 'Invoke Database Assessment id action mismatch');
 
-		let result = await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
-		assert.ok(result, 'Invoke Database Assessment action should succeed');
+		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		mockAsmtViewComponent.verify(s => s.showProgress(AssessmentType.InvokeAssessment), TypeMoq.Times.once());
 		mockAsmtViewComponent.verify(s => s.showInitialResults(TypeMoq.It.isAny(), AssessmentType.InvokeAssessment), TypeMoq.Times.once());
 		mockAsmtViewComponent.verify(s => s.stopProgress(AssessmentType.InvokeAssessment), TypeMoq.Times.once());
@@ -204,8 +200,7 @@ suite('Assessment Actions', () => {
 		assert.equal(action.id, AsmtExportAsScriptAction.ID, 'Generate Assessment script id action mismatch');
 		assert.equal(action.label, AsmtExportAsScriptAction.LABEL, 'Generate Assessment script label action mismatch');
 
-		let result = await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
-		assert.ok(result, 'Generate Script action should succeed');
+		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		mockAssessmentService.verify(s => s.generateAssessmentScript(TypeMoq.It.isAnyString(), TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
@@ -217,8 +212,7 @@ suite('Assessment Actions', () => {
 		assert.equal(action.id, AsmtSamplesLinkAction.ID, 'Samples Link id action mismatch');
 		assert.equal(action.label, AsmtSamplesLinkAction.LABEL, 'Samples Link label action mismatch');
 
-		let result = await action.run();
-		assert.ok(result, 'Samples Link action should succeed');
+		await action.run();
 		openerService.verify(s => s.open(TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
@@ -259,8 +253,7 @@ suite('Assessment Actions', () => {
 		assert.equal(action.id, AsmtGenerateHTMLReportAction.ID, 'Generate HTML Report id action mismatch');
 		assert.equal(action.label, AsmtGenerateHTMLReportAction.LABEL, 'Generate HTML Report label action mismatch');
 
-		let result = await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
-		assert.ok(result, 'Generate HTML Report action should succeed');
+		await action.run({ ownerUri: '', component: mockAsmtViewComponent.object, connectionId: '' });
 		notificationService.verify(s => s.prompt(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 });

--- a/src/sql/workbench/contrib/dashboard/browser/core/actions.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/core/actions.ts
@@ -30,14 +30,9 @@ export class EditDashboardAction extends Action {
 		super(EditDashboardAction.ID, EditDashboardAction.EDITLABEL, EditDashboardAction.ICON);
 	}
 
-	run(): Promise<boolean> {
-		try {
-			this.editFn.apply(this.context);
-			this.toggleLabel();
-			return Promise.resolve(true);
-		} catch (e) {
-			return Promise.resolve(false);
-		}
+	async run(): Promise<void> {
+		this.editFn.apply(this.context);
+		this.toggleLabel();
 	}
 
 	private toggleLabel(): void {
@@ -64,13 +59,8 @@ export class RefreshWidgetAction extends Action {
 		super(RefreshWidgetAction.ID, RefreshWidgetAction.LABEL, RefreshWidgetAction.ICON);
 	}
 
-	run(): Promise<boolean> {
-		try {
-			this.refreshFn.apply(this.context);
-			return Promise.resolve(true);
-		} catch (e) {
-			return Promise.resolve(false);
-		}
+	async run(): Promise<void> {
+		this.refreshFn.apply(this.context);
 	}
 }
 
@@ -86,13 +76,11 @@ export class ToolbarAction extends Action {
 		super(id, label, cssClass);
 	}
 
-	run(): Promise<boolean> {
+	async run(): Promise<void> {
 		try {
 			this.runFn.apply(this.context, [this.id]);
-			return Promise.resolve(true);
 		} catch (e) {
 			this.logService.error(e);
-			return Promise.resolve(false);
 		}
 	}
 }
@@ -111,13 +99,12 @@ export class ToggleMoreWidgetAction extends Action {
 		super(ToggleMoreWidgetAction.ID, ToggleMoreWidgetAction.LABEL, ToggleMoreWidgetAction.ICON);
 	}
 
-	run(context: StandardKeyboardEvent): Promise<boolean> {
+	async run(context: StandardKeyboardEvent): Promise<void> {
 		this._contextMenuService.showContextMenu({
 			getAnchor: () => context.target,
 			getActions: () => this._actions,
 			getActionsContext: () => this._context
 		});
-		return Promise.resolve(true);
 	}
 }
 
@@ -134,9 +121,8 @@ export class DeleteWidgetAction extends Action {
 		super(DeleteWidgetAction.ID, DeleteWidgetAction.LABEL, DeleteWidgetAction.ICON);
 	}
 
-	run(): Promise<boolean> {
+	async run(): Promise<void> {
 		this.angularEventService.sendAngularEvent(this._uri, AngularEventType.DELETE_WIDGET, { id: this._widgetId });
-		return Promise.resolve(true);
 	}
 }
 
@@ -167,11 +153,10 @@ export class PinUnpinTabAction extends Action {
 		}
 	}
 
-	public run(): Promise<boolean> {
+	public async run(): Promise<void> {
 		this._isPinned = !this._isPinned;
 		this.updatePinStatus();
 		this.angularEventService.sendAngularEvent(this._uri, AngularEventType.PINUNPIN_TAB, { tabId: this._tabId, isPinned: this._isPinned });
-		return Promise.resolve(true);
 	}
 }
 
@@ -191,9 +176,8 @@ export class AddFeatureTabAction extends Action {
 		this._register(this._angularEventService.onAngularEvent(this._uri)(event => this.handleDashboardEvent(event)));
 	}
 
-	run(): Promise<boolean> {
+	async run(): Promise<void> {
 		this._newDashboardTabService.showDialog(this._dashboardTabs, this._openedTabs, this._uri);
-		return Promise.resolve(true);
 	}
 
 	private handleDashboardEvent(event: IAngularEvent): void {
@@ -236,10 +220,9 @@ export class CollapseWidgetAction extends Action {
 		this.expanded = !this.collpasedState;
 	}
 
-	run(): Promise<boolean> {
+	async run(): Promise<void> {
 		this._toggleState();
 		this._angularEventService.sendAngularEvent(this._uri, AngularEventType.COLLAPSE_WIDGET, this._widgetUuid);
-		return Promise.resolve(true);
 	}
 
 	private _toggleState(): void {

--- a/src/sql/workbench/contrib/dashboard/browser/dashboardActions.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/dashboardActions.ts
@@ -72,20 +72,14 @@ export class OEManageConnectionAction extends Action {
 		super(id, label);
 	}
 
-	run(actionContext: ObjectExplorerActionsContext): Promise<any> {
+	async run(actionContext: ObjectExplorerActionsContext): Promise<void> {
 		this._treeSelectionHandler = this._instantiationService.createInstance(TreeSelectionHandler);
 		this._treeSelectionHandler.onTreeActionStateChange(true);
-		let self = this;
-		let promise = new Promise<boolean>((resolve, reject) => {
-			self.doManage(actionContext).then((success) => {
-				self.done();
-				resolve(success);
-			}, error => {
-				self.done();
-				reject(error);
-			});
-		});
-		return promise;
+		try {
+			await this.doManage(actionContext);
+		} finally {
+			this.done();
+		}
 	}
 
 	private async doManage(actionContext: ObjectExplorerActionsContext): Promise<boolean> {

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerActions.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/explorer/explorerActions.ts
@@ -18,9 +18,8 @@ export class ExplorerManageAction extends ManageAction {
 		super(id, label, connectionManagementService, angularEventingService);
 	}
 
-	public run(actionContext: ManageActionContext): Promise<boolean> {
-		const promise = super.run(actionContext);
-		return promise;
+	public async run(actionContext: ManageActionContext): Promise<void> {
+		await super.run(actionContext);
 	}
 }
 

--- a/src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/insights/actions.ts
@@ -24,7 +24,7 @@ export class RunInsightQueryAction extends Action {
 		super(id, label);
 	}
 
-	public run(context: InsightActionContext): Promise<boolean> {
+	public async run(context: InsightActionContext): Promise<void> {
 		let queryString: string = undefined;
 		let eol: string = this._textResourcePropertiesService.getEOL(undefined);
 		if (context.insight && context.insight.query) {
@@ -34,9 +34,9 @@ export class RunInsightQueryAction extends Action {
 				queryString = context.insight.query.join(eol);
 			}
 		} else {
-			return Promise.resolve(false);
+			return;
 		}
-		return this.instantiationService.invokeFunction(openNewQuery, context.profile, queryString,
-			RunQueryOnConnectionMode.executeQuery).then(() => true, () => false);
+		await this.instantiationService.invokeFunction(openNewQuery, context.profile, queryString,
+			RunQueryOnConnectionMode.executeQuery);
 	}
 }

--- a/src/sql/workbench/contrib/editData/browser/editDataGridActions.ts
+++ b/src/sql/workbench/contrib/editData/browser/editDataGridActions.ts
@@ -43,9 +43,8 @@ export class DeleteRowAction extends Action {
 		super(id, label);
 	}
 
-	public run(gridInfo: IGridInfo): Promise<boolean> {
+	public async run(gridInfo: IGridInfo): Promise<void> {
 		this.callback(gridInfo.rowIndex);
-		return Promise.resolve(true);
 	}
 }
 
@@ -61,8 +60,7 @@ export class RevertRowAction extends Action {
 		super(id, label);
 	}
 
-	public run(gridInfo: IGridInfo): Promise<boolean> {
+	public async run(gridInfo: IGridInfo): Promise<void> {
 		this.callback();
-		return Promise.resolve(true);
 	}
 }

--- a/src/sql/workbench/contrib/editData/browser/gridActions.ts
+++ b/src/sql/workbench/contrib/editData/browser/gridActions.ts
@@ -74,14 +74,13 @@ class SaveResultAction extends Action {
 		super(id, label);
 	}
 
-	public run(gridInfo: IGridInfo): Promise<boolean> {
+	public async run(gridInfo: IGridInfo): Promise<void> {
 		this.dataService.sendSaveRequest({
 			batchIndex: gridInfo.batchIndex,
 			resultSetNumber: gridInfo.resultSetNumber,
 			selection: gridInfo.selection,
 			format: this.format
 		});
-		return Promise.resolve(true);
 	}
 }
 
@@ -101,9 +100,8 @@ class CopyResultAction extends Action {
 		super(id, label);
 	}
 
-	public run(gridInfo: IGridInfo): Promise<boolean> {
+	public async run(gridInfo: IGridInfo): Promise<void> {
 		this.dataService.copyResults(gridInfo.selection, gridInfo.batchIndex, gridInfo.resultSetNumber, this.copyHeader);
-		return Promise.resolve(true);
 	}
 }
 
@@ -119,8 +117,7 @@ class SelectAllGridAction extends Action {
 		super(id, label);
 	}
 
-	public run(gridInfo: IGridInfo): Promise<boolean> {
+	public async run(gridInfo: IGridInfo): Promise<void> {
 		this.selectAllCallback(gridInfo.gridIndex);
-		return Promise.resolve(true);
 	}
 }

--- a/src/sql/workbench/contrib/jobManagement/browser/jobActions.ts
+++ b/src/sql/workbench/contrib/jobManagement/browser/jobActions.ts
@@ -47,17 +47,8 @@ export class JobsRefreshAction extends Action {
 		super(JobsRefreshAction.ID, JobsRefreshAction.LABEL, 'refreshIcon');
 	}
 
-	public run(context: IJobActionInfo): Promise<boolean> {
-		return new Promise<boolean>((resolve, reject) => {
-			if (context) {
-				if (context.component) {
-					context.component.refreshJobs();
-				}
-				resolve(true);
-			} else {
-				reject(false);
-			}
-		});
+	public async run(context: IJobActionInfo): Promise<void> {
+		context.component.refreshJobs();
 	}
 }
 
@@ -70,16 +61,9 @@ export class NewJobAction extends Action {
 		super(NewJobAction.ID, NewJobAction.LABEL, 'newStepIcon');
 	}
 
-	public run(context: IJobActionInfo): Promise<boolean> {
-		let component = context.component as JobsViewComponent;
-		return new Promise<boolean>(async (resolve, reject) => {
-			try {
-				await component.openCreateJobDialog();
-				resolve(true);
-			} catch (e) {
-				reject(e);
-			}
-		});
+	public async run(context: IJobActionInfo): Promise<void> {
+		const component = context.component as JobsViewComponent;
+		await component.openCreateJobDialog();
 	}
 }
 
@@ -97,24 +81,19 @@ export class RunJobAction extends Action {
 		super(RunJobAction.ID, RunJobAction.LABEL, 'start');
 	}
 
-	public run(context: IJobActionInfo): Promise<boolean> {
+	public async run(context: IJobActionInfo): Promise<void> {
 		let jobName = context.targetObject.job.name;
 		let ownerUri = context.ownerUri;
 		let refreshAction = this.instantationService.createInstance(JobsRefreshAction);
 		this.telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.RunAgentJob);
-		return new Promise<boolean>((resolve, reject) => {
-			this.jobManagementService.jobAction(ownerUri, jobName, JobActions.Run).then(async (result) => {
-				if (result.success) {
-					let startMsg = nls.localize('jobSuccessfullyStarted', ": The job was successfully started.");
-					this.notificationService.info(jobName + startMsg);
-					await refreshAction.run(context);
-					resolve(true);
-				} else {
-					this.errorMessageService.showDialog(Severity.Error, errorLabel, result.errorMessage);
-					resolve(false);
-				}
-			});
-		});
+		const result = await this.jobManagementService.jobAction(ownerUri, jobName, JobActions.Run);
+		if (result.success) {
+			let startMsg = nls.localize('jobSuccessfullyStarted', ": The job was successfully started.");
+			this.notificationService.info(jobName + startMsg);
+			await refreshAction.run(context);
+		} else {
+			this.errorMessageService.showDialog(Severity.Error, errorLabel, result.errorMessage);
+		}
 	}
 }
 
@@ -132,24 +111,19 @@ export class StopJobAction extends Action {
 		super(StopJobAction.ID, StopJobAction.LABEL, 'stop');
 	}
 
-	public run(context: IJobActionInfo): Promise<boolean> {
+	public async run(context: IJobActionInfo): Promise<void> {
 		let jobName = context.targetObject.name;
 		let ownerUri = context.ownerUri;
 		let refreshAction = this.instantationService.createInstance(JobsRefreshAction);
 		this.telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.StopAgentJob);
-		return new Promise<boolean>((resolve, reject) => {
-			this.jobManagementService.jobAction(ownerUri, jobName, JobActions.Stop).then(async (result) => {
-				if (result.success) {
-					await refreshAction.run(context);
-					let stopMsg = nls.localize('jobSuccessfullyStopped', ": The job was successfully stopped.");
-					this.notificationService.info(jobName + stopMsg);
-					resolve(true);
-				} else {
-					this.errorMessageService.showDialog(Severity.Error, 'Error', result.errorMessage);
-					resolve(false);
-				}
-			});
-		});
+		const result = await this.jobManagementService.jobAction(ownerUri, jobName, JobActions.Stop);
+		if (result.success) {
+			await refreshAction.run(context);
+			let stopMsg = nls.localize('jobSuccessfullyStopped', ": The job was successfully stopped.");
+			this.notificationService.info(jobName + stopMsg);
+		} else {
+			this.errorMessageService.showDialog(Severity.Error, 'Error', result.errorMessage);
+		}
 	}
 }
 
@@ -163,12 +137,11 @@ export class EditJobAction extends Action {
 		super(EditJobAction.ID, EditJobAction.LABEL, 'edit');
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
-		this._commandService.executeCommand(
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
+		await this._commandService.executeCommand(
 			'agent.openJobDialog',
 			actionInfo.ownerUri,
 			actionInfo.targetObject.job);
-		return Promise.resolve(true);
 	}
 }
 
@@ -180,9 +153,8 @@ export class OpenMaterializedNotebookAction extends Action {
 		super(OpenMaterializedNotebookAction.ID, OpenMaterializedNotebookAction.LABEL, 'openNotebook');
 	}
 
-	public run(context: any): Promise<boolean> {
+	public async run(context: any): Promise<void> {
 		context.component.openNotebook(context.history);
-		return Promise.resolve(true);
 	}
 }
 
@@ -199,24 +171,23 @@ export class DeleteJobAction extends Action {
 		super(DeleteJobAction.ID, DeleteJobAction.LABEL);
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
-		let self = this;
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
 		let job = actionInfo.targetObject.job as azdata.AgentJobInfo;
-		self._notificationService.prompt(
+		this._notificationService.prompt(
 			Severity.Info,
 			nls.localize('jobaction.deleteJobConfirm', "Are you sure you'd like to delete the job '{0}'?", job.name),
 			[{
 				label: DeleteJobAction.LABEL,
 				run: () => {
 					this._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentJob);
-					self._jobService.deleteJob(actionInfo.ownerUri, actionInfo.targetObject.job).then(result => {
+					this._jobService.deleteJob(actionInfo.ownerUri, actionInfo.targetObject.job).then(result => {
 						if (!result || !result.success) {
 							let errorMessage = nls.localize("jobaction.failedToDeleteJob", "Could not delete job '{0}'.\nError: {1}",
 								job.name, result.errorMessage ? result.errorMessage : 'Unknown error');
-							self._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
+							this._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
 						} else {
 							let successMessage = nls.localize('jobaction.deletedJob', "The job was successfully deleted");
-							self._notificationService.info(successMessage);
+							this._notificationService.info(successMessage);
 						}
 					});
 				}
@@ -225,7 +196,6 @@ export class DeleteJobAction extends Action {
 				run: () => { }
 			}]
 		);
-		return Promise.resolve(true);
 	}
 }
 
@@ -241,13 +211,11 @@ export class NewStepAction extends Action {
 		super(NewStepAction.ID, NewStepAction.LABEL, 'newStepIcon');
 	}
 
-	public run(context: JobHistoryComponent): Promise<boolean> {
+	public async run(context: JobHistoryComponent): Promise<void> {
 		let ownerUri = context.ownerUri;
 		let server = context.serverName;
 		let jobInfo = context.agentJobInfo;
-		return new Promise<boolean>((resolve, reject) => {
-			resolve(this._commandService.executeCommand('agent.openNewStepDialog', ownerUri, server, jobInfo, null));
-		});
+		await this._commandService.executeCommand('agent.openNewStepDialog', ownerUri, server, jobInfo, undefined);
 	}
 }
 
@@ -265,26 +233,25 @@ export class DeleteStepAction extends Action {
 		super(DeleteStepAction.ID, DeleteStepAction.LABEL);
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
-		let self = this;
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
 		let step = actionInfo.targetObject as azdata.AgentJobStepInfo;
 		let refreshAction = this.instantationService.createInstance(JobsRefreshAction);
-		self._notificationService.prompt(
+		this._notificationService.prompt(
 			Severity.Info,
 			nls.localize('jobaction.deleteStepConfirm', "Are you sure you'd like to delete the step '{0}'?", step.stepName),
 			[{
 				label: DeleteStepAction.LABEL,
 				run: () => {
 					this._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentJobStep);
-					self._jobService.deleteJobStep(actionInfo.ownerUri, actionInfo.targetObject).then(async (result) => {
+					this._jobService.deleteJobStep(actionInfo.ownerUri, actionInfo.targetObject).then(async (result) => {
 						if (!result || !result.success) {
 							let errorMessage = nls.localize('jobaction.failedToDeleteStep', "Could not delete step '{0}'.\nError: {1}",
 								step.stepName, result.errorMessage ? result.errorMessage : 'Unknown error');
-							self._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
+							this._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
 							await refreshAction.run(actionInfo);
 						} else {
 							let successMessage = nls.localize('jobaction.deletedStep', "The job step was successfully deleted");
-							self._notificationService.info(successMessage);
+							this._notificationService.info(successMessage);
 						}
 					});
 				}
@@ -293,7 +260,6 @@ export class DeleteStepAction extends Action {
 				run: () => { }
 			}]
 		);
-		return Promise.resolve(true);
 	}
 }
 
@@ -308,16 +274,9 @@ export class NewAlertAction extends Action {
 		super(NewAlertAction.ID, NewAlertAction.LABEL, 'newStepIcon');
 	}
 
-	public run(context: IJobActionInfo): Promise<boolean> {
+	public async run(context: IJobActionInfo): Promise<void> {
 		let component = context.component as AlertsViewComponent;
-		return new Promise<boolean>((resolve, reject) => {
-			try {
-				component.openCreateAlertDialog();
-				resolve(true);
-			} catch (e) {
-				reject(e);
-			}
-		});
+		await component.openCreateAlertDialog();
 	}
 }
 
@@ -331,13 +290,12 @@ export class EditAlertAction extends Action {
 		super(EditAlertAction.ID, EditAlertAction.LABEL);
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
-		this._commandService.executeCommand(
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
+		await this._commandService.executeCommand(
 			'agent.openAlertDialog',
 			actionInfo.ownerUri,
 			actionInfo.targetObject.jobInfo,
 			actionInfo.targetObject.alertInfo);
-		return Promise.resolve(true);
 	}
 }
 
@@ -355,33 +313,30 @@ export class DeleteAlertAction extends Action {
 		super(DeleteAlertAction.ID, DeleteAlertAction.LABEL);
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
-		let self = this;
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
 		let alert = actionInfo.targetObject.alertInfo as azdata.AgentAlertInfo;
-		self._notificationService.prompt(
+		this._notificationService.prompt(
 			Severity.Info,
 			nls.localize('jobaction.deleteAlertConfirm', "Are you sure you'd like to delete the alert '{0}'?", alert.name),
 			[{
 				label: DeleteAlertAction.LABEL,
-				run: () => {
-					self._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentAlert);
-					self._jobService.deleteAlert(actionInfo.ownerUri, alert).then(result => {
-						if (!result || !result.success) {
-							let errorMessage = nls.localize("jobaction.failedToDeleteAlert", "Could not delete alert '{0}'.\nError: {1}",
-								alert.name, result.errorMessage ? result.errorMessage : 'Unknown error');
-							self._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
-						} else {
-							let successMessage = nls.localize('jobaction.deletedAlert', "The alert was successfully deleted");
-							self._notificationService.info(successMessage);
-						}
-					});
+				run: async () => {
+					this._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentAlert);
+					const result = await this._jobService.deleteAlert(actionInfo.ownerUri, alert);
+					if (!result || !result.success) {
+						let errorMessage = nls.localize("jobaction.failedToDeleteAlert", "Could not delete alert '{0}'.\nError: {1}",
+							alert.name, result.errorMessage ? result.errorMessage : 'Unknown error');
+						this._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
+					} else {
+						let successMessage = nls.localize('jobaction.deletedAlert', "The alert was successfully deleted");
+						this._notificationService.info(successMessage);
+					}
 				}
 			}, {
 				label: DeleteAlertAction.CancelLabel,
 				run: () => { }
 			}]
 		);
-		return Promise.resolve(true);
 	}
 }
 
@@ -396,16 +351,9 @@ export class NewOperatorAction extends Action {
 		super(NewOperatorAction.ID, NewOperatorAction.LABEL, 'newStepIcon');
 	}
 
-	public run(context: IJobActionInfo): Promise<boolean> {
+	public async run(context: IJobActionInfo): Promise<void> {
 		let component = context.component as OperatorsViewComponent;
-		return new Promise<boolean>((resolve, reject) => {
-			try {
-				component.openCreateOperatorDialog();
-				resolve(true);
-			} catch (e) {
-				reject(e);
-			}
-		});
+		await component.openCreateOperatorDialog();
 	}
 }
 
@@ -419,12 +367,11 @@ export class EditOperatorAction extends Action {
 		super(EditOperatorAction.ID, EditOperatorAction.LABEL);
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
-		this._commandService.executeCommand(
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
+		await this._commandService.executeCommand(
 			'agent.openOperatorDialog',
 			actionInfo.ownerUri,
 			actionInfo.targetObject);
-		return Promise.resolve(true);
 	}
 }
 
@@ -441,33 +388,30 @@ export class DeleteOperatorAction extends Action {
 		super(DeleteOperatorAction.ID, DeleteOperatorAction.LABEL);
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
-		const self = this;
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
 		let operator = actionInfo.targetObject as azdata.AgentOperatorInfo;
-		self._notificationService.prompt(
+		this._notificationService.prompt(
 			Severity.Info,
 			nls.localize('jobaction.deleteOperatorConfirm', "Are you sure you'd like to delete the operator '{0}'?", operator.name),
 			[{
 				label: DeleteOperatorAction.LABEL,
-				run: () => {
-					self._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentOperator);
-					self._jobService.deleteOperator(actionInfo.ownerUri, actionInfo.targetObject).then(result => {
-						if (!result || !result.success) {
-							let errorMessage = nls.localize("jobaction.failedToDeleteOperator", "Could not delete operator '{0}'.\nError: {1}",
-								operator.name, result.errorMessage ? result.errorMessage : 'Unknown error');
-							self._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
-						} else {
-							let successMessage = nls.localize('joaction.deletedOperator', "The operator was deleted successfully");
-							self._notificationService.info(successMessage);
-						}
-					});
+				run: async () => {
+					this._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentOperator);
+					const result = await this._jobService.deleteOperator(actionInfo.ownerUri, actionInfo.targetObject);
+					if (!result || !result.success) {
+						let errorMessage = nls.localize("jobaction.failedToDeleteOperator", "Could not delete operator '{0}'.\nError: {1}",
+							operator.name, result.errorMessage ? result.errorMessage : 'Unknown error');
+						this._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
+					} else {
+						let successMessage = nls.localize('joaction.deletedOperator', "The operator was deleted successfully");
+						this._notificationService.info(successMessage);
+					}
 				}
 			}, {
 				label: DeleteAlertAction.CancelLabel,
 				run: () => { }
 			}]
 		);
-		return Promise.resolve(true);
 	}
 }
 
@@ -483,16 +427,9 @@ export class NewProxyAction extends Action {
 		super(NewProxyAction.ID, NewProxyAction.LABEL, 'newStepIcon');
 	}
 
-	public run(context: IJobActionInfo): Promise<boolean> {
-		let component = context.component as ProxiesViewComponent;
-		return new Promise<boolean>((resolve, reject) => {
-			try {
-				component.openCreateProxyDialog();
-				resolve(true);
-			} catch (e) {
-				reject(e);
-			}
-		});
+	public async run(context: IJobActionInfo): Promise<void> {
+		const component = context.component as ProxiesViewComponent;
+		component.openCreateProxyDialog();
 	}
 }
 
@@ -507,19 +444,15 @@ export class EditProxyAction extends Action {
 		super(EditProxyAction.ID, EditProxyAction.LABEL);
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
-		return Promise.resolve(this._jobManagementService.getCredentials(actionInfo.ownerUri).then((result) => {
-			if (result && result.credentials) {
-				this._commandService.executeCommand(
-					'agent.openProxyDialog',
-					actionInfo.ownerUri,
-					actionInfo.targetObject,
-					result.credentials);
-				return true;
-			} else {
-				return false;
-			}
-		}));
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
+		const result = await this._jobManagementService.getCredentials(actionInfo.ownerUri);
+		if (result && result.credentials) {
+			await this._commandService.executeCommand(
+				'agent.openProxyDialog',
+				actionInfo.ownerUri,
+				actionInfo.targetObject,
+				result.credentials);
+		}
 	}
 }
 
@@ -536,33 +469,30 @@ export class DeleteProxyAction extends Action {
 		super(DeleteProxyAction.ID, DeleteProxyAction.LABEL);
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
-		let self = this;
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
 		let proxy = actionInfo.targetObject as azdata.AgentProxyInfo;
-		self._notificationService.prompt(
+		this._notificationService.prompt(
 			Severity.Info,
 			nls.localize('jobaction.deleteProxyConfirm', "Are you sure you'd like to delete the proxy '{0}'?", proxy.accountName),
 			[{
 				label: DeleteProxyAction.LABEL,
-				run: () => {
-					self._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentProxy);
-					self._jobService.deleteProxy(actionInfo.ownerUri, actionInfo.targetObject).then(result => {
-						if (!result || !result.success) {
-							let errorMessage = nls.localize("jobaction.failedToDeleteProxy", "Could not delete proxy '{0}'.\nError: {1}",
-								proxy.accountName, result.errorMessage ? result.errorMessage : 'Unknown error');
-							self._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
-						} else {
-							let successMessage = nls.localize('jobaction.deletedProxy', "The proxy was deleted successfully");
-							self._notificationService.info(successMessage);
-						}
-					});
+				run: async () => {
+					this._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentProxy);
+					const result = await this._jobService.deleteProxy(actionInfo.ownerUri, actionInfo.targetObject);
+					if (!result || !result.success) {
+						let errorMessage = nls.localize("jobaction.failedToDeleteProxy", "Could not delete proxy '{0}'.\nError: {1}",
+							proxy.accountName, result.errorMessage ? result.errorMessage : 'Unknown error');
+						this._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
+					} else {
+						let successMessage = nls.localize('jobaction.deletedProxy', "The proxy was deleted successfully");
+						this._notificationService.info(successMessage);
+					}
 				}
 			}, {
 				label: DeleteAlertAction.CancelLabel,
 				run: () => { }
 			}]
 		);
-		return Promise.resolve(true);
 	}
 }
 
@@ -577,10 +507,9 @@ export class NewNotebookJobAction extends Action {
 		super(NewNotebookJobAction.ID, NewNotebookJobAction.LABEL, 'newStepIcon');
 	}
 
-	public async run(context: IJobActionInfo): Promise<boolean> {
+	public async run(context: IJobActionInfo): Promise<void> {
 		let component = context.component as NotebooksViewComponent;
 		await component.openCreateNotebookDialog();
-		return true;
 	}
 }
 
@@ -594,12 +523,11 @@ export class EditNotebookJobAction extends Action {
 		super(EditNotebookJobAction.ID, EditNotebookJobAction.LABEL, 'edit');
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
-		this._commandService.executeCommand(
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
+		await this._commandService.executeCommand(
 			'agent.openNotebookDialog',
 			actionInfo.ownerUri,
 			actionInfo.targetObject.job);
-		return Promise.resolve(true);
 	}
 }
 
@@ -611,9 +539,8 @@ export class OpenTemplateNotebookAction extends Action {
 		super(OpenTemplateNotebookAction.ID, OpenTemplateNotebookAction.LABEL, 'opennotebook');
 	}
 
-	public run(actionInfo: any): Promise<boolean> {
+	public async run(actionInfo: any): Promise<void> {
 		actionInfo.component.openTemplateNotebook();
-		return Promise.resolve(true);
 	}
 }
 
@@ -631,35 +558,32 @@ export class DeleteNotebookAction extends Action {
 		super(DeleteNotebookAction.ID, DeleteNotebookAction.LABEL);
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
-		let self = this;
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
 		let notebook = actionInfo.targetObject.job as azdata.AgentNotebookInfo;
 		let refreshAction = this.instantationService.createInstance(JobsRefreshAction);
-		self._notificationService.prompt(
+		this._notificationService.prompt(
 			Severity.Info,
 			nls.localize('jobaction.deleteNotebookConfirm', "Are you sure you'd like to delete the notebook '{0}'?", notebook.name),
 			[{
 				label: DeleteNotebookAction.LABEL,
-				run: () => {
-					self._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentJob);
-					self._jobService.deleteNotebook(actionInfo.ownerUri, actionInfo.targetObject.job).then(async (result) => {
-						if (!result || !result.success) {
-							await refreshAction.run(actionInfo);
-							let errorMessage = nls.localize("jobaction.failedToDeleteNotebook", "Could not delete notebook '{0}'.\nError: {1}",
-								notebook.name, result.errorMessage ? result.errorMessage : 'Unknown error');
-							self._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
-						} else {
-							let successMessage = nls.localize('jobaction.deletedNotebook', "The notebook was successfully deleted");
-							self._notificationService.info(successMessage);
-						}
-					});
+				run: async () => {
+					this._telemetryService.sendActionEvent(TelemetryView.Agent, TelemetryAction.DeleteAgentJob);
+					const result = await this._jobService.deleteNotebook(actionInfo.ownerUri, actionInfo.targetObject.job);
+					if (!result || !result.success) {
+						await refreshAction.run(actionInfo);
+						let errorMessage = nls.localize("jobaction.failedToDeleteNotebook", "Could not delete notebook '{0}'.\nError: {1}",
+							notebook.name, result.errorMessage ? result.errorMessage : 'Unknown error');
+						this._errorMessageService.showDialog(Severity.Error, errorLabel, errorMessage);
+					} else {
+						let successMessage = nls.localize('jobaction.deletedNotebook', "The notebook was successfully deleted");
+						this._notificationService.info(successMessage);
+					}
 				}
 			}, {
 				label: DeleteAlertAction.CancelLabel,
 				run: () => { }
 			}]
 		);
-		return Promise.resolve(true);
 	}
 
 }
@@ -672,9 +596,8 @@ export class PinNotebookMaterializedAction extends Action {
 		super(PinNotebookMaterializedAction.ID, PinNotebookMaterializedAction.LABEL);
 	}
 
-	public run(actionInfo: any): Promise<boolean> {
+	public async run(actionInfo: any): Promise<void> {
 		actionInfo.component.toggleNotebookPin(actionInfo.history, true);
-		return Promise.resolve(true);
 	}
 }
 
@@ -686,9 +609,8 @@ export class DeleteMaterializedNotebookAction extends Action {
 		super(DeleteMaterializedNotebookAction.ID, DeleteMaterializedNotebookAction.LABEL);
 	}
 
-	public run(actionInfo: any): Promise<boolean> {
+	public async run(actionInfo: any): Promise<void> {
 		actionInfo.component.deleteMaterializedNotebook(actionInfo.history);
-		return Promise.resolve(true);
 	}
 }
 
@@ -700,9 +622,8 @@ export class UnpinNotebookMaterializedAction extends Action {
 		super(UnpinNotebookMaterializedAction.ID, UnpinNotebookMaterializedAction.LABEL);
 	}
 
-	public run(actionInfo: any): Promise<boolean> {
+	public async run(actionInfo: any): Promise<void> {
 		actionInfo.component.toggleNotebookPin(actionInfo.history, false);
-		return Promise.resolve(true);
 	}
 }
 
@@ -714,9 +635,8 @@ export class RenameNotebookMaterializedAction extends Action {
 		super(RenameNotebookMaterializedAction.ID, RenameNotebookMaterializedAction.LABEL);
 	}
 
-	public run(actionInfo: any): Promise<boolean> {
+	public async run(actionInfo: any): Promise<void> {
 		actionInfo.component.renameNotebook(actionInfo.history);
-		return Promise.resolve(true);
 	}
 }
 
@@ -728,8 +648,7 @@ export class OpenLatestRunMaterializedNotebook extends Action {
 		super(OpenLatestRunMaterializedNotebook.ID, OpenLatestRunMaterializedNotebook.LABEL);
 	}
 
-	public run(actionInfo: IJobActionInfo): Promise<boolean> {
+	public async run(actionInfo: IJobActionInfo): Promise<void> {
 		actionInfo.component.openLastNRun(actionInfo.targetObject.job, 0, 1);
-		return Promise.resolve(true);
 	}
 }

--- a/src/sql/workbench/contrib/jobManagement/browser/jobActions.ts
+++ b/src/sql/workbench/contrib/jobManagement/browser/jobActions.ts
@@ -47,8 +47,8 @@ export class JobsRefreshAction extends Action {
 		super(JobsRefreshAction.ID, JobsRefreshAction.LABEL, 'refreshIcon');
 	}
 
-	public async run(context: IJobActionInfo): Promise<void> {
-		context.component.refreshJobs();
+	public async run(context?: IJobActionInfo): Promise<void> {
+		context?.component?.refreshJobs();
 	}
 }
 

--- a/src/sql/workbench/contrib/jobManagement/test/browser/jobActions.test.ts
+++ b/src/sql/workbench/contrib/jobManagement/test/browser/jobActions.test.ts
@@ -266,8 +266,10 @@ suite('Job Management Actions', () => {
 	});
 
 	test('Delete Operator Action', async () => {
-		mockDeleteOperatorAction = TypeMoq.Mock.ofType(DeleteOperatorAction, TypeMoq.MockBehavior.Strict, DeleteOperatorAction.ID, DeleteOperatorAction.LABEL, null, null, mockJobManagementService);
-		mockDeleteOperatorAction.setup(s => s.run(TypeMoq.It.isAny()));
+		mockDeleteOperatorAction = TypeMoq.Mock.ofType(DeleteOperatorAction, TypeMoq.MockBehavior.Strict, null, null, mockJobManagementService);
+		mockDeleteOperatorAction.setup(s => s.run(TypeMoq.It.isAny())).returns(async () => {
+			await mockJobManagementService.object.deleteOperator(null, null);
+		});
 		mockDeleteOperatorAction.setup(s => s.id).returns(() => DeleteOperatorAction.ID);
 		mockDeleteOperatorAction.setup(s => s.label).returns(() => DeleteOperatorAction.LABEL);
 		assert.equal(mockDeleteOperatorAction.object.id, DeleteOperatorAction.ID);

--- a/src/sql/workbench/contrib/jobManagement/test/browser/jobActions.test.ts
+++ b/src/sql/workbench/contrib/jobManagement/test/browser/jobActions.test.ts
@@ -108,11 +108,7 @@ suite('Job Management Actions', () => {
 
 	test('Edit Job Action', async () => {
 		mockEditJobAction = TypeMoq.Mock.ofType(EditJobAction, TypeMoq.MockBehavior.Strict, EditJobAction.ID, EditJobAction.LABEL);
-		let commandServiceCalled: boolean = false;
-		mockEditJobAction.setup(s => s.run(TypeMoq.It.isAny())).returns(() => {
-			commandServiceCalled = true;
-			return Promise.resolve(commandServiceCalled);
-		});
+		mockEditJobAction.setup(s => s.run(TypeMoq.It.isAny()));
 		mockEditJobAction.setup(s => s.id).returns(() => EditJobAction.ID);
 		mockEditJobAction.setup(s => s.label).returns(() => EditJobAction.LABEL);
 		assert.equal(mockEditJobAction.object.id, EditJobAction.ID);
@@ -120,14 +116,13 @@ suite('Job Management Actions', () => {
 
 		// Edit Job Action from Jobs View should open a dialog
 		await mockEditJobAction.object.run(null);
-		assert(commandServiceCalled);
+		mockEditJobAction.verify(s => s.run(TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
 	test('Run Job Action', async () => {
 		mockRunJobAction = TypeMoq.Mock.ofType(RunJobAction, TypeMoq.MockBehavior.Strict, RunJobAction.ID, RunJobAction.LABEL, null, null, mockJobManagementService);
 		mockRunJobAction.setup(s => s.run(TypeMoq.It.isAny())).returns(async () => {
-			let result = await mockJobManagementService.object.jobAction(null, null, null).then((result) => result.success);
-			return result;
+			await mockJobManagementService.object.jobAction(null, null, null);
 		});
 
 		mockRunJobAction.setup(s => s.id).returns(() => RunJobAction.ID);
@@ -143,8 +138,7 @@ suite('Job Management Actions', () => {
 	test('Stop Job Action', async () => {
 		mockStopJobAction = TypeMoq.Mock.ofType(StopJobAction, TypeMoq.MockBehavior.Strict, StopJobAction.ID, StopJobAction.LABEL, null, null, mockJobManagementService);
 		mockStopJobAction.setup(s => s.run(TypeMoq.It.isAny())).returns(async () => {
-			let result = await mockJobManagementService.object.jobAction(null, null, null).then((result) => result.success);
-			return result;
+			await mockJobManagementService.object.jobAction(null, null, null);
 		});
 
 		mockStopJobAction.setup(s => s.id).returns(() => RunJobAction.ID);
@@ -160,8 +154,7 @@ suite('Job Management Actions', () => {
 	test('Delete Job Action', async () => {
 		mockDeleteJobAction = TypeMoq.Mock.ofType(DeleteJobAction, TypeMoq.MockBehavior.Strict, DeleteJobAction.ID, DeleteJobAction.LABEL, null, null, mockJobManagementService);
 		mockDeleteJobAction.setup(s => s.run(TypeMoq.It.isAny())).returns(async () => {
-			let result = await mockJobManagementService.object.jobAction(null, null, null).then((result) => result.success);
-			return result;
+			await mockJobManagementService.object.jobAction(null, null, null);
 		});
 
 		mockDeleteJobAction.setup(s => s.id).returns(() => DeleteJobAction.ID);
@@ -177,11 +170,7 @@ suite('Job Management Actions', () => {
 	// Step Actions
 	test('New Step Action', async () => {
 		mockNewStepAction = TypeMoq.Mock.ofType(NewStepAction, TypeMoq.MockBehavior.Strict, NewJobAction.ID, NewJobAction.LABEL);
-		let commandServiceCalled = false;
-		mockNewStepAction.setup(s => s.run(TypeMoq.It.isAny())).returns(() => {
-			commandServiceCalled = true;
-			return Promise.resolve(commandServiceCalled);
-		});
+		mockNewStepAction.setup(s => s.run(TypeMoq.It.isAny()));
 		mockNewStepAction.setup(s => s.id).returns(() => NewJobAction.ID);
 		mockNewStepAction.setup(s => s.label).returns(() => NewJobAction.LABEL);
 		assert.equal(mockNewStepAction.object.id, NewJobAction.ID);
@@ -189,16 +178,13 @@ suite('Job Management Actions', () => {
 
 		// New Step Action should called command service
 		await mockNewStepAction.object.run(null);
-		assert(commandServiceCalled);
+		mockNewStepAction.verify(s => s.run(TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
 	test('Delete Step Action', async () => {
 		mockDeleteStepAction = TypeMoq.Mock.ofType(DeleteStepAction, TypeMoq.MockBehavior.Strict, DeleteStepAction.ID, DeleteStepAction.LABEL);
-		let commandServiceCalled = false;
 		mockDeleteStepAction.setup(s => s.run(TypeMoq.It.isAny())).returns(async () => {
-			commandServiceCalled = true;
-			await mockJobManagementService.object.deleteJobStep(null, null).then((result) => result.success);
-			return commandServiceCalled;
+			await mockJobManagementService.object.deleteJobStep(null, null);
 		});
 		mockDeleteStepAction.setup(s => s.id).returns(() => DeleteStepAction.ID);
 		mockDeleteStepAction.setup(s => s.label).returns(() => DeleteStepAction.LABEL);
@@ -207,7 +193,6 @@ suite('Job Management Actions', () => {
 
 		// Delete Step Action should called command service
 		await mockDeleteStepAction.object.run(null);
-		assert(commandServiceCalled);
 		mockJobManagementService.verify(s => s.deleteJobStep(null, null), TypeMoq.Times.once());
 	});
 
@@ -227,11 +212,7 @@ suite('Job Management Actions', () => {
 
 	test('Edit Alert Action', async () => {
 		mockEditAlertAction = TypeMoq.Mock.ofType(EditAlertAction, TypeMoq.MockBehavior.Strict, EditAlertAction.ID, EditAlertAction.LABEL);
-		let commandServiceCalled: boolean = false;
-		mockEditAlertAction.setup(s => s.run(TypeMoq.It.isAny())).returns(() => {
-			commandServiceCalled = true;
-			return Promise.resolve(commandServiceCalled);
-		});
+		mockEditAlertAction.setup(s => s.run(TypeMoq.It.isAny()));
 		mockEditAlertAction.setup(s => s.id).returns(() => EditAlertAction.ID);
 		mockEditAlertAction.setup(s => s.label).returns(() => EditAlertAction.LABEL);
 		assert.equal(mockEditAlertAction.object.id, EditAlertAction.ID);
@@ -239,16 +220,13 @@ suite('Job Management Actions', () => {
 
 		// Edit Alert Action from Jobs View should open a dialog
 		await mockEditAlertAction.object.run(null);
-		assert(commandServiceCalled);
+		mockEditAlertAction.verify(s => s.run(TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
 	test('Delete Alert Action', async () => {
 		mockDeleteAlertAction = TypeMoq.Mock.ofType(DeleteAlertAction, TypeMoq.MockBehavior.Strict, DeleteAlertAction.ID, DeleteAlertAction.LABEL, null, null, mockJobManagementService);
-		let commandServiceCalled = false;
 		mockDeleteAlertAction.setup(s => s.run(TypeMoq.It.isAny())).returns(async () => {
-			commandServiceCalled = true;
-			await mockJobManagementService.object.deleteAlert(null, null).then((result) => result.success);
-			return commandServiceCalled;
+			await mockJobManagementService.object.deleteAlert(null, null);
 		});
 		mockDeleteAlertAction.setup(s => s.id).returns(() => DeleteAlertAction.ID);
 		mockDeleteAlertAction.setup(s => s.label).returns(() => DeleteAlertAction.LABEL);
@@ -257,7 +235,6 @@ suite('Job Management Actions', () => {
 
 		// Delete Alert Action should call job management service
 		await mockDeleteAlertAction.object.run(null);
-		assert(commandServiceCalled);
 		mockJobManagementService.verify(s => s.deleteAlert(null, null), TypeMoq.Times.once());
 	});
 
@@ -277,11 +254,7 @@ suite('Job Management Actions', () => {
 
 	test('Edit Operator Action', async () => {
 		mockEditOperatorAction = TypeMoq.Mock.ofType(EditOperatorAction, TypeMoq.MockBehavior.Strict, EditOperatorAction.ID, EditOperatorAction.LABEL);
-		let commandServiceCalled: boolean = false;
-		mockEditOperatorAction.setup(s => s.run(TypeMoq.It.isAny())).returns(() => {
-			commandServiceCalled = true;
-			return Promise.resolve(commandServiceCalled);
-		});
+		mockEditOperatorAction.setup(s => s.run(TypeMoq.It.isAny()));
 		mockEditOperatorAction.setup(s => s.id).returns(() => EditOperatorAction.ID);
 		mockEditOperatorAction.setup(s => s.label).returns(() => EditOperatorAction.LABEL);
 		assert.equal(mockEditOperatorAction.object.id, EditOperatorAction.ID);
@@ -289,17 +262,12 @@ suite('Job Management Actions', () => {
 
 		// Edit Operator Action from Jobs View should open a dialog
 		await mockEditOperatorAction.object.run(null);
-		assert(commandServiceCalled);
+		mockEditOperatorAction.verify(s => s.run(TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
 	test('Delete Operator Action', async () => {
 		mockDeleteOperatorAction = TypeMoq.Mock.ofType(DeleteOperatorAction, TypeMoq.MockBehavior.Strict, DeleteOperatorAction.ID, DeleteOperatorAction.LABEL, null, null, mockJobManagementService);
-		let commandServiceCalled = false;
-		mockDeleteOperatorAction.setup(s => s.run(TypeMoq.It.isAny())).returns(async () => {
-			commandServiceCalled = true;
-			await mockJobManagementService.object.deleteOperator(null, null).then((result) => result.success);
-			return commandServiceCalled;
-		});
+		mockDeleteOperatorAction.setup(s => s.run(TypeMoq.It.isAny()));
 		mockDeleteOperatorAction.setup(s => s.id).returns(() => DeleteOperatorAction.ID);
 		mockDeleteOperatorAction.setup(s => s.label).returns(() => DeleteOperatorAction.LABEL);
 		assert.equal(mockDeleteOperatorAction.object.id, DeleteOperatorAction.ID);
@@ -307,7 +275,6 @@ suite('Job Management Actions', () => {
 
 		// Delete Operator Action should call job management service
 		await mockDeleteOperatorAction.object.run(null);
-		assert(commandServiceCalled);
 		mockJobManagementService.verify(s => s.deleteOperator(null, null), TypeMoq.Times.once());
 	});
 
@@ -327,11 +294,7 @@ suite('Job Management Actions', () => {
 
 	test('Edit Proxy Action', async () => {
 		mockEditProxyAction = TypeMoq.Mock.ofType(EditProxyAction, TypeMoq.MockBehavior.Strict, EditProxyAction.ID, EditProxyAction.LABEL);
-		let commandServiceCalled: boolean = false;
-		mockEditProxyAction.setup(s => s.run(TypeMoq.It.isAny())).returns(() => {
-			commandServiceCalled = true;
-			return Promise.resolve(commandServiceCalled);
-		});
+		mockEditProxyAction.setup(s => s.run(TypeMoq.It.isAny()));
 		mockEditProxyAction.setup(s => s.id).returns(() => EditProxyAction.ID);
 		mockEditProxyAction.setup(s => s.label).returns(() => EditProxyAction.LABEL);
 		assert.equal(mockEditProxyAction.object.id, EditProxyAction.ID);
@@ -339,16 +302,13 @@ suite('Job Management Actions', () => {
 
 		// Edit Proxy Action from Proxies View should open a dialog
 		await mockEditProxyAction.object.run(null);
-		assert(commandServiceCalled);
+		mockEditProxyAction.verify(s => s.run(TypeMoq.It.isAny()), TypeMoq.Times.once());
 	});
 
 	test('Delete Proxy Action', async () => {
 		mockDeleteProxyAction = TypeMoq.Mock.ofType(DeleteProxyAction, TypeMoq.MockBehavior.Strict, DeleteProxyAction.ID, DeleteProxyAction.LABEL, null, null, mockJobManagementService);
-		let commandServiceCalled = false;
 		mockDeleteProxyAction.setup(s => s.run(TypeMoq.It.isAny())).returns(async () => {
-			commandServiceCalled = true;
-			await mockJobManagementService.object.deleteProxy(null, null).then((result) => result.success);
-			return commandServiceCalled;
+			await mockJobManagementService.object.deleteProxy(null, null);
 		});
 		mockDeleteProxyAction.setup(s => s.id).returns(() => DeleteProxyAction.ID);
 		mockDeleteProxyAction.setup(s => s.label).returns(() => DeleteProxyAction.LABEL);
@@ -357,7 +317,6 @@ suite('Job Management Actions', () => {
 
 		// Delete Proxy Action should call job management service
 		await mockDeleteProxyAction.object.run(null);
-		assert(commandServiceCalled);
 		mockJobManagementService.verify(s => s.deleteProxy(null, null), TypeMoq.Times.once());
 	});
 });

--- a/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellToolbarActions.ts
@@ -52,17 +52,9 @@ export class EditCellAction extends ToggleableAction {
 		this.toggle(value);
 	}
 
-	public run(context: CellContext): Promise<boolean> {
-		let self = this;
-		return new Promise<boolean>((resolve, reject) => {
-			try {
-				self.editMode = !self.editMode;
-				context.cell.isEditMode = self.editMode;
-				resolve(true);
-			} catch (e) {
-				reject(e);
-			}
-		});
+	public async run(context: CellContext): Promise<void> {
+		this.editMode = !this.editMode;
+		context.cell.isEditMode = this.editMode;
 	}
 }
 
@@ -358,13 +350,12 @@ export class ToggleMoreActions extends Action {
 		super(ToggleMoreActions.ID, ToggleMoreActions.LABEL, ToggleMoreActions.ICON);
 	}
 
-	run(context: StandardKeyboardEvent): Promise<boolean> {
+	async run(context: StandardKeyboardEvent): Promise<void> {
 		this._contextMenuService.showContextMenu({
 			getAnchor: () => context.target,
 			getActions: () => this._actions,
 			getActionsContext: () => this._context
 		});
-		return Promise.resolve(true);
 	}
 }
 

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/codeActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/codeActions.ts
@@ -53,11 +53,10 @@ export abstract class CellActionBase extends Action {
 		return true;
 	}
 
-	public run(context: CellContext): Promise<boolean> {
+	public async run(context: CellContext): Promise<void> {
 		if (hasModelAndCell(context, this.notificationService)) {
-			return this.doRun(context).then(() => true);
+			return this.doRun(context);
 		}
-		return Promise.resolve(true);
 	}
 
 	abstract doRun(context: CellContext): Promise<void>;
@@ -172,8 +171,8 @@ export class RunCellAction extends MultiStateAction<CellExecutionState> {
 		this.ensureContextIsUpdated(context);
 	}
 
-	public run(context?: CellContext): Promise<boolean> {
-		return this.doRun(context).then(() => true);
+	public async run(context?: CellContext): Promise<void> {
+		return this.doRun(context);
 	}
 
 	public async doRun(context: CellContext): Promise<void> {

--- a/src/sql/workbench/contrib/notebook/browser/markdownToolbarActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/markdownToolbarActions.ts
@@ -31,14 +31,13 @@ export class TransformMarkdownAction extends Action {
 		super(id, label, cssClass);
 		this._tooltip = tooltip;
 	}
-	public async run(context: any): Promise<boolean> {
+	public async run(context: any): Promise<void> {
 		if (!context?.cellModel?.showMarkdown && context?.cellModel?.showPreview) {
 			this.transformDocumentCommand();
 		} else {
 			let markdownTextTransformer = new MarkdownTextTransformer(this._notebookService, this._cellModel);
 			await markdownTextTransformer.transformText(this._type);
 		}
-		return true;
 	}
 
 	private transformDocumentCommand() {
@@ -607,7 +606,7 @@ export class ToggleViewAction extends Action {
 		this._tooltip = tooltip;
 	}
 
-	public async run(context: MarkdownToolbarComponent): Promise<boolean> {
+	public async run(context: MarkdownToolbarComponent): Promise<void> {
 		context.removeActiveClassFromModeActions();
 		this.class += ' active';
 		context.cellModel.showPreview = this.showPreview;
@@ -618,6 +617,5 @@ export class ToggleViewAction extends Action {
 		} else {
 			context.showLinkAndImageButtons();
 		}
-		return true;
 	}
 }

--- a/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebookActions.ts
@@ -126,9 +126,9 @@ export class ClearAllOutputsAction extends TooltipFromLabelAction {
 		});
 	}
 
-	public run(context: URI): Promise<boolean> {
+	public async run(context: URI): Promise<void> {
 		const editor = this._notebookService.findNotebookEditor(context);
-		return editor.clearAllOutputs();
+		await editor.clearAllOutputs();
 	}
 }
 
@@ -208,11 +208,10 @@ export class TrustedAction extends ToggleableAction {
 		this.toggle(value);
 	}
 
-	public async run(context: URI): Promise<boolean> {
+	public async run(context: URI): Promise<void> {
 		const editor = this._notebookService.findNotebookEditor(context);
 		this.trusted = !this.trusted;
 		editor.model.trustedMode = this.trusted;
-		return true;
 	}
 }
 
@@ -226,15 +225,13 @@ export class RunAllCellsAction extends Action {
 	) {
 		super(id, label, cssClass);
 	}
-	public async run(context: URI): Promise<boolean> {
+	public async run(context: URI): Promise<void> {
 		try {
 			this._telemetryService.sendActionEvent(TelemetryKeys.TelemetryView.Notebook, TelemetryKeys.NbTelemetryAction.RunAll);
 			const editor = this._notebookService.findNotebookEditor(context);
 			await editor.runAllCells();
-			return true;
 		} catch (e) {
 			this.notificationService.error(getErrorMessage(e));
-			return false;
 		}
 	}
 }
@@ -270,13 +267,12 @@ export class CollapseCellsAction extends ToggleableAction {
 		this.expanded = !value;
 	}
 
-	public async run(context: URI): Promise<boolean> {
+	public async run(context: URI): Promise<void> {
 		const editor = this._notebookService.findNotebookEditor(context);
 		this.setCollapsed(!this.isCollapsed);
 		editor.cells.forEach(cell => {
 			cell.isCollapsed = this.isCollapsed;
 		});
-		return true;
 	}
 }
 

--- a/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/outputs/gridOutput.component.ts
@@ -557,7 +557,7 @@ export class NotebookChartAction extends ToggleableAction {
 		});
 	}
 
-	public async run(context: IGridActionContext): Promise<boolean> {
+	public async run(context: IGridActionContext): Promise<void> {
 		this.resourceTable.toggleChartVisibility();
 		this.toggle(!this.state.isOn);
 		if (this.state.isOn) {
@@ -573,6 +573,5 @@ export class NotebookChartAction extends ToggleableAction {
 			).send();
 			this.resourceTable.updateChartData(Math.min(rowCount, maxRowCount), columnCount, context.gridDataProvider);
 		}
-		return true;
 	}
 }

--- a/src/sql/workbench/contrib/notebook/test/browser/notebookActions.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/notebookActions.test.ts
@@ -151,16 +151,14 @@ suite('Notebook Actions', function (): void {
 		// Normal use case
 		mockNotebookEditor.setup(c => c.clearAllOutputs()).returns(() => Promise.resolve(true));
 
-		let result = await action.run(testUri);
-		assert.ok(result, 'Clear All Outputs Action should succeed');
+		await action.run(testUri);
 		mockNotebookEditor.verify(c => c.clearAllOutputs(), TypeMoq.Times.once());
 
 		// Handle failure case
 		mockNotebookEditor.reset();
 		mockNotebookEditor.setup(c => c.clearAllOutputs()).returns(() => Promise.resolve(false));
 
-		result = await action.run(testUri);
-		assert.strictEqual(result, false, 'Clear All Outputs Action should have failed');
+		await action.run(testUri);
 		mockNotebookEditor.verify(c => c.clearAllOutputs(), TypeMoq.Times.once());
 	});
 
@@ -177,14 +175,12 @@ suite('Notebook Actions', function (): void {
 
 		mockNotebookEditor.setup(x => x.model).returns(() => testNotebookModel);
 		// Normal use case
-		let result = await action.run(testUri);
-		assert.ok(result, 'Trusted Action should succeed');
+		await action.run(testUri);
 		assert.strictEqual(action.trusted, true, 'Should be trusted after toggling trusted state');
 		assert.strictEqual(testNotebookModel.trustedMode, true, 'Model should be true after toggling trusted state');
 
 		// Should toggle trusted to false on subsequent action
-		result = await action.run(testUri);
-		assert.ok(result, 'Trusted Action should succeed again');
+		await action.run(testUri);
 		assert.strictEqual(action.trusted, false, 'Should toggle trusted to false');
 		assert.strictEqual(testNotebookModel.trustedMode, false, 'Model should be false again after toggling trusted state');
 	});
@@ -198,16 +194,14 @@ suite('Notebook Actions', function (): void {
 		// Normal use case
 		mockNotebookEditor.setup(c => c.runAllCells()).returns(() => Promise.resolve(true));
 
-		let result = await action.run(testUri);
-		assert.ok(result, 'Run All Cells Action should succeed');
+		await action.run(testUri);
 		mockNotebookEditor.verify(c => c.runAllCells(), TypeMoq.Times.once());
 
 		// Handle errors
 		mockNotebookEditor.reset();
 		mockNotebookEditor.setup(c => c.runAllCells()).throws(new Error('Test Error'));
 
-		result = await action.run(testUri);
-		assert.strictEqual(result, false, 'Run All Cells Action should fail on error');
+		await action.run(testUri);
 	});
 
 	test('Collapse Cells Action', async function (): Promise<void> {
@@ -225,8 +219,7 @@ suite('Notebook Actions', function (): void {
 		mockNotebookEditor.setup(x => x.cells).returns(() => testCells);
 
 		// Collapse cells case
-		let result = await action.run(testUri);
-		assert.ok(result, 'Collapse Cells Action should succeed');
+		await action.run(testUri);
 
 		assert.strictEqual(action.isCollapsed, true, 'Action should be collapsed after first toggle');
 		testCells.forEach(cell => {
@@ -234,8 +227,7 @@ suite('Notebook Actions', function (): void {
 		});
 
 		// Toggle cells to uncollapsed
-		result = await action.run(testUri);
-		assert.ok(result, 'Collapse Cells Action should succeed');
+		await action.run(testUri);
 
 		assert.strictEqual(action.isCollapsed, false, 'Action should not be collapsed after second toggle');
 		testCells.forEach(cell => {
@@ -254,7 +246,7 @@ suite('Notebook Actions', function (): void {
 			});
 
 		let action = new NewNotebookAction('TestId', 'TestLabel', mockCommandService.object, undefined, new NullAdsTelemetryService());
-		action.run(undefined);
+		await action.run(undefined);
 
 		assert.strictEqual(actualCmdId, NewNotebookAction.INTERNAL_NEW_NOTEBOOK_CMD_ID);
 	});

--- a/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scriptingActions.ts
@@ -40,7 +40,7 @@ export const EDIT_DATA_COMMAND_ID = 'dataExplorer.scriptAsEdit';
 // Script as Create
 CommandsRegistry.registerCommand({
 	id: SCRIPT_AS_CREATE_COMMAND_ID,
-	handler: async (accessor, args: TreeViewItemHandleArg): Promise<boolean | undefined> => {
+	handler: async (accessor, args: TreeViewItemHandleArg): Promise<void> => {
 		if (args.$treeItem?.payload) {
 			const capabilitiesService = accessor.get(ICapabilitiesService);
 			const oeShimService = accessor.get(IOEShimService);
@@ -56,16 +56,15 @@ CommandsRegistry.registerCommand({
 			};
 			const scriptCreateAction = new ScriptCreateAction(ScriptCreateAction.ID, ScriptCreateAction.LABEL,
 				queryEditorService, connectionManagementService, scriptingService, errorMessageService);
-			return progressService.withProgress({ location: VIEWLET_ID }, () => scriptCreateAction.run(baseContext));
+			await progressService.withProgress({ location: VIEWLET_ID }, async () => await scriptCreateAction.run(baseContext));
 		}
-		return undefined;
 	}
 });
 
 // Script as Delete
 CommandsRegistry.registerCommand({
 	id: SCRIPT_AS_DELETE_COMMAND_ID,
-	handler: async (accessor, args: TreeViewItemHandleArg): Promise<boolean | undefined> => {
+	handler: async (accessor, args: TreeViewItemHandleArg): Promise<void> => {
 		if (args.$treeItem?.payload) {
 			const capabilitiesService = accessor.get(ICapabilitiesService);
 			const oeShimService = accessor.get(IOEShimService);
@@ -81,16 +80,15 @@ CommandsRegistry.registerCommand({
 			};
 			const scriptDeleteAction = new ScriptDeleteAction(ScriptDeleteAction.ID, ScriptDeleteAction.LABEL,
 				queryEditorService, connectionManagementService, scriptingService, errorMessageService);
-			return progressService.withProgress({ location: VIEWLET_ID }, () => scriptDeleteAction.run(baseContext));
+			await progressService.withProgress({ location: VIEWLET_ID }, async () => await scriptDeleteAction.run(baseContext));
 		}
-		return undefined;
 	}
 });
 
 // Script as Select
 CommandsRegistry.registerCommand({
 	id: SCRIPT_AS_SELECT_COMMAND_ID,
-	handler: async (accessor, args: TreeViewItemHandleArg): Promise<boolean | undefined> => {
+	handler: async (accessor, args: TreeViewItemHandleArg): Promise<void> => {
 		if (args.$treeItem?.payload) {
 			const capabilitiesService = accessor.get(ICapabilitiesService);
 			const oeShimService = accessor.get(IOEShimService);
@@ -105,16 +103,15 @@ CommandsRegistry.registerCommand({
 			};
 			const scriptSelectAction = new ScriptSelectAction(ScriptSelectAction.ID, ScriptSelectAction.LABEL,
 				queryEditorService, connectionManagementService, scriptingService);
-			return progressService.withProgress({ location: VIEWLET_ID }, () => scriptSelectAction.run(baseContext));
+			await progressService.withProgress({ location: VIEWLET_ID }, async () => await scriptSelectAction.run(baseContext));
 		}
-		return undefined;
 	}
 });
 
 // Script as Execute
 CommandsRegistry.registerCommand({
 	id: SCRIPT_AS_EXECUTE_COMMAND_ID,
-	handler: async (accessor, args: TreeViewItemHandleArg): Promise<boolean | undefined> => {
+	handler: async (accessor, args: TreeViewItemHandleArg): Promise<void> => {
 		if (args.$treeItem?.payload) {
 			const capabilitiesService = accessor.get(ICapabilitiesService);
 			const oeShimService = accessor.get(IOEShimService);
@@ -130,16 +127,15 @@ CommandsRegistry.registerCommand({
 			};
 			const scriptExecuteAction = new ScriptExecuteAction(ScriptExecuteAction.ID, ScriptExecuteAction.LABEL,
 				queryEditorService, connectionManagementService, scriptingService, errorMessageService);
-			return progressService.withProgress({ location: VIEWLET_ID }, () => scriptExecuteAction.run(baseContext));
+			await progressService.withProgress({ location: VIEWLET_ID }, async () => await scriptExecuteAction.run(baseContext));
 		}
-		return undefined;
 	}
 });
 
 // Script as Alter
 CommandsRegistry.registerCommand({
 	id: SCRIPT_AS_ALTER_COMMAND_ID,
-	handler: async (accessor, args: TreeViewItemHandleArg): Promise<boolean | undefined> => {
+	handler: async (accessor, args: TreeViewItemHandleArg): Promise<void> => {
 		if (args.$treeItem?.payload) {
 			const capabilitiesService = accessor.get(ICapabilitiesService);
 			const oeShimService = accessor.get(IOEShimService);
@@ -155,16 +151,15 @@ CommandsRegistry.registerCommand({
 			};
 			const scriptAlterAction = new ScriptAlterAction(ScriptAlterAction.ID, ScriptAlterAction.LABEL,
 				queryEditorService, connectionManagementService, scriptingService, errorMessageService);
-			return progressService.withProgress({ location: VIEWLET_ID }, () => scriptAlterAction.run(baseContext));
+			await progressService.withProgress({ location: VIEWLET_ID }, async () => await scriptAlterAction.run(baseContext));
 		}
-		return undefined;
 	}
 });
 
 // Edit Data
 CommandsRegistry.registerCommand({
 	id: EDIT_DATA_COMMAND_ID,
-	handler: async (accessor, args: TreeViewItemHandleArg): Promise<boolean | undefined> => {
+	handler: async (accessor, args: TreeViewItemHandleArg): Promise<void> => {
 		if (args.$treeItem?.payload) {
 			const capabilitiesService = accessor.get(ICapabilitiesService);
 			const oeShimService = accessor.get(IOEShimService);
@@ -179,9 +174,8 @@ CommandsRegistry.registerCommand({
 			};
 			const editDataAction = new EditDataAction(EditDataAction.ID, EditDataAction.LABEL,
 				queryEditorService, connectionManagementService, scriptingService);
-			return progressService.withProgress({ location: VIEWLET_ID }, () => editDataAction.run(baseContext));
+			await progressService.withProgress({ location: VIEWLET_ID }, async () => await editDataAction.run(baseContext));
 		}
-		return undefined;
 	}
 });
 //#endregion
@@ -367,8 +361,8 @@ export class ExplorerScriptSelectAction extends ScriptSelectAction {
 		super(id, label, queryEditorService, connectionManagementService, scriptingService);
 	}
 
-	public run(actionContext: BaseActionContext): Promise<boolean> {
-		return this.progressService.withProgress({ location: ProgressLocation.Window }, () => super.run(actionContext));
+	public async run(actionContext: BaseActionContext): Promise<void> {
+		await this.progressService.withProgress({ location: ProgressLocation.Window }, async () => await super.run(actionContext));
 	}
 }
 
@@ -384,8 +378,8 @@ export class ExplorerScriptCreateAction extends ScriptCreateAction {
 		super(id, label, queryEditorService, connectionManagementService, scriptingService, errorMessageService);
 	}
 
-	public run(actionContext: BaseActionContext): Promise<boolean> {
-		return this.progressService.withProgress({ location: ProgressLocation.Window }, () => super.run(actionContext));
+	public async run(actionContext: BaseActionContext): Promise<void> {
+		await this.progressService.withProgress({ location: ProgressLocation.Window }, async () => await super.run(actionContext));
 	}
 }
 
@@ -401,8 +395,8 @@ export class ExplorerScriptAlterAction extends ScriptAlterAction {
 		super(id, label, queryEditorService, connectionManagementService, scriptingService, errorMessageService);
 	}
 
-	public run(actionContext: BaseActionContext): Promise<boolean> {
-		return this.progressService.withProgress({ location: ProgressLocation.Window }, () => super.run(actionContext));
+	public async run(actionContext: BaseActionContext): Promise<void> {
+		await this.progressService.withProgress({ location: ProgressLocation.Window }, async () => await super.run(actionContext));
 	}
 }
 
@@ -418,8 +412,8 @@ export class ExplorerScriptExecuteAction extends ScriptExecuteAction {
 		super(id, label, queryEditorService, connectionManagementService, scriptingService, errorMessageService);
 	}
 
-	public run(actionContext: BaseActionContext): Promise<boolean> {
-		return this.progressService.withProgress({ location: ProgressLocation.Window }, () => super.run(actionContext));
+	public async run(actionContext: BaseActionContext): Promise<void> {
+		await this.progressService.withProgress({ location: ProgressLocation.Window }, async () => await super.run(actionContext));
 	}
 }
 //#endregion

--- a/src/sql/workbench/contrib/tasks/common/tasksAction.ts
+++ b/src/sql/workbench/contrib/tasks/common/tasksAction.ts
@@ -23,19 +23,18 @@ export class CancelAction extends Action {
 	) {
 		super(id, label);
 	}
-	public run(element: TaskNode): Promise<boolean> {
+	public async run(element: TaskNode): Promise<void> {
 		if (element instanceof TaskNode && element.providerName) {
-			this._taskService.cancelTask(element.providerName, element.id).then((result) => {
+			try {
+				const result = await this._taskService.cancelTask(element.providerName, element.id);
 				if (!result) {
-					let error = localize('errorMsgFromCancelTask', "The task is failed to cancel.");
+					let error = localize('errorMsgFromCancelTask', "The task failed to cancel.");
 					this.showError(error);
 				}
-			}, error => {
+			} catch (error) {
 				this.showError(error);
-				return Promise.resolve(true);
-			});
+			}
 		}
-		return Promise.resolve(true);
 	}
 
 	private showError(errorMessage: string) {
@@ -57,12 +56,11 @@ export class ScriptAction extends Action {
 		super(id, label);
 	}
 
-	public async run(element: TaskNode): Promise<boolean> {
+	public async run(element: TaskNode): Promise<void> {
 		if (element instanceof TaskNode) {
-			if (element.script && element.script !== '') {
-				this._queryEditorService.newSqlEditor({ initalContent: element.script });
+			if (element.script) {
+				await this._queryEditorService.newSqlEditor({ initalContent: element.script });
 			}
 		}
-		return true;
 	}
 }

--- a/src/sql/workbench/contrib/views/browser/treeView.ts
+++ b/src/sql/workbench/contrib/views/browser/treeView.ts
@@ -941,7 +941,7 @@ class MultipleSelectionActionRunner extends ActionRunner {
 		}));
 	}
 
-	runAction(action: IAction, context: TreeViewItemHandleArg): Promise<void> {
+	async runAction(action: IAction, context: TreeViewItemHandleArg): Promise<void> {
 		const selection = this.getSelectedResources();
 		let selectionHandleArgs: TreeViewItemHandleArg[] | undefined = undefined;
 		let actionInSelected: boolean = false;
@@ -958,7 +958,7 @@ class MultipleSelectionActionRunner extends ActionRunner {
 			selectionHandleArgs = undefined;
 		}
 
-		return action.run(...[context, selectionHandleArgs]);
+		await action.run(...[context, selectionHandleArgs]);
 	}
 }
 

--- a/src/sql/workbench/services/connection/test/browser/testTreeView.ts
+++ b/src/sql/workbench/services/connection/test/browser/testTreeView.ts
@@ -963,7 +963,7 @@ class MultipleSelectionActionRunner extends ActionRunner {
 		}));
 	}
 
-	runAction(action: IAction, context: TreeViewItemHandleArg): Promise<void> {
+	async runAction(action: IAction, context: TreeViewItemHandleArg): Promise<void> {
 		const selection = this.getSelectedResources();
 		let selectionHandleArgs: TreeViewItemHandleArg[] | undefined = undefined;
 		let actionInSelected: boolean = false;
@@ -980,7 +980,7 @@ class MultipleSelectionActionRunner extends ActionRunner {
 			selectionHandleArgs = undefined;
 		}
 
-		return action.run(...[context, selectionHandleArgs]);
+		await action.run(...[context, selectionHandleArgs]);
 	}
 }
 

--- a/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/connectionTreeAction.ts
@@ -43,7 +43,7 @@ export class RefreshAction extends Action {
 	) {
 		super(id, label);
 	}
-	public async run(): Promise<boolean> {
+	public async run(): Promise<void> {
 		let treeNode: TreeNode | undefined = undefined;
 		if (this.element instanceof ConnectionProfile) {
 			let connection: ConnectionProfile = this.element;
@@ -67,7 +67,7 @@ export class RefreshAction extends Action {
 					}
 				} catch (error) {
 					this.showError(error);
-					return true;
+					return;
 				}
 				if (this._tree instanceof AsyncServerTree) {
 					await this._tree.updateChildren(this.element);
@@ -76,10 +76,9 @@ export class RefreshAction extends Action {
 				}
 			} catch (ex) {
 				this._logService.error(ex);
-				return true;
+				return;
 			}
 		}
-		return true;
 	}
 
 	private showError(errorMessage: string) {
@@ -104,13 +103,10 @@ export class EditConnectionAction extends Action {
 		this.class = 'edit-server-action';
 	}
 
-	public async run(): Promise<boolean> {
-		if (!this._connectionProfile) {
-			return false;
+	public async run(): Promise<void> {
+		if (this._connectionProfile) {
+			await this._connectionManagementService.showEditConnectionDialog(this._connectionProfile);
 		}
-
-		await this._connectionManagementService.showEditConnectionDialog(this._connectionProfile);
-		return true;
 	}
 }
 
@@ -162,7 +158,7 @@ export class AddServerAction extends Action {
 		super(id, label, SqlIconId.addServerAction);
 	}
 
-	public async run(element: ConnectionProfileGroup): Promise<boolean> {
+	public async run(element: ConnectionProfileGroup): Promise<void> {
 		// Not sure how to fix this....
 		let connection: Partial<IConnectionProfile> | undefined = element === undefined ? undefined : {
 			connectionName: undefined,
@@ -182,7 +178,6 @@ export class AddServerAction extends Action {
 			id: element.id!
 		} as Partial<IConnectionProfile>;
 		await this._connectionManagementService.showConnectionDialog(undefined, undefined, connection);
-		return true;
 	}
 }
 
@@ -201,9 +196,8 @@ export class AddServerGroupAction extends Action {
 		super(id, label, SqlIconId.addServerGroupAction);
 	}
 
-	public async run(): Promise<boolean> {
-		await this.serverGroupController.showCreateGroupDialog();
-		return true;
+	public async run(): Promise<void> {
+		return this.serverGroupController.showCreateGroupDialog();
 	}
 }
 
@@ -224,9 +218,8 @@ export class EditServerGroupAction extends Action {
 		this.class = 'edit-server-group-action';
 	}
 
-	public run(): Promise<boolean> {
-		this.serverGroupController.showEditGroupDialog(this._group);
-		return Promise.resolve(true);
+	public run(): Promise<void> {
+		return this.serverGroupController.showEditGroupDialog(this._group);
 	}
 }
 
@@ -248,7 +241,7 @@ export class ActiveConnectionsFilterAction extends Action {
 		super(id, label, SqlIconId.activeConnectionsAction);
 	}
 
-	public async run(): Promise<boolean> {
+	public async run(): Promise<void> {
 		const serverTreeView = this._objectExplorerService.getServerTreeView();
 		if (serverTreeView.view !== ServerTreeViewView.active) {
 			// show active connections in the tree
@@ -257,7 +250,6 @@ export class ActiveConnectionsFilterAction extends Action {
 			// show full tree
 			await serverTreeView.refreshTree();
 		}
-		return true;
 	}
 }
 
@@ -289,12 +281,11 @@ export class DeleteConnectionAction extends Action {
 		}
 	}
 
-	public run(): Promise<boolean> {
+	public async run(): Promise<void> {
 		if (this.element instanceof ConnectionProfile) {
-			this._connectionManagementService.deleteConnection(this.element);
+			await this._connectionManagementService.deleteConnection(this.element);
 		} else if (this.element instanceof ConnectionProfileGroup) {
-			this._connectionManagementService.deleteConnectionGroup(this.element);
+			await this._connectionManagementService.deleteConnectionGroup(this.element);
 		}
-		return Promise.resolve(true);
 	}
 }


### PR DESCRIPTION
In a recent [VS Code change](https://github.com/Microsoft/vscode/commit/7031abadeafec54c8876231e3579c938dee6e1a5#diff-f94d2d5f2236e3698d0375242f759563cf9e3e744b06f9f605f87d727c36a3f9) they changed actions to no longer return any values from the run function. This caused a ton of compile errors in places where we overrode the run function with a value with that returned a boolean - so will need to be fixed in order for the VS Code merge with that change to get through. 

Since updating this for our code is going to be a pretty big task LOC-wise I thought it best to do that separate from the VS Code merge (since otherwise trying to review these changes in that would be a lot more difficult). This shouldn't have any impact on the running of the actions in our code base as it is currently - looking through the code I couldn't find any instances of anything (in our code or theirs) that actually used the result of the action. Just the error if one occurred. 

I went through and tested a few different areas of actions that I updated and things seemed to work fine, but having some of the area owners go through and do some validation of their own once this gets in would be great. 