### PR TITLE
fix extension view issues

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsList.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsList.ts
@@ -222,6 +222,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 
 		//data.installCount.style.display = ''; {{SQL CARBON EDIT}} Hide unused options
 		//data.ratings.style.display = ''; {{SQL CARBON EDIT}} Hide unused options
+		data.extension = extension;
 
 		if (extension.gallery && extension.gallery.properties && extension.gallery.properties.localizedLanguages && extension.gallery.properties.localizedLanguages.length) {
 			data.description.textContent = extension.gallery.properties.localizedLanguages.map(name => name[0].toLocaleUpperCase() + name.slice(1)).join(', ');


### PR DESCRIPTION
This PR fixes #15822

the line to set the extension context is missing during the merge: 
https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/extensions/browser/extensionsList.ts#L220

and caused the actions and the recommendation widget to not showing correctly.

before:
![image](https://user-images.githubusercontent.com/13777222/122604619-15a15d80-d02b-11eb-9151-b1c74e287988.png)

after:
![image](https://user-images.githubusercontent.com/13777222/122841343-9a50dd80-d2b0-11eb-9302-a98b77fbb554.png)
