### PR TITLE
Fix notebook icon highlights

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/code.css
@@ -36,10 +36,11 @@ code-component .toolbar .carbon-taskbar {
 }
 
 code-component .toolbar .carbon-taskbar.monaco-toolbar .monaco-action-bar .codicon.action-label {
-	height: 20px;
-	padding-bottom: 10px;
+	height: 25px;
+	width: 25px;
+	padding: 0px;
 	background-size: 20px;
-	width: 40px;
+	background-position: center;
 }
 
 .notebook-cell:not(.active):hover code-component .toolbarIconRun {

--- a/src/sql/workbench/contrib/notebook/browser/notebook.css
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.css
@@ -79,18 +79,7 @@
 	.actions-container
 	.action-item
 	.codicon.masked-icon:before {
-	margin-right: 0;
-	padding-left: 18px;
-	width: 16px;
-}
-
-.notebookEditor
-	.in-preview
-	.actions-container
-	.action-item
-	.codicon.icon-run-with-parameters:before {
-	padding-left: 20px;
-	width: 18px;
+	width: 100%;
 }
 
 .notebookEditor .in-preview .actions-container .action-item:last-child {


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/azuredatastudio/issues/15969 and  fixes https://github.com/microsoft/azuredatastudio/issues/15982 

The uneven padding was causing the highlight to be offset.

![Screen Shot 2021-07-06 at 3 22 16 PM](https://user-images.githubusercontent.com/23462877/124678691-ea669d00-de77-11eb-95f7-ef6f9c374a35.png)

![Screen Shot 2021-07-06 at 4 34 21 PM](https://user-images.githubusercontent.com/23462877/124678748-09fdc580-de78-11eb-989c-786f4bfd48d7.png)
