### PR TITLE
[ADS Web] Fix Plotly notebook rendering issue 

### DIFF
--- a/remote/package.json
+++ b/remote/package.json
@@ -31,6 +31,7 @@
     "ng2-charts": "^1.6.0",
     "node-pty": "0.10.1",
     "nsfw": "2.1.2",
+    "plotly.js-dist-min": "^1.53.0",
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.4.0",
     "sanitize-html": "1.19.1",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -21,6 +21,7 @@
 		"jschardet": "2.3.0",
 		"mark.js": "^8.11.1",
 		"ng2-charts": "^1.6.0",
+    "plotly.js-dist-min": "^1.53.0",
 		"reflect-metadata": "^0.1.8",
 		"rxjs": "5.4.0",
 		"sanitize-html": "1.19.1",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -259,6 +259,11 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
+plotly.js-dist-min@^1.53.0:
+  version "1.58.4"
+  resolved "https://registry.yarnpkg.com/plotly.js-dist-min/-/plotly.js-dist-min-1.58.4.tgz#6a5b9baf1988b6aca6b20804503e4d70f3085186"
+  integrity sha512-9O3q1Wl5vL1diYwPE1AJQHtSBVqEGwUXCP+i6Xf6jA1iMFYUL4Rld5WCEcZXPtk/8owq6eqjQ78KEdxqRWHnfw==
+
 postcss@^6.0.14:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -639,6 +639,11 @@ picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
+plotly.js-dist-min@^1.53.0:
+  version "1.58.4"
+  resolved "https://registry.yarnpkg.com/plotly.js-dist-min/-/plotly.js-dist-min-1.58.4.tgz#6a5b9baf1988b6aca6b20804503e4d70f3085186"
+  integrity sha512-9O3q1Wl5vL1diYwPE1AJQHtSBVqEGwUXCP+i6Xf6jA1iMFYUL4Rld5WCEcZXPtk/8owq6eqjQ78KEdxqRWHnfw==
+
 postcss@^6.0.14:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"

--- a/src/vs/code/browser/workbench/workbench-dev.html
+++ b/src/vs/code/browser/workbench/workbench-dev.html
@@ -90,7 +90,8 @@
 				'jschardet': `${window.location.origin}/static/remote/web/node_modules/jschardet/dist/jschardet.min.js`,
 				'turndown': `${window.location.origin}/static/remote/web/node_modules/turndown/lib/turndown.browser.umd.js`,
 				'mark.js': `${window.location.origin}/static/remote/web/node_modules/mark.js/dist/mark.min.js`,
-				'gridstack': `${window.location.origin}/static/node_modules/gridstack/dist/gridstack-h5.js`
+				'gridstack': `${window.location.origin}/static/node_modules/gridstack/dist/gridstack-h5.js`,
+				'plotly.js-dist-min': `${window.location.origin}/static/node_modules/plotly.js-dist-min/plotly.min.js`
 			}
 		};
 	</script>

--- a/src/vs/code/browser/workbench/workbench-web-dev.html
+++ b/src/vs/code/browser/workbench/workbench-web-dev.html
@@ -56,6 +56,7 @@
 			'tas-client-umd': `${baseUrl}/node_modules/tas-client-umd/lib/tas-client-umd.js`,
 			'iconv-lite-umd': `${baseUrl}/node_modules/iconv-lite-umd/lib/iconv-lite-umd.js`,
 			'jschardet': `${baseUrl}/node_modules/jschardet/dist/jschardet.min.js`,
+			'plotly.js-dist-min': `${window.location.origin}/static/node_modules/plotly.js-dist-min/plotly.min.js`
 		}
 	};
 </script>

--- a/src/vs/code/browser/workbench/workbench-web-dev.html
+++ b/src/vs/code/browser/workbench/workbench-web-dev.html
@@ -56,7 +56,6 @@
 			'tas-client-umd': `${baseUrl}/node_modules/tas-client-umd/lib/tas-client-umd.js`,
 			'iconv-lite-umd': `${baseUrl}/node_modules/iconv-lite-umd/lib/iconv-lite-umd.js`,
 			'jschardet': `${baseUrl}/node_modules/jschardet/dist/jschardet.min.js`,
-			'plotly.js-dist-min': `${window.location.origin}/static/node_modules/plotly.js-dist-min/plotly.min.js`
 		}
 	};
 </script>

--- a/src/vs/code/browser/workbench/workbench.html
+++ b/src/vs/code/browser/workbench/workbench.html
@@ -76,7 +76,8 @@
 				'jschardet': `${window.location.origin}/static/node_modules/jschardet/dist/jschardet.min.js`,
 				'turndown': `${window.location.origin}/static/node_modules/turndown/lib/turndown.browser.umd.js`,
 				'mark.js': `${window.location.origin}/static/node_modules/mark.js/dist/mark.min.js`,
-				'gridstack': `${window.location.origin}/static/node_modules/gridstack/dist/gridstack-h5.js`
+				'gridstack': `${window.location.origin}/static/node_modules/gridstack/dist/gridstack-h5.js`,
+				'plotly.js-dist-min': `${window.location.origin}/static/node_modules/plotly.js-dist-min/plotly.min.js`
 			}
 		};
 	</script>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15951, the Plotly rendering issue within ADS Web Notebooks was not rendering due to an uncaught promise when trying to locate: plotly.js-dist-min module. As such we need to include this to render Plotly graphs within ADS Web mode. 

Confirmed with latest ADS Web image in the build pipeline that it displays properly show below:
![image](https://user-images.githubusercontent.com/23587151/123894288-c1438b00-d912-11eb-9f41-95e612759c0a.png)
