### PR TITLE
Add allow root setting for Ubuntu and Web Mode users

### DIFF
--- a/extensions/notebook/package.json
+++ b/extensions/notebook/package.json
@@ -54,6 +54,11 @@
           "default": true,
           "description": "%notebook.overrideEditorTheming.description%"
         },
+        "notebook.allowRoot": {
+          "type": "boolean",
+          "default": false,
+          "description": "%notebook.allowRoot.description%"
+        },
         "notebook.maxTableRows": {
           "type": "number",
           "default": 5000,

--- a/extensions/notebook/package.nls.json
+++ b/extensions/notebook/package.nls.json
@@ -13,7 +13,7 @@
 	"notebook.collapseBookItems.description": "Collapse Book items at root level in the Notebooks Viewlet",
 	"notebook.remoteBookDownloadTimeout.description": "Download timeout in milliseconds for GitHub books",
 	"notebook.pinnedNotebooks.description": "Notebooks that are pinned by the user for the current workspace",
-	"notebook.allowRoot.description": "Allow notebook to run as root",
+	"notebook.allowRoot.description": "Allow Jupyter server to run as root user",
 	"notebook.command.new": "New Notebook",
 	"notebook.command.open": "Open Notebook",
 	"notebook.analyzeJupyterNotebook": "Analyze in Notebook",

--- a/extensions/notebook/package.nls.json
+++ b/extensions/notebook/package.nls.json
@@ -13,6 +13,7 @@
 	"notebook.collapseBookItems.description": "Collapse Book items at root level in the Notebooks Viewlet",
 	"notebook.remoteBookDownloadTimeout.description": "Download timeout in milliseconds for GitHub books",
 	"notebook.pinnedNotebooks.description": "Notebooks that are pinned by the user for the current workspace",
+	"notebook.allowRoot.description": "Allow notebook to run as root",
 	"notebook.command.new": "New Notebook",
 	"notebook.command.open": "Open Notebook",
 	"notebook.analyzeJupyterNotebook": "Analyze in Notebook",

--- a/extensions/notebook/src/common/constants.ts
+++ b/extensions/notebook/src/common/constants.ts
@@ -24,6 +24,7 @@ export const pinnedBooksConfigKey = 'pinnedNotebooks';
 export const maxBookSearchDepth = 'maxBookSearchDepth';
 export const remoteBookDownloadTimeout = 'remoteBookDownloadTimeout';
 export const collapseBookItems = 'collapseBookItems';
+export const allowRoot = 'allowRoot';
 
 export const winPlatform = 'win32';
 export const macPlatform = 'darwin';

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -212,11 +212,8 @@ export class PerFolderServerInstance implements IServerInstance {
 		}
 		let notebookDirectory = this.getNotebookDirectory();
 		this._token = await utils.getRandomToken();
-		if (allowRoot) {
-			startCommand = `"${this.options.install.pythonExecutable}" "${this.notebookScriptPath}" --no-browser --ip=127.0.0.1 --allow-root --no-mathjax --notebook-dir "${notebookDirectory}" --NotebookApp.token=${this._token}`;
-		} else {
-			startCommand = `"${this.options.install.pythonExecutable}" "${this.notebookScriptPath}" --no-browser --ip=127.0.0.1 --no-mathjax --notebook-dir "${notebookDirectory}" --NotebookApp.token=${this._token}`;
-		}
+		const allowRootParam = allowRoot ? '--allow-root' : '';
+		startCommand = `"${this.options.install.pythonExecutable}" "${this.notebookScriptPath}" --no-browser --ip=127.0.0.1 ${allowRootParam} --no-mathjax --notebook-dir "${notebookDirectory}" --NotebookApp.token=${this._token}`;
 		this.notifyStarting(this.options.install, startCommand);
 
 		// Execute the command

--- a/extensions/notebook/src/jupyter/serverInstance.ts
+++ b/extensions/notebook/src/jupyter/serverInstance.ts
@@ -204,12 +204,19 @@ export class PerFolderServerInstance implements IServerInstance {
 	 * started when the log message with URL to connect to is emitted.
 	 */
 	protected async startInternal(): Promise<void> {
+		let startCommand: string;
+		let notebookConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(constants.notebookConfigKey);
+		let allowRoot: boolean = notebookConfig.get(constants.allowRoot);
 		if (this.isStarted) {
 			return;
 		}
 		let notebookDirectory = this.getNotebookDirectory();
 		this._token = await utils.getRandomToken();
-		let startCommand = `"${this.options.install.pythonExecutable}" "${this.notebookScriptPath}" --no-browser --ip=127.0.0.1 --allow-root --no-mathjax --notebook-dir "${notebookDirectory}" --NotebookApp.token=${this._token}`;
+		if (allowRoot) {
+			startCommand = `"${this.options.install.pythonExecutable}" "${this.notebookScriptPath}" --no-browser --ip=127.0.0.1 --allow-root --no-mathjax --notebook-dir "${notebookDirectory}" --NotebookApp.token=${this._token}`;
+		} else {
+			startCommand = `"${this.options.install.pythonExecutable}" "${this.notebookScriptPath}" --no-browser --ip=127.0.0.1 --no-mathjax --notebook-dir "${notebookDirectory}" --NotebookApp.token=${this._token}`;
+		}
 		this.notifyStarting(this.options.install, startCommand);
 
 		// Execute the command


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15927

The allow root setting allows the jupyter notebook server to run the notebook as root. This is needed for web mode as there were issues with starting the notebook server due to permission issues.


