### PR TITLE
fix the input box validation

### DIFF
--- a/src/sql/base/parts/editableDropdown/browser/dropdown.ts
+++ b/src/sql/base/parts/editableDropdown/browser/dropdown.ts
@@ -139,7 +139,7 @@ export class Dropdown extends Disposable implements IListVirtualDelegate<string>
 		this._register(DOM.addStandardDisposableListener(this._input.inputElement, DOM.EventType.KEY_DOWN, (e: StandardKeyboardEvent) => {
 			switch (e.keyCode) {
 				case KeyCode.Enter:
-					if (this._input.validate()) {
+					if (this._input.validate() === undefined) {
 						this._onValueChange.fire(this._input.value);
 					}
 					e.stopPropagation();

--- a/src/sql/workbench/browser/modal/optionsDialogHelper.ts
+++ b/src/sql/workbench/browser/modal/optionsDialogHelper.ts
@@ -116,7 +116,7 @@ export function validateInputs(optionsMap: { [optionName: string]: IOptionElemen
 			optionElement.option.valueType === ServiceOptionType.number);
 
 		if (isInputBox) {
-			if (!widget.validate()) {
+			if (widget.validate() !== undefined) {
 				isValid = false;
 				if (!isFocused) {
 					isFocused = true;

--- a/src/sql/workbench/browser/modelComponents/inputbox.component.ts
+++ b/src/sql/workbench/browser/modelComponents/inputbox.component.ts
@@ -159,7 +159,7 @@ export default class InputBoxComponent extends ComponentBase<azdata.InputBoxProp
 	public async validate(): Promise<boolean> {
 		await super.validate();
 		// Let the input validate handle showing/hiding the error message
-		const valid = this.inputElement.validate();
+		const valid = this.inputElement.validate() === undefined;
 
 		// set aria label based on validity of input
 		if (valid) {

--- a/src/sql/workbench/contrib/backup/browser/backup.component.ts
+++ b/src/sql/workbench/contrib/backup/browser/backup.component.ts
@@ -826,7 +826,7 @@ export class BackupComponent extends AngularDisposable {
 
 	private enableBackupButton(): void {
 		if (!this.backupButton!.enabled) {
-			if (this.pathListBox!.count > 0 && (!this.isFormatChecked || this.mediaNameBox!.value) && this.backupRetainDaysBox!.validate()) {
+			if (this.pathListBox!.count > 0 && (!this.isFormatChecked || this.mediaNameBox!.value) && this.backupRetainDaysBox!.validate() === undefined) {
 				this.backupEnabled = true;
 			}
 		}
@@ -851,7 +851,7 @@ export class BackupComponent extends AngularDisposable {
 	}
 
 	private backupRetainDaysChanged(days: string): void {
-		if (!this.backupRetainDaysBox!.validate()) {
+		if (this.backupRetainDaysBox!.validate() !== undefined) {
 			this.backupEnabled = false;
 		} else {
 			this.enableBackupButton();

--- a/src/sql/workbench/services/connection/browser/connectionWidget.ts
+++ b/src/sql/workbench/services/connection/browser/connectionWidget.ts
@@ -887,27 +887,27 @@ export class ConnectionWidget extends lifecycle.Disposable {
 
 	private validateInputs(): boolean {
 		let isFocused = false;
-		let validateServerName = this._serverNameInputBox.validate();
-		if (!validateServerName) {
+		const isServerNameValid = this._serverNameInputBox.validate() === undefined;
+		if (!isServerNameValid) {
 			this._serverNameInputBox.focus();
 			isFocused = true;
 		}
-		let validateUserName = this._userNameInputBox.validate();
-		if (!validateUserName && !isFocused) {
+		const isUserNameValid = this._userNameInputBox.validate() === undefined;
+		if (!isUserNameValid && !isFocused) {
 			this._userNameInputBox.focus();
 			isFocused = true;
 		}
-		let validatePassword = this._passwordInputBox.validate();
-		if (!validatePassword && !isFocused) {
+		const isPasswordValid = this._passwordInputBox.validate() === undefined;
+		if (!isPasswordValid && !isFocused) {
 			this._passwordInputBox.focus();
 			isFocused = true;
 		}
-		let validateAzureAccount = this.validateAzureAccountSelection();
-		if (!validateAzureAccount && !isFocused) {
+		const isAzureAccountValid = this.validateAzureAccountSelection();
+		if (!isAzureAccountValid && !isFocused) {
 			this._azureAccountDropdown.focus();
 			isFocused = true;
 		}
-		return validateServerName && validateUserName && validatePassword && validateAzureAccount;
+		return isServerNameValid && isUserNameValid && isPasswordValid && isAzureAccountValid;
 	}
 
 	public connect(model: IConnectionProfile): boolean {

--- a/src/sql/workbench/services/serverGroup/browser/serverGroupDialog.ts
+++ b/src/sql/workbench/services/serverGroup/browser/serverGroupDialog.ts
@@ -307,11 +307,11 @@ export class ServerGroupDialog extends Modal {
 
 	private validateInputs(): boolean {
 		const renderedDialog = this.withRenderedDialog;
-		let validate = renderedDialog.groupNameInputBox.validate();
-		if (!validate) {
+		const isNameValid = renderedDialog.groupNameInputBox.validate() === undefined;
+		if (!isNameValid) {
 			renderedDialog.groupNameInputBox.focus();
 		}
-		return validate;
+		return isNameValid;
 	}
 
 	// initialize the view based on the current state of the view model

--- a/src/sql/workbench/test/browser/modal/optionsDialogHelper.test.ts
+++ b/src/sql/workbench/test/browser/modal/optionsDialogHelper.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as OptionsDialogHelper from 'sql/workbench/browser/modal/optionsDialogHelper';
-import { InputBox } from 'vs/base/browser/ui/inputbox/inputBox';
+import { InputBox, MessageType } from 'vs/base/browser/ui/inputbox/inputBox';
 import * as azdata from 'azdata';
 import * as TypeMoq from 'typemoq';
 import * as assert from 'assert';
@@ -100,7 +100,7 @@ suite('Advanced options helper tests', () => {
 
 		inputBox = TypeMoq.Mock.ofType(InputBox, TypeMoq.MockBehavior.Loose, $('div'), null, null);
 		inputBox.callBase = true;
-		inputBox.setup(x => x.validate()).returns(() => isValid);
+		inputBox.setup(x => x.validate()).returns(() => isValid ? undefined : MessageType.ERROR);
 		inputBox.setup(x => x.value).returns(() => inputValue);
 	});
 

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -425,7 +425,7 @@ export class InputBox extends Widget {
 		return !!this.validation && !this.validation(this.value);
 	}
 
-	public validate(): boolean { // {{SQL CARBON EDIT}}
+	public validate(): MessageType | undefined {
 		let errorMsg: IMessage | null = null;
 
 		if (this.validation) {
@@ -449,8 +449,7 @@ export class InputBox extends Widget {
 			}
 		}
 
-		// {{SQL CARBON EDIT}} Candidate for addition to vscode
-		return errorMsg ? errorMsg.type !== MessageType.ERROR : true;
+		return errorMsg?.type;
 	}
 
 	public stylesForType(type: MessageType | undefined): { border: Color | undefined; background: Color | undefined; foreground: Color | undefined } {

--- a/src/vs/workbench/contrib/remote/browser/tunnelView.ts
+++ b/src/vs/workbench/contrib/remote/browser/tunnelView.ts
@@ -342,7 +342,7 @@ class TunnelTreeRenderer extends Disposable implements ITreeRenderer<ITunnelGrou
 			inputBox,
 			dom.addStandardDisposableListener(inputBox.inputElement, dom.EventType.KEY_DOWN, (e: IKeyboardEvent) => {
 				if (e.equals(KeyCode.Enter)) {
-					if (inputBox.validate()) { // {{SQL CARBON EDIT}}
+					if (inputBox.validate() !== MessageType.ERROR) {
 						done(true, true);
 					} else {
 						done(false, true);
@@ -352,7 +352,7 @@ class TunnelTreeRenderer extends Disposable implements ITreeRenderer<ITunnelGrou
 				}
 			}),
 			dom.addDisposableListener(inputBox.inputElement, dom.EventType.BLUR, () => {
-				done(inputBox.validate(), true); // {{SQL CARBON EDIT}}
+				done(inputBox.validate() !== MessageType.ERROR, true);
 			}),
 			styler
 		];


### PR DESCRIPTION
This PR fixes #15529

Root cause:
The rename is not committed because it is treated as invalid. the root cause is vscode changed the implementation of validate method of input box component in this commit:https://github.com/microsoft/vscode/commit/e7c84aab5b172cdc59f53141f3e5679ebae13a96#diff-8530ffbbb8892d45476f17f7b5bb48305ae674ad618f9852307144a33831c588R401. 
Previously, it will return a boolean value indicating whether the input box value is valid, after this commit, it is returning messageType, undefined means valid which is the opposite of its previous behavior. in the recent merge, we kept its old behavior and but didn't update the code that is responsible for file/folder renaming: https://github.com/microsoft/azuredatastudio/blob/main/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts#L454

Fix:
Instead of keeping the old logic, I chose to update all the references to use the new logic to avoid future issues, vscode could add new references of the validate method of inputbox, it is very likely we won't be able to catch it during compilation just like this one.