### PR TITLE
remove "Edit Data" menu option for SqlDataWarehouse

### DIFF
--- a/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
+++ b/src/sql/workbench/contrib/scripting/browser/scripting.contribution.ts
@@ -81,7 +81,12 @@ MenuRegistry.appendMenuItem(MenuId.DataExplorerContext, {
 		id: commands.EDIT_DATA_COMMAND_ID,
 		title: localize('editData', "Edit Data")
 	},
-	when: ContextKeyExpr.and(MssqlNodeContext.CanEditData, MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()))
+	when:
+		ContextKeyExpr.and(
+			MssqlNodeContext.CanEditData,
+			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()),
+			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlDataWarehouse.toString())
+		)
 });
 //#endregion
 
@@ -123,7 +128,13 @@ MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
 		id: commands.OE_EDIT_DATA_COMMAND_ID,
 		title: localize('editData', "Edit Data")
 	},
-	when: ContextKeyExpr.and(TreeNodeContextKey.NodeType.isEqualTo('Table'), ConnectionContextKey.Provider.notEqualsTo('KUSTO'), MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()))
+	when:
+		ContextKeyExpr.and(
+			TreeNodeContextKey.NodeType.isEqualTo('Table'),
+			ConnectionContextKey.Provider.notEqualsTo('KUSTO'),
+			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()),
+			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlDataWarehouse.toString())
+		)
 });
 
 MenuRegistry.appendMenuItem(MenuId.ObjectExplorerItemContext, {
@@ -291,7 +302,13 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerWidgetContext, {
 		id: ExplorerEditDataActionID,
 		title: EditDataAction.LABEL
 	},
-	when: ContextKeyExpr.and(ItemContextKey.ItemType.isEqualTo('table'), MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()), ItemContextKey.ConnectionProvider.notEqualsTo('kusto')),
+	when:
+		ContextKeyExpr.and(
+			ItemContextKey.ItemType.isEqualTo('table'),
+			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlOnDemand.toString()),
+			ItemContextKey.ConnectionProvider.notEqualsTo('kusto'),
+			MssqlNodeContext.EngineEdition.notEqualsTo(DatabaseEngineEdition.SqlDataWarehouse.toString())
+		),
 	order: 2
 });
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #9065 by removing "Edit Data" option on SqlDataWarehouse as this feature is not currently supported for SQLDW.

### Before:

SERVERS:
![image](https://user-images.githubusercontent.com/21186993/122596511-d5d47900-d01e-11eb-97ed-74d844407048.png)

AZURE:
![Screen Shot 2021-06-18 at 12 00 26](https://user-images.githubusercontent.com/21186993/122605838-daa02980-d02c-11eb-9a16-8e124a258e9d.png)

Server Management:
![image](https://user-images.githubusercontent.com/21186993/122596546-e1c03b00-d01e-11eb-86e9-e085b7d37d0e.png)


### After:
SERVERS:
![image](https://user-images.githubusercontent.com/21186993/122595981-12ec3b80-d01e-11eb-8be8-c310df436cca.png)

AZURE:
![Screen Shot 2021-06-18 at 11 54 17](https://user-images.githubusercontent.com/21186993/122605401-3fa74f80-d02c-11eb-8ec7-640e3bb26b2f.png)

Sever Management:
![image](https://user-images.githubusercontent.com/21186993/122596127-46c76100-d01e-11eb-8c74-ba8262e0f160.png)

