### PR TITLE
Remove awaits that were blocking data workspace extension from loading

### DIFF
--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -17,9 +17,9 @@ import { ProjectDashboard } from './dialogs/projectDashboard';
 export async function activate(context: vscode.ExtensionContext): Promise<IExtension> {
 	const workspaceService = new WorkspaceService(context);
 	await workspaceService.loadTempProjects();
-	await workspaceService.checkForProjectsNotAddedToWorkspace();
-	context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(async () => {
-		await workspaceService.checkForProjectsNotAddedToWorkspace();
+	workspaceService.checkForProjectsNotAddedToWorkspace();
+	context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(() => {
+		workspaceService.checkForProjectsNotAddedToWorkspace();
 	}));
 
 	const workspaceTreeDataProvider = new WorkspaceTreeDataProvider(workspaceService);

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -17,6 +17,9 @@ import { ProjectDashboard } from './dialogs/projectDashboard';
 export async function activate(context: vscode.ExtensionContext): Promise<IExtension> {
 	const workspaceService = new WorkspaceService(context);
 	await workspaceService.loadTempProjects();
+
+	// this isn't awaited because if the notification shows, the rest of this activate function will be blocked from running and
+	// the contributed commands won't be registered until the notifation gets dismissed
 	workspaceService.checkForProjectsNotAddedToWorkspace();
 	context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(() => {
 		workspaceService.checkForProjectsNotAddedToWorkspace();

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -16,11 +16,12 @@ import { ProjectDashboard } from './dialogs/projectDashboard';
 
 export async function activate(context: vscode.ExtensionContext): Promise<IExtension> {
 	const workspaceService = new WorkspaceService(context);
-	await workspaceService.loadTempProjects();
 
-	// this isn't awaited because if the notification shows, the rest of this activate function will be blocked from running and
-	// the contributed commands won't be registered until the notifation gets dismissed
-	workspaceService.checkForProjectsNotAddedToWorkspace();
+	// this is not being awaited to not block the rest of activate function from running while loading any temp projects and
+	// checking for projects not added to the workspace yet
+	workspaceService.loadTempProjects().then(async () => await workspaceService.checkForProjectsNotAddedToWorkspace())
+		.catch(e => console.log(e));
+
 	context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(() => {
 		workspaceService.checkForProjectsNotAddedToWorkspace();
 	}));

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -21,6 +21,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 	// checking for projects not added to the workspace yet
 	workspaceService.loadTempProjects().then(() => {
 		return workspaceService.checkForProjectsNotAddedToWorkspace();
+	}).catch(error => {
+		console.error(error);
+		vscode.window.showErrorMessage(error instanceof Error ? error.message : error);
 	});
 
 	context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(() => {

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -19,8 +19,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 
 	// this is not being awaited to not block the rest of activate function from running while loading any temp projects and
 	// checking for projects not added to the workspace yet
-	workspaceService.loadTempProjects().then(async () => await workspaceService.checkForProjectsNotAddedToWorkspace())
-		.catch(e => console.log(e));
+	workspaceService.loadTempProjects().then(() => {
+		return workspaceService.checkForProjectsNotAddedToWorkspace();
+	});
 
 	context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(() => {
 		workspaceService.checkForProjectsNotAddedToWorkspace();


### PR DESCRIPTION
I added these awaits in #15890 because I noticed it was an async function that wasn't being awaited, but weren't actually necessary for the bug fix. Turns out they weren't there because it would block the rest of the data workspace extension getting activated if the notification showed until it got dismissed. 
