### PR TITLE
Fix WYWIWYG Table cell adding new line in table cell

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -176,8 +176,8 @@ export class HTMLMarkdownConverter {
 			replacement: function (content, node, options) {
 				// For elements that aren't lists, convert <br> into its markdown equivalent
 				if (node.parentElement?.nodeName !== 'LI') {
-					// Keeps <br> in table cell to create new line in the table cell
-					if (node.parentElement?.nodeName === 'TD') {
+					// Keeps <br> in table cell/head in order to keep new linehow
+					if (node.parentElement?.nodeName === 'TD' || node.parentElement?.nodeName === 'TH') {
 						return '<br>';
 					}
 					return options.br + '\n';

--- a/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
+++ b/src/sql/workbench/contrib/notebook/browser/htmlMarkdownConverter.ts
@@ -176,6 +176,10 @@ export class HTMLMarkdownConverter {
 			replacement: function (content, node, options) {
 				// For elements that aren't lists, convert <br> into its markdown equivalent
 				if (node.parentElement?.nodeName !== 'LI') {
+					// Keeps <br> in table cell to create new line in the table cell
+					if (node.parentElement?.nodeName === 'TD') {
+						return '<br>';
+					}
 					return options.br + '\n';
 				}
 				// One (and only one) line break is ignored when it's inside of a list item

--- a/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
@@ -260,9 +260,11 @@ suite('HTML Markdown Converter', function (): void {
 		assert.equal(htmlMarkdownConverter.convert(htmlString), `| Test | Test | Test |\n| :-: | --- | --- |\n| test | test | test |\n| test | test | test |\n| test | test | test |\n| test | test | test |`, 'Table with center align column header failed');
 	});
 
-	test('Should transform table to keep <br> for new line within table cell', () => {
+	test('Should transform table to keep <br> for new line in table head and cell', () => {
 		htmlString = '<table>\n<thead>\n<tr>\n<th></th>\n<th></th>\n<th></th>\n</tr>\n</thead>\n<tbody><tr>\n<td>test</td>\n<td>test<br>test</td>\n<td></td>\n</tr>\n</tbody></table>\n';
 		assert.equal(htmlMarkdownConverter.convert(htmlString), `|  |  |  |\n| --- | --- | --- |\n| test | test<br>test |  |`, 'Table with new line in cell failed');
+		htmlString = '<table>\n<thead>\n<tr>\n<th>TEST<br>TEST</th>\n<th>TEST</th>\n<th>TEST</th>\n</tr>\n</thead>\n<tbody><tr>\n<td>test</td>\n<td>test</td>\n<td>test</td>\n</tr>\n</tbody></table>\n';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `| TEST<br>TEST | TEST | TEST |\n| --- | --- | --- |\n| test | test | test |`, 'Table with new line in table head failed');
 	});
 
 	test('Should transform <b> and <strong> tags', () => {

--- a/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/browser/htmlMarkdownConverter.test.ts
@@ -260,6 +260,11 @@ suite('HTML Markdown Converter', function (): void {
 		assert.equal(htmlMarkdownConverter.convert(htmlString), `| Test | Test | Test |\n| :-: | --- | --- |\n| test | test | test |\n| test | test | test |\n| test | test | test |\n| test | test | test |`, 'Table with center align column header failed');
 	});
 
+	test('Should transform table to keep <br> for new line within table cell', () => {
+		htmlString = '<table>\n<thead>\n<tr>\n<th></th>\n<th></th>\n<th></th>\n</tr>\n</thead>\n<tbody><tr>\n<td>test</td>\n<td>test<br>test</td>\n<td></td>\n</tr>\n</tbody></table>\n';
+		assert.equal(htmlMarkdownConverter.convert(htmlString), `|  |  |  |\n| --- | --- | --- |\n| test | test<br>test |  |`, 'Table with new line in cell failed');
+	});
+
 	test('Should transform <b> and <strong> tags', () => {
 		htmlString = '<b>test string</b>';
 		assert.equal(htmlMarkdownConverter.convert(htmlString), '**test string**', 'Basic bold test failed');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15552. 
Fixes when a user presses enter within the table cell to use <br> to create a new line within the cell. This makes sure the new line is inside the table cell.
 
Before Fix:
![image](https://user-images.githubusercontent.com/23587151/119892016-7b983a80-beee-11eb-88ca-222d3775657c.png)

With Fix: 
![image](https://user-images.githubusercontent.com/23587151/119891894-5c99a880-beee-11eb-9b49-c156b6e71aa7.png)
