### PR TITLE
Do not prompt user on opening Notebooks with File URI

### DIFF
--- a/extensions/notebook/src/protocol/notebookUriHandler.ts
+++ b/extensions/notebook/src/protocol/notebookUriHandler.ts
@@ -87,19 +87,18 @@ export class NotebookUriHandler implements vscode.UriHandler {
 					vscode.window.showErrorMessage(localize('unsupportedScheme', "Cannot open link {0} as only HTTP, HTTPS, and File links are supported", url));
 					return;
 			}
-
-			let doOpen = await this.prompter.promptSingle<boolean>(<IQuestion>{
-				type: QuestionTypes.confirm,
-				message: localize('notebook.confirmOpen', "Download and open '{0}'?", url),
-				default: true
-			});
-			if (!doOpen) {
-				return;
-			}
 			let contents: string;
 			if (uri.scheme === 'file') {
 				contents = await readJson(uri.fsPath);
 			} else {
+				let doOpen = await this.prompter.promptSingle<boolean>(<IQuestion>{
+					type: QuestionTypes.confirm,
+					message: localize('notebook.confirmOpen', "Download and open '{0}'?", url),
+					default: true
+				});
+				if (!doOpen) {
+					return;
+				}
 				contents = await this.download(url);
 			}
 			let untitledUriPath = this.getUntitledUriPath(path.basename(uri.fsPath));

--- a/extensions/notebook/src/test/protocol/notebookUriHandler.test.ts
+++ b/extensions/notebook/src/test/protocol/notebookUriHandler.test.ts
@@ -19,7 +19,6 @@ import * as constants from '../../common/constants';
 
 import { NotebookUriHandler } from '../../protocol/notebookUriHandler';
 import { CellTypes } from '../../contracts/content';
-import { winPlatform } from '../../common/constants';
 
 describe('Notebook URI Handler', function (): void {
 	let notebookUriHandler: NotebookUriHandler;
@@ -55,10 +54,8 @@ describe('Notebook URI Handler', function (): void {
 	});
 
 	it('should show error message when no query passed into open', async function (): Promise<void> {
-		let showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(Promise.resolve(loc.msgYes) as any);
 		await notebookUriHandler.handleUri(vscode.Uri.parse('azuredatastudio://microsoft.notebook/open'));
 
-		sinon.assert.calledOnce(showQuickPickStub);
 		sinon.assert.calledOnce(showErrorMessageSpy);
 	});
 
@@ -123,13 +120,12 @@ describe('Notebook URI Handler', function (): void {
 	});
 
 	it('should open notebook when file uri is valid', async function (): Promise<void> {
-		let showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(Promise.resolve(loc.msgYes) as any);
 		let notebookDir: string = path.join(os.tmpdir(), `notebook_${uuid.v4()}`);
 		let notebookPath: string = path.join(notebookDir, 'hello.ipynb');
 
 		await fs.mkdir(notebookDir);
 		let baseUrl = 'azuredatastudio://microsoft.notebook/open?url=file://';
-		if (process.platform === winPlatform) {
+		if (process.platform === constants.winPlatform) {
 			// URI paths are formatted as "hostname/path", but since we're using a local path
 			// we omit the host part and just add the slash. Unix paths already start with a
 			// forward slash, but we have to prepend it manually when using Windows paths.
@@ -159,7 +155,6 @@ describe('Notebook URI Handler', function (): void {
 
 		await notebookUriHandler.handleUri(fileNotebookUri);
 
-		sinon.assert.calledOnce(showQuickPickStub);
 		sinon.assert.calledWith(showNotebookDocumentStub, sinon.match.any, sinon.match({ initialContent: notebookContent }));
 		sinon.assert.callCount(showErrorMessageSpy, 0);
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15653.

As per discussion, we do not need to prompt a user to download and open a file. VSCode also does not prompt as well upon opening a [file uri](https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls). 
As such we will prompt for HTTPS and HTTP schemas only. 
