### PR TITLE
Fix for Portuguese Language Pack Entry in Gallery

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -2094,7 +2094,7 @@
 				},
 				{
 					"extensionId": "47",
-					"extensionName": "ads-language-pack-pt-br",
+					"extensionName": "ads-language-pack-pt-BR",
 					"displayName": "Portuguese (Brazil) Language Pack for Azure Data Studio",
 					"shortDescription": "Language pack extension for Portuguese (Brazil)",
 					"publisher": {
@@ -2111,7 +2111,7 @@
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-pt-br-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-pt-BR-1.29.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -2094,7 +2094,7 @@
 				},
 				{
 					"extensionId": "47",
-					"extensionName": "ads-language-pack-pt-br",
+					"extensionName": "ads-language-pack-pt-BR",
 					"displayName": "Portuguese (Brazil) Language Pack for Azure Data Studio",
 					"shortDescription": "Language pack extension for Portuguese (Brazil)",
 					"publisher": {
@@ -2111,7 +2111,7 @@
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-pt-br-1.29.0.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/langpacks/1.29.0/ads-language-pack-pt-BR-1.29.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR fixes the identity of the Portuguese gallery entry to match the actual name of the extension as well as its file name, so it can download it from the repo properly.

This PR fixes #15639
