### PR TITLE
Fix BDC auth

### DIFF
--- a/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
+++ b/extensions/big-data-cluster/src/bigDataCluster/controller/clusterControllerApi.ts
@@ -20,9 +20,7 @@ class SslAuth implements Authentication {
 	constructor() { }
 
 	applyToRequest(requestOptions: request.Options): void {
-		requestOptions['agentOptions'] = {
-			rejectUnauthorized: !getIgnoreSslVerificationConfigSetting()
-		};
+		requestOptions.rejectUnauthorized = !getIgnoreSslVerificationConfigSetting();
 	}
 }
 

--- a/extensions/mssql/src/hdfs/webhdfs.ts
+++ b/extensions/mssql/src/hdfs/webhdfs.ts
@@ -961,7 +961,7 @@ export class WebHDFS {
 		this.unlink(path, recursive, callback);
 	}
 
-	public static createClient(opts: IHdfsOptions, requestParams: IRequestParams): WebHDFS {
+	public static createClient(opts: IHdfsOptions): WebHDFS {
 		return new WebHDFS(
 			Object.assign(
 				{
@@ -971,7 +971,7 @@ export class WebHDFS {
 				},
 				opts || {}
 			),
-			requestParams
+			opts.requestParams ?? { }
 		);
 	}
 }

--- a/extensions/mssql/src/objectExplorerNodeProvider/connection.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/connection.ts
@@ -8,6 +8,7 @@ import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
 import * as constants from '../constants';
+import { getIgnoreSslVerificationConfigSetting } from '../util/auth';
 import { IFileSource, IHdfsOptions, FileSourceFactory } from './fileSources';
 
 export class SqlClusterConnection {
@@ -56,6 +57,7 @@ export class SqlClusterConnection {
 			user: this.user,
 			path: 'gateway/default/webhdfs/v1',
 			requestParams: {
+				rejectUnauthorized: !getIgnoreSslVerificationConfigSetting()
 			}
 		};
 		if (this.isIntegratedAuth()) {

--- a/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
+++ b/extensions/mssql/src/objectExplorerNodeProvider/fileSources.ts
@@ -18,7 +18,6 @@ import { WebHDFS, HdfsError } from '../hdfs/webhdfs';
 import { PermissionStatus } from '../hdfs/aclEntry';
 import { Mount, MountStatus } from '../hdfs/mount';
 import { FileStatus, hdfsFileTypeToFileType } from '../hdfs/fileStatus';
-import { getIgnoreSslVerificationConfigSetting } from '../util/auth';
 
 const localize = nls.loadMessageBundle();
 
@@ -129,6 +128,7 @@ export interface IRequestParams {
 	timeout?: number;
 	agent?: https.Agent;
 	headers?: {};
+	rejectUnauthorized?: boolean;
 }
 
 export class FileSourceFactory {
@@ -143,19 +143,7 @@ export class FileSourceFactory {
 
 	public async createHdfsFileSource(options: IHdfsOptions): Promise<IFileSource> {
 		options = options && options.host ? FileSourceFactory.removePortFromHost(options) : options;
-		let requestParams: IRequestParams = options.requestParams ? options.requestParams : {};
-		if (requestParams.auth || requestParams.isKerberos) {
-			let agentOptions = {
-				host: options.host,
-				port: options.port,
-				path: constants.hdfsRootPath,
-				rejectUnauthorized: !getIgnoreSslVerificationConfigSetting()
-			};
-			let agent = new https.Agent(agentOptions);
-			requestParams['agent'] = agent;
-
-		}
-		return new HdfsFileSource(WebHDFS.createClient(options, requestParams));
+		return new HdfsFileSource(WebHDFS.createClient(options));
 	}
 
 	// remove port from host when port is specified after a comma or colon


### PR DESCRIPTION

In the end I'm not exactly sure what caused this to break. Both places are using the request library which hasn't been updated so that doesn't seem likely to be the cause. But that uses the https library to do the actual calls so it's likely that either some NodeJS update brought in a new version with changed behavior or VS Code changed the behavior of the default agent.

 There were two places this was broken though : 

1. BDC Extension - this was setting the rejectUnauthorized through the agentOptions we passed to the request library - which is supposed to be applied to the agent. But given that we don't specify our own agent it's possible that something changed to make this not be apply correctly. So I'm just setting the option at the top level for the request which will directly be applied to the request itself.

2. MSSQL Extension - sort of similar but in this case we were creating the agent ourself. So this one should have been working, but something apparently was causing it to ignore the settings on that agent (possibly something was misconfigured with the agent being created?). Reading [various docs](https://nodejs.org/api/https.html#https_class_https_agent) though I couldn't find a good  reason to use our own custom agent over the global one - agents are primarily used when you want to control stuff like cache time, max sockets the agent keeps open and other stuff. But since we don't do any of that it seemed reasonable to just let it default to the global agent instead - and then do the same thing of setting the rejectUnauthorized at the request level instead. 

Along the way I did some cleanup to simplify the code a bit. 