### PR TITLE
Fix create book dialog clearing input boxes on browse cancel

### DIFF
--- a/extensions/notebook/src/dialog/createBookDialog.ts
+++ b/extensions/notebook/src/dialog/createBookDialog.ts
@@ -116,11 +116,17 @@ export class CreateBookDialog {
 			}).component();
 
 			browseFolderButton.onDidClick(async () => {
-				this.saveLocationInputBox.value = await this.selectFolder();
+				const selectedFolder = await this.selectFolder();
+				if (selectedFolder) {
+					this.saveLocationInputBox.value = selectedFolder;
+				}
 			});
 
 			browseContentFolderButton.onDidClick(async () => {
-				this.contentFolderInputBox.value = await this.selectFolder();
+				const selectedFolder = await this.selectFolder();
+				if (selectedFolder) {
+					this.contentFolderInputBox.value = selectedFolder;
+				}
 			});
 
 			this.formModel = this.view.modelBuilder.formContainer()


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15712 - don't replace the value if the user didn't select anything