### PR TITLE
fix insights widget issue

### DIFF
--- a/src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component.ts
+++ b/src/sql/workbench/contrib/dashboard/browser/widgets/insights/insightsWidget.component.ts
@@ -80,6 +80,7 @@ export class InsightsWidget extends DashboardWidget implements IDashboardWidget,
 		@Inject(IFileService) private readonly fileService: IFileService
 	) {
 		super(changeRef);
+		this._config = _config;
 		this.insightConfig = <IInsightsConfig>this._config.widget['insights-widget'];
 		this._loadingMessage = nls.localize('insightsWidgetLoadingMessage', "Loading {0}", this._config.name);
 		this._loadingCompletedMessage = nls.localize('insightsWidgetLoadingCompletedMessage', "Loading {0} completed", this._config.name);


### PR DESCRIPTION
This PR fixes #15818 

during recent vscode merge, the protected modifier for the _config parameter was removed due to the newly introduced override keyword. but the actual protected variable _config in base class is not initialized.

fix: assign the value to this._config before consuming it.

I also checked other classes that extends the dashboardWidget class, and they already have the change applied, seems Charles might have missed this class during the merge.
