### PR TITLE
Fix view action icon sizes

### DIFF
--- a/src/vs/base/browser/ui/splitview/paneview.css
+++ b/src/vs/base/browser/ui/splitview/paneview.css
@@ -52,6 +52,14 @@
 	margin-left: auto;
 }
 
+/* {{SQL CARBON EDIT}} Bring back styles for action labels - ours aren't sized correctly without these */
+.monaco-pane-view .pane > .pane-header > .actions .action-label.icon,
+.monaco-pane-view .pane > .pane-header > .actions .action-label.codicon {
+	background-size: 16px;
+	background-position: center center;
+	background-repeat: no-repeat;
+}
+
 .monaco-pane-view .pane > .pane-header > .actions .action-item {
 	margin-right: 4px;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15783

This was removed in https://github.com/microsoft/vscode/pull/120247 as part of adding the highlighted background when hovering over actions. It's not exactly clear why this was removed - but it's likely the same as the other icon-sizing related stuff where VS Code using the font icons means they don't need to set the background sizes like that (but we do since we're using SVG's)

![image](https://user-images.githubusercontent.com/28519865/122653498-c5450100-d0f9-11eb-90c6-502115c7eb48.png)

VS Code contributed icons still appear the same 

![image](https://user-images.githubusercontent.com/28519865/122653526-09380600-d0fa-11eb-8569-a45c5c2a84ed.png)

Have private build queued to verify built version still has correct ordering for CSS rules. 