### PR TITLE
Fix create book dialog smoke test

### DIFF
--- a/extensions/notebook/src/common/localizedConstants.ts
+++ b/extensions/notebook/src/common/localizedConstants.ts
@@ -87,13 +87,12 @@ export function msgDownloadLocation(downloadLocation: string): string { return l
 export const newBook = localize('newBook', "New Jupyter Book (Preview)");
 export const bookDescription = localize('bookDescription', "Jupyter Books are used to organize Notebooks.");
 export const learnMore = localize('learnMore', "Learn more.");
-export const locationBrowser = localize('locationBrowser', "Browse locations...");
-export const selectContentFolder = localize('selectContentFolder', "Select content folder");
+export const contentFolder = localize('contentFolder', "Content folder");
 export const browse = localize('browse', "Browse");
 export const create = localize('create', "Create");
 export const name = localize('name', "Name");
 export const saveLocation = localize('saveLocation', "Save location");
-export const contentFolder = localize('contentFolder', "Content folder (Optional)");
+export const contentFolderOptional = localize('contentFolderOptional', "Content folder (Optional)");
 export const msgContentFolderError = localize('msgContentFolderError', "Content folder path does not exist");
 export const msgSaveFolderError = localize('msgSaveFolderError', "Save location path does not exist.");
 export function msgCreateBookWarningMsg(file: string): string { return localize('msgCreateBookWarningMsg', "Error while trying to access: {0}", file); }

--- a/extensions/notebook/src/dialog/createBookDialog.ts
+++ b/extensions/notebook/src/dialog/createBookDialog.ts
@@ -81,34 +81,31 @@ export class CreateBookDialog {
 				}).component();
 
 			this.bookNameInputBox = this.view.modelBuilder.inputBox()
-				.withProperties({
-					values: [],
+				.withProps({
 					value: '',
 					enabled: true
 				}).component();
 
-			this.saveLocationInputBox = this.view.modelBuilder.inputBox().withProperties({
-				values: [],
+			this.saveLocationInputBox = this.view.modelBuilder.inputBox().withProps({
 				value: '',
-				placeHolder: loc.locationBrowser,
+				ariaLabel: loc.saveLocation,
 				width: '400px'
 			}).component();
 
-			this.contentFolderInputBox = this.view.modelBuilder.inputBox().withProperties({
-				values: [],
+			this.contentFolderInputBox = this.view.modelBuilder.inputBox().withProps({
 				value: '',
-				placeHolder: loc.selectContentFolder,
+				ariaLabel: loc.contentFolder,
 				width: '400px'
 			}).component();
 
-			const browseFolderButton = view.modelBuilder.button().withProperties<azdata.ButtonProperties>({
+			const browseFolderButton = view.modelBuilder.button().withProps({
 				ariaLabel: loc.browse,
 				iconPath: IconPathHelper.folder,
 				width: '18px',
 				height: '20px',
 			}).component();
 
-			const browseContentFolderButton = view.modelBuilder.button().withProperties<azdata.ButtonProperties>({
+			const browseContentFolderButton = view.modelBuilder.button().withProps({
 				ariaLabel: loc.browse,
 				iconPath: IconPathHelper.folder,
 				width: '18px',
@@ -147,7 +144,7 @@ export class CreateBookDialog {
 							component: this.createHorizontalContainer(view, [this.saveLocationInputBox, browseFolderButton])
 						},
 						{
-							title: loc.contentFolder,
+							title: loc.contentFolderOptional,
 							required: false,
 							component: this.createHorizontalContainer(view, [this.contentFolderInputBox, browseContentFolderButton])
 						},

--- a/test/automation/src/sql/createBookDialog.ts
+++ b/test/automation/src/sql/createBookDialog.ts
@@ -9,8 +9,8 @@ import { Dialog } from './dialog';
 const CREATE_BOOK_DIALOG_TITLE = 'New Jupyter Book (Preview)';
 
 const NAME_INPUT_SELECTOR = '.modal .modal-body input[aria-label="Name. Please fill out this field."]';
-const LOCATION_INPUT_SELECTOR = '.modal .modal-body input[title="Browse locations..."]';
-const CONTENT_FOLDER_INPUT_SELECTOR = '.modal .modal-body input[title="Select content folder"]';
+const LOCATION_INPUT_SELECTOR = '.modal .modal-body input[aria-label="Save location"]';
+const CONTENT_FOLDER_INPUT_SELECTOR = '.modal .modal-body input[aria-label="Content folder"]';
 const CREATE_BUTTON_SELECTOR = '.modal .modal-footer a[aria-label="Create"]:not(.disabled)';
 
 export class CreateBookDialog extends Dialog {


### PR DESCRIPTION
The VS Code merge broke this test - they changed the input box behavior such that by default input boxes no longer set their title attribute to the placeholder value. (see https://github.com/microsoft/vscode/commit/2275dba01afe2b8814d4ebdd67d1027fa51bdcb4 and https://github.com/microsoft/vscode/commit/c2b6d30e9efb9b8a0048bef57acf09c931c8c0c0)

So fixing the smoke tests could have just been updating it to use the placeholder attribute instead, but in thinking about it I'm not really sure that text as placeholder makes sense for these input boxes anyways. Normally placeholders should indicate some example values or something - we already have the title above the input boxes to indicate what these are for. So I removed the placeholder and then just directly added an aria-label attribute on each so that screenreaders can know what input box each is. 

I also updated the code to use `withProps` for proper typing support, and in doing so noticed that we had invalid properties (values) there. Since we weren't using them I just removed them. 

![image](https://user-images.githubusercontent.com/28519865/122823252-f9ecc000-d293-11eb-96cd-05e2a4137ae4.png)
