### PR TITLE
Fix python dialog selectors in Python smoke test

### DIFF
--- a/test/automation/src/sql/configurePythonDialog.ts
+++ b/test/automation/src/sql/configurePythonDialog.ts
@@ -19,28 +19,27 @@ export class ConfigurePythonDialog extends Dialog {
 	}
 
 	async installPython(): Promise<void> {
-		const dialog = '.modal .modal-dialog';
-		await this.code.waitAndClick(dialog);
+		const dialogPageInView = '.modal .modal-body .dialogModal-pane:not(.dialogModal-hidden)';
+		const dialogButtonInView = '.modal .modal-footer .footer-button:not(.dialogModal-hidden)';
 
-		const newPythonInstallation = `${dialog} .modal-body input[aria-label="New Python installation"]`;
+		const newPythonInstallation = `${dialogPageInView} input[aria-label="New Python installation"]`;
 		await this.code.waitAndClick(newPythonInstallation);
 
 		// Wait for the python install location to be loaded before clicking the next button.
 		// There may be a timing issue where the smoke test attempts to go to the next page before
 		// the contents are loaded, causing the test to fail.
-		const pythonInstallLocationDropdownValue = `${dialog} select[aria-label="Python Install Location"] option`;
+		const pythonInstallLocationDropdownValue = `${dialogPageInView} option[value*="/azuredatastudio-python (Default)"]`;
 		await this.code.waitForElement(pythonInstallLocationDropdownValue);
 
-		const nextButton = `${dialog} .modal-content .modal-footer .right-footer .footer-button a[aria-label="Next"][aria-disabled="false"]:not(.dialogModal-hidden)`;
-		await this.code.waitAndClick(dialog);
+		const loadingSpinner = `${dialogPageInView} .modelview-loadingComponent-content-loading`;
+		await this.code.waitForElementGone(loadingSpinner);
+
+		const nextButton = `${dialogButtonInView} a[aria-label="Next"][aria-disabled="false"]`;
 		await this.code.waitAndClick(nextButton);
 
-		// wait up to 1 minute for the required kernel dependencies to load
-		const requiredKernelDependencies = `${dialog} table[class="declarative-table"][aria-label="Install required kernel dependencies"]`;
-		await this.code.waitForElement(requiredKernelDependencies, undefined, 600);
-
-		const installButton = `${dialog} .modal-content .modal-footer .right-footer .footer-button a[aria-label="Install"][aria-disabled="false"]:not(.dialogModal-hidden)`;
-		await this.code.waitAndClick(dialog);
+		const installButton = `${dialogButtonInView} a[aria-label="Install"][aria-disabled="false"]`;
+		// wait up to 1 minute for the required kernel dependencies to load before clicking install button
+		await this.code.waitForElement(installButton, undefined, 600);
 		await this.code.waitAndClick(installButton);
 
 		await this.waitForDialogGone();


### PR DESCRIPTION
Contents from both pages of the Python Dialog are on the DOM, the hidden one has the 'dialogModal-hidden' class. 
I changed the selectors to correctly select items that are not hidden.

Note: `:not(.dialogModal-hidden)` must be placed next to the correct element selector. Ex. previously I placed it in the nextButton selector but that didn't work since the nextButton element doesn't actually have the `.dialogModal-hidden` class, it's parent div (`.footer-button`) is what has the hidden class.