### PR TITLE
new taskbar separator style

### DIFF
--- a/src/sql/base/browser/ui/taskbar/media/taskbar.css
+++ b/src/sql/base/browser/ui/taskbar/media/taskbar.css
@@ -78,7 +78,7 @@
 .taskbarSeparator {
 	min-width: 1px;
 	background-color:#A5A5A5;
-	margin: 6px 8px;
+	margin: 0px 16px;
 	align-self: stretch;
 }
 


### PR DESCRIPTION
as per @radentonev , adjusting the style of the taskbar separator style.

before:
![image](https://user-images.githubusercontent.com/13777222/125143728-6eb35d00-e0d0-11eb-87de-662d7c6b32d5.png)


after:
![image](https://user-images.githubusercontent.com/13777222/125143710-5f341400-e0d0-11eb-8065-43b814faa8b7.png)


@chlafreniere , notebook has some custom width set on the buttons, I'll leave it to you to make changes there and remove the custom separator style in notebook