### PR TITLE
Fix toolbar style

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.css
@@ -31,6 +31,10 @@ cell-toolbar-component ul.actions-container li.action-item {
 	width: 29px;
 }
 
+cell-toolbar-component ul.actions-container li.action-item a.codicon.masked-icon {
+	height: 24px;
+}
+
 cell-toolbar-component ul.actions-container li:last-child {
 	margin-right: 0;
 }

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.css
@@ -27,6 +27,8 @@ cell-toolbar-component ul.actions-container li.action-item {
 	display: inline-flex;
 	margin-right: 0;
 	text-align: center;
+	height: 24px;
+	width: 29px;
 }
 
 cell-toolbar-component ul.actions-container li:last-child {

--- a/src/sql/workbench/contrib/notebook/browser/notebook.css
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.css
@@ -59,6 +59,10 @@
 	width: 28px;
 }
 
+.notebookEditor .markdown-toolbar .actions-container .action-item {
+	width: 23px;
+}
+
 .notebookEditor .in-preview .actions-container .action-item .codicon,
 .notebookEditor .in-preview .actions-container .action-item .codicon:before {
 	display: flex;

--- a/src/vs/base/browser/ui/actionbar/actionbar.css
+++ b/src/vs/base/browser/ui/actionbar/actionbar.css
@@ -41,8 +41,8 @@
 .monaco-action-bar .action-item .codicon {
 	display: flex;
 	align-items: center;
-	width: 16px;
-	height: 16px;
+	width: 29px;
+	height: 24px;
 }
 
 .monaco-action-bar .action-label {

--- a/src/vs/base/browser/ui/actionbar/actionbar.css
+++ b/src/vs/base/browser/ui/actionbar/actionbar.css
@@ -41,6 +41,8 @@
 .monaco-action-bar .action-item .codicon {
 	display: flex;
 	align-items: center;
+	width: 16px;
+	height: 16px;
 }
 
 .monaco-action-bar .action-label {

--- a/src/vs/base/browser/ui/actionbar/actionbar.css
+++ b/src/vs/base/browser/ui/actionbar/actionbar.css
@@ -41,8 +41,6 @@
 .monaco-action-bar .action-item .codicon {
 	display: flex;
 	align-items: center;
-	width: 29px;
-	height: 24px;
 }
 
 .monaco-action-bar .action-label {


### PR DESCRIPTION
Fixes #15794
Resize cell toolbar + adjust the icon height
Adjust the icon width for WYSIWYG toolbar.
![Screen Shot 2021-06-18 at 11 06 59 AM](https://user-images.githubusercontent.com/34872381/122600985-775ec900-d025-11eb-9909-896ed38d37d5.png)