### PR TITLE
Remove layout call in output component ngOnInit

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/output.component.ts
@@ -54,7 +54,6 @@ export class OutputComponent extends CellView implements OnInit, AfterViewInit {
 	ngOnInit() {
 		this._register(this._themeService.onDidColorThemeChange(event => this.updateTheme(event)));
 		this.loadComponent();
-		this.layout();
 		this._initialized = true;
 		this._register(Event.debounce(this.cellModel.notebookModel.layoutChanged, (l, e) => e, 50, /*leading=*/false)
 			(() => this.layout()));


### PR DESCRIPTION
This PR starts to address https://github.com/microsoft/azuredatastudio/issues/15543. 
Removing the layout call improves the loading time for the 475kb notebook (with result grids) that Julie used by up to 30%.

I did a bunch of testing to make sure removing this does not affect anything. Tested:
- notebooks with large text outputs
- notebooks with result grids of various sizes
- resizing ADS window and then open/run a notebook with outputs
- zoom in and then open/run a notebook with outputs

Please let me know if there are any other things I should test. In addition, here is an ad hoc build if anyone wants to test: https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=108751&view=artifacts&pathAsName=false&type=publishedArtifacts
 
