### PR TITLE
Change LocProject to better reflect ADS file structure.

### DIFF
--- a/resources/xlf/LocProject.json
+++ b/resources/xlf/LocProject.json
@@ -6,152 +6,152 @@
         {
           "SourceFile": "resources\\xlf\\en\\admin-tool-ext-win.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\admin-tool-ext-win.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\agent.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\agent.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
     {
           "SourceFile": "resources\\xlf\\en\\arc.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\arc.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
     {
           "SourceFile": "resources\\xlf\\en\\asde-deployment.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\asde-deployment.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
     {
           "SourceFile": "resources\\xlf\\en\\azdata.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\azdata.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\azurecore.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\azurecore.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
     {
           "SourceFile": "resources\\xlf\\en\\azurehybridtoolkit.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\azurehybridtoolkit.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\big-data-cluster.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\big-data-cluster.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\cms.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\cms.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\dacpac.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\dacpac.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
     {
           "SourceFile": "resources\\xlf\\en\\data-workspace.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\data-workspace.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\import.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\import.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
     {
           "SourceFile": "resources\\xlf\\en\\kusto.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\kusto.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
     {
           "SourceFile": "resources\\xlf\\en\\machine-learning.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\machine-learning.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\Microsoft.sqlservernotebook.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\Microsoft.sqlservernotebook.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\mssql.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\mssql.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\notebook.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\notebook.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\profiler.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\profiler.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
     {
           "SourceFile": "resources\\xlf\\en\\query-history.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\query-history.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\resource-deployment.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\resource-deployment.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\schema-compare.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\schema-compare.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
     {
           "SourceFile": "resources\\xlf\\en\\sql-assessment.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\sql-assessment.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
     {
           "SourceFile": "resources\\xlf\\en\\sql-database-projects.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\sql-database-projects.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
     {
           "SourceFile": "resources\\xlf\\en\\sql-migration.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\sql-migration.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         },
 		{
           "SourceFile": "resources\\xlf\\en\\sql.xlf",
           "LclFile": "resources\\localization\\LCL\\{Lang}\\sql.xlf.lcl",
-          "CopyOption": "LangIDOnName",
-          "OutputPath": "resources\\xlf\\Localized"
+          "CopyOption": "LangIDOnPath",
+          "OutputPath": "resources\\xlf"
         }
       ]
     }


### PR DESCRIPTION
Currently when localized XLF files are retrieved in the drop file from the azuredatastudio-CI pipeline, they have the very confusing filepath of "/<language_id>/resources/xlf/en/file.<language_id>.xlf" This has been a road bump in regards to automating and simplifying the translation process as the last folder is incorrectly named.

I have read the documentation on onelocbuild: (https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=add-onelocbuild-task-to-build-definition) and following the instructions there, I have changed the output path to "resources/xlf" as "Localized" does not seem to exist in our ADS folders anywhere. Also I changed the CopyOption to having LangIDOnPath, so that creating the i18n.json files will have less processing (in regards to renaming the file), while also hopefully having the correct language directory be generated.

@khoiph1 If you have any clarifications on the localization process, please let me know as I cannot see the CI scripts on my side, I'm only basing this change based on what I could find in the document.
