### PR TITLE
left align the account information

### DIFF
--- a/src/sql/workbench/services/accountManagement/browser/media/accountPicker.css
+++ b/src/sql/workbench/services/accountManagement/browser/media/accountPicker.css
@@ -9,6 +9,7 @@
 	padding: 6px;
 	display: flex;
 	align-items: flex-start;
+	width: 100%;
 }
 
 .selected-account-container .codicon {


### PR DESCRIPTION
for #15820 

in recent vscode merge, the base dropdown style got a new style, justify-content:center, to restore the previous behavior I am adding a width property so that it takes full width.

before:
![image](https://user-images.githubusercontent.com/13777222/125363612-ceef0c80-e325-11eb-84c0-c6e753b053a3.png)



after:
![image](https://user-images.githubusercontent.com/13777222/125363499-8df6f800-e325-11eb-8c87-b5a79f8edaba.png)



