### PR TITLE
Fix truncated focus on checkbox for accessiblity

### DIFF
--- a/src/sql/workbench/browser/modelComponents/declarativeTable.component.html
+++ b/src/sql/workbench/browser/modelComponents/declarativeTable.component.html
@@ -4,6 +4,7 @@
 		<tr role="row">
 			<ng-container *ngFor="let column of columns; let c = index;">
 				<th class="declarative-table-header" aria-sort="none" [style.width]="getColumnWidth(column)"
+					[ngClass]="{'declarative-table-cell-checkbox' : isCheckBox(c)}"
 					[ngStyle]="column.headerCssStyles" [attr.aria-label]="getHeaderAriaLabel(c)">
 					{{column.displayName}}
 					<checkbox *ngIf="headerCheckboxVisible(c)" [checked]="isHeaderChecked(c)"
@@ -20,6 +21,7 @@
 					<ng-container *ngFor="let cellData of row;let c = index;trackBy:trackByFnCols">
 						<td class="declarative-table-cell" [style.width]="getColumnWidth(c)"
 							[attr.aria-label]="getAriaLabel(r, c)"
+							[ngClass]="{'declarative-table-cell-checkbox' : isCheckBox(c)}"
 							[ngStyle]="mergeCss(columns[c].rowCssStyles, cellData.style)" role="gridcell">
 							<checkbox *ngIf="isCheckBox(c)" label="" (onChange)="onCheckBoxChanged($event,r,c)"
 								[enabled]="isControlEnabled(r, c)" [checked]="isChecked(r,c)"

--- a/src/sql/workbench/browser/modelComponents/media/declarativeTable.css
+++ b/src/sql/workbench/browser/modelComponents/media/declarativeTable.css
@@ -20,17 +20,18 @@
 	border: 1px solid;
 }
 
-.declarative-table-cell>checkbox {
-	float: left;
-	margin: 0 auto;
-	width: 100%;
-	text-align: center;
-}
-
 .declarative-table .declarative-table-cell .codicon.toggle-more {
 	border-width: 0px;
 	height: 16px;
 	width: 26px;
 	vertical-align: middle;
 	cursor: pointer;
+}
+
+.declarative-table checkbox input[type='checkbox'] {
+	margin: 3px;
+}
+
+.declarative-table-cell-checkbox {
+	text-align: center;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15773

The truncated checkbox in SQL Migration extensions' Assessment Dialog table can be fully focused using keyboard tabs.

Override default checkbox margins ([PR#15014](https://github.com/microsoft/azuredatastudio/pull/15014))

Ensured changes don't modify the checkbox/check all used in other parts of code. This component is currently used by Modify Columns in the Import extension  ([PR#10751](https://github.com/microsoft/azuredatastudio/pull/10751))

Before:
![image](https://user-images.githubusercontent.com/14362577/124685981-26edc500-de87-11eb-8915-8d5da9617bfd.png)

After:
![image](https://user-images.githubusercontent.com/14362577/124685181-9a8ed280-de85-11eb-8b57-fb6664b61ad5.png)

![image](https://user-images.githubusercontent.com/14362577/124685195-a11d4a00-de85-11eb-8513-3b31d3490d1d.png)

