### PR TITLE
Trim pathname for link callout file paths

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -351,10 +351,11 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 
 	private getCurrentLinkUrl(): string {
 		if (this.cellModel.currentMode === CellEditModes.WYSIWYG) {
-			if (document.getSelection().anchorNode.parentNode['protocol'] === 'file:') {
-				return document.getSelection().anchorNode.parentNode['pathname'] || '';
+			const parentNode = document.getSelection().anchorNode.parentNode as HTMLAnchorElement;
+			if (parentNode.protocol === 'file:') {
+				return URI.parse(parentNode.href).fsPath || '';
 			} else {
-				return document.getSelection().anchorNode.parentNode['href'] || '';
+				return parentNode.href || '';
 			}
 		} else {
 			const editorControl = this.getCellEditorControl();

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -353,7 +353,8 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 		if (this.cellModel.currentMode === CellEditModes.WYSIWYG) {
 			const parentNode = document.getSelection().anchorNode.parentNode as HTMLAnchorElement;
 			if (parentNode.protocol === 'file:') {
-				return URI.parse(parentNode.href).fsPath || '';
+				// Pathname starts with / per https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/pathname so trim it off
+				return parentNode.pathname?.slice(1) || '';
 			} else {
 				return parentNode.href || '';
 			}


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15663

Pathname will always have a preceeding / per https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/pathname

So fixed the logic to trim that off when populating the callout dialog. 

Also fixed up the typing while I was here, it's still just assuming that it's actually an HTMLAnchorElement but given the usage that should be safe.

![image](https://user-images.githubusercontent.com/28519865/122002037-18b7f780-cd66-11eb-843e-b4f771041fc2.png)
