### PR TITLE
Fix icons getting cut off

### DIFF
--- a/src/sql/workbench/services/objectExplorer/browser/iconRenderer.ts
+++ b/src/sql/workbench/services/objectExplorer/browser/iconRenderer.ts
@@ -69,7 +69,7 @@ class BadgeRenderer {
 		return `position: absolute;
 			height: 0.25rem;
 			width: 0.25rem;
-			top: 14px;
+			top: 12px;
 			left: 19px;
 			border: 2.4px solid ${circleColor};
 			border-radius: 100%;


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/15877

Before - 
<img width="356" alt="Screen Shot 2021-06-24 at 10 54 41 AM" src="https://user-images.githubusercontent.com/6411451/123310958-7c1af580-d4db-11eb-984b-477db205e3a8.png">


After -

<img width="355" alt="Screen Shot 2021-06-24 at 10 52 01 AM" src="https://user-images.githubusercontent.com/6411451/123310995-8210d680-d4db-11eb-8c52-f8231fef0bd5.png">

This issue only shows when the option "Use Async Server Tree" is not checked off and thus doesn't need any change for that case.