### PR TITLE
Changed default 2

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -617,7 +617,7 @@
                               "description": "%should.be.integer%"
                             }
                           ],
-                          "defaultValue": "0",
+                          "defaultValue": "2",
                           "min": 0
                         },
                         {


### PR DESCRIPTION
We still provide customer the flexibility to change the number of workers when they deploy. We just lead with a default of 2 workers.
