### PR TITLE
Fix focus element on connect dialog

### DIFF
--- a/extensions/arc/src/ui/dialogs/connectSqlDialog.ts
+++ b/extensions/arc/src/ui/dialogs/connectSqlDialog.ts
@@ -78,7 +78,7 @@ export abstract class ConnectToSqlDialog extends InitializingComponent {
 					title: ''
 				}]).withLayout({ width: '100%' }).component();
 			await view.initializeModel(formModel);
-			this.serverNameInputBox.focus();
+			this.usernameInputBox.focus();
 			this.initialized = true;
 		});
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio/issues/15772

Not the ideal fix, dialogs have logic for picking the first focusable element and focusing that when opened, but that doesn't work for modleview dialogs since the content is all created after that logic is called.

Doing this quick fix now and will plan on coming back to this to investigate further to see if we can fix all modal dialogs to run that logic after the content is created. 