### PR TITLE
fix image overflow in an empty notebook cell issue

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.css
@@ -7,7 +7,7 @@ text-cell-component {
 	display: block;
 }
 text-cell-component .notebook-text {
-	display: flex;
+	display: inline-block;
 	outline: none;
 	min-height: 50px;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15491 

![image](https://user-images.githubusercontent.com/12754347/119588130-00674500-bd85-11eb-912e-e100011356a9.png)

![image](https://user-images.githubusercontent.com/12754347/119588392-8e433000-bd85-11eb-8df1-1c92bf3b1f59.png)

![image](https://user-images.githubusercontent.com/12754347/119588471-b92d8400-bd85-11eb-8eaa-9ac7415edf80.png)

