### PR TITLE
fix the missing asc/desc icons

### DIFF
--- a/src/sql/base/browser/ui/table/media/table.css
+++ b/src/sql/base/browser/ui/table/media/table.css
@@ -22,19 +22,26 @@
 	background-size: 8px;
 	background-repeat: no-repeat;
 }
+
+.vs .slick-header-menuicon.ascending,
 .vs .monaco-table .slick-sort-indicator-asc {
 	background-image: url('sort_asc.svg');
 }
 
+.vs-dark .slick-header-menuicon.ascending,
+.hc-black .slick-header-menuicon.ascending,
 .vs-dark .monaco-table .slick-sort-indicator-asc,
 .hc-black .monaco-table .slick-sort-indicator-asc {
 	background-image: url('sort_asc_inverse.svg');
 }
 
+.vs .slick-header-menuicon.descending,
 .vs .monaco-table .slick-sort-indicator-desc {
 	background-image: url('sort_desc.svg');
 }
 
+.vs-dark .slick-header-menuicon.descending,
+.hc-black .slick-header-menuicon.descending,
 .vs-dark .monaco-table .slick-sort-indicator-desc,
 .hc-black .monaco-table .slick-sort-indicator-desc {
 	background-image: url('sort_desc_inverse.svg');
@@ -198,14 +205,7 @@
 	width: 100%;
 	padding: 0 0 0 18px;
 	margin: 0px;
-}
-
-.slick-header-menuicon.ascending {
-	background-image: url('sort-asc.gif');
-}
-
-.slick-header-menuicon.descending {
-	background-image: url('sort-desc.gif');
+	background-size: 10px;
 }
 
 .slick-header-menucontent {


### PR DESCRIPTION
I deleted the gif images earlier and didn't realized it is being used by the menu items. 

the fix is to update it to use the svg images.

before:
![image](https://user-images.githubusercontent.com/13777222/119883857-da58b680-bee4-11eb-82e2-61ffe411355a.png)

after:
![image](https://user-images.githubusercontent.com/13777222/119883903-e775a580-bee4-11eb-8981-bbb79ebae017.png)

![image](https://user-images.githubusercontent.com/13777222/119883940-f2c8d100-bee4-11eb-8c8f-c2a32b36a5bb.png)
