### PR TITLE
make the toolbar items keyboard focusable

### DIFF
--- a/src/sql/base/browser/ui/taskbar/actionbar.ts
+++ b/src/sql/base/browser/ui/taskbar/actionbar.ts
@@ -238,6 +238,9 @@ export class ActionBar extends ActionRunner implements IActionRunner {
 			//this.addEmitter(item);
 			item.render(actionItemElement);
 
+			// VSCode toolbar now will only receive one tab stop, by default all items are not focusable.
+			// Adding the following change to make sure the ADS toolbars are keyboard focusable to match the previous behavior as a temporary solution.
+			// TODO: https://github.com/microsoft/azuredatastudio/issues/16016
 			if (item instanceof BaseActionViewItem) {
 				item.setFocusable(true);
 			}

--- a/src/sql/base/browser/ui/taskbar/actionbar.ts
+++ b/src/sql/base/browser/ui/taskbar/actionbar.ts
@@ -238,6 +238,10 @@ export class ActionBar extends ActionRunner implements IActionRunner {
 			//this.addEmitter(item);
 			item.render(actionItemElement);
 
+			if (item instanceof BaseActionViewItem) {
+				item.setFocusable(true);
+			}
+
 			if (index === null || index < 0 || index >= this._actionsList.children.length) {
 				this._actionsList.appendChild(actionItemElement);
 			} else {


### PR DESCRIPTION
This PR fixes #16015 

In recent VSCode merge, a change to the toolbar was brought in, the keyboard focus will only receive one tab stop: https://github.com/microsoft/vscode/commit/da6a819b54a80c097430ad1ae034531cc607f880
, as a result of this change, ActionViewItems in our actionbar implementation are left not focusable.

this is what vscode is doing, only the first element is focusable

![image](https://user-images.githubusercontent.com/13777222/124713762-ca55ce80-deb5-11eb-910f-894dea3eca3a.png)
https://github.com/microsoft/vscode/blob/main/src/vs/base/browser/ui/actionbar/actionbar.ts#L328

this is not the ultimate fix for the issue, giving the time we have and focus on other projects, I am making this code change to make the toolbar items keyboard focusable for now and I've created an issue in August milestone to properly fix the issue:
https://github.com/microsoft/azuredatastudio/issues/16016
