### PR TITLE
Add max size setting for Rich Text undo history in notebooks.

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -118,7 +118,7 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		this.markdownRenderer = this._instantiationService.createInstance(NotebookMarkdownRenderer);
 		this.doubleClickEditEnabled = this._configurationService.getValue('notebook.enableDoubleClickEdit');
 		this.markdownPreviewLineHeight = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
-		let maxStackSize: number = this._configurationService.getValue('notebook.maxUndoStackSize');
+		let maxStackSize: number = this._configurationService.getValue('notebook.maxRichTextUndoHistory');
 		this._undoStack = new RichTextEditStack(maxStackSize);
 		this._redoStack = new RichTextEditStack(maxStackSize);
 
@@ -134,8 +134,8 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 				this.markdownPreviewLineHeight = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
 				this.updatePreview();
 			}
-			if (e.affectsConfiguration('notebook.maxUndoStackSize')) {
-				let newStackSize: number = this._configurationService.getValue('notebook.maxUndoStackSize');
+			if (e.affectsConfiguration('notebook.maxRichTextUndoHistory')) {
+				let newStackSize: number = this._configurationService.getValue('notebook.maxRichTextUndoHistory');
 				this._undoStack.maxStackSize = newStackSize;
 				this._redoStack.maxStackSize = newStackSize;
 			}

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/textCell.component.ts
@@ -104,8 +104,8 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 	private _highlightRange: NotebookRange;
 	private _isFindActive: boolean = false;
 
-	private readonly _undoStack = new RichTextEditStack();
-	private readonly _redoStack = new RichTextEditStack();
+	private readonly _undoStack: RichTextEditStack;
+	private readonly _redoStack: RichTextEditStack;
 
 	constructor(
 		@Inject(forwardRef(() => ChangeDetectorRef)) private _changeRef: ChangeDetectorRef,
@@ -118,6 +118,10 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 		this.markdownRenderer = this._instantiationService.createInstance(NotebookMarkdownRenderer);
 		this.doubleClickEditEnabled = this._configurationService.getValue('notebook.enableDoubleClickEdit');
 		this.markdownPreviewLineHeight = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
+		let maxStackSize: number = this._configurationService.getValue('notebook.maxUndoStackSize');
+		this._undoStack = new RichTextEditStack(maxStackSize);
+		this._redoStack = new RichTextEditStack(maxStackSize);
+
 		this._register(toDisposable(() => {
 			if (this.markdownResult) {
 				this.markdownResult.dispose();
@@ -129,6 +133,11 @@ export class TextCellComponent extends CellView implements OnInit, OnChanges {
 			if (e.affectsConfiguration('notebook.markdownPreviewLineHeight')) {
 				this.markdownPreviewLineHeight = this._configurationService.getValue('notebook.markdownPreviewLineHeight');
 				this.updatePreview();
+			}
+			if (e.affectsConfiguration('notebook.maxUndoStackSize')) {
+				let newStackSize: number = this._configurationService.getValue('notebook.maxUndoStackSize');
+				this._undoStack.maxStackSize = newStackSize;
+				this._redoStack.maxStackSize = newStackSize;
 			}
 		}));
 	}
@@ -551,12 +560,24 @@ function preventDefaultAndExecCommand(e: KeyboardEvent, commandId: string) {
 export class RichTextEditStack {
 	private _list: string[] = [];
 
+	constructor(private _maxStackSize: number) {
+	}
+
+	public set maxStackSize(stackSize: number) {
+		this._maxStackSize = stackSize;
+	}
+
 	/**
-	 * Adds an element to the top of the stack.
+	 * Adds an element to the top of the stack. If the number of elements
+	 * exceeds the max stack size, then the oldest elements are removed until
+	 * the max size is reached.
 	 * @param element The string element to add to the stack.
 	 */
 	public push(element: string): void {
 		this._list.push(element);
+		if (this._list.length > this._maxStackSize) {
+			this._list = this._list.slice(this._list.length - this._maxStackSize);
+		}
 	}
 
 	/**

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -325,6 +325,12 @@ configurationRegistry.registerConfiguration({
 			'default': false,
 			'description': localize('notebook.showRenderedNotebookinDiffEditor', "(Preview) Show rendered notebook in diff editor.")
 		},
+		'notebook.maxRichTextUndoHistory': {
+			'type': 'number',
+			'default': 200,
+			'minimum': 1,
+			'description': localize('notebook.maxRichTextUndoHistory', "The maximum number of changes stored in the undo history for the notebook Rich Text editor.")
+		}
 	}
 });
 

--- a/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -328,7 +328,7 @@ configurationRegistry.registerConfiguration({
 		'notebook.maxRichTextUndoHistory': {
 			'type': 'number',
 			'default': 200,
-			'minimum': 1,
+			'minimum': 10,
 			'description': localize('notebook.maxRichTextUndoHistory', "The maximum number of changes stored in the undo history for the notebook Rich Text editor.")
 		}
 	}

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
@@ -264,7 +264,8 @@ suite('notebookUtils', function (): void {
 	});
 
 	test('EditStack test', async function (): Promise<void> {
-		let stack = new RichTextEditStack();
+		let maxStackSize = 200;
+		let stack = new RichTextEditStack(maxStackSize);
 		assert.strictEqual(stack.count, 0);
 
 		stack.push('1');
@@ -290,5 +291,13 @@ suite('notebookUtils', function (): void {
 		topElement = stack.pop();
 		assert.strictEqual(topElement, undefined);
 		assert.strictEqual(stack.peek(), undefined);
+
+		// Check max stack size
+		for (let i = 0; i < maxStackSize; i++) {
+			stack.push('a');
+		}
+		stack.push('b');
+		assert.strictEqual(stack.count, maxStackSize);
+		assert.strictEqual(stack.peek(), 'b');
 	});
 });

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
@@ -293,6 +293,7 @@ suite('notebookUtils', function (): void {
 		assert.strictEqual(stack.peek(), undefined);
 
 		// Check max stack size
+		stack.clear();
 		for (let i = 0; i < maxStackSize; i++) {
 			stack.push('a');
 		}

--- a/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
+++ b/src/sql/workbench/contrib/notebook/test/electron-browser/notebookUtils.test.ts
@@ -300,5 +300,12 @@ suite('notebookUtils', function (): void {
 		stack.push('b');
 		assert.strictEqual(stack.count, maxStackSize);
 		assert.strictEqual(stack.peek(), 'b');
+
+		// update max stack size and add new element
+		maxStackSize = 20;
+		stack.maxStackSize = maxStackSize;
+		stack.push('c');
+		assert.strictEqual(stack.count, maxStackSize);
+		assert.strictEqual(stack.peek(), 'c');
 	});
 });


### PR DESCRIPTION
Currently our notebook Rich Text undo/redo functionality is a bit basic, since we don't have all the features of a dedicated Editor. One of the drawbacks of that implementation is that we store a snapshot of the whole cell text in each element of the undo stack. Thus if the user is typing a lot, there will be a buildup of many similar elements in the undo stack, which could take up a nontrivial amount of memory over time if they always leave VSCode open, or if they are frequently making changes to a very large Rich Text cell. This change adds a user setting that sets the max size of the undo stack, so that we don't take up too much space when tracking changes.
