### PR TITLE
fix projects notification showing when it shouldn't

### DIFF
--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -14,12 +14,12 @@ import { IWorkspaceService } from './common/interfaces';
 import { IconPathHelper } from './common/iconHelper';
 import { ProjectDashboard } from './dialogs/projectDashboard';
 
-export function activate(context: vscode.ExtensionContext): Promise<IExtension> {
+export async function activate(context: vscode.ExtensionContext): Promise<IExtension> {
 	const workspaceService = new WorkspaceService(context);
-	workspaceService.loadTempProjects();
-	workspaceService.checkForProjectsNotAddedToWorkspace();
-	context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(() => {
-		workspaceService.checkForProjectsNotAddedToWorkspace();
+	await workspaceService.loadTempProjects();
+	await workspaceService.checkForProjectsNotAddedToWorkspace();
+	context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(async () => {
+		await workspaceService.checkForProjectsNotAddedToWorkspace();
 	}));
 
 	const workspaceTreeDataProvider = new WorkspaceTreeDataProvider(workspaceService);

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -218,6 +218,11 @@ export class WorkspaceService implements IWorkspaceService {
 		}
 	}
 
+	/**
+	 * Returns an array of all the supported projects in the folder
+	 * @param folder folder to look look for projects
+	 * @returns array of file paths of supported projects
+	 */
 	async getAllProjectsInFolder(folder: vscode.Uri): Promise<string[]> {
 		// get the unique supported project extensions
 		const supportedProjectExtensions = [...new Set((await this.getAllProjectTypes()).map(p => { return p.projectFileExtension; }))];
@@ -229,7 +234,8 @@ export class WorkspaceService implements IWorkspaceService {
 		// so the filter needs to be in the format folder/**/*.sqlproj if there's only one supported projectextension
 		const projFilter = supportedProjectExtensions.length > 1 ? path.posix.join(escapedPath, '**', `*.{${supportedProjectExtensions.toString()}}`) : path.posix.join(escapedPath, '**', `*.${supportedProjectExtensions[0]}`);
 
-		return await glob(projFilter);
+		// glob will return an array of file paths with forward slashes, so they need to be converted back if on windows
+		return (await glob(projFilter)).map(p => folder.fsPath.includes('\\') ? p.split('/').join('\\') : p);
 	}
 
 	async getProjectProvider(projectFile: vscode.Uri): Promise<dataworkspace.IProjectProvider | undefined> {

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -235,7 +235,7 @@ export class WorkspaceService implements IWorkspaceService {
 		const projFilter = supportedProjectExtensions.length > 1 ? path.posix.join(escapedPath, '**', `*.{${supportedProjectExtensions.toString()}}`) : path.posix.join(escapedPath, '**', `*.${supportedProjectExtensions[0]}`);
 
 		// glob will return an array of file paths with forward slashes, so they need to be converted back if on windows
-		return (await glob(projFilter)).map(p => folder.fsPath.includes('\\') ? p.split('/').join('\\') : p);
+		return (await glob(projFilter)).map(p => path.resolve(p));
 	}
 
 	async getProjectProvider(projectFile: vscode.Uri): Promise<dataworkspace.IProjectProvider | undefined> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15889. 

Fixing 2 problems:
1. When creating a new project that also creates a new workspace, ADS restarts to create and enter the new workspace and the project gets added to the workspace when the extension activates. This part wasn't being awaited, so sometimes the check for not added projects was seeing that the newly added workspace folder, but it was before the project was added to the workspace. 
2. Glob returns forward slash paths, so this was notification was always showing on windows because those forward slash paths were being compared to the project paths in the workspace file which have backslashes on windows.
