### PR TITLE
open query editor as default editor

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -286,7 +286,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 			if (this.isEmpty) {
 				EventHelper.stop(e);
 
-				this.openEditor(this.editorService.createEditorInput({ forceUntitled: true }), EditorOptions.create({ pinned: true }));
+				// {{SQL CARBON EDIT}} - use editor service to open editor, which will go through the override step and resolve to UntitledQueryEditorInput.
+				this.editorService.openEditor(this.editorService.createEditorInput({ forceUntitled: true }), EditorOptions.create({ pinned: true }));
 			}
 		}));
 

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -236,14 +236,13 @@ export class TabsTitleControl extends TitleControl {
 				}
 
 				EventHelper.stop(e);
-
-				this.group.openEditor(
+				// {{SQL CARBON EDIT}} - use editor service to open editor, which will go through the override step and resolve to UntitledQueryEditorInput.
+				this.editorService.openEditor(
 					this.editorService.createEditorInput({ forceUntitled: true }),
 					{
 						pinned: true,			// untitled is always pinned
 						index: this.group.count // always at the end
-					}
-				);
+					}, this.group);
 			}));
 		});
 


### PR DESCRIPTION

This PR fixes #15823

1. double click on the blank editor group area (when no editor is opened)
![image](https://user-images.githubusercontent.com/13777222/123018448-71e5e380-d383-11eb-99d7-a569cfb34b1d.png)

2. double click on the editor group title blank area
![image](https://user-images.githubusercontent.com/13777222/123018510-8924d100-d383-11eb-8fbf-011207246c9c.png)

previously we were relying on the editorGroup.onWillOpenEditor event to override the input type and resolve it to UntitledQueryEditorInput, but it is removed in: 
https://github.com/microsoft/vscode/pull/119274/files#diff-4729038e6d08c333e1fca18d18afac8a5a2f7fc6dffd55f0cb16ca66dab09190L562

the fix is to use the editorService.openEditor (which has the override logic and this is the 'New Query' command is leveraging) for the scenarios that are currently broken


after:

![before1](https://user-images.githubusercontent.com/13777222/123018909-44e60080-d384-11eb-9352-579d49bbac57.gif)
![before2](https://user-images.githubusercontent.com/13777222/123018912-457e9700-d384-11eb-9290-28f12e3e6787.gif)