### PR TITLE
fix race condition in declarative table

### DIFF
--- a/extensions/machine-learning/src/test/views/utils.ts
+++ b/extensions/machine-learning/src/test/views/utils.ts
@@ -109,7 +109,8 @@ export function createViewContext(): ViewTestContext {
 		onRowSelected: undefined!,
 		setFilter: undefined!,
 		data: [],
-		columns: []
+		columns: [],
+		setDataValues: undefined!
 	});
 
 	let loadingComponent: () => azdata.LoadingComponent = () => Object.assign({}, componentBase, {

--- a/extensions/notebook/src/test/common.ts
+++ b/extensions/notebook/src/test/common.ts
@@ -350,6 +350,7 @@ class TestDeclarativeTableComponent extends TestComponentBase implements azdata.
 	setFilter: undefined;
 	data: any[][];
 	columns: azdata.DeclarativeTableColumn[];
+	setDataValues: undefined;
 }
 
 class TestButtonComponent extends TestComponentBase implements azdata.ButtonComponent {

--- a/extensions/notebook/src/test/managePackages/managePackagesDialog.test.ts
+++ b/extensions/notebook/src/test/managePackages/managePackagesDialog.test.ts
@@ -186,7 +186,8 @@ describe('Manage Package Dialog', () => {
 			onRowSelected: undefined!,
 			setFilter: undefined!,
 			data: [],
-			columns: []
+			columns: [],
+			setDataValues: undefined!
 		});
 
 		let loadingComponent: () => azdata.LoadingComponent = () => Object.assign({}, componentBase, {

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -274,6 +274,12 @@ declare module 'azdata' {
 		 * will clear the filter
 		 */
 		setFilter(rowIndexes: number[] | undefined): void;
+
+		/**
+		 * Sets the data values.
+		 * @param v The new data values
+		 */
+		setDataValues(v: DeclarativeTableCellValue[][]): Promise<void>;
 	}
 
 	/*
@@ -372,7 +378,8 @@ declare module 'azdata' {
 
 	export interface DeclarativeTableProperties {
 		/**
-		 * dataValues will only be used if data is an empty array
+		 * dataValues will only be used if data is an empty array.
+		 * To set the dataValues, it is recommended to use the setDataValues method that returns a promise.
 		 */
 		dataValues?: DeclarativeTableCellValue[][];
 

--- a/src/sql/workbench/api/common/extHostModelView.ts
+++ b/src/sql/workbench/api/common/extHostModelView.ts
@@ -1568,6 +1568,11 @@ class DeclarativeTableWrapper extends ComponentWrapper implements azdata.Declara
 		});
 	}
 
+	async setDataValues(v: azdata.DeclarativeTableCellValue[][]): Promise<void> {
+		await this.clearItems();
+		await this.setProperty('dataValues', v);
+	}
+
 	public get columns(): azdata.DeclarativeTableColumn[] {
 		return this.properties['columns'];
 	}

--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.ts
@@ -298,17 +298,18 @@ export default class DeclarativeTableComponent extends ContainerBase<any, azdata
 			this._data = finalData;
 		}
 
-		const newSelectedRow = properties.selectedRow ?? -1;
-		if (newSelectedRow !== this.selectedRow && properties.enableRowSelection) {
+		const previousSelectedRow = this.selectedRow;
+
+		super.setProperties(properties);
+
+		if (this.selectedRow !== previousSelectedRow && this.enableRowSelection) {
 			this.fireEvent({
 				eventType: ComponentEventType.onSelectedRowChanged,
 				args: {
-					row: properties.selectedRow
+					row: this.selectedRow
 				}
 			});
 		}
-
-		super.setProperties(properties);
 	}
 
 	public override clearContainer(): void {


### PR DESCRIPTION
@brian-harris noticed that the newly introduced selectedRow of declarative table is not reliable. He was setting dataValues first and then the selectedRow, but the setter of dataValues is not a synchronous call, most of the time the actual values came after the selectedRow is set because of this.

fix:
for backward compatibility, I introduced a new async method but leaving the existing setting untouched. 