### PR TITLE
Stringify titles when creating toc entry from UI

### DIFF
--- a/extensions/notebook/src/book/bookVersionHandler.ts
+++ b/extensions/notebook/src/book/bookVersionHandler.ts
@@ -79,7 +79,7 @@ export function convertTo(version: string, section: JupyterBookSection): Jupyter
 	if (version === BookVersion.v1) {
 		if (section.sections && section.sections.length > 0) {
 			let temp: JupyterBookSection = {};
-			temp.title = section.title;
+			temp.title = JSON.stringify(section.title);
 			temp.url = section.url ? section.url : section.file;
 			temp.expand_sections = section.expand_sections;
 			temp.not_numbered = convertNotNumbered(section);
@@ -95,7 +95,7 @@ export function convertTo(version: string, section: JupyterBookSection): Jupyter
 			return temp;
 		} else {
 			let newSection: JupyterBookSection = {};
-			newSection.title = section.title;
+			newSection.title = JSON.stringify(section.title);
 			newSection.url = section.url ? section.url : section.file;
 			newSection.sections = section.sections;
 			newSection.not_numbered = convertNotNumbered(section);
@@ -110,7 +110,7 @@ export function convertTo(version: string, section: JupyterBookSection): Jupyter
 	else if (version === BookVersion.v2) {
 		if (section.sections && section.sections.length > 0) {
 			let temp: JupyterBookSection = {};
-			temp.title = section.title;
+			temp.title = JSON.stringify(section.title);
 			temp.file = section.file;
 			temp.expand_sections = section.expand_sections;
 			temp.header = section.header;
@@ -126,7 +126,7 @@ export function convertTo(version: string, section: JupyterBookSection): Jupyter
 			return temp;
 		} else {
 			let newSection: JupyterBookSection = {};
-			newSection.title = section.title;
+			newSection.title = JSON.stringify(section.title);
 			newSection.file = section.file;
 			newSection.sections = section.sections;
 			newSection.expand_sections = section.expand_sections;


### PR DESCRIPTION
This PR addresses #15689
Creating notebooks with titles starting with special characters or containing only number would crash the toc when updating the book.
This is not a final fix, I'll work next release to add more validations when reading the toc.

![Screen Shot 2021-06-11 at 1 16 36 PM](https://user-images.githubusercontent.com/34872381/121744107-40cdff00-cab7-11eb-8826-7e4d9df7ae9f.png)

![Screen Shot 2021-06-11 at 1 15 57 PM](https://user-images.githubusercontent.com/34872381/121744046-2a27a800-cab7-11eb-9fff-23125ddff9ff.png)

