### PR TITLE
Add open existing project functionality for VS Code

### DIFF
--- a/extensions/data-workspace/src/common/constants.ts
+++ b/extensions/data-workspace/src/common/constants.ts
@@ -51,7 +51,6 @@ export const OpenExistingDialogTitle = localize('dataworkspace.openExistingDialo
 export const FileNotExistError = (fileType: string, filePath: string): string => { return localize('dataworkspace.fileNotExistError', "The selected {0} file '{1}' does not exist or is not a file.", fileType, filePath); };
 export const CloneParentDirectoryNotExistError = (location: string): string => { return localize('dataworkspace.cloneParentDirectoryNotExistError', "The selected clone path '{0}' does not exist or is not a directory.", location); };
 export const Project = localize('dataworkspace.project', "Project");
-export const Workspace = localize('dataworkspace.workspace', "Workspace");
 export const LocationSelectorTitle = localize('dataworkspace.locationSelectorTitle', "Location");
 export const ProjectFilePlaceholder = localize('dataworkspace.projectFilePlaceholder', "Select project file");
 export const WorkspacePlaceholder = localize('dataworkspace.workspacePlaceholder', "Select workspace ({0}) file", WorkspaceFileExtension);

--- a/extensions/data-workspace/src/main.ts
+++ b/extensions/data-workspace/src/main.ts
@@ -9,7 +9,7 @@ import { WorkspaceService } from './services/workspaceService';
 import { WorkspaceTreeItem, IExtension } from 'dataworkspace';
 import { DataWorkspaceExtension } from './common/dataWorkspaceExtension';
 import { NewProjectDialog } from './dialogs/newProjectDialog';
-import { OpenExistingDialog } from './dialogs/openExistingDialog';
+import { browseForProject, OpenExistingDialog } from './dialogs/openExistingDialog';
 import { IWorkspaceService } from './common/interfaces';
 import { IconPathHelper } from './common/iconHelper';
 import { ProjectDashboard } from './dialogs/projectDashboard';
@@ -37,13 +37,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<IExten
 		} else {
 			await createNewProjectWithQuickpick(workspaceService);
 		}
-
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('projects.openExisting', async () => {
-		const dialog = new OpenExistingDialog(workspaceService);
-		await dialog.open();
-
+		if (getAzdataApi()) {
+			const dialog = new OpenExistingDialog(workspaceService);
+			await dialog.open();
+		} else {
+			const projectFileUri = await browseForProject(workspaceService);
+			if (!projectFileUri) {
+				return;
+			}
+			await workspaceService.addProjectsToWorkspace([projectFileUri]);
+		}
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('dataworkspace.refresh', () => {

--- a/extensions/data-workspace/src/services/workspaceService.ts
+++ b/extensions/data-workspace/src/services/workspaceService.ts
@@ -143,7 +143,7 @@ export class WorkspaceService implements IWorkspaceService {
 		const provider = ProjectProviderRegistry.getProviderByProjectType(projectTypeId);
 		if (provider) {
 			const projectFile = await provider.createProject(name, location, projectTypeId);
-			this.addProjectsToWorkspace([projectFile]);
+			await this.addProjectsToWorkspace([projectFile]);
 			this._onDidWorkspaceProjectsChange.fire();
 			return projectFile;
 		} else {

--- a/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
+++ b/extensions/data-workspace/src/test/dialogs/openExistingDialog.test.ts
@@ -62,18 +62,18 @@ suite('Open Existing Dialog', function (): void {
 	test('project browse', async function (): Promise<void> {
 		const workspaceServiceMock = TypeMoq.Mock.ofType<WorkspaceService>();
 		workspaceServiceMock.setup(x => x.getAllProjectTypes()).returns(() => Promise.resolve([testProjectType]));
-		sinon.stub(vscode.window, 'showOpenDialog').returns(Promise.resolve([]));
+		const showOpenDialogStub = sinon.stub(vscode.window, 'showOpenDialog').returns(Promise.resolve([]));
 
 		const dialog = new OpenExistingDialog(workspaceServiceMock.object);
 		await dialog.open();
 		should.equal(dialog.filePathTextBox!.value ?? '', '', 'Project file should initially be empty');
-		await dialog.projectBrowse();
+		await dialog.onBrowseButtonClick();
 		should.equal(dialog.filePathTextBox!.value ?? '', '', 'Project file should not be set when no file is selected');
 
-		sinon.restore();
+		showOpenDialogStub.restore();
 		const projectFile = vscode.Uri.file(generateUniqueProjectFilePath('testproj'));
 		sinon.stub(vscode.window, 'showOpenDialog').returns(Promise.resolve([projectFile]));
-		await dialog.projectBrowse();
+		await dialog.onBrowseButtonClick();
 		should.equal(dialog.filePathTextBox!.value, projectFile.fsPath, 'Project file should be set');
 	});
 });


### PR DESCRIPTION
Since we don't currently support the remote git option (due to lack of the clone API being exposed) the button will just open up the folder browse dialog directly. 

Also cleaning up an unused string and fixing a missing await