### PR TITLE
Fixing next button on flat file wizard file configuration page

### DIFF
--- a/extensions/import/src/test/wizard/pages/fileConfigPage.test.ts
+++ b/extensions/import/src/test/wizard/pages/fileConfigPage.test.ts
@@ -238,7 +238,6 @@ describe('File config page', function () {
 				fileConfigPage = new FileConfigPage(mockFlatFileWizard.object, page, mockImportModel.object, view, TypeMoq.It.isAny());
 				pages.set(1, fileConfigPage);
 				await fileConfigPage.start();
-				fileConfigPage.setupNavigationValidator();
 				resolve();
 			});
 			wizard.generateScriptButton.hidden = true;

--- a/extensions/import/src/wizard/api/basePage.ts
+++ b/extensions/import/src/wizard/api/basePage.ts
@@ -40,7 +40,8 @@ export abstract class BasePage {
 	 * Sets up a navigation validator.
 	 * This will be called right before onPageEnter().
 	 */
-	public abstract setupNavigationValidator(): void;
+	public setupNavigationValidator(): void {
+	}
 
 	public async getServerValues(): Promise<{ connection: azdata.connection.Connection, displayName: string, name: string }[]> {
 		let cons = await azdata.connection.getActiveConnections();

--- a/extensions/import/src/wizard/pages/fileConfigPage.ts
+++ b/extensions/import/src/wizard/pages/fileConfigPage.ts
@@ -126,15 +126,6 @@ export class FileConfigPage extends ImportPage {
 		return true;
 	}
 
-	public setupNavigationValidator() {
-		this.instance.registerNavigationValidator((info) => {
-			if (this.schemaLoader.loading || this.databaseDropdown.loading) {
-				return false;
-			}
-			return true;
-		});
-	}
-
 	private async createServerDropdown(): Promise<azdata.FormComponent> {
 		this.serverDropdown = this.view.modelBuilder.dropDown().withProps({
 			required: true

--- a/extensions/import/src/wizard/pages/fileConfigPage.ts
+++ b/extensions/import/src/wizard/pages/fileConfigPage.ts
@@ -111,7 +111,10 @@ export class FileConfigPage extends ImportPage {
 
 	async onPageEnter(): Promise<boolean> {
 		this.serverDropdown.focus();
-		return await this.populateServerDropdown();
+		let r1 = await this.populateServerDropdown();
+		let r2 = await this.populateDatabaseDropdown();
+		let r3 = await this.populateSchemaDropdown();
+		return r1 && r2 && r3;
 	}
 
 	override async onPageLeave(): Promise<boolean> {
@@ -124,10 +127,6 @@ export class FileConfigPage extends ImportPage {
 		delete this.model.table;
 
 		return true;
-	}
-
-	public setupNavigationValidator(): void {
-		return;
 	}
 
 	private async createServerDropdown(): Promise<azdata.FormComponent> {

--- a/extensions/import/src/wizard/pages/fileConfigPage.ts
+++ b/extensions/import/src/wizard/pages/fileConfigPage.ts
@@ -126,6 +126,10 @@ export class FileConfigPage extends ImportPage {
 		return true;
 	}
 
+	public setupNavigationValidator(): void {
+		return;
+	}
+
 	private async createServerDropdown(): Promise<azdata.FormComponent> {
 		this.serverDropdown = this.view.modelBuilder.dropDown().withProps({
 			required: true

--- a/extensions/import/src/wizard/pages/modifyColumnsPage.ts
+++ b/extensions/import/src/wizard/pages/modifyColumnsPage.ts
@@ -147,9 +147,9 @@ export class ModifyColumnsPage extends ImportPage {
 		return true;
 	}
 
-	public setupNavigationValidator() {
+	public override setupNavigationValidator() {
 		this.instance.registerNavigationValidator((info) => {
-			return !this.loading.loading && this.table.data && this.table.data.length > 0;
+			return this.table.data && this.table.data.length > 0;
 		});
 	}
 

--- a/extensions/import/src/wizard/pages/prosePreviewPage.ts
+++ b/extensions/import/src/wizard/pages/prosePreviewPage.ts
@@ -144,12 +144,12 @@ export class ProsePreviewPage extends ImportPage {
 		return true;
 	}
 
-	public setupNavigationValidator() {
+	public override setupNavigationValidator() {
 		this.instance.registerNavigationValidator((info) => {
 			if (info) {
 				// Prose Preview to Modify Columns
 				if (info.lastPage === 1 && info.newPage === 2) {
-					return !this.loading.loading && this.table.data && this.table.data.length > 0;
+					return this.table.data && this.table.data.length > 0;
 				}
 			}
 			return !this.loading.loading;

--- a/extensions/import/src/wizard/pages/summaryPage.ts
+++ b/extensions/import/src/wizard/pages/summaryPage.ts
@@ -85,11 +85,6 @@ export class SummaryPage extends ImportPage {
 
 		return true;
 	}
-	public setupNavigationValidator() {
-		this.instance.registerNavigationValidator((info) => {
-			return !this.loading.loading;
-		});
-	}
 
 	private populateTable() {
 		this.table.updateProperties({

--- a/src/sql/workbench/browser/modelComponents/dropdown.component.ts
+++ b/src/sql/workbench/browser/modelComponents/dropdown.component.ts
@@ -113,7 +113,7 @@ export default class DropDownComponent extends ComponentBase<azdata.DropDownProp
 			}));
 			this._validations.push(() => !this.required || this.editable || !!this._selectBox.value);
 		}
-
+		this._validations.push(() => !this.loading);
 		this.baseInit();
 	}
 


### PR DESCRIPTION
This PR fixes the broken next button validation on the import wizard file selection page. 

There is another problem over here which is not addressed by the PR. The loading state of the dropdown is not correctly reflected in the extension. 

I am now invalidating the dropdown when it is in the loading state.