### PR TITLE
toolbar separator overlapping with other items

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/notebook.css
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.css
@@ -7,10 +7,6 @@
 	padding-top: 16px;
 }
 
-.notebookEditor .taskbarSeparator {
-	margin: 0 16px 0 -8px;
-}
-
 .notebookEditor .editor-toolbar {
 	border-bottom-style: solid;
 	border-width: 0px 0px 1px 0px;

--- a/src/sql/workbench/contrib/notebook/browser/notebook.css
+++ b/src/sql/workbench/contrib/notebook/browser/notebook.css
@@ -7,6 +7,9 @@
 	padding-top: 16px;
 }
 
+.notebookEditor .taskbarSeparator {
+	margin: 0px 8px;
+}
 .notebookEditor .editor-toolbar {
 	border-bottom-style: solid;
 	border-width: 0px 0px 1px 0px;


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15981

before 
![image](https://user-images.githubusercontent.com/13777222/124685722-af1f9a80-de86-11eb-819a-cdf50e22ceb7.png)

after:
![image](https://user-images.githubusercontent.com/13777222/124826911-3ffb8200-df2a-11eb-98b0-e241404c96cb.png)


the offending change was introduced in this PR: https://github.com/microsoft/azuredatastudio/pull/10271, I am not sure why is it needed, I don't see any other impact to the notebook UI after removing it.