### PR TITLE
Increase jupyter server shutdown timeout

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterNotebookProvider.ts
+++ b/extensions/notebook/src/jupyter/jupyterNotebookProvider.ts
@@ -64,13 +64,13 @@ export class JupyterNotebookProvider implements nb.NotebookProvider {
 				manager.sessionManager.shutdown(session.id);
 			}
 			if (sessionManager.listRunning().length === 0) {
-				const FiveMinutesInMs = 5 * 60 * 1000;
+				const TenMinutesInMs = 10 * 60 * 1000;
 				setTimeout(() => {
 					if (sessionManager.listRunning().length === 0) {
 						this.managerTracker.delete(baseFolder);
 						manager.dispose();
 					}
-				}, FiveMinutesInMs);
+				}, TenMinutesInMs);
 			}
 		}
 	}


### PR DESCRIPTION
The last python notebook smoke test is failing in the product build pipeline because the Jupyter server is shutdown before the notebook finishes loading the Python kernel. It didn't happen before since we weren't closing each notebook after each test (which is what is triggering the timeout for the server to shutdown). And this doesn't happen locally since all the Python notebook tests finish before the 5 minute timeout.

I'm temporarily increasing the timeout to fix the smoke test while I work on reseting the timeout like Charles suggested here: https://github.com/microsoft/azuredatastudio/pull/7744/files#r336047335.
