### PR TITLE
Updating extensionGallery and extensionGallery-insider for Sql Db Projects 0.10.0

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -3442,14 +3442,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.9.1",
-							"lastUpdated": "5/13/2021",
+							"version": "0.10.0",
+							"lastUpdated": "06/10/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-database-projects/sql-database-projects-0.9.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-database-projects/sql-database-projects-0.10.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -3442,14 +3442,14 @@
 					},
 					"versions": [
 						{
-							"version": "0.9.1",
-							"lastUpdated": "5/13/2021",
+							"version": "0.10.0",
+							"lastUpdated": "06/10/2021",
 							"assetUri": "",
 							"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 								{
 									"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-database-projects/sql-database-projects-0.9.1.vsix"
+									"source": "https://sqlopsextensions.blob.core.windows.net/extensions/sql-database-projects/sql-database-projects-0.10.0.vsix"
 								},
 								{
 									"assetType": "Microsoft.VisualStudio.Services.Icons.Default",


### PR DESCRIPTION
This PR fixes #15680.
VSIX from the release build: https://mssqltools.visualstudio.com/_apis/resources/Containers/3115191/drop?itemPath=drop%2Fextensions%2Fsql-database-projects-0.10.0.vsix
