### PR TITLE
Add jupyter server shutdown timeout setting

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -43,6 +43,11 @@
           "default": false,
           "description": "%notebook.dontPromptPythonUpdate.description%"
         },
+        "notebook.jupyterServerShutdownTimeout": {
+          "type": "number",
+          "default": 5,
+          "description": "%notebook.jupyterServerShutdownTimeout.description%"
+        },
         "notebook.overrideEditorTheming": {
           "type": "boolean",
           "default": true,

--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -46,6 +46,7 @@
         "notebook.jupyterServerShutdownTimeout": {
           "type": "number",
           "default": 5,
+          "minimum": 0,
           "description": "%notebook.jupyterServerShutdownTimeout.description%"
         },
         "notebook.overrideEditorTheming": {

--- a/extensions/notebook/package.nls.json
+++ b/extensions/notebook/package.nls.json
@@ -5,6 +5,7 @@
 	"notebook.pythonPath.description": "Local path to python installation used by Notebooks.",
 	"notebook.useExistingPython.description": "Local path to a preexisting python installation used by Notebooks.",
 	"notebook.dontPromptPythonUpdate.description": "Do not show prompt to update Python.",
+	"notebook.jupyterServerShutdownTimeout.description": "The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed.",
 	"notebook.overrideEditorTheming.description": "Override editor default settings in the Notebook editor. Settings include background color, current line color and border",
 	"notebook.maxTableRows.description": "Maximum number of rows returned per table in the Notebook editor",
 	"notebook.trustedBooks.description": "Notebooks contained in these books will automatically be trusted.",

--- a/extensions/notebook/package.nls.json
+++ b/extensions/notebook/package.nls.json
@@ -5,7 +5,7 @@
 	"notebook.pythonPath.description": "Local path to python installation used by Notebooks.",
 	"notebook.useExistingPython.description": "Local path to a preexisting python installation used by Notebooks.",
 	"notebook.dontPromptPythonUpdate.description": "Do not show prompt to update Python.",
-	"notebook.jupyterServerShutdownTimeout.description": "The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed.",
+	"notebook.jupyterServerShutdownTimeout.description": "The amount of time (in minutes) to wait before shutting down a server after all notebooks are closed. (Enter 0 to not shutdown)",
 	"notebook.overrideEditorTheming.description": "Override editor default settings in the Notebook editor. Settings include background color, current line color and border",
 	"notebook.maxTableRows.description": "Maximum number of rows returned per table in the Notebook editor",
 	"notebook.trustedBooks.description": "Notebooks contained in these books will automatically be trusted.",

--- a/extensions/notebook/src/common/constants.ts
+++ b/extensions/notebook/src/common/constants.ts
@@ -17,6 +17,7 @@ export const pythonVersion = '3.8.10';
 export const pythonPathConfigKey = 'pythonPath';
 export const existingPythonConfigKey = 'useExistingPython';
 export const dontPromptPythonUpdate = 'dontPromptPythonUpdate';
+export const jupyterServerShutdownTimeoutConfigKey = 'jupyterServerShutdownTimeout';
 export const notebookConfigKey = 'notebook';
 export const trustedBooksConfigKey = 'trustedBooks';
 export const pinnedBooksConfigKey = 'pinnedNotebooks';

--- a/extensions/notebook/src/jupyter/jupyterNotebookProvider.ts
+++ b/extensions/notebook/src/jupyter/jupyterNotebookProvider.ts
@@ -64,13 +64,15 @@ export class JupyterNotebookProvider implements nb.NotebookProvider {
 				manager.sessionManager.shutdown(session.id);
 			}
 			if (sessionManager.listRunning().length === 0) {
-				const TenMinutesInMs = 10 * 60 * 1000;
+				let notebookConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(constants.notebookConfigKey);
+				let timeoutInMinutes: number = notebookConfig.get(constants.jupyterServerShutdownTimeoutConfigKey);
+				const timeoutInMs = timeoutInMinutes * 60 * 1000;
 				setTimeout(() => {
 					if (sessionManager.listRunning().length === 0) {
 						this.managerTracker.delete(baseFolder);
 						manager.dispose();
 					}
-				}, TenMinutesInMs);
+				}, timeoutInMs);
 			}
 		}
 	}

--- a/extensions/notebook/src/jupyter/jupyterNotebookProvider.ts
+++ b/extensions/notebook/src/jupyter/jupyterNotebookProvider.ts
@@ -66,13 +66,15 @@ export class JupyterNotebookProvider implements nb.NotebookProvider {
 			if (sessionManager.listRunning().length === 0) {
 				let notebookConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(constants.notebookConfigKey);
 				let timeoutInMinutes: number = notebookConfig.get(constants.jupyterServerShutdownTimeoutConfigKey);
-				const timeoutInMs = timeoutInMinutes * 60 * 1000;
-				setTimeout(() => {
-					if (sessionManager.listRunning().length === 0) {
-						this.managerTracker.delete(baseFolder);
-						manager.dispose();
-					}
-				}, timeoutInMs);
+				if (timeoutInMinutes > 0) {
+					const timeoutInMs = timeoutInMinutes * 60 * 1000;
+					setTimeout(() => {
+						if (sessionManager.listRunning().length === 0) {
+							this.managerTracker.delete(baseFolder);
+							manager.dispose();
+						}
+					}, timeoutInMs);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Follow-up to this PR https://github.com/microsoft/azuredatastudio/pull/15899. I'm setting the default timeout back to 5 minutes and will add the setting in the smoke test repo and configure to 10 minutes.