### PR TITLE
make dropdown arrow larger to meet accessibility requirement (#127839)

### DIFF
--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -192,10 +192,10 @@ body.web {
 .monaco-workbench .select-container:after {
 	content: "\eab4";
 	font-family: codicon;
-	font-size: 14px;
-	width: 14px;
-	height: 14px;
-	line-height: 14px;
+	font-size: 16px;
+	width: 16px;
+	height: 16px;
+	line-height: 16px;
 	position: absolute;
 	top: 0;
 	bottom: 0;


### PR DESCRIPTION
This PR fixes #15767

port the change from vscode: https://github.com/microsoft/vscode/pull/127839
