### PR TITLE
fix duplicate sqlcmd var header when loading publish profile multiple times

### DIFF
--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -566,8 +566,15 @@ export class PublishDatabaseDialog {
 					this.targetDatabaseDropDown!.value = result.databaseName;
 				}
 
-				// save count for later to see if we need to add the SQLCMD Variables table
-				const sqlCmdVarBeforeCount = Object.keys(<Record<string, string>>this.sqlCmdVars).length;
+				if (Object.keys(result.sqlCmdVariables).length) {
+					// add SQLCMD Variables table if it wasn't there before and the profile had sqlcmd variables
+					if (Object.keys(this.project.sqlCmdVariables).length === 0 && Object.keys(<Record<string, string>>this.sqlCmdVars).length === 0) {
+						this.formBuilder?.addFormItem(<azdataType.FormComponentGroup>this.sqlCmdVariablesFormComponentGroup);
+					}
+				} else if (Object.keys(this.project.sqlCmdVariables).length === 0) {
+					// remove the table if there are no SQLCMD variables in the project and loaded profile
+					this.formBuilder?.removeFormItem(<azdataType.FormComponentGroup>this.sqlCmdVariablesFormComponentGroup);
+				}
 
 				for (let key in result.sqlCmdVariables) {
 					(<Record<string, string>>this.sqlCmdVars)[key] = result.sqlCmdVariables[key];
@@ -579,16 +586,6 @@ export class PublishDatabaseDialog {
 				await (<azdataType.DeclarativeTableComponent>this.sqlCmdVariablesTable).updateProperties({
 					dataValues: data
 				});
-
-				if (Object.keys(result.sqlCmdVariables).length) {
-					// add SQLCMD Variables table if it wasn't there before
-					if (Object.keys(this.project.sqlCmdVariables).length === 0 && sqlCmdVarBeforeCount === 0) {
-						this.formBuilder?.addFormItem(<azdataType.FormComponentGroup>this.sqlCmdVariablesFormComponentGroup);
-					}
-				} else if (Object.keys(this.project.sqlCmdVariables).length === 0) {
-					// remove the table if there are no SQLCMD variables in the project and loaded profile
-					this.formBuilder?.removeFormItem(<azdataType.FormComponentGroup>this.sqlCmdVariablesFormComponentGroup);
-				}
 
 				// show file path in text box and hover text
 				this.loadProfileTextBox!.value = fileUris[0].fsPath;

--- a/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
+++ b/extensions/sql-database-projects/src/dialogs/publishDatabaseDialog.ts
@@ -566,6 +566,9 @@ export class PublishDatabaseDialog {
 					this.targetDatabaseDropDown!.value = result.databaseName;
 				}
 
+				// save count for later to see if we need to add the SQLCMD Variables table
+				const sqlCmdVarBeforeCount = Object.keys(<Record<string, string>>this.sqlCmdVars).length;
+
 				for (let key in result.sqlCmdVariables) {
 					(<Record<string, string>>this.sqlCmdVars)[key] = result.sqlCmdVariables[key];
 				}
@@ -579,7 +582,7 @@ export class PublishDatabaseDialog {
 
 				if (Object.keys(result.sqlCmdVariables).length) {
 					// add SQLCMD Variables table if it wasn't there before
-					if (Object.keys(this.project.sqlCmdVariables).length === 0) {
+					if (Object.keys(this.project.sqlCmdVariables).length === 0 && sqlCmdVarBeforeCount === 0) {
 						this.formBuilder?.addFormItem(<azdataType.FormComponentGroup>this.sqlCmdVariablesFormComponentGroup);
 					}
 				} else if (Object.keys(this.project.sqlCmdVariables).length === 0) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15991. We weren't accounting for the possibility that a publish profile had previously been loaded and already added the sqlcmd table. The model view components can only get added once, but since this was adding a form component group, the title of the group was getting added again when a publish profile with sqlcmd variables is loadedmultiple times and the project didn't have sqlcmd variables.

before:
![image](https://user-images.githubusercontent.com/28519865/124337345-f3ddc580-db56-11eb-9543-d35fe12c7fbd.png)

fixed:
![fixDuplicateHeader](https://user-images.githubusercontent.com/31145923/124669439-3b21ca00-de67-11eb-8c5e-16ae4adc05d3.gif)

