### PR TITLE
Fix CalloutDialog not opening after bad link

### DIFF
--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -351,10 +351,12 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 
 	private getCurrentLinkUrl(): string {
 		if (this.cellModel.currentMode === CellEditModes.WYSIWYG) {
-			const parentNode = document.getSelection().anchorNode.parentNode as HTMLAnchorElement || '';
-			if (parentNode === '') {
+			const anchorNode = document.getSelection().anchorNode;
+			if (!anchorNode) {
 				return '';
-			} else if (parentNode?.protocol === 'file:') {
+			}
+			const parentNode = anchorNode.parentNode as HTMLAnchorElement;
+			if (parentNode?.protocol === 'file:') {
 				// Pathname starts with / per https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/pathname so trim it off
 				return parentNode.pathname?.slice(1) || '';
 			} else {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -351,8 +351,10 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 
 	private getCurrentLinkUrl(): string {
 		if (this.cellModel.currentMode === CellEditModes.WYSIWYG) {
-			const parentNode = document.getSelection().anchorNode.parentNode as HTMLAnchorElement;
-			if (parentNode.protocol === 'file:') {
+			const parentNode = document.getSelection().anchorNode.parentNode as HTMLAnchorElement || '';
+			if (parentNode === '') {
+				return '';
+			} else if (parentNode?.protocol === 'file:') {
 				// Pathname starts with / per https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/pathname so trim it off
 				return parentNode.pathname?.slice(1) || '';
 			} else {
@@ -369,6 +371,7 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 			}
 			return '';
 		}
+
 	}
 
 	private getCellEditorControl(): IEditor | undefined {

--- a/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
+++ b/src/sql/workbench/contrib/notebook/browser/cellViews/markdownToolbar.component.ts
@@ -373,7 +373,6 @@ export class MarkdownToolbarComponent extends AngularDisposable {
 			}
 			return '';
 		}
-
 	}
 
 	private getCellEditorControl(): IEditor | undefined {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/Microsoft/azuredatastudio/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #15660. 

The issue was when clicking the insert link dialog the document.getSelection() would return null on anchorNode and therefore would then give the error described in the issue `ERR Cannot read property 'parentNode' of null: TypeError: Cannot read property 'parentNode' of null`. So now that we check the anchornode properly it won't error out and we will open the callout dialog unfilled.