### PR TITLE
Notebooks A11Y: Add button role for Placeholder Links

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component.html
@@ -7,7 +7,7 @@
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div class="placeholder-cell-component" style="flex: 0 0 auto;">
 		<div class="placeholder-cell-component text">
-			<p>{{clickOn}} <a id="addCode" href="#" (click)="addCell('code', $event)">{{plusCode}}</a> {{or}} <a id="addMarkdown" href="#" (click)="addCell('markdown', $event)">{{plusText}}</a> {{toAddCell}}</p>
+			<p>{{clickOn}} <a id="addCode" href="#" role="button" (click)="addCell('code', $event)">{{plusCode}}</a> {{or}} <a id="addMarkdown" href="#" role="button" (click)="addCell('markdown', $event)">{{plusText}}</a> {{toAddCell}}</p>
 		</div>
 	</div>
 </div>

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component.html
@@ -7,7 +7,7 @@
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div class="placeholder-cell-component" style="flex: 0 0 auto;">
 		<div class="placeholder-cell-component text">
-			<p>{{clickOn}} <a id="addCode" href="#" role="button" aria-label="Add a code cell" (click)="addCell('code', $event)">{{plusCode}}</a> {{or}} <a id="addMarkdown" href="#" role="button" aria-label="Add a text cell" (click)="addCell('markdown', $event)">{{plusText}}</a> {{toAddCell}}</p>
+			<p>{{clickOn}} <a id="addCode" href="#" role="button" [attr.aria-label]=plusCodeAriaLabel (click)="addCell('code', $event)">{{plusCode}}</a> {{or}} <a id="addMarkdown" href="#" role="button" [attr.aria-label]=plusTextAriaLabel (click)="addCell('markdown', $event)">{{plusText}}</a> {{toAddCell}}</p>
 		</div>
 	</div>
 </div>

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component.html
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component.html
@@ -7,7 +7,7 @@
 <div style="overflow: hidden; width: 100%; height: 100%; display: flex; flex-flow: column">
 	<div class="placeholder-cell-component" style="flex: 0 0 auto;">
 		<div class="placeholder-cell-component text">
-			<p>{{clickOn}} <a id="addCode" href="#" role="button" (click)="addCell('code', $event)">{{plusCode}}</a> {{or}} <a id="addMarkdown" href="#" role="button" (click)="addCell('markdown', $event)">{{plusText}}</a> {{toAddCell}}</p>
+			<p>{{clickOn}} <a id="addCode" href="#" role="button" aria-label="Add a code cell" (click)="addCell('code', $event)">{{plusCode}}</a> {{or}} <a id="addMarkdown" href="#" role="button" aria-label="Add a text cell" (click)="addCell('markdown', $event)">{{plusText}}</a> {{toAddCell}}</p>
 		</div>
 	</div>
 </div>

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/placeholderCell.component.ts
@@ -68,6 +68,14 @@ export class PlaceholderCellComponent extends CellView implements OnInit, OnChan
 		return localize('toAddCell', "to add a code or text cell");
 	}
 
+	get plusCodeAriaLabel(): string {
+		return localize('plusCodeAriaLabel', "Add a code cell");
+	}
+
+	get plusTextAriaLabel(): string {
+		return localize('plusTextAriaLabel', "Add a text cell");
+	}
+
 	public addCell(cellType: string, event?: Event): void {
 		if (event) {
 			event.preventDefault();


### PR DESCRIPTION
Fixes #15843, which is asking for screen readers to treat these links as buttons.

After fix:
![image](https://user-images.githubusercontent.com/40371649/122846458-b6f21300-d2ba-11eb-8193-fd2ca69d6659.png)
