### PR TITLE
Hide dropdown loading container when not used

### DIFF
--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -228,9 +228,6 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 		return this.getPropertyOrDefault<boolean>((props) => props.fireOnTextChange, false);
 	}
 
-	public get displayEditable(): boolean {
-		return (this.editable && !this._isInAccessibilityMode) && !this.loading;
-	}
 	public getEditableDisplay(): string {
 		return (this.editable && !this._isInAccessibilityMode) && !this.loading ? '' : 'none';
 	}

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -29,9 +29,9 @@ import { ILogService } from 'vs/platform/log/common/log';
 	template: `
 
 	<div [ngStyle]="CSSStyles">
-		<div [style.display]="getLoadingDisplay()" style="width: 100%; position: relative">
+		<div *ngIf="loading" style="width: 100%; position: relative">
 			<div class="modelview-loadingComponent-spinner" style="position:absolute; right: 0px; margin-right: 5px; height:15px; z-index:1" #spinnerElement></div>
-			<div [style.display]="getLoadingDisplay()" #loadingBox style="width: 100%;"></div>
+			<div #loadingBox style="width: 100%;"></div>
 		</div>
 		<div [style.display]="getEditableDisplay()" #editableDropDown style="width: 100%;"></div>
 		<div [style.display]="getNotEditableDisplay()" #dropDown style="width: 100%;"></div>
@@ -114,11 +114,6 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 			this._validations.push(() => !this.required || this.editable || !!this._selectBox.value);
 		}
 
-		this._loadingBox = new SelectBox([this.getStatusText()], this.getStatusText(), this.contextViewService, this._loadingBoxContainer.nativeElement);
-		this._loadingBox.render(this._loadingBoxContainer.nativeElement);
-		this._register(this._loadingBox);
-		this._register(attachSelectBoxStyler(this._loadingBox, this.themeService));
-		this._loadingBoxContainer.nativeElement.className = ''; // Removing the dropdown arrow icon from the right
 		this.baseInit();
 	}
 
@@ -137,9 +132,10 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 		super.setProperties(properties);
 
 		if (this.ariaLabel !== '') {
-			this._selectBox.setAriaLabel(this.ariaLabel);
-			this._editableDropdown.ariaLabel = this.ariaLabel;
-			this._loadingBox.setAriaLabel(this.ariaLabel);
+			this._selectBox?.setAriaLabel(this.ariaLabel);
+			if (this._editableDropdown) {
+				this._editableDropdown.ariaLabel = this.ariaLabel;
+			}
 		}
 
 		if (this.editable && !this._isInAccessibilityMode) {
@@ -160,11 +156,20 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 		}
 
 		if (this.loading) {
+			// Lazily create the select box for the loading portion since many dropdowns won't use it
+			if (!this._loadingBox) {
+				this._loadingBox = new SelectBox([this.getStatusText()], this.getStatusText(), this.contextViewService, this._loadingBoxContainer.nativeElement);
+				this._loadingBox.render(this._loadingBoxContainer.nativeElement);
+				this._register(this._loadingBox);
+				this._register(attachSelectBoxStyler(this._loadingBox, this.themeService));
+				this._loadingBoxContainer.nativeElement.className = ''; // Removing the dropdown arrow icon from the right
+			}
+			if (this.ariaLabel !== '') {
+				this._loadingBox.setAriaLabel(this.ariaLabel);
+			}
 			this._loadingBox.setOptions([this.getStatusText()]);
 			this._loadingBox.selectWithOptionName(this.getStatusText());
 			this._loadingBox.enable();
-		} else {
-			this._loadingBox.disable();
 		}
 
 		this._selectBox.selectElem.required = this.required;
@@ -223,16 +228,15 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 		return this.getPropertyOrDefault<boolean>((props) => props.fireOnTextChange, false);
 	}
 
+	public get displayEditable(): boolean {
+		return (this.editable && !this._isInAccessibilityMode) && !this.loading;
+	}
 	public getEditableDisplay(): string {
 		return (this.editable && !this._isInAccessibilityMode) && !this.loading ? '' : 'none';
 	}
 
 	public getNotEditableDisplay(): string {
 		return (!this.editable || this._isInAccessibilityMode) && !this.loading ? '' : 'none';
-	}
-
-	public getLoadingDisplay(): string {
-		return this.loading ? '' : 'none';
 	}
 
 	private set value(newValue: string | azdata.CategoryValue) {


### PR DESCRIPTION
Currently we're always creating the dropdown loading component, which means we end up with duplicated select boxes in the DOM. Not only is this unnecessary for most cases but it can cause problems with CSS selectors since the select boxes are very similar.

In general we should really try to avoid hiding elements by using display: none - especially for things that are only conditionally active. 

GIF with both loading dropdowns and non-loading ones (DB is loading, server is normal)

![LoadingDropdown](https://user-images.githubusercontent.com/28519865/123839947-9cbfc280-d8c2-11eb-86e9-3248db81e9ae.gif)
