### PR TITLE
fix for Portuguese

### DIFF
--- a/i18n/ads-language-pack-pt-BR/package.json
+++ b/i18n/ads-language-pack-pt-BR/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "ads-language-pack-pt-BR",
+	"name": "ads-language-pack-pt-br",
 	"displayName": "Portuguese (Brazil) Language Pack for Azure Data Studio",
 	"description": "Language pack extension for Portuguese (Brazil)",
 	"version": "1.29.0",


### PR DESCRIPTION
In the older langpacks, the language id for Portuguese was lowercase, while the folder was capitalized. This PR restores that and the resulting vsix package is properly capitalized, matching the extension gallery entry.
This PR fixes #15639
