### PR TITLE
Remove old python installation after new Python is successfully downloaded

### DIFF
--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -474,9 +474,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 								await this.createInstallPipPackagesHelpNotebook(this._oldUserInstalledPipPackages);
 							}
 
-							await fs.remove(this._oldPythonInstallationPath).catch(err => {
-								throw (err);
-							});
+							await fs.remove(this._oldPythonInstallationPath);
 							this._upgradeInProcess = false;
 						} else {
 							await vscode.commands.executeCommand('notebook.action.restartJupyterNotebookSessions');

--- a/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
+++ b/extensions/notebook/src/jupyter/jupyterServerInstallation.ts
@@ -202,9 +202,6 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 						// Remove '0.0.1' from python executable path since the bundle version is removed from the path for ADS-Python 3.8.10+.
 						this._pythonExecutable = path.join(this._pythonInstallationPath, process.platform === constants.winPlatform ? 'python.exe' : 'bin/python3');
 					}
-					await fs.remove(this._oldPythonInstallationPath).catch(err => {
-						throw (err);
-					});
 				}
 			}
 
@@ -476,6 +473,10 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 							if (this._oldUserInstalledPipPackages.length !== 0) {
 								await this.createInstallPipPackagesHelpNotebook(this._oldUserInstalledPipPackages);
 							}
+
+							await fs.remove(this._oldPythonInstallationPath).catch(err => {
+								throw (err);
+							});
 							this._upgradeInProcess = false;
 						} else {
 							await vscode.commands.executeCommand('notebook.action.restartJupyterNotebookSessions');
@@ -529,7 +530,7 @@ export class JupyterServerInstallation implements IJupyterServerInstallation {
 
 		let response = await vscode.window.showInformationMessage(msgPythonVersionUpdatePrompt(constants.pythonVersion), yes, no, dontAskAgain);
 		if (response === yes) {
-			this._oldPythonInstallationPath = path.join(this._pythonInstallationPath);
+			this._oldPythonInstallationPath = path.join(this._pythonInstallationPath, '0.0.1');
 			this._oldPythonExecutable = this._pythonExecutable;
 			vscode.commands.executeCommand(constants.jupyterConfigurePython);
 		} else if (response === dontAskAgain) {


### PR DESCRIPTION
This PR partially addresses https://github.com/microsoft/azuredatastudio/issues/15835. 
Tested on mac and windows to make sure old python is removed correctly.