### PR TITLE
Update jupyter launch arguments to enable Notebooks in docker container

### DIFF
--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -209,7 +209,7 @@ export class PerFolderServerInstance implements IServerInstance {
 		}
 		let notebookDirectory = this.getNotebookDirectory();
 		this._token = await utils.getRandomToken();
-		let startCommand = `"${this.options.install.pythonExecutable}" "${this.notebookScriptPath}" --no-browser --no-mathjax --notebook-dir "${notebookDirectory}" --NotebookApp.token=${this._token}`;
+		let startCommand = `"${this.options.install.pythonExecutable}" "${this.notebookScriptPath}" --no-browser --ip=127.0.0.1 --allow-root --no-mathjax --notebook-dir "${notebookDirectory}" --NotebookApp.token=${this._token}`;
 		this.notifyStarting(this.options.install, startCommand);
 
 		// Execute the command


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #https://github.com/microsoft/azuredatastudio/issues/9837.  These parameters enable running the Notebook feature when the extension host is running in a standard linux docker container (e.g. where opened ports are exposed externally by default and user is root).
