### PR TITLE
Fix missing secondary actions for Notebook editor toolbar

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.css
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.css
@@ -37,6 +37,10 @@
 	min-height: 21px;
 }
 
+.notebookEditor .in-preview .actions-container .action-item {
+	height: 100%;
+}
+
 .notebookEditor .editor-toolbar .actions-container .action-item .codicon.masked-pseudo {
 	padding-right: 18px;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15785

Similar issue to https://github.com/microsoft/azuredatastudio/pull/15786 - action buttons were changed and in this case the way that we insert icons for the Notebook toolbar for the secondary actions ended up with a 0 height (since we're not using codicons).

![image](https://user-images.githubusercontent.com/28519865/122469108-6785ad00-cf71-11eb-9eab-c1ba4f17e591.png)


