### PR TITLE
SQL Migration extension - accessibility bug - fixes filter enter and focus

### DIFF
--- a/extensions/sql-migration/src/api/utils.ts
+++ b/extensions/sql-migration/src/api/utils.ts
@@ -156,3 +156,35 @@ export function findDropDownItemIndex(dropDown: DropDownComponent, value: string
 
 	return -1;
 }
+
+export function debounce(delay: number): Function {
+	return decorate((fn, key) => {
+		const timerKey = `$debounce$${key}`;
+
+		return function (this: any, ...args: any[]) {
+			clearTimeout(this[timerKey]);
+			this[timerKey] = setTimeout(() => fn.apply(this, args), delay);
+		};
+	});
+}
+
+export function decorate(decorator: (fn: Function, key: string) => Function): Function {
+	return (_target: any, key: string, descriptor: any) => {
+		let fnKey: string | null = null;
+		let fn: Function | null = null;
+
+		if (typeof descriptor.value === 'function') {
+			fnKey = 'value';
+			fn = descriptor.value;
+		} else if (typeof descriptor.get === 'function') {
+			fnKey = 'get';
+			fn = descriptor.get;
+		}
+
+		if (!fn || !fnKey) {
+			throw new Error('not supported');
+		}
+
+		descriptor[fnKey] = decorator(fn, key);
+	};
+}

--- a/extensions/sql-migration/src/dialog/assessmentResults/assessmentResultsDialog.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/assessmentResultsDialog.ts
@@ -46,7 +46,8 @@ export class AssessmentResultsDialog {
 					}).component();
 					flex.addItem(await this._tree.createRootContainer(view), { flex: '1 1 auto' });
 
-					view.initializeModel(flex);
+					await view.initializeModel(flex);
+					await this._tree.focusComponent.focus();
 					resolve();
 				} catch (ex) {
 					reject(ex);

--- a/extensions/sql-migration/src/dialog/assessmentResults/assessmentResultsDialog.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/assessmentResultsDialog.ts
@@ -47,7 +47,6 @@ export class AssessmentResultsDialog {
 					flex.addItem(await this._tree.createRootContainer(view), { flex: '1 1 auto' });
 
 					await view.initializeModel(flex);
-					await this._tree.focusComponent.focus();
 					resolve();
 				} catch (ex) {
 					reject(ex);

--- a/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
@@ -47,6 +47,8 @@ const blockingIssues: Array<string> = [
 ];
 
 export class SqlDatabaseTree {
+	public focusComponent!: azdata.Component;
+
 	private _view!: azdata.ModelView;
 	private _instanceTable!: azdata.DeclarativeTableComponent;
 	private _databaseTable!: azdata.DeclarativeTableComponent;
@@ -201,9 +203,30 @@ export class SqlDatabaseTree {
 
 	private createSearchComponent(): azdata.DivContainer {
 		let resourceSearchBox = this._view.modelBuilder.inputBox().withProps({
+			stopEnterPropagation: true,
 			placeHolder: constants.SEARCH,
 			width: 200
 		}).component();
+		this.focusComponent = resourceSearchBox;
+
+		resourceSearchBox.onTextChanged(value => {
+			const filter: number[] = [];
+			if (this._databaseTableValues && value && value.length > 0) {
+				this._databaseTableValues.forEach((row, index) => {
+					const cell: any = row[1]?.value;
+					const cellText: string = cell?.items[1]?.value?.toLowerCase();
+					const searchText: string = value.toLowerCase();
+					if (cellText?.includes(searchText)) {
+						filter.push(index);
+					}
+				});
+			}
+
+			this._databaseTable.setFilter(
+				filter.length > 0
+					? filter
+					: undefined);
+		});
 
 		const searchContainer = this._view.modelBuilder.divContainer().withItems([resourceSearchBox]).withProps({
 			CSSStyles: {

--- a/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
@@ -224,8 +224,9 @@ export class SqlDatabaseTree {
 		if (this._databaseTableValues && value?.length > 0) {
 			const filter: number[] = [];
 			this._databaseTableValues.forEach((row, index) => {
-				const cell: any = row[1]?.value;
-				const cellText: string = cell?.items[1]?.value?.toLowerCase();
+				const flexContainer: azdata.FlexContainer = row[1]?.value as azdata.FlexContainer;
+				const textComponent: azdata.TextComponent = flexContainer.items[1] as azdata.TextComponent;
+				const cellText = textComponent.value?.toLowerCase();
 				const searchText: string = value.toLowerCase();
 				if (cellText?.includes(searchText)) {
 					filter.push(index);

--- a/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
+++ b/extensions/sql-migration/src/dialog/assessmentResults/sqlDatabasesTree.ts
@@ -221,7 +221,7 @@ export class SqlDatabaseTree {
 
 	@debounce(500)
 	private _filterTableList(value: string): void {
-		if (this._databaseTableValues && value && value.length > 0) {
+		if (this._databaseTableValues && value?.length > 0) {
 			const filter: number[] = [];
 			this._databaseTableValues.forEach((row, index) => {
 				const cell: any = row[1]?.value;

--- a/extensions/sql-migration/src/dialog/migrationStatus/migrationStatusDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationStatus/migrationStatusDialog.ts
@@ -33,7 +33,7 @@ export class MigrationStatusDialog {
 
 	initialize() {
 		let tab = azdata.window.createTab('');
-		tab.registerContent((view: azdata.ModelView) => {
+		tab.registerContent(async (view: azdata.ModelView) => {
 			this._view = view;
 
 			this._statusDropdown = this._view.modelBuilder.dropDown().withProps({
@@ -72,7 +72,8 @@ export class MigrationStatusDialog {
 			this._view.onClosed(e => {
 				clearInterval(this._autoRefreshHandle);
 			});
-			return view.initializeModel(form);
+			await view.initializeModel(form);
+			return await this._searchBox.focus();
 		});
 		this._dialogObject.content = [tab];
 		this._dialogObject.cancelButton.hidden = true;
@@ -85,6 +86,7 @@ export class MigrationStatusDialog {
 
 	private createSearchAndRefreshContainer(): azdata.FlexContainer {
 		this._searchBox = this._view.modelBuilder.inputBox().withProps({
+			stopEnterPropagation: true,
 			placeHolder: loc.SEARCH_FOR_MIGRATIONS,
 			width: '360px'
 		}).component();

--- a/extensions/sql-migration/src/dialog/migrationStatus/migrationStatusDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationStatus/migrationStatusDialog.ts
@@ -72,7 +72,7 @@ export class MigrationStatusDialog {
 			this._view.onClosed(e => {
 				clearInterval(this._autoRefreshHandle);
 			});
-			return await view.initializeModel(form);
+			return view.initializeModel(form);
 		});
 		this._dialogObject.content = [tab];
 		this._dialogObject.cancelButton.hidden = true;

--- a/extensions/sql-migration/src/dialog/migrationStatus/migrationStatusDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationStatus/migrationStatusDialog.ts
@@ -72,8 +72,7 @@ export class MigrationStatusDialog {
 			this._view.onClosed(e => {
 				clearInterval(this._autoRefreshHandle);
 			});
-			await view.initializeModel(form);
-			return await this._searchBox.focus();
+			return await view.initializeModel(form);
 		});
 		this._dialogObject.content = [tab];
 		this._dialogObject.cancelButton.hidden = true;


### PR DESCRIPTION
This PR fixes #15855 

* set focus to first control when Assessment results dialog is opened
* implement database filter in assessment results dialog
* block enter key in assessment results filter textbox from closing dialog
* set focus to first control when Migration status dialog is opened
* block enter key in migration status search from closing dialog
