### PR TITLE
Set notebook path before moving.

### DIFF
--- a/extensions/notebook/src/book/bookTocManager.ts
+++ b/extensions/notebook/src/book/bookTocManager.ts
@@ -367,6 +367,7 @@ export class BookTocManager implements IBookTocManager {
 		let fileName = undefined;
 		try {
 			await fs.move(file.book.contentPath, path.join(rootPath, filePath.base), { overwrite: false });
+			this.movedFiles.set(file.book.contentPath, path.join(rootPath, filePath.base));
 		} catch (error) {
 			if (error.code === 'EEXIST') {
 				fileName = await this.renameFile(file.book.contentPath, path.join(rootPath, filePath.base));

--- a/extensions/notebook/src/book/bookTocManager.ts
+++ b/extensions/notebook/src/book/bookTocManager.ts
@@ -130,8 +130,8 @@ export class BookTocManager implements IBookTocManager {
 		while (await fs.pathExists(path.join(newFileName.concat(' - ', counter.toString())).concat(path.parse(dest).ext))) {
 			counter++;
 		}
-		await fs.move(src, path.join(newFileName.concat(' - ', counter.toString())).concat(path.parse(dest).ext), { overwrite: true });
 		this.movedFiles.set(src, path.join(newFileName.concat(' - ', counter.toString())).concat(path.parse(dest).ext));
+		await fs.move(src, path.join(newFileName.concat(' - ', counter.toString())).concat(path.parse(dest).ext), { overwrite: true });
 		vscode.window.showInformationMessage(loc.duplicateFileError(path.parse(dest).base, src, newFileName.concat(' - ', counter.toString())));
 		return newFileName.concat(' - ', counter.toString());
 	}
@@ -280,8 +280,8 @@ export class BookTocManager implements IBookTocManager {
 			if (elem.file) {
 				let fileName = undefined;
 				try {
-					await fs.move(path.join(this.sourceBookContentPath, elem.file).concat('.ipynb'), path.join(this.targetBookContentPath, elem.file).concat('.ipynb'), { overwrite: false });
 					this.movedFiles.set(path.join(this.sourceBookContentPath, elem.file).concat('.ipynb'), path.join(this.targetBookContentPath, elem.file).concat('.ipynb'));
+					await fs.move(path.join(this.sourceBookContentPath, elem.file).concat('.ipynb'), path.join(this.targetBookContentPath, elem.file).concat('.ipynb'), { overwrite: false });
 				} catch (error) {
 					if (error.code === 'EEXIST') {
 						fileName = await this.renameFile(path.join(this.sourceBookContentPath, elem.file).concat('.ipynb'), path.join(this.targetBookContentPath, elem.file).concat('.ipynb'));
@@ -291,8 +291,8 @@ export class BookTocManager implements IBookTocManager {
 					}
 				}
 				try {
-					await fs.move(path.join(this.sourceBookContentPath, elem.file).concat('.md'), path.join(this.targetBookContentPath, elem.file).concat('.md'), { overwrite: false });
 					this.movedFiles.set(path.join(this.sourceBookContentPath, elem.file).concat('.md'), path.join(this.targetBookContentPath, elem.file).concat('.md'));
+					await fs.move(path.join(this.sourceBookContentPath, elem.file).concat('.md'), path.join(this.targetBookContentPath, elem.file).concat('.md'), { overwrite: false });
 				} catch (error) {
 					if (error.code === 'EEXIST') {
 						fileName = await this.renameFile(path.join(this.sourceBookContentPath, elem.file).concat('.md'), path.join(this.targetBookContentPath, elem.file).concat('.md'));
@@ -321,8 +321,8 @@ export class BookTocManager implements IBookTocManager {
 		let moveFile = path.join(path.parse(uri).dir, path.parse(uri).name);
 		let fileName = undefined;
 		try {
-			await fs.move(section.book.contentPath, path.join(this.targetBookContentPath, moveFile).concat(path.parse(uri).ext), { overwrite: false });
 			this.movedFiles.set(section.book.contentPath, path.join(this.targetBookContentPath, moveFile).concat(path.parse(uri).ext));
+			await fs.move(section.book.contentPath, path.join(this.targetBookContentPath, moveFile).concat(path.parse(uri).ext), { overwrite: false });
 		} catch (error) {
 			if (error.code === 'EEXIST') {
 				fileName = await this.renameFile(section.book.contentPath, path.join(this.targetBookContentPath, moveFile).concat(path.parse(uri).ext));
@@ -366,8 +366,8 @@ export class BookTocManager implements IBookTocManager {
 		const filePath = path.parse(file.book.contentPath);
 		let fileName = undefined;
 		try {
-			await fs.move(file.book.contentPath, path.join(rootPath, filePath.base), { overwrite: false });
 			this.movedFiles.set(file.book.contentPath, path.join(rootPath, filePath.base));
+			await fs.move(file.book.contentPath, path.join(rootPath, filePath.base), { overwrite: false });
 		} catch (error) {
 			if (error.code === 'EEXIST') {
 				fileName = await this.renameFile(file.book.contentPath, path.join(rootPath, filePath.base));


### PR DESCRIPTION
Save the original path before moving in case the fs.move method throws an error. 
The recovery method will be called in case of error and it'll move back the files to their original place and will restore the original toc file.