### PR TITLE
Add Markdown Toolbar functionality to notebook smoke tests.

### DIFF
--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -13,11 +13,13 @@ const winOrCtrl = process.platform === 'darwin' ? 'ctrl' : 'win';
 
 export class Notebook {
 
-	public readonly toolbar: NotebookToolbar;
+	public readonly notebookToolbar: NotebookToolbar;
+	public readonly textCellToolbar: TextCellToolbar;
 	public readonly view: NotebookView;
 
 	constructor(private code: Code, private quickAccess: QuickAccess, private quickInput: QuickInput, private editors: Editors) {
-		this.toolbar = new NotebookToolbar(code);
+		this.notebookToolbar = new NotebookToolbar(code);
+		this.textCellToolbar = new TextCellToolbar(code);
 		this.view = new NotebookView(code, quickAccess);
 	}
 
@@ -48,11 +50,11 @@ export class Notebook {
 	}
 
 	async changeKernel(kernel: string): Promise<void> {
-		await this.toolbar.changeKernel(kernel);
+		await this.notebookToolbar.changeKernel(kernel);
 	}
 
 	async waitForKernel(kernel: string): Promise<void> {
-		await this.toolbar.waitForKernel(kernel);
+		await this.notebookToolbar.waitForKernel(kernel);
 	}
 
 	async runActiveCell(): Promise<void> {
@@ -70,15 +72,15 @@ export class Notebook {
 	}
 
 	async trustNotebook(): Promise<void> {
-		await this.toolbar.trustNotebook();
+		await this.notebookToolbar.trustNotebook();
 	}
 
 	async waitForTrustedIcon(): Promise<void> {
-		await this.toolbar.waitForTrustedIcon();
+		await this.notebookToolbar.waitForTrustedIcon();
 	}
 
 	async waitForNotTrustedIcon(): Promise<void> {
-		await this.toolbar.waitForNotTrustedIcon();
+		await this.notebookToolbar.waitForNotTrustedIcon();
 	}
 
 	// Cell Actions
@@ -97,6 +99,19 @@ export class Notebook {
 	private async _waitForActiveCellEditorContents(accept: (contents: string) => boolean): Promise<any> {
 		const selector = '.notebook-cell.active .monaco-editor .view-lines';
 		return this.code.waitForTextContent(selector, undefined, c => accept(c.replace(/\u00a0/g, ' ')));
+	}
+
+	private static readonly richTextEditorSelector = '.notebook-cell.active div.notebook-preview[contenteditable="true"]';
+	public async waitForTypeInRichTextEditor(text: string) {
+		await this.code.waitAndClick(Notebook.richTextEditorSelector);
+		await this.code.waitForActiveElement(Notebook.richTextEditorSelector);
+		await this.code.waitForTypeInEditor(Notebook.richTextEditorSelector, text);
+		await this._waitForActiveCellEditorContents(c => c.indexOf(text) > -1);
+	}
+
+	public async selectAllTextInRichTextEditor(): Promise<void> {
+		await this.code.waitAndClick(Notebook.richTextEditorSelector);
+		await this.code.dispatchKeybinding('ctrl+a');
 	}
 
 	private static readonly placeholderSelector = 'div.placeholder-cell-component';
@@ -126,14 +141,11 @@ export class Notebook {
 		await this.code.waitForElementGone(Notebook.doubleClickToEditSelector);
 	}
 
-	private static readonly textCellToolbar = 'text-cell-component markdown-toolbar-component ul.actions-container';
-	async changeTextCellView(view: 'Rich Text View' | 'Split View' | 'Markdown View'): Promise<void> {
-		const actionSelector = `${Notebook.textCellToolbar} a[title="${view}"]`;
-		await this.code.waitAndClick(actionSelector);
-	}
-
-	async waitForTextCellPreviewContent(text: string, fontType: 'p' | 'h1' | 'h2' | 'h3'): Promise<void> {
-		const textSelector = `${Notebook.textCellPreviewSelector} ${fontType}`;
+	async waitForTextCellPreviewContent(text: string, fontType: 'p' | 'h1' | 'h2' | 'h3', textStyle?: 'strong' | 'i' | 'u' | 'mark'): Promise<void> {
+		let textSelector = `${Notebook.textCellPreviewSelector} ${fontType}`;
+		if (textStyle) {
+			textSelector = `${textSelector} ${textStyle}`;
+		}
 		await this.code.waitForElement(textSelector, result => result?.textContent === text);
 	}
 
@@ -193,6 +205,57 @@ export class Notebook {
 		await this.code.waitForElementGone(`${cellSelector} dialog`);
 		await this.code.waitForElementGone(`${cellSelector} embed`);
 		await this.code.waitForElementGone(`${cellSelector} svg`);
+	}
+}
+
+export class TextCellToolbar {
+	private static readonly textCellToolbar = 'text-cell-component markdown-toolbar-component ul.actions-container';
+
+	constructor(private code: Code) { }
+
+	public async changeTextCellView(view: 'Rich Text View' | 'Split View' | 'Markdown View'): Promise<void> {
+		await this.clickToolbarButton(view);
+	}
+
+	public async boldSelectedText(): Promise<void> {
+		await this.clickToolbarButton('Bold');
+	}
+
+	public async italicizeSelectedText(): Promise<void> {
+		await this.clickToolbarButton('Italics');
+	}
+
+	public async underlineSelectedText(): Promise<void> {
+		await this.clickToolbarButton('Underline');
+	}
+
+	public async highlightSelectedText(): Promise<void> {
+		await this.clickToolbarButton('Highlight');
+	}
+
+	public async codifySelectedText(): Promise<void> {
+		await this.clickToolbarButton('Code');
+	}
+
+	public async insertLink(): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+
+	public async insertList(): Promise<void> {
+		await this.clickToolbarButton('List');
+	}
+
+	public async insertOrderedList(): Promise<void> {
+		await this.clickToolbarButton('Ordered list');
+	}
+
+	public async changeSelectedTextSize(): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+
+	private async clickToolbarButton(buttonTitle: string) {
+		const actionSelector = `${TextCellToolbar.textCellToolbar} a[title="${buttonTitle}"]`;
+		await this.code.waitAndClick(actionSelector);
 	}
 }
 

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -107,19 +107,6 @@ export class Notebook {
 		await this.code.dispatchKeybinding('ctrl+a');
 	}
 
-	private static readonly richTextEditorSelector = '.notebook-cell.active div.notebook-preview[contenteditable="true"]';
-	public async waitForTypeInRichTextEditor(text: string) {
-		await this.code.waitAndClick(Notebook.richTextEditorSelector);
-		await this.code.waitForActiveElement(Notebook.richTextEditorSelector);
-		await this.code.waitForTypeInEditor(Notebook.richTextEditorSelector, text);
-		await this._waitForActiveCellEditorContents(c => c.indexOf(text) > -1);
-	}
-
-	public async selectAllTextInRichTextEditor(): Promise<void> {
-		await this.code.waitAndClick(Notebook.richTextEditorSelector);
-		await this.code.dispatchKeybinding('ctrl+a');
-	}
-
 	private static readonly placeholderSelector = 'div.placeholder-cell-component';
 	async addCellFromPlaceholder(cellType: 'Markdown' | 'Code'): Promise<void> {
 		await this.code.waitAndClick(`${Notebook.placeholderSelector} p a[id="add${cellType}"]`);

--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -101,6 +101,12 @@ export class Notebook {
 		return this.code.waitForTextContent(selector, undefined, c => accept(c.replace(/\u00a0/g, ' ')));
 	}
 
+	public async selectAllTextInEditor(): Promise<void> {
+		const editor = '.notebook-cell.active .monaco-editor';
+		await this.code.waitAndClick(editor);
+		await this.code.dispatchKeybinding('ctrl+a');
+	}
+
 	private static readonly richTextEditorSelector = '.notebook-cell.active div.notebook-preview[contenteditable="true"]';
 	public async waitForTypeInRichTextEditor(text: string) {
 		await this.code.waitAndClick(Notebook.richTextEditorSelector);

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -83,23 +83,6 @@ export function setup() {
 
 			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 		});
-
-		it('can perform basic Rich Text cell editing', async function () {
-			const app = this.app as Application;
-			await app.workbench.sqlNotebook.newUntitledNotebook();
-			await app.workbench.sqlNotebook.addCellFromPlaceholder('Markdown');
-			await app.workbench.sqlNotebook.waitForPlaceholderGone();
-
-			await app.workbench.sqlNotebook.textCellToolbar.changeTextCellView('Rich Text View');
-			const sampleText: string = 'Test Rich Text cells';
-			await app.workbench.sqlNotebook.waitForTypeInRichTextEditor(sampleText);
-			await app.workbench.sqlNotebook.selectAllTextInRichTextEditor();
-			await app.workbench.sqlNotebook.textCellToolbar.boldSelectedText();
-			await app.code.dispatchKeybinding('escape');
-			await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'strong');
-
-			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
-		});
 	});
 }
 

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -76,8 +76,10 @@ export function setup() {
 			await app.workbench.sqlNotebook.textCellToolbar.changeTextCellView('Split View');
 			const sampleText: string = 'Test text cells';
 			await app.workbench.sqlNotebook.waitForTypeInEditor(sampleText);
+			await app.workbench.sqlNotebook.selectAllTextInEditor();
+			await app.workbench.sqlNotebook.textCellToolbar.boldSelectedText();
 			await app.code.dispatchKeybinding('escape');
-			await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p');
+			await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'strong');
 
 			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 		});

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -73,11 +73,28 @@ export function setup() {
 			await app.workbench.sqlNotebook.doubleClickTextCell();
 			await app.workbench.sqlNotebook.waitForDoubleClickToEditGone();
 
-			await app.workbench.sqlNotebook.changeTextCellView('Split View');
+			await app.workbench.sqlNotebook.textCellToolbar.changeTextCellView('Split View');
 			const sampleText: string = 'Test text cells';
 			await app.workbench.sqlNotebook.waitForTypeInEditor(sampleText);
 			await app.code.dispatchKeybinding('escape');
 			await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p');
+
+			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
+		});
+
+		it('can perform basic Rich Text cell editing', async function () {
+			const app = this.app as Application;
+			await app.workbench.sqlNotebook.newUntitledNotebook();
+			await app.workbench.sqlNotebook.addCellFromPlaceholder('Markdown');
+			await app.workbench.sqlNotebook.waitForPlaceholderGone();
+
+			await app.workbench.sqlNotebook.textCellToolbar.changeTextCellView('Rich Text View');
+			const sampleText: string = 'Test Rich Text cells';
+			await app.workbench.sqlNotebook.waitForTypeInRichTextEditor(sampleText);
+			await app.workbench.sqlNotebook.selectAllTextInRichTextEditor();
+			await app.workbench.sqlNotebook.textCellToolbar.boldSelectedText();
+			await app.code.dispatchKeybinding('escape');
+			await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p', 'strong');
 
 			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 		});


### PR DESCRIPTION
I tried adding some WYSIWYG editor tests, but it looks like we can't set the editor div's inner HTML using the driver methods we have currently.