### PR TITLE
sql-migration: update migration status page latest design

### DIFF
--- a/extensions/sql-migration/package.json
+++ b/extensions/sql-migration/package.json
@@ -44,8 +44,70 @@
         "command": "sqlmigration.openNotebooks",
         "title": "%migration-notebook-command-title%",
         "category": "%migration-command-category%"
+      },
+      {
+        "command": "sqlmigration.cutover",
+        "title": "%complete-cutover-menu%",
+        "category": "%migration-context-menu-category%"
+      },
+      {
+        "command": "sqlmigration.view.database",
+        "title": "%database-details-menu%",
+        "category": "%migration-context-menu-category%"
+      },
+      {
+        "command": "sqlmigration.view.target",
+        "title": "%view-target-menu%",
+        "category": "%migration-context-menu-category%"
+      },
+      {
+        "command": "sqlmigration.view.service",
+        "title": "%view-service-menu%",
+        "category": "%migration-context-menu-category%"
+      },
+      {
+        "command": "sqlmigration.copy.migration",
+        "title": "%copy-migration-menu%",
+        "category": "%migration-context-menu-category%"
+      },
+      {
+        "command": "sqlmigration.cancel.migration",
+        "title": "%cancel-migration-menu%",
+        "category": "%migration-context-menu-category%"
       }
     ],
+    "menu": {
+      "commandPalette": [
+        {
+          "command": "sqlmigration.sendfeedback",
+          "when": "false"
+        },
+        {
+          "command": "sqlmigration.cutover",
+          "when": "false"
+        },
+        {
+          "command": "sqlmigration.view.database",
+          "when": "false"
+        },
+        {
+          "command": "sqlmigration.view.target",
+          "when": "false"
+        },
+        {
+          "command": "sqlmigration.view.service",
+          "when": "false"
+        },
+        {
+          "command": "sqlmigration.copy.migration",
+          "when": "false"
+        },
+        {
+          "command": "sqlmigration.cancel.migration",
+          "when": "false"
+        }
+      ]
+    },
     "dashboard.tabs": [
       {
         "id": "migration-dashboard",

--- a/extensions/sql-migration/package.nls.json
+++ b/extensions/sql-migration/package.nls.json
@@ -6,5 +6,12 @@
 	"migration-dashboard-tasks": "Migration Tasks",
 	"migration-command-category": "Azure SQL Migration",
 	"start-migration-command": "Migrate to Azure SQL",
-	"send-feedback-command": "Feedback"
+	"send-feedback-command": "Feedback",
+	"migration-context-menu-category": "Migration Context Menu",
+	"complete-cutover-menu": "Complete cutover",
+	"database-details-menu": "Database details",
+	"view-target-menu": "Azure SQL Target details",
+	"view-service-menu": "Dataase Migration Service details",
+	"copy-migration-menu": "Copy migration details",
+	"cancel-migration-menu": "Cancel migration"
 }

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -369,6 +369,9 @@ export const CONFIRM_CUTOVER_CHECKBOX = localize('sql.migration.confirm.checkbox
 export function CUTOVER_IN_PROGRESS(dbName: string): string {
 	return localize('sql.migration.cutover.in.progress', "Cutover in progress for database '{0}'", dbName);
 }
+export const MIGRATION_CANNOT_CANCEL = localize('sql.migration.cannot.cancel', 'Migration is not in progress and cannot be cancelled.');
+export const MIGRATION_CANNOT_CUTOVER = localize('sql.migration.cannot.cutover', 'Migration is not in progress and cannot be cutover.');
+
 //Migration status dialog
 export const SEARCH_FOR_MIGRATIONS = localize('sql.migration.search.for.migration', "Search for migrations");
 export const ONLINE = localize('sql.migration.online', "Online");
@@ -470,6 +473,8 @@ export function WARNINGS_COUNT(totalCount: number): string {
 export const AUTHENTICATION_TYPE = localize('sql.migration.authentication.type', "Authentication Type");
 export const SQL_LOGIN = localize('sql.migration.sql.login', "SQL Login");
 export const WINDOWS_AUTHENTICATION = localize('sql.migration.windows.auth', "Windows Authentication");
+
+export const REFRESH_BUTTON_LABEL = localize('sql.migration.status.refresh.label', 'Refresh');
 
 //AutoRefresh
 export function AUTO_REFRESH_BUTTON_TEXT(interval: SupportedAutoRefreshIntervals): string {

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -327,7 +327,7 @@ export const SOURCE_VERSION = localize('sql.migration.source.version', "Source v
 export const TARGET_DATABASE_NAME = localize('sql.migration.target.database.name', "Target database name");
 export const TARGET_SERVER = localize('sql.migration.target.server', "Target server");
 export const TARGET_VERSION = localize('sql.migration.target.version', "Target version");
-export const MIGRATION_STATUS = localize('sql.migration.migration.status', "Migration status");
+export const MIGRATION_STATUS = localize('sql.migration.migration.status', "Migration Status");
 export const MIGRATION_STATUS_FILTER = localize('sql.migration.migration.status.filter', "Migration status filter");
 export const FULL_BACKUP_FILES = localize('sql.migration.full.backup.files', "Full backup files");
 export const LAST_APPLIED_LSN = localize('sql.migration.last.applied.lsn', "Last applied LSN");
@@ -386,24 +386,47 @@ export const TARGET_AZURE_SQL_INSTANCE_NAME = localize('sql.migration.target.azu
 export const MIGRATION_MODE = localize('sql.migration.cutover.type', "Migration Mode");
 export const START_TIME = localize('sql.migration.start.time', "Start Time");
 export const FINISH_TIME = localize('sql.migration.finish.time', "Finish Time");
-export function STATUS_WARNING_COUNT(status: string, count: number): string {
-	if (status === 'InProgress' || status === 'Creating' || status === 'Completing' || status === 'Creating') {
+
+export function STATUS_VALUE(status: string, count: number): string {
+	if (count > 0) {
+		return localize('sql.migration.status.error.count.some', "{0} (", StatusLookup[status]);
+	}
+
+	return localize('sql.migration.status.error.count.none', "{0}", StatusLookup[status]);
+}
+
+export interface LookupTable<T> {
+	[key: string]: T;
+}
+
+export const StatusLookup: LookupTable<string | undefined> = {
+	['InProgress']: localize('sql.migration.status.inprogress', 'In progress'),
+	['Succeeded']: localize('sql.migration.status.succeeded', 'Succeeded'),
+	['Creating']: localize('sql.migration.status.creating', 'Creating'),
+	['Completing']: localize('sql.migration.status.completing', 'Completing'),
+	['Cancelling']: localize('sql.migration.status.cancelling', 'Cancelling'),
+	['Failed']: localize('sql.migration.status.failed', 'Failed'),
+	default: undefined,
+};
+
+export function STATUS_WARNING_COUNT(status: string, count: number): string | undefined {
+	if (status === 'InProgress' || status === 'Creating' || status === 'Completing') {
 		switch (count) {
 			case 0:
-				return localize('sql.migration.status.warning.count.none', "{0}", status);
+				return undefined;
 			case 1:
-				return localize('sql.migration.status.warning.count.single', "{0} ({1} Warning)", status, count);
+				return localize('sql.migration.status.warning.count.single', "{0} Warning)", count);
 			default:
-				return localize('sql.migration.status.warning.count.multiple', "{0} ({1} Warnings)", status, count);
+				return localize('sql.migration.status.warning.count.multiple', "{0} Warnings)", count);
 		}
 	} else {
 		switch (count) {
 			case 0:
-				return localize('sql.migration.status.error.count.none', "{0}", status);
+				return undefined;
 			case 1:
-				return localize('sql.migration.status.error.count.single', "{0} ({1} Error)", status, count);
+				return localize('sql.migration.status.error.count.single', "{0} Error)", count);
 			default:
-				return localize('sql.migration.status.error.count.multiple', "{0} ({1} Errors)", status, count);
+				return localize('sql.migration.status.error.count.multiple', "{0} Errors)", count);
 		}
 	}
 }

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -77,6 +77,9 @@ export const AZURE_TENANT = localize('sql.migration.azure.tenant', "Azure AD ten
 export function ACCOUNT_STALE_ERROR(account: AzureAccount) {
 	return localize('azure.accounts.accountStaleError', "The access token for selected account '{0}' is no longer valid. Please click the 'Link Account' button and refresh the account or select a different account.", `${account.displayInfo.displayName} (${account.displayInfo.userId})`);
 }
+export function ACCOUNT_ACCESS_ERROR(account: AzureAccount, error: Error) {
+	return localize('azure.accounts.accountAccessError', "Am error occurred while accessing the selected account '{0}'. Please click the 'Link Account' button and refresh the account or select a different account. Error '{1}'", `${account.displayInfo.displayName} (${account.displayInfo.userId})`, error.message);
+}
 
 // database backup page
 export const DATABASE_BACKUP_PAGE_TITLE = localize('sql.migration.database.page.title', "Database Backup");

--- a/extensions/sql-migration/src/constants/strings.ts
+++ b/extensions/sql-migration/src/constants/strings.ts
@@ -78,7 +78,7 @@ export function ACCOUNT_STALE_ERROR(account: AzureAccount) {
 	return localize('azure.accounts.accountStaleError', "The access token for selected account '{0}' is no longer valid. Please click the 'Link Account' button and refresh the account or select a different account.", `${account.displayInfo.displayName} (${account.displayInfo.userId})`);
 }
 export function ACCOUNT_ACCESS_ERROR(account: AzureAccount, error: Error) {
-	return localize('azure.accounts.accountAccessError', "Am error occurred while accessing the selected account '{0}'. Please click the 'Link Account' button and refresh the account or select a different account. Error '{1}'", `${account.displayInfo.displayName} (${account.displayInfo.userId})`, error.message);
+	return localize('azure.accounts.accountAccessError', "An error occurred while accessing the selected account '{0}'. Please click the 'Link Account' button and refresh the account or select a different account. Error '{1}'", `${account.displayInfo.displayName} (${account.displayInfo.userId})`, error.message);
 }
 
 // database backup page

--- a/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationCutover/migrationCutoverDialog.ts
@@ -39,13 +39,11 @@ export class MigrationCutoverDialog {
 	private _lastAppliedLSN!: azdata.TextComponent;
 	private _lastAppliedBackupFile!: azdata.TextComponent;
 	private _lastAppliedBackupTakenOn!: azdata.TextComponent;
-
 	private _fileCount!: azdata.TextComponent;
-
 	private fileTable!: azdata.TableComponent;
 	private _autoRefreshHandle!: any;
-	readonly _infoFieldWidth: string = '250px';
 
+	readonly _infoFieldWidth: string = '250px';
 
 	constructor(migration: MigrationContext) {
 		this._model = new MigrationCutoverDialogModel(migration);
@@ -55,244 +53,233 @@ export class MigrationCutoverDialog {
 	async initialize(): Promise<void> {
 		let tab = azdata.window.createTab('');
 		tab.registerContent(async (view: azdata.ModelView) => {
-			this._view = view;
-			const sourceDatabase = this.createInfoField(loc.SOURCE_DATABASE, '');
-			const sourceDetails = this.createInfoField(loc.SOURCE_SERVER, '');
-			const sourceVersion = this.createInfoField(loc.SOURCE_VERSION, '');
+			try {
+				this._view = view;
+				const sourceDatabase = this.createInfoField(loc.SOURCE_DATABASE, '');
+				const sourceDetails = this.createInfoField(loc.SOURCE_SERVER, '');
+				const sourceVersion = this.createInfoField(loc.SOURCE_VERSION, '');
 
-			this._sourceDatabase = sourceDatabase.text;
-			this._serverName = sourceDetails.text;
-			this._serverVersion = sourceVersion.text;
+				this._sourceDatabase = sourceDatabase.text;
+				this._serverName = sourceDetails.text;
+				this._serverVersion = sourceVersion.text;
 
-			const flexServer = view.modelBuilder.flexContainer().withLayout({
-				flexFlow: 'column'
-			}).component();
+				const flexServer = view.modelBuilder.flexContainer().withLayout({
+					flexFlow: 'column'
+				}).component();
 
-			flexServer.addItem(sourceDatabase.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-			flexServer.addItem(sourceDetails.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-			flexServer.addItem(sourceVersion.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-
-			const targetDatabase = this.createInfoField(loc.TARGET_DATABASE_NAME, '');
-			const targetServer = this.createInfoField(loc.TARGET_SERVER, '');
-			const targetVersion = this.createInfoField(loc.TARGET_VERSION, '');
-
-			this._targetDatabase = targetDatabase.text;
-			this._targetServer = targetServer.text;
-			this._targetVersion = targetVersion.text;
-
-			const flexTarget = view.modelBuilder.flexContainer().withLayout({
-				flexFlow: 'column'
-			}).component();
-
-			flexTarget.addItem(targetDatabase.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-			flexTarget.addItem(targetServer.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-			flexTarget.addItem(targetVersion.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-
-			const migrationStatus = this.createInfoField(loc.MIGRATION_STATUS, '');
-			const fullBackupFileOn = this.createInfoField(loc.FULL_BACKUP_FILES, '');
-			const backupLocation = this.createInfoField(loc.BACKUP_LOCATION, '');
-
-
-			this._migrationStatus = migrationStatus.text;
-			this._fullBackupFile = fullBackupFileOn.text;
-			this._backupLocation = backupLocation.text;
-
-			const flexStatus = view.modelBuilder.flexContainer().withLayout({
-				flexFlow: 'column'
-			}).component();
-
-			flexStatus.addItem(migrationStatus.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-			flexStatus.addItem(fullBackupFileOn.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-			flexStatus.addItem(backupLocation.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-
-			const lastSSN = this.createInfoField(loc.LAST_APPLIED_LSN, '');
-			const lastAppliedBackup = this.createInfoField(loc.LAST_APPLIED_BACKUP_FILES, '');
-			const lastAppliedBackupOn = this.createInfoField(loc.LAST_APPLIED_BACKUP_FILES_TAKEN_ON, '');
-
-
-			this._lastAppliedLSN = lastSSN.text;
-			this._lastAppliedBackupFile = lastAppliedBackup.text;
-			this._lastAppliedBackupTakenOn = lastAppliedBackupOn.text;
-
-			const flexFile = view.modelBuilder.flexContainer().withLayout({
-				flexFlow: 'column'
-			}).component();
-			flexFile.addItem(lastSSN.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-			flexFile.addItem(lastAppliedBackup.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-			flexFile.addItem(lastAppliedBackupOn.flexContainer, {
-				CSSStyles: {
-					'width': this._infoFieldWidth
-				}
-			});
-			const flexInfo = view.modelBuilder.flexContainer().withProps({
-				width: 1000
-			}).component();
-
-			flexInfo.addItem(flexServer, {
-				flex: '0',
-				CSSStyles: {
-					'flex': '0',
-					'width': this._infoFieldWidth
-				}
-			});
-
-			flexInfo.addItem(flexTarget, {
-				flex: '0',
-				CSSStyles: {
-					'flex': '0',
-					'width': this._infoFieldWidth
-				}
-			});
-
-			flexInfo.addItem(flexStatus, {
-				flex: '0',
-				CSSStyles: {
-					'flex': '0',
-					'width': this._infoFieldWidth
-				}
-			});
-
-			flexInfo.addItem(flexFile, {
-				flex: '0',
-				CSSStyles: {
-					'flex': '0',
-					'width': this._infoFieldWidth
-				}
-			});
-
-			this._fileCount = view.modelBuilder.text().withProps({
-				width: '500px',
-				CSSStyles: {
-					'font-size': '14px',
-					'font-weight': 'bold'
-				}
-			}).component();
-
-			this.fileTable = view.modelBuilder.table().withProps({
-				columns: [
-					{
-						value: loc.ACTIVE_BACKUP_FILES,
-						width: 230,
-						type: azdata.ColumnType.text,
-					},
-					{
-						value: loc.TYPE,
-						width: 90,
-						type: azdata.ColumnType.text
-					},
-					{
-						value: loc.STATUS,
-						width: 60,
-						type: azdata.ColumnType.text
-					},
-					{
-						value: loc.DATA_UPLOADED,
-						width: 120,
-						type: azdata.ColumnType.text
-					},
-					{
-						value: loc.COPY_THROUGHPUT,
-						width: 150,
-						type: azdata.ColumnType.text
-					},
-					{
-						value: loc.BACKUP_START_TIME,
-						width: 130,
-						type: azdata.ColumnType.text
-					},
-					{
-						value: loc.FIRST_LSN,
-						width: 120,
-						type: azdata.ColumnType.text
-					},
-					{
-						value: loc.LAST_LSN,
-						width: 120,
-						type: azdata.ColumnType.text
+				flexServer.addItem(sourceDatabase.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
 					}
-				],
-				data: [],
-				width: '1100px',
-				height: '300px',
-				fontSize: '12px'
-			}).component();
-
-			const formBuilder = view.modelBuilder.formContainer().withFormItems(
-				[
-					{
-						component: this.migrationContainerHeader()
-					},
-					{
-						component: this._view.modelBuilder.separator().withProps({ width: 1000 }).component()
-					},
-					{
-						component: flexInfo
-					},
-					{
-						component: this._view.modelBuilder.separator().withProps({ width: 1000 }).component()
-					},
-					{
-						component: this._fileCount
-					},
-					{
-						component: this.fileTable
+				});
+				flexServer.addItem(sourceDetails.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
 					}
-				],
-				{
-					horizontal: false
-				}
-			);
-			const form = formBuilder.withLayout({ width: '100%' }).component();
-			this._view.onClosed(e => {
-				clearInterval(this._autoRefreshHandle);
-			});
-			return view.initializeModel(form).then((value) => {
-				this.refreshStatus();
-			});
+				});
+				flexServer.addItem(sourceVersion.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
+					}
+				});
+
+				const targetDatabase = this.createInfoField(loc.TARGET_DATABASE_NAME, '');
+				const targetServer = this.createInfoField(loc.TARGET_SERVER, '');
+				const targetVersion = this.createInfoField(loc.TARGET_VERSION, '');
+
+				this._targetDatabase = targetDatabase.text;
+				this._targetServer = targetServer.text;
+				this._targetVersion = targetVersion.text;
+
+				const flexTarget = view.modelBuilder.flexContainer().withLayout({
+					flexFlow: 'column'
+				}).component();
+
+				flexTarget.addItem(targetDatabase.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
+					}
+				});
+				flexTarget.addItem(targetServer.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
+					}
+				});
+				flexTarget.addItem(targetVersion.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
+					}
+				});
+
+				const migrationStatus = this.createInfoField(loc.MIGRATION_STATUS, '');
+				const fullBackupFileOn = this.createInfoField(loc.FULL_BACKUP_FILES, '');
+				const backupLocation = this.createInfoField(loc.BACKUP_LOCATION, '');
+
+				this._migrationStatus = migrationStatus.text;
+				this._fullBackupFile = fullBackupFileOn.text;
+				this._backupLocation = backupLocation.text;
+
+				const flexStatus = view.modelBuilder.flexContainer().withLayout({
+					flexFlow: 'column'
+				}).component();
+
+				flexStatus.addItem(migrationStatus.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
+					}
+				});
+				flexStatus.addItem(fullBackupFileOn.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
+					}
+				});
+				flexStatus.addItem(backupLocation.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
+					}
+				});
+
+				const lastSSN = this.createInfoField(loc.LAST_APPLIED_LSN, '');
+				const lastAppliedBackup = this.createInfoField(loc.LAST_APPLIED_BACKUP_FILES, '');
+				const lastAppliedBackupOn = this.createInfoField(loc.LAST_APPLIED_BACKUP_FILES_TAKEN_ON, '');
+
+				this._lastAppliedLSN = lastSSN.text;
+				this._lastAppliedBackupFile = lastAppliedBackup.text;
+				this._lastAppliedBackupTakenOn = lastAppliedBackupOn.text;
+
+				const flexFile = view.modelBuilder.flexContainer().withLayout({
+					flexFlow: 'column'
+				}).component();
+				flexFile.addItem(lastSSN.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
+					}
+				});
+				flexFile.addItem(lastAppliedBackup.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
+					}
+				});
+				flexFile.addItem(lastAppliedBackupOn.flexContainer, {
+					CSSStyles: {
+						'width': this._infoFieldWidth
+					}
+				});
+				const flexInfo = view.modelBuilder.flexContainer().withProps({
+					width: 1000
+				}).component();
+
+				flexInfo.addItem(flexServer, {
+					flex: '0',
+					CSSStyles: {
+						'flex': '0',
+						'width': this._infoFieldWidth
+					}
+				});
+
+				flexInfo.addItem(flexTarget, {
+					flex: '0',
+					CSSStyles: {
+						'flex': '0',
+						'width': this._infoFieldWidth
+					}
+				});
+
+				flexInfo.addItem(flexStatus, {
+					flex: '0',
+					CSSStyles: {
+						'flex': '0',
+						'width': this._infoFieldWidth
+					}
+				});
+
+				flexInfo.addItem(flexFile, {
+					flex: '0',
+					CSSStyles: {
+						'flex': '0',
+						'width': this._infoFieldWidth
+					}
+				});
+
+				this._fileCount = view.modelBuilder.text().withProps({
+					width: '500px',
+					CSSStyles: {
+						'font-size': '14px',
+						'font-weight': 'bold'
+					}
+				}).component();
+
+				this.fileTable = view.modelBuilder.table().withProps({
+					columns: [
+						{
+							value: loc.ACTIVE_BACKUP_FILES,
+							width: 230,
+							type: azdata.ColumnType.text,
+						},
+						{
+							value: loc.TYPE,
+							width: 90,
+							type: azdata.ColumnType.text
+						},
+						{
+							value: loc.STATUS,
+							width: 60,
+							type: azdata.ColumnType.text
+						},
+						{
+							value: loc.DATA_UPLOADED,
+							width: 120,
+							type: azdata.ColumnType.text
+						},
+						{
+							value: loc.COPY_THROUGHPUT,
+							width: 150,
+							type: azdata.ColumnType.text
+						},
+						{
+							value: loc.BACKUP_START_TIME,
+							width: 130,
+							type: azdata.ColumnType.text
+						},
+						{
+							value: loc.FIRST_LSN,
+							width: 120,
+							type: azdata.ColumnType.text
+						},
+						{
+							value: loc.LAST_LSN,
+							width: 120,
+							type: azdata.ColumnType.text
+						}
+					],
+					data: [],
+					width: '1100px',
+					height: '300px',
+					fontSize: '12px'
+				}).component();
+
+				const formBuilder = view.modelBuilder.formContainer().withFormItems(
+					[
+						{ component: this.migrationContainerHeader() },
+						{ component: this._view.modelBuilder.separator().withProps({ width: 1000 }).component() },
+						{ component: flexInfo },
+						{ component: this._view.modelBuilder.separator().withProps({ width: 1000 }).component() },
+						{ component: this._fileCount },
+						{ component: this.fileTable }
+					],
+					{ horizontal: false }
+				);
+				const form = formBuilder.withLayout({ width: '100%' }).component();
+				this._view.onClosed(e => {
+					clearInterval(this._autoRefreshHandle);
+				});
+
+				return view.initializeModel(form).then((value) => {
+					this.refreshStatus();
+				});
+			} catch (e) {
+				console.log(e);
+			}
 		});
 		this._dialogObject.content = [tab];
 
@@ -304,7 +291,6 @@ export class MigrationCutoverDialog {
 		});
 		azdata.window.openDialog(this._dialogObject);
 	}
-
 
 	private migrationContainerHeader(): azdata.FlexContainer {
 		const sqlDatbaseLogo = this._view.modelBuilder.image().withProps({
@@ -404,7 +390,7 @@ export class MigrationCutoverDialog {
 		this._cancelButton.onDidClick((e) => {
 			vscode.window.showInformationMessage(loc.CANCEL_MIGRATION_CONFIRMATION, loc.YES, loc.NO).then(async (v) => {
 				if (v === loc.YES) {
-					await this.cancelMigration();
+					await this._model.cancelMigration();
 					await this.refreshStatus();
 				}
 			});
@@ -427,9 +413,8 @@ export class MigrationCutoverDialog {
 			}
 		}).component();
 
-		this._refreshButton.onDidClick((e) => {
-			this.refreshStatus();
-		});
+		this._refreshButton.onDidClick(
+			async (e) => await this.refreshStatus());
 
 		headerActions.addItem(this._refreshButton, {
 			flex: '0',
@@ -597,7 +582,7 @@ export class MigrationCutoverDialog {
 
 			this._fileCount.value = loc.ACTIVE_BACKUP_FILES_ITEMS(tableData.length);
 
-			//Sorting files in descending order of backupStartTime
+			// Sorting files in descending order of backupStartTime
 			tableData.sort((file1, file2) => new Date(file1.backupStartTime) > new Date(file2.backupStartTime) ? - 1 : 1);
 
 			this.fileTable.data = tableData.map((row) => {
@@ -663,11 +648,6 @@ export class MigrationCutoverDialog {
 			flexContainer: flexContainer,
 			text: textComponent
 		};
-	}
-
-	private async cancelMigration(): Promise<void> {
-		await this._model.cancelMigration();
-		await this.refreshStatus();
 	}
 }
 

--- a/extensions/sql-migration/src/dialog/migrationStatus/migrationStatusDialog.ts
+++ b/extensions/sql-migration/src/dialog/migrationStatus/migrationStatusDialog.ts
@@ -392,7 +392,6 @@ export class MigrationStatusDialog {
 	}
 
 	private _getStatusControl(status: string, count: number): azdata.FlexContainer {
-		status = 'InProgress';
 		const control = this._view.modelBuilder
 			.flexContainer()
 			.withItems([


### PR DESCRIPTION
This PR adds:
* context menu actions to migration status page
* database icon next to database name
* migration status and error images around migration status
* localize status display text
* add Azure account connection and authentication validation to account selection page

Migration status with context menu
Dark theme
![image](https://user-images.githubusercontent.com/61598682/125402905-c5879380-e369-11eb-9d31-7bf083f0fb56.png)

Light theme:
![image](https://user-images.githubusercontent.com/61598682/125402928-cae4de00-e369-11eb-8625-90272d0d1146.png)

In progress:
![image](https://user-images.githubusercontent.com/61598682/125402943-cf10fb80-e369-11eb-85be-5441dc3c2d68.png)

