### PR TITLE
add focus outline style for hyperlink

### DIFF
--- a/src/sql/workbench/browser/modelComponents/hyperlink.component.ts
+++ b/src/sql/workbench/browser/modelComponents/hyperlink.component.ts
@@ -14,7 +14,7 @@ import * as azdata from 'azdata';
 import { TitledComponent } from 'sql/workbench/browser/modelComponents/titledComponent';
 import { IComponent, IComponentDescriptor, IModelStore, ComponentEventType } from 'sql/platform/dashboard/browser/interfaces';
 import { registerThemingParticipant, IColorTheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
-import { textLinkForeground, textLinkActiveForeground } from 'vs/platform/theme/common/colorRegistry';
+import { textLinkForeground, textLinkActiveForeground, focusBorder } from 'vs/platform/theme/common/colorRegistry';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import * as DOM from 'vs/base/browser/dom';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -101,6 +101,15 @@ registerThemingParticipant((theme: IColorTheme, collector: ICssStyleCollector) =
 		collector.addRule(`
 		modelview-hyperlink a:hover {
 			color: ${activeForeground};
+		}
+		`);
+	}
+
+	const outlineColor = theme.getColor(focusBorder);
+	if (outlineColor) {
+		collector.addRule(`
+		modelview-hyperlink a {
+			outline-color: ${outlineColor};
 		}
 		`);
 	}

--- a/src/sql/workbench/browser/modelComponents/media/hyperlink.css
+++ b/src/sql/workbench/browser/modelComponents/media/hyperlink.css
@@ -9,3 +9,9 @@ modelview-hyperlink .link-with-icon::after {
 	margin-left: 5px;
 	vertical-align: bottom;
 }
+
+modelview-hyperlink a:focus {
+	outline-width: 1px;
+	outline-style: solid;
+	outline-offset: 1px;
+}


### PR DESCRIPTION
This PR fixes #15730 
This PR fixes #15741
apply the same outline color we use everywhere else to hyperlink component
![image](https://user-images.githubusercontent.com/13777222/124207592-b0be1c80-da9a-11eb-811b-a63786062007.png)

![image](https://user-images.githubusercontent.com/13777222/124207614-b9aeee00-da9a-11eb-9e7f-fd9d466c4b0e.png)
