### PR TITLE
set the width of the 'clear list' button

### DIFF
--- a/src/sql/workbench/services/connection/browser/media/connectionDialog.css
+++ b/src/sql/workbench/services/connection/browser/media/connectionDialog.css
@@ -92,6 +92,7 @@
 	background-position: 2px center;
 	background-repeat: no-repeat;
 	padding-left: 25px;
+	width: auto;
 }
 
 .search-action.clear-search-results {


### PR DESCRIPTION
This PR fixes #15825 

previously @Charles-Gagnon fixed the sizing issue of the places using our own version of taskbar, this place is using the vscode actionbar directly, and I did a search, this is the only place in sql folder using vscode actionbar and showing both text and image. 

by default the width is set to be 16px, the fix is to let the button auto decide its width.

after:
![image](https://user-images.githubusercontent.com/13777222/124843399-ae4e3d80-df46-11eb-8389-63be22a39a58.png)
