### PR TITLE
fix css selector

### DIFF
--- a/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/sql/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -953,7 +953,10 @@ registerThemingParticipant((theme, collector) => {
 	}
 	const foregroundColor = theme.getColor(foreground);
 	if (foregroundColor) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage h1, h2, h3, h4, h5, h6, h7, p { color: ${foregroundColor}; }`);
+		collector.addRule(`
+		.monaco-workbench .part.editor > .content .welcomePage a p,
+		.monaco-workbench .part.editor > .content .welcomePage a h3,
+		.monaco-workbench .part.editor > .content .welcomePage a h4 { color: ${foregroundColor}; }`);
 		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage .ads-homepage .resources .label { color: ${foregroundColor}; }`);
 		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePageContainer .ads-homepage .ads-homepage-section .history .list li a { color: ${foregroundColor};}`);
 		collector.addRule(`.monaco-workbench .part.editor > .content .welcomePage .ads-homepage .resources .label { color: ${foregroundColor}; }`);


### PR DESCRIPTION
This PR fixes #15937

turns out the issue is caused by bad css selector in welcome page, it meant to apply the style to the h1.. and p to the welcome page, but it is not written correctly, as a result, the color is applied globally.

fix:
fix the css selector, I tested and it only needs p, h3, and h4.

no impact to the welcome page:

Before:
![image](https://user-images.githubusercontent.com/13777222/123874080-6a2abf80-d8ec-11eb-96c8-40be735f8779.png)
![image](https://user-images.githubusercontent.com/13777222/123874133-7e6ebc80-d8ec-11eb-913e-3adc16563223.png)


After:
![image](https://user-images.githubusercontent.com/13777222/123874048-5d0dd080-d8ec-11eb-91d4-1c97410ee890.png)
![image](https://user-images.githubusercontent.com/13777222/123874152-8a5a7e80-d8ec-11eb-8ff5-58c70fc4353d.png)

Migration wizard:

Before:
![image](https://user-images.githubusercontent.com/13777222/123873860-099b8280-d8ec-11eb-8cea-d260f3d0b7c4.png)
![image](https://user-images.githubusercontent.com/13777222/123873962-35b70380-d8ec-11eb-9133-fb88f61fe8f5.png)

After:
![image](https://user-images.githubusercontent.com/13777222/123873886-1324ea80-d8ec-11eb-89e6-e84e8b705ae5.png)

![image](https://user-images.githubusercontent.com/13777222/123873921-22a43380-d8ec-11eb-9acb-05593060e51f.png)


