### PR TITLE
fix separator not visible issue

### DIFF
--- a/src/sql/base/browser/ui/taskbar/media/taskbar.css
+++ b/src/sql/base/browser/ui/taskbar/media/taskbar.css
@@ -79,6 +79,7 @@
 	min-width: 1px;
 	background-color:#A5A5A5;
 	margin: 6px 8px;
+	align-self: stretch;
 }
 
 .taskbarTextSeparator {


### PR DESCRIPTION
This PR fixes #15885 

in this commit: https://github.com/microsoft/vscode/commit/7c3f60f86e6776c4a339c23f85fd9a11c3424bbb#diff-addd7132dee13457b17c0ce8af86416722108e69b8a60d63a865f524a8323f5fR19

the align-items property of the toolbar container is changed to 'center' from default value 'stretch', this caused the height of our task separator to become 0 (not visible).

fix: set it to stretch specifically for the separator to fit the container.
