### PR TITLE
use more specific css selectors

### DIFF
--- a/src/sql/base/browser/ui/taskbar/media/taskbar.css
+++ b/src/sql/base/browser/ui/taskbar/media/taskbar.css
@@ -50,16 +50,13 @@
 
 .carbon-taskbar .monaco-action-bar .action-item .codicon.action-label {
 	width: 100%;
+	background-repeat: no-repeat;
+	background-position: 0% 50%;
+	padding-left: 15px;
 }
 
 .carbon-taskbar .action-item.more {
 	padding-right: 15px;
-}
-
-.carbon-taskbar .action-label {
-	background-repeat: no-repeat;
-	background-position: 0% 50%;
-	padding-left: 15px;
 }
 
 .carbon-taskbar .action-item-label {

--- a/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
+++ b/src/sql/workbench/contrib/dashboard/browser/core/dashboardPage.css
@@ -32,7 +32,7 @@ dashboard-page .default-tab-icon {
 	background-image: url("media/default.svg");
 }
 
-dashboard-page .actions-container .action-item .action-label{
+dashboard-page .carbon-taskbar .monaco-action-bar .actions-container .action-item .action-label{
 	padding-left: 20px;
 	padding-right: 5px;
 	background-size: 16px;

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/cellToolbar.css
@@ -32,7 +32,7 @@ cell-toolbar-component ul.actions-container li.action-item {
 cell-toolbar-component ul.actions-container li:last-child {
 	margin-right: 0;
 }
-cell-toolbar-component .carbon-taskbar .action-label {
+cell-toolbar-component .carbon-taskbar.monaco-toolbar .monaco-action-bar .codicon.action-label {
 	padding: 0;
 }
 cell-toolbar-component .monaco-action-bar .action-label {
@@ -41,8 +41,8 @@ cell-toolbar-component .monaco-action-bar .action-label {
 cell-toolbar-component ul.actions-container li a.masked-icon {
 	display: flex;
 }
-cell-toolbar-component ul.actions-container li a.masked-icon,
-cell-toolbar-component ul.actions-container li a.masked-icon:before {
+cell-toolbar-component .carbon-taskbar.monaco-toolbar .monaco-action-bar ul.actions-container li a.masked-icon,
+cell-toolbar-component .carbon-taskbar.monaco-toolbar .monaco-action-bar ul.actions-container li a.masked-icon:before {
 	height: 24px;
 	width: 29px;
 }

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
@@ -35,9 +35,11 @@ code-component .toolbar .carbon-taskbar {
 	margin-top: 5px;
 }
 
-code-component .toolbar .codicon {
+code-component .toolbar .carbon-taskbar.monaco-toolbar .monaco-action-bar .codicon.action-label {
 	height: 20px;
 	padding-bottom: 10px;
+	background-size: 20px;
+	width: 40px;
 }
 
 .notebook-cell:not(.active):hover code-component .toolbarIconRun {
@@ -76,11 +78,6 @@ code-component .monaco-editor .decorationsOverviewRuler {
 
 .vs-dark code-component .monaco-editor .rangeHighlight {
 	background-color: rgba(255, 255, 0, 0.2)
-}
-
-code-component .carbon-taskbar .codicon {
-	background-size: 20px;
-	width: 40px;
 }
 
 code-component .carbon-taskbar .codicon.hideIcon {


### PR DESCRIPTION
This PR fixes #15815

in recent vscode merge, vscode added some css selector that caused our styles not being applied correctly. 

the fix is to use more specific css selectors so that our own css styles can have high priority.

after:
![image](https://user-images.githubusercontent.com/13777222/122623541-50b68780-d051-11eb-9492-bc4c97330a9d.png)

![image](https://user-images.githubusercontent.com/13777222/122623550-5c09b300-d051-11eb-9ce5-855ca925cb58.png)

![image](https://user-images.githubusercontent.com/13777222/122623558-65931b00-d051-11eb-88bf-1399b80c5f09.png)

![image](https://user-images.githubusercontent.com/13777222/122623575-79d71800-d051-11eb-9fdc-872ba8b42636.png)

