### PR TITLE
Fix edit command to take in worker count of 0

### DIFF
--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -151,7 +151,7 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 					if (args.port) { argsArray.push('--port', args.port.toString()); }
 					if (args.replaceEngineSettings) { argsArray.push('--replace-engine-settings'); }
 					if (args.workerEngineSettings) { argsArray.push('--worker-engine-settings', args.workerEngineSettings); }
-					if (args.workers) { argsArray.push('--workers', args.workers.toString()); }
+					if (args.workers || args.workers === 0) { argsArray.push('--workers', args.workers.toString()); }
 					return this.executeCommand<void>(argsArray, additionalEnvVars, azdataContext);
 				}
 			}

--- a/extensions/azdata/src/azdata.ts
+++ b/extensions/azdata/src/azdata.ts
@@ -151,7 +151,7 @@ export class AzdataTool implements azdataExt.IAzdataApi {
 					if (args.port) { argsArray.push('--port', args.port.toString()); }
 					if (args.replaceEngineSettings) { argsArray.push('--replace-engine-settings'); }
 					if (args.workerEngineSettings) { argsArray.push('--worker-engine-settings', args.workerEngineSettings); }
-					if (args.workers || args.workers === 0) { argsArray.push('--workers', args.workers.toString()); }
+					if (args.workers !== undefined) { argsArray.push('--workers', args.workers.toString()); }
 					return this.executeCommand<void>(argsArray, additionalEnvVars, azdataContext);
 				}
 			}


### PR DESCRIPTION
When trying to scale to 0, edit command would not add worker argument: 
CLI output
[2021-06-01T21:48:20.867Z] Executing command: '"C:\Program Files (x86)\Microsoft SDKs\Azdata\CLI\wbin\azdata.cmd" arc postgres server **edit -n pgt0** --output json --debug'