### PR TITLE
Add simple notebook code cell smoke test

### DIFF
--- a/test/automation/src/sql/notebook.ts
+++ b/test/automation/src/sql/notebook.ts
@@ -104,7 +104,7 @@ export class Notebook {
 	public async selectAllTextInEditor(): Promise<void> {
 		const editor = '.notebook-cell.active .monaco-editor';
 		await this.code.waitAndClick(editor);
-		await this.code.dispatchKeybinding('ctrl+a');
+		await this.code.dispatchKeybinding('cmd+a');
 	}
 
 	private static readonly placeholderSelector = 'div.placeholder-cell-component';

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -8,37 +8,32 @@ import { Application } from '../../../../../automation';
 export function setup() {
 	describe('Notebook', () => {
 
-		it('can open new notebook, configure Python, and execute one cell', async function () {
+		it('can perform basic text cell functionality', async function () {
 			const app = this.app as Application;
 			await app.workbench.sqlNotebook.newUntitledNotebook();
-			await app.workbench.sqlNotebook.addCell('code');
-			await app.workbench.sqlNotebook.waitForTypeInEditor('print("Hello world!")');
-			await app.workbench.sqlNotebook.waitForKernel('SQL');
+			await app.workbench.sqlNotebook.addCellFromPlaceholder('Markdown');
+			await app.workbench.sqlNotebook.waitForPlaceholderGone();
 
-			await app.workbench.sqlNotebook.changeKernel('Python 3');
-			await app.workbench.configurePythonDialog.waitForConfigurePythonDialog();
-			await app.workbench.configurePythonDialog.installPython();
-			await app.workbench.sqlNotebook.waitForKernel('Python 3');
+			await app.code.dispatchKeybinding('escape');
+			await app.workbench.sqlNotebook.waitForDoubleClickToEdit();
+			await app.workbench.sqlNotebook.doubleClickTextCell();
+			await app.workbench.sqlNotebook.waitForDoubleClickToEditGone();
 
-			await app.workbench.sqlNotebook.runActiveCell();
-			await app.workbench.sqlNotebook.waitForActiveCellResults();
-
-			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
+			await app.workbench.sqlNotebook.changeTextCellView('Split View');
+			const sampleText: string = 'Test text cells';
+			await app.workbench.sqlNotebook.waitForTypeInEditor(sampleText);
+			await app.code.dispatchKeybinding('escape');
+			await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p');
 		});
 
-		it('can open ipynb file, run all, and save notebook with outputs', async function () {
+		it('can perform basic code cell functionality', async function () {
 			const app = this.app as Application;
-			await openAndRunNotebook(app, 'hello.ipynb');
-		});
+			await app.workbench.sqlNotebook.newUntitledNotebook();
+			await app.workbench.sqlNotebook.addCellFromPlaceholder('Code');
+			await app.workbench.sqlNotebook.waitForPlaceholderGone();
 
-		it('can open ipynb file from path with spaces, run all, and save notebook with outputs', async function () {
-			const app = this.app as Application;
-			await openAndRunNotebook(app, 'helloWithSpaces.ipynb');
-		});
-
-		it('can open ipynb file from path with escaped spaces, run all, and save notebook with outputs', async function () {
-			const app = this.app as Application;
-			await openAndRunNotebook(app, 'helloWithEscapedSpaces.ipynb');
+			const sampleText: string = 'SELECT * FROM sys.tables';
+			await app.workbench.sqlNotebook.waitForTypeInEditor(sampleText);
 		});
 
 		it('can open untrusted notebook, trust, save, and reopen trusted notebook', async function () {
@@ -58,39 +53,43 @@ export function setup() {
 			await app.workbench.sqlNotebook.openFile('untrusted.ipynb');
 			await app.workbench.sqlNotebook.waitForTrustedIcon();
 			await app.workbench.sqlNotebook.waitForTrustedElements();
-
-			await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
 		});
 
-		it('can perform basic text cell functionality', async function () {
+		// Python Notebooks
+
+		it('can open new notebook, configure Python, and execute one cell', async function () {
 			const app = this.app as Application;
 			await app.workbench.sqlNotebook.newUntitledNotebook();
-			await app.workbench.sqlNotebook.addCellFromPlaceholder('Markdown');
-			await app.workbench.sqlNotebook.waitForPlaceholderGone();
+			await app.workbench.sqlNotebook.addCell('code');
+			await app.workbench.sqlNotebook.waitForTypeInEditor('print("Hello world!")');
+			await app.workbench.sqlNotebook.waitForKernel('SQL');
 
-			await app.code.dispatchKeybinding('escape');
-			await app.workbench.sqlNotebook.waitForDoubleClickToEdit();
-			await app.workbench.sqlNotebook.doubleClickTextCell();
-			await app.workbench.sqlNotebook.waitForDoubleClickToEditGone();
+			await app.workbench.sqlNotebook.changeKernel('Python 3');
+			await app.workbench.configurePythonDialog.waitForConfigurePythonDialog();
+			await app.workbench.configurePythonDialog.installPython();
+			await app.workbench.sqlNotebook.waitForKernel('Python 3');
 
-			await app.workbench.sqlNotebook.changeTextCellView('Split View');
-			const sampleText: string = 'Test text cells';
-			await app.workbench.sqlNotebook.waitForTypeInEditor(sampleText);
-			await app.code.dispatchKeybinding('escape');
-			await app.workbench.sqlNotebook.waitForTextCellPreviewContent(sampleText, 'p');
-
-			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
+			await app.workbench.sqlNotebook.runActiveCell();
+			await app.workbench.sqlNotebook.waitForActiveCellResults();
 		});
 
-		it('can perform basic code cell functionality', async function () {
+		it('can open ipynb file, run all, and save notebook with outputs', async function () {
 			const app = this.app as Application;
-			await app.workbench.sqlNotebook.newUntitledNotebook();
-			await app.workbench.sqlNotebook.addCellFromPlaceholder('Code');
-			await app.workbench.sqlNotebook.waitForPlaceholderGone();
+			await openAndRunNotebook(app, 'hello.ipynb');
+		});
 
-			const sampleText: string = 'SELECT * FROM sys.tables';
-			await app.workbench.sqlNotebook.waitForTypeInEditor(sampleText);
+		it('can open ipynb file from path with spaces, run all, and save notebook with outputs', async function () {
+			const app = this.app as Application;
+			await openAndRunNotebook(app, 'helloWithSpaces.ipynb');
+		});
 
+		it('can open ipynb file from path with escaped spaces, run all, and save notebook with outputs', async function () {
+			const app = this.app as Application;
+			await openAndRunNotebook(app, 'helloWithEscapedSpaces.ipynb');
+		});
+
+		afterEach(async function () {
+			const app = this.app as Application;
 			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 		});
 	});
@@ -111,6 +110,4 @@ async function openAndRunNotebook(app: Application, filename: string): Promise<v
 	await app.workbench.sqlNotebook.openFile(filename);
 	await app.workbench.sqlNotebook.waitForKernel('Python 3');
 	await app.workbench.sqlNotebook.waitForAllResults();
-
-	await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 }

--- a/test/smoke/src/sql/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/sql/areas/notebook/notebook.test.ts
@@ -81,6 +81,18 @@ export function setup() {
 
 			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
 		});
+
+		it('can perform basic code cell functionality', async function () {
+			const app = this.app as Application;
+			await app.workbench.sqlNotebook.newUntitledNotebook();
+			await app.workbench.sqlNotebook.addCellFromPlaceholder('Code');
+			await app.workbench.sqlNotebook.waitForPlaceholderGone();
+
+			const sampleText: string = 'SELECT * FROM sys.tables';
+			await app.workbench.sqlNotebook.waitForTypeInEditor(sampleText);
+
+			await app.workbench.quickaccess.runCommand('workbench.action.revertAndCloseActiveEditor');
+		});
 	});
 }
 


### PR DESCRIPTION
Also re-ordered the tests so that the Python dependent tests go last. This way if Python installation fails, at least other tests can be run beforehand.  (new code cell test starts on line 29 and content of other tests were not changed)

I'll be adding more to the code cell test for intellisense checks.