### PR TITLE
Add accessibility information for MIAA deployment link

### DIFF
--- a/extensions/arc/package.json
+++ b/extensions/arc/package.json
@@ -1092,6 +1092,9 @@
           "links": [
             {
               "text": "%arc.agreement.sql.help.text.learn.more%",
+              "accessibilityInformation": {
+                "label": "%arc.agreement.sql.help.text.learn.more.ariaLabel%"
+              },
               "url": "https://go.microsoft.com/fwlink/?linkid=2141849"
             }
           ],

--- a/extensions/arc/package.nls.json
+++ b/extensions/arc/package.nls.json
@@ -154,5 +154,6 @@
 	"requested.memory.less.than.or.equal.to.memory.limit": "Requested memory must be less than or equal to memory limit",
 	"memory.limit.greater.than.or.equal.to.requested.memory": "Memory limit must be greater than or equal to requested memory",
 	"arc.agreement.sql.help.text": "Azure Arc enabled Managed Instance provides SQL Server access and feature compatibility that can be deployed on the infrastructure of your choice. While this service is in preview, it has some feature limitations compared to SQL Managed Instance on Azure. {0}",
-	"arc.agreement.sql.help.text.learn.more": "Learn more"
+	"arc.agreement.sql.help.text.learn.more": "Learn more",
+	"arc.agreement.sql.help.text.learn.more.ariaLabel": "Learn more about Azure Arc enabled Managed Instance"
 }

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -887,6 +887,15 @@ declare module 'azdata' {
 		appendData(data: any[][]): Thenable<void>;
 	}
 
+	export interface LinkArea {
+		/*
+		* Accessibility information used when screen reader interacts with this link.
+		* Generally, a link has no need to set the `role` of the accessibilityInformation;
+		* but it is exposed for situations that may require it.
+		*/
+		accessibilityInformation: vscode.AccessibilityInformation
+	}
+
 	export interface IconColumnCellValue {
 		/**
 		 * The icon to be displayed.

--- a/src/sql/azdata.proposed.d.ts
+++ b/src/sql/azdata.proposed.d.ts
@@ -893,7 +893,7 @@ declare module 'azdata' {
 		* Generally, a link has no need to set the `role` of the accessibilityInformation;
 		* but it is exposed for situations that may require it.
 		*/
-		accessibilityInformation: vscode.AccessibilityInformation
+		accessibilityInformation?: vscode.AccessibilityInformation
 	}
 
 	export interface IconColumnCellValue {

--- a/src/sql/workbench/browser/modelComponents/text.component.ts
+++ b/src/sql/workbench/browser/modelComponents/text.component.ts
@@ -124,6 +124,13 @@ export default class TextComponent extends TitledComponent<azdata.TextComponentP
 				label: link.text,
 				href: link.url
 			}));
+			if (link.accessibilityInformation) {
+				linkElement.el.setAttribute('aria-label', link.accessibilityInformation.label);
+				if (link.accessibilityInformation.role) {
+					linkElement.el.setAttribute('role', link.accessibilityInformation.role);
+				}
+			}
+
 			this._register(attachLinkStyler(linkElement, this.themeService));
 			(<HTMLElement>this.textContainer.nativeElement).appendChild(linkElement.el);
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15807

Screen reader text : 
`Learn more about Azure Arc enabled Managed Instance  link`

Even though we don't use it here I tested the role attribute and verified it works in case anyone else has need to use it. 