### PR TITLE
Re-enable notebook text cell smoke test

### DIFF
--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -15,7 +15,6 @@ export class Notebook {
 
 	public readonly toolbar: NotebookToolbar;
 	public readonly view: NotebookView;
-	private newNotebookCount: number = 0;
 
 	constructor(private code: Code, private quickAccess: QuickAccess, private quickInput: QuickInput, private editors: Editors) {
 		this.toolbar = new NotebookToolbar(code);
@@ -32,9 +31,8 @@ export class Notebook {
 
 	async newUntitledNotebook(): Promise<void> {
 		await this.code.dispatchKeybinding(winOrCtrl + '+alt+n');
-		await this.editors.waitForActiveTab(`Notebook-${this.newNotebookCount}`);
+		await this.editors.waitForActiveTab(`Notebook-0`);
 		await this.code.waitForElement('.notebookEditor');
-		this.newNotebookCount++;
 	}
 
 	// Notebook Toolbar Actions

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -22,6 +22,8 @@ export function setup() {
 
 			await app.workbench.sqlNotebook.runActiveCell();
 			await app.workbench.sqlNotebook.waitForActiveCellResults();
+
+			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 		});
 
 		it('can open ipynb file, run all, and save notebook with outputs', async function () {
@@ -60,7 +62,7 @@ export function setup() {
 			await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
 		});
 
-		it.skip('can perform basic text cell functionality', async function () {
+		it('can perform basic text cell functionality', async function () {
 			const app = this.app as Application;
 			await app.workbench.sqlNotebook.newUntitledNotebook();
 			await app.workbench.sqlNotebook.addCellFromPlaceholder('Markdown');
@@ -95,4 +97,6 @@ async function openAndRunNotebook(app: Application, filename: string): Promise<v
 	await app.workbench.sqlNotebook.openFile(filename);
 	await app.workbench.sqlNotebook.waitForKernel('Python 3');
 	await app.workbench.sqlNotebook.waitForAllResults();
+
+	await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 }

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -78,6 +78,8 @@ export function setup() {
 			await app.workbench.sqlNotebook.waitForTypeInEditor(sampleText);
 			await app.code.dispatchKeybinding('escape');
 			await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p');
+
+			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 		});
 	});
 }

--- a/test/smoke/src/sql/areas/queryEditor/queryEditor.test.ts
+++ b/test/smoke/src/sql/areas/queryEditor/queryEditor.test.ts
@@ -21,6 +21,8 @@ export function setup() {
 			await app.workbench.connectionDialog.connect();
 			await app.workbench.queryEditor.commandBar.run();
 			await app.workbench.queryEditor.waitForResults();
+
+			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 		});
 	});
 }


### PR DESCRIPTION
Use revert and close command to close all previous untitled editors/notebooks so that they do not interfere with later tests.